### PR TITLE
fix(celery): handle errors with app.context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 +## [unreleased]
 
+- fix(celery): use application context for task error handling
 - fix(websockets): remove client when connection is closed
 - add `service.find` method which is using mongo syntax for queries
 

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -44,7 +44,7 @@ class NINJSFormatter(Formatter):
                 ninjs['located'] = located.get('city', '')
 
             for copy_property in self.direct_copy_properties:
-                if copy_property in article and article[copy_property] != None:
+                if copy_property in article and article[copy_property] is not None:
                     ninjs[copy_property] = article[copy_property]
 
             if 'description' in article:


### PR DESCRIPTION
when sending notifications on ingest error it was out
of application context and thus raising runtime error.

now all error handing is done in celery task `on_failure`
callback using application context.