### PR TITLE
fix(ci): remove exception logging when connecting to ws

### DIFF
--- a/superdesk/notification.py
+++ b/superdesk/notification.py
@@ -43,9 +43,8 @@ def init_app(app):
     try:
         app.ws_client = loop.run_until_complete(websockets.connect('ws://%s:%s/server' % (host, port)))
         logger.info('websocket connected on=%s:%s' % app.ws_client.local_address)
-    except OSError as err:
+    except OSError:
         # not working now, but we can try later when actually sending something
-        logger.exception(err)
         app.ws_client = ClosedSocket()
 
 


### PR DESCRIPTION
with stack traces for every unittest it has too long output on travis.

and there should be no need for details, there is another log entry when
message can't be delivered.