### PR TITLE
refactor(locks): use mongo for task locking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ statsd==3.1
 httmock==1.2.3
 boto3==1.0.0
 websockets==2.6
+mongolock==1.3.4

--- a/superdesk/celery_task_utils.py
+++ b/superdesk/celery_task_utils.py
@@ -8,6 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+import os
 import logging
 from flask import current_app as app
 from superdesk.utc import utcnow, get_date
@@ -15,6 +16,21 @@ from eve.utils import date_to_str
 from datetime import timedelta
 
 logger = logging.getLogger(__name__)
+
+
+def get_lock_id(*args):
+    """Get id for task using all given args."""
+    return '-'.join((str(x) for x in args))
+
+
+def get_host_id(task):
+    """Get host id for given task.
+
+    It should be unique on process level.
+
+    :param task: celery task
+    """
+    return '%s:%s' % (task.request.hostname, os.getpid())
 
 
 def __get_running_key(name, id):

--- a/superdesk/lock.py
+++ b/superdesk/lock.py
@@ -1,0 +1,42 @@
+
+import mongolock
+
+from werkzeug.local import LocalProxy
+from flask import current_app as app
+from superdesk.logging import logger
+
+
+def _get_lock():
+    """Get mongolock instance using app mongodb."""
+    return mongolock.MongoLock(client=app.data.mongo.pymongo().db)
+
+
+_lock = LocalProxy(_get_lock)
+
+
+def lock(task, host, expire=300, timeout=None):
+    """Try to lock task.
+
+    :param task: task name
+    :param host: current host id
+    :param expire: lock ttl in seconds
+    :param timeout: how long should it wait if task is locked
+    """
+    got_lock = _lock.lock(task, host, expire=expire, timeout=timeout)
+    if got_lock:
+        logger.info('got lock task=%s host=%s' % (task, host))
+    else:
+        logger.info('task locked already task=%s host=%s' % (task, host))
+    return got_lock
+
+
+def unlock(task, host):
+    """Release lock on given task.
+
+    Lock can be only released by host which locked it.
+
+    :param task: task name
+    :param host: current host id
+    """
+    logger.info('releasing lock task=%s host=%s' % (task, host))
+    return _lock.release(task, host)


### PR DESCRIPTION
move away from redis and use mongo instead for locking.
so far it's a poc in `ingest_update` task.

seems to work, not sure if we would need any extra wrapping for the library.

cc @mdhaman @akintolga @amagdas