### PR TITLE
fix(dpa and rss ingest)

### DIFF
--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -53,7 +53,7 @@ def is_service_and_parser_registered(provider):
     """
 
     return provider.get('feeding_service') in registered_feeding_services and \
-        provider.get('feed_parser') in registered_feed_parsers
+        provider.get('feed_parser') is None or provider.get('feed_parser') in registered_feed_parsers
 
 
 def is_scheduled(provider):

--- a/superdesk/io/feed_parsers/iptc7901.py
+++ b/superdesk/io/feed_parsers/iptc7901.py
@@ -30,7 +30,7 @@ class IPTC7901FeedParser(FileFeedParser):
             with open(file_path, 'rb') as f:
                 lines = [line for line in f]
                 return re.match(b'\x01([a-zA-Z]*)([0-9]*) (.) (.) ([0-9]*) ([a-zA-Z0-9 ]*)', lines[0], flags=re.I)
-        finally:
+        except:
             return False
 
     def parse(self, file_path, provider=None):


### PR DESCRIPTION
For RSS the parser and the service are tightly bound, so has no separate parser.
For DPA can parse always returned false