### PR TITLE
(fix) [SD-3387] This should fix the create/update of an Ingest Provider.

### DIFF
--- a/superdesk/io/__init__.py
+++ b/superdesk/io/__init__.py
@@ -20,8 +20,10 @@ from .commands.add_provider import AddProvider  # NOQA
 from .ingest import IngestResource, IngestService
 
 registered_feed_parsers = {}
+allowed_feed_parsers = []
 
 registered_feeding_services = {}
+allowed_feeding_services = []
 feeding_service_errors = {}
 publish_errors = []
 
@@ -64,6 +66,7 @@ def register_feeding_service(service_name, service_class, errors):
                                  .format(service_name, type(registered_feeding_services[service_name])))
 
     registered_feeding_services[service_name] = service_class
+    allowed_feeding_services.append(service_name)
 
     errors.append(SuperdeskIngestError.parserNotFoundError().get_error_description())
     feeding_service_errors[service_name] = dict(errors)
@@ -84,6 +87,7 @@ def register_feed_parser(parser_name, parser_class):
                                  .format(parser_name, type(registered_feed_parsers[parser_name])))
 
     registered_feed_parsers[parser_name] = parser_class
+    allowed_feed_parsers.append(parser_name)
 
 
 @celery.task(soft_time_limit=15)


### PR DESCRIPTION
1. Replaced Dictionary view objects for allowed_feeding_services and allowed_feed_parsers with normal list as Cerberus doesn't support Dictionary view objects.

2. There might be cases where a feeding service doesn't need a feed parser to parse the content. RSS is an example. That's the reason moved the validation from on_create/on_update to schema declaration instead of handling it in event methods, so that Cerberus can handle it before triggering the service.