### PR TITLE
Fix iunique validator (handling input valus with special regex characters)

### DIFF
--- a/superdesk/validator.py
+++ b/superdesk/validator.py
@@ -77,7 +77,8 @@ class SuperdeskValidator(Validator):
         """Validate uniqueness ignoring case.MONGODB USE ONLY"""
 
         if unique:
-            query = {field: re.compile('^{}$'.format(value.strip()), re.IGNORECASE)}
+            pattern = '^{}$'.format(re.escape(value.strip()))
+            query = {field: re.compile(pattern, re.IGNORECASE)}
             self._set_id_query(query)
 
             if superdesk.get_resource_service(self.resource).find_one(req=None, **query):
@@ -91,8 +92,11 @@ class SuperdeskValidator(Validator):
         parent_field_value = update.get(parent_field, original.get(parent_field))
 
         if parent_field:
-            query = {field: re.compile('^{}$'.format(value.strip()),
-                                       re.IGNORECASE), parent_field: parent_field_value}
+            pattern = '^{}$'.format(re.escape(value.strip()))
+            query = {
+                field: re.compile(pattern, re.IGNORECASE),
+                parent_field: parent_field_value
+            }
             self._set_id_query(query)
 
             if superdesk.get_resource_service(self.resource).find_one(req=None, **query):

--- a/tests/validator_tests.py
+++ b/tests/validator_tests.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.tests import TestCase
+from unittest import mock
+
+
+class SuperdeskValidatorTest(TestCase):
+    """Base class for the SuperdeskValidator class tests."""
+
+    def _get_target_class(self):
+        """Return the class under test.
+
+        Make the test fail immediately if the class cannot be imported.
+        """
+        try:
+            from superdesk.validator import SuperdeskValidator
+        except ImportError:
+            self.fail("Could not import class under test (SuperdeskValidator)")
+        else:
+            return SuperdeskValidator
+
+
+@mock.patch('superdesk.validator.superdesk')
+class ValidateIuniqueMethodTestCase(SuperdeskValidatorTest):
+    """Tests for the _validate_iunique() method."""
+
+    def setUp(self):
+        super().setUp()
+        klass = self._get_target_class()
+        self.validator = klass(schema={})
+
+    def test_does_not_raise_error_on_inputs_containing_special_regex_chars(
+        self, fake_superdesk
+    ):
+        field = 'field_name'
+        value = 'foo(bar++^$$^'  # an invalid regex pattern
+
+        try:
+            self.validator._validate_iunique(True, field, value)
+        except Exception as ex:
+            self.fail("Error unexpectedly raised: {}".format(ex))
+
+
+@mock.patch('superdesk.validator.superdesk')
+class ValidateIuniquePerParentMethodTestCase(SuperdeskValidatorTest):
+    """Tests for the _validate_iunique_per_parent() method."""
+
+    def setUp(self):
+        super().setUp()
+        klass = self._get_target_class()
+        self.validator = klass(schema={})
+        self.validator.document = {}
+
+    def test_does_not_raise_error_on_inputs_containing_special_regex_chars(
+        self, fake_superdesk
+    ):
+        parent_field = 'parent_field_name'
+        field = 'field_name'
+        value = 'foo(bar++^$$^'  # an invalid regex pattern
+
+        try:
+            self.validator._validate_iunique_per_parent(
+                parent_field, field, value)
+        except Exception as ex:
+            self.fail("Error unexpectedly raised: {}".format(ex))


### PR DESCRIPTION
The validator failed to escape the input before compiling it into a regular expression, and this PR fixes the issue.

Resolves [SD-3208](https://dev.sourcefabric.org/browse/SD-3208).