### PR TITLE
(feat) [SD-3626] Modified schema and added elasticsearch settings to query with phrase prefix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cerberus==0.9.1
 Events==0.2.1
-Eve-Elastic==0.2.19
+Eve-Elastic==0.2.20
 Eve==0.6.0
 Flask==0.10.1
 Flask-Mail==0.9.1

--- a/superdesk/commands/rebuild_elastic_index.py
+++ b/superdesk/commands/rebuild_elastic_index.py
@@ -28,7 +28,7 @@ class RebuildElasticIndex(superdesk.Command):
             es = get_es(superdesk.app.config['ELASTICSEARCH_URL'])
             clone_name = index_name + '-' + get_random_string()
             print('Creating index: ', clone_name)
-            get_indices(es).create(clone_name)
+            superdesk.app.data.elastic.create_index(clone_name, superdesk.app.config['ELASTICSEARCH_SETTINGS'])
             print('Putting mapping for index: ', clone_name)
             superdesk.app.data.elastic.put_mapping(superdesk.app, clone_name)
             print('Starting index rebuilding.')

--- a/superdesk/factory/settings.py
+++ b/superdesk/factory/settings.py
@@ -67,6 +67,27 @@ ELASTICSEARCH_INDEX = env('ELASTICSEARCH_INDEX', 'superdesk')
 if env('ELASTIC_PORT'):
     ELASTICSEARCH_URL = env('ELASTIC_PORT').replace('tcp:', 'http:')
 
+ELASTICSEARCH_SETTINGS = {
+    'settings': {
+        'analysis': {
+            'filter': {
+                'remove_hyphen': {
+                    'pattern': '[-]',
+                    'type': 'pattern_replace',
+                    'replacement': ' '
+                }
+            },
+            'analyzer': {
+                'phrase_prefix_analyzer': {
+                    'type': 'custom',
+                    'filter': ['remove_hyphen', 'lowercase'],
+                    'tokenizer': 'keyword'
+                }
+            }
+        }
+    }
+}
+
 REDIS_URL = env('REDIS_URL', 'redis://localhost:6379')
 if env('REDIS_PORT'):
     REDIS_URL = env('REDIS_PORT').replace('tcp:', 'redis:')

--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -169,7 +169,17 @@ metadata_schema = {
         'type': 'string'
     },
     'slugline': {
-        'type': 'string'
+        'type': 'string',
+        'mapping': {
+            'type': 'string',
+            'fields': {
+                'phrase': {
+                    'type': 'string',
+                    'index_analyzer': 'phrase_prefix_analyzer',
+                    'search_analyzer': 'phrase_prefix_analyzer'
+                }
+            }
+        }
     },
     'anpa_take_key': {
         'type': 'string',

--- a/tests/elasticsearch_settings_test.py
+++ b/tests/elasticsearch_settings_test.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+import json
+from eve.utils import ParsedRequest
+from superdesk.tests import TestCase
+from superdesk import get_resource_service
+
+
+class ElasticSearchSettingsTest(TestCase):
+    items = [
+        {
+            '_id': '123', 'headline': 'Test 1', 'slugline': 'Soccer England', 'body_html': 'Test'
+        },
+        {
+            '_id': '456', 'headline': 'Test 2', 'slugline': 'Soccer England Result', 'body_html': 'Test'
+        },
+        {
+            '_id': '489', 'headline': 'Test 3', 'slugline': 'Soccer-England/Result', 'body_html': 'Test'
+        },
+        {
+            '_id': '321', 'headline': 'Test 4', 'slugline': 'Test Soccer England', 'body_html': 'Test'
+        },
+        {
+            '_id': '654', 'headline': 'Test 5', 'slugline': 'England Test Soccer', 'body_html': 'Test'
+        },
+        {
+            '_id': '984', 'headline': 'Test 6', 'slugline': 'Soccer Germany', 'body_html': 'Test'
+        }
+    ]
+
+    def setUp(self):
+        super().setUp()
+        get_resource_service('ingest').post(self.items)
+
+    def test_query_prefix_soccer(self):
+        query = {
+            'query': {
+                'filtered': {
+                    'query': {
+                        'match_phrase_prefix': {
+                            'slugline.phrase': 'soccer'
+                        }
+                    }
+                }
+            }
+        }
+
+        req = ParsedRequest()
+        req.args = {'source': json.dumps(query)}
+        query_result = get_resource_service('ingest').get(req=req, lookup=None)
+        self.assertEqual(query_result.count(), 4)
+        sluglines = [item.get('slugline') for item in query_result]
+        self.assertIn('Soccer Germany', sluglines)
+        self.assertIn('Soccer-England/Result', sluglines)
+        self.assertIn('Soccer England', sluglines)
+        self.assertIn('Soccer England Result', sluglines)
+
+    def test_query_prefix_soccer_england(self):
+        query = {
+            'query': {
+                'filtered': {
+                    'query': {
+                        'match_phrase_prefix': {
+                            'slugline.phrase': 'soccer england'
+                        }
+                    }
+                }
+            }
+        }
+
+        req = ParsedRequest()
+        req.args = {'source': json.dumps(query)}
+        query_result = get_resource_service('ingest').get(req=req, lookup=None)
+        self.assertEqual(query_result.count(), 3)
+        sluglines = [item.get('slugline') for item in query_result]
+        self.assertIn('Soccer-England/Result', sluglines)
+        self.assertIn('Soccer England', sluglines)
+        self.assertIn('Soccer England Result', sluglines)
+
+    def test_query_prefix_soccer_england_result_without_forward_slash(self):
+        query = {
+            'query': {
+                'filtered': {
+                    'query': {
+                        'match_phrase_prefix': {
+                            'slugline.phrase': 'soccer-england result'
+                        }
+                    }
+                }
+            }
+        }
+
+        req = ParsedRequest()
+        req.args = {'source': json.dumps(query)}
+        query_result = get_resource_service('ingest').get(req=req, lookup=None)
+        self.assertEqual(query_result.count(), 1)
+        sluglines = [item.get('slugline') for item in query_result]
+        self.assertIn('Soccer England Result', sluglines)
+
+    def test_query_prefix_soccer_england_result_with_forward_slash(self):
+        query = {
+            'query': {
+                'filtered': {
+                    'query': {
+                        'match_phrase_prefix': {
+                            'slugline.phrase': 'soccer england/result'
+                        }
+                    }
+                }
+            }
+        }
+
+        req = ParsedRequest()
+        req.args = {'source': json.dumps(query)}
+        query_result = get_resource_service('ingest').get(req=req, lookup=None)
+        self.assertEqual(query_result.count(), 1)
+        sluglines = [item.get('slugline') for item in query_result]
+        self.assertIn('Soccer-England/Result', sluglines)


### PR DESCRIPTION
This PR is dependent on [EVE-ELASTIC PR](https://github.com/petrjasek/eve-elastic/pull/48).

This allows configureing elasticsearch index settings. For example, different analyser and filters.