### PR TITLE
[SD-3559] Stop ingest sending updates when nothing updates

### DIFF
--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -239,7 +239,9 @@ def update_provider(self, provider, rule_set=None, routing_scheme=None):
                 last=provider[LAST_ITEM_UPDATE].replace(tzinfo=timezone.utc).astimezone(tz=None).strftime("%c"))
 
         logger.info('Provider {0} updated'.format(provider[superdesk.config.ID_FIELD]))
-        push_notification('ingest:update', provider_id=str(provider[superdesk.config.ID_FIELD]))
+        # Only push a notification if there has been an update
+        if LAST_ITEM_UPDATE in update:
+            push_notification('ingest:update', provider_id=str(provider[superdesk.config.ID_FIELD]))
     finally:
         unlock(lock_name, host_name)
 


### PR DESCRIPTION
Stop unnecessary notifications being sent as it causes the monitoring page to fire off a heap of requests. 