### PR TITLE
feat(ninjs): add profile and slugline fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 +## [unreleased]
 
+- feat(ninjs): output profile and slugline in ninjs
 - fix(celery): use application context for task error handling
 - fix(websockets): remove client when connection is closed
 - add `service.find` method which is using mongo syntax for queries

--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -189,6 +189,9 @@ metadata_schema = {
         'type': 'integer',
         'nullable': True
     },
+    'profile': {
+        'type': 'string',
+    },
 
     # Related to state of an article
     ITEM_STATE: {

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -23,7 +23,7 @@ class NINJSFormatter(Formatter):
     """
     direct_copy_properties = ['versioncreated', 'usageterms', 'subject', 'language', 'headline',
                               'urgency', 'pubstatus', 'mimetype', 'renditions', 'place',
-                              'body_text', 'body_html']
+                              'body_text', 'body_html', 'profile', 'slugline']
 
     def format(self, article, subscriber):
         try:
@@ -44,7 +44,7 @@ class NINJSFormatter(Formatter):
                 ninjs['located'] = located.get('city', '')
 
             for copy_property in self.direct_copy_properties:
-                if copy_property in article and article[copy_property] is not None:
+                if article.get(copy_property) is not None:
                     ninjs[copy_property] = article[copy_property]
 
             if 'description' in article:

--- a/tests/publish/ninjs_formatter_test.py
+++ b/tests/publish/ninjs_formatter_test.py
@@ -21,6 +21,7 @@ class NinjsFormatterTest(TestCase):
         super().setUp()
         self.formatter = NINJSFormatter()
         init_app(self.app)
+        self.maxDiff = None
 
     def testTextFomatter(self):
         embargo_ts = (utcnow() + timedelta(days=2))
@@ -41,6 +42,7 @@ class NinjsFormatterTest(TestCase):
             'type': 'text',
             'word_count': '1',
             'priority': 1,
+            'profile': 'snap',
             '_id': 'urn:localhost.abc',
             'state': 'published',
             'urgency': 2,
@@ -52,11 +54,23 @@ class NinjsFormatterTest(TestCase):
             'embargo': embargo_ts
         }
         seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
-        expected = {"version": "1", "place": "Australia", "pubstatus": "usable", "body_html": "The story body",
-                    "type": "text", "subject": [{"qcode": "02011001", "name": "international court or tribunal"},
-                                                {"qcode": "02011002", "name": "extradition"}],
-                    "headline": "This is a test headline", "byline": "joe", "_id": "urn:localhost.abc", "urgency": 2,
-                    "priority": 1, "embargoed": embargo_ts.isoformat()}
+        expected = {
+            "version": "1",
+            "place": "Australia",
+            "pubstatus": "usable",
+            "body_html": "The story body",
+            "type": "text",
+            "subject": [{"qcode": "02011001", "name": "international court or tribunal"},
+                        {"qcode": "02011002", "name": "extradition"}],
+            "headline": "This is a test headline",
+            "byline": "joe",
+            "_id": "urn:localhost.abc",
+            "urgency": 2,
+            "priority": 1,
+            "embargoed": embargo_ts.isoformat(),
+            "profile": "snap",
+            "slugline": "slugline",
+        }
         self.assertEqual(json.loads(doc), expected)
 
     def testPictureFomatter(self):
@@ -88,17 +102,31 @@ class NinjsFormatterTest(TestCase):
             'guid': '20150723001158606583'
         }
         seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
-        expected = json.loads('{"byline": "MICKEY MOUSE", \
-                "renditions": {"viewImage": \
-                {"href": "http://localhost:5000/api/upload/55b032041d41c8d278d21b6f/raw?_schema=http", \
-                "mimetype": "image/jpeg", "width": 640, "height": 401}, \
-                "original_source": {"href": \
-                "https://one-api.aap.com.au/api/v3/Assets/20150723001158606583/Original/download", \
-                "mimetype": "image/jpeg"}}, "headline": "AMAZING PICTURE", "pubstatus": "usable", \
-                "version": "1", "versioncreated": "2015-07-23T00:15:00.000Z", "_id": "20150723001158606583", \
-                "description_text": "The most amazing picture you will ever see", \
-                "type": "picture", "priority": 5}')
-        self.assertEqual(json.loads(doc), expected)
+        expected = {
+            "byline": "MICKEY MOUSE",
+            "renditions": {
+                "viewImage": {
+                    "href": "http://localhost:5000/api/upload/55b032041d41c8d278d21b6f/raw?_schema=http",
+                    "mimetype": "image/jpeg",
+                    "width": 640,
+                    "height": 401
+                },
+                "original_source": {
+                    "href": "https://one-api.aap.com.au/api/v3/Assets/20150723001158606583/Original/download",
+                    "mimetype": "image/jpeg"
+                },
+            },
+            "headline": "AMAZING PICTURE",
+            "pubstatus": "usable",
+            "version": "1",
+            "versioncreated": "2015-07-23T00:15:00.000Z",
+            "_id": "20150723001158606583",
+            "description_text": "The most amazing picture you will ever see",
+            "type": "picture",
+            "priority": 5,
+            "slugline": "AMAZING PICTURE",
+        }
+        self.assertEqual(expected, json.loads(doc))
 
     def testCompositeFomatter(self):
         article = {
@@ -215,13 +243,27 @@ class NinjsFormatterTest(TestCase):
         }
 
         seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
-        expected = json.loads('{"headline": "WA:Navy steps in with WA asylum-seeker boat", \
-        "version": "2", \
-        "_id": "urn:newsml:localhost:2015-07-24T15:05:00.116047:435c93c2-492c-4668-ab47-ae6e2b9b1c2c", \
-        "associations": {"main": \
-        [{"_id": "tag:localhost:2015:515b895a-b336-48b2-a506-5ffaf561b916", "type": "text"}], \
-        "sidebars": \
-        [{"_id": "urn:newsml:localhost:2015-07-24T15:04:29.589984:af3bef9a-5002-492b-a15a-8b460e69b164", \
-        "type": "picture"}]}, "description_text": "", "versioncreated": "2015-07-24T05:05:14.000Z", "type": \
-        "composite", "pubstatus": "usable", "language": "en", "priority": 5}')
-        self.assertEqual(json.loads(doc), expected)
+        expected = {
+            "headline": "WA:Navy steps in with WA asylum-seeker boat",
+            "version": "2",
+            "_id": "urn:newsml:localhost:2015-07-24T15:05:00.116047:435c93c2-492c-4668-ab47-ae6e2b9b1c2c",
+            "associations": {
+                "main": [
+                    {"_id": "tag:localhost:2015:515b895a-b336-48b2-a506-5ffaf561b916", "type": "text"}
+                ],
+                "sidebars": [
+                    {
+                        "_id": "urn:newsml:localhost:2015-07-24T15:04:29.589984:af3bef9a-5002-492b-a15a-8b460e69b164",
+                        "type": "picture"
+                    }
+                ]
+            },
+            "description_text": "",
+            "versioncreated": "2015-07-24T05:05:14.000Z",
+            "type": "composite",
+            "pubstatus": "usable",
+            "language": "en",
+            "priority": 5,
+            "slugline": "Boat",
+        }
+        self.assertEqual(expected, json.loads(doc))


### PR DESCRIPTION
- adding profile field to item metadata
- making ninjs formatter keep profile and slugline

not sure how gracefuly can content-api handle schema changes, does it require an update?
ping @amagdas @mugurrus @plamut 