### PR TITLE
(fix)(elasticsearch) use analyzer instead index_analyzer in item schema

### DIFF
--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -175,7 +175,7 @@ metadata_schema = {
             'fields': {
                 'phrase': {
                     'type': 'string',
-                    'index_analyzer': 'phrase_prefix_analyzer',
+                    'analyzer': 'phrase_prefix_analyzer',
                     'search_analyzer': 'phrase_prefix_analyzer'
                 }
             }


### PR DESCRIPTION
Fix `analyzer on field [phrase] must be set when search_analyzer is set` error on schema build