### PR TITLE
notification: create a new event loop for send_message

### DIFF
--- a/superdesk/notification.py
+++ b/superdesk/notification.py
@@ -58,7 +58,7 @@ def _notify(**kwargs):
     def send_message():
         yield from app.notification_client.send(message)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.run_until_complete(send_message())
 
 

--- a/superdesk/notification.py
+++ b/superdesk/notification.py
@@ -40,7 +40,11 @@ def init_app(app):
     host = app.config['WS_HOST']
     port = app.config['WS_PORT']
     try:
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_event_loop()
+        except:
+            loop = asyncio.new_event_loop()
+      
         app.notification_client = loop.run_until_complete(websockets.connect('ws://%s:%s/server' % (host, port)))
         logger.info('websocket connected on=%s:%s' % app.notification_client.local_address)
     except (RuntimeError, OSError):
@@ -58,7 +62,10 @@ def _notify(**kwargs):
     def send_message():
         yield from app.notification_client.send(message)
 
-    loop = asyncio.new_event_loop()
+    try:
+        loop = asyncio.get_event_loop()
+    except:
+        loop = asyncio.new_event_loop()
     loop.run_until_complete(send_message())
 
 


### PR DESCRIPTION
I needed to do that in order to prevent this error:
```
17:19:42 rest.1 | Traceback (most recent call last):
17:19:42 rest.1 |   File "env/src/superdesk-core/superdesk/notification.py", line 83, in push_notification
17:19:42 rest.1 |     _notify(event=name, extra=kwargs)
17:19:42 rest.1 |   File "env/src/superdesk-core/superdesk/notification.py", line 61, in _notify
17:19:42 rest.1 |     loop = asyncio.get_event_loop()
17:19:42 rest.1 |   File "/usr/lib/python3.4/asyncio/events.py", line 576, in get_event_loop
17:19:42 rest.1 |     return get_event_loop_policy().get_event_loop()
17:19:42 rest.1 |   File "/usr/lib/python3.4/asyncio/events.py", line 522, in get_event_loop
17:19:42 rest.1 |     % threading.current_thread().name)
17:19:42 rest.1 | RuntimeError: There is no current event loop in thread 'Thread-2'.
```