### PR TITLE
[SD-3760] Revisit ingest providers conversion of preformatted to html

### DIFF
--- a/superdesk/io/feed_parsers/__init__.py
+++ b/superdesk/io/feed_parsers/__init__.py
@@ -142,3 +142,5 @@ import superdesk.io.feed_parsers.nitf  # NOQA
 import superdesk.io.feed_parsers.rfc822  # NOQA
 import superdesk.io.feed_parsers.wenn_parser  # NOQA
 import superdesk.io.feed_parsers.zczc  # NOQA
+import superdesk.io.feed_parsers.dpa_iptc7901  # NOQA
+import superdesk.io.feed_parsers.afp_newsml_1_2  # NOQA

--- a/superdesk/io/feed_parsers/afp_newsml_1_2.py
+++ b/superdesk/io/feed_parsers/afp_newsml_1_2.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.io.feed_parsers.newsml_1_2 import NewsMLOneFeedParser
+from superdesk.io import register_feed_parser
+from superdesk.utc import utcnow
+from pytz import utc
+
+
+class AFPNewsMLOneFeedParser(NewsMLOneFeedParser):
+    """
+    Feed Parser which can parse the AFP feed basicaly it is in NewsML 1.2 format, but the firstcreated and versoincreted
+    times are localised.
+    """
+
+    NAME = 'afpnewsml12'
+
+    def parse(self, xml, provider=None):
+        item = super().parse(xml, provider)
+        item['firstcreated'] = utc.localize(item['firstcreated']) if item.get('firstcreated') else utcnow()
+        item['versioncreated'] = utc.localize(item['versioncreated']) if item.get('versioncreated') else utcnow()
+        return item
+
+register_feed_parser(AFPNewsMLOneFeedParser.NAME, AFPNewsMLOneFeedParser())

--- a/superdesk/io/feed_parsers/dpa_iptc7901.py
+++ b/superdesk/io/feed_parsers/dpa_iptc7901.py
@@ -1,0 +1,57 @@
+
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from .iptc7901 import IPTC7901FeedParser
+from superdesk.io import register_feed_parser
+from superdesk.locators.locators import find_cities
+from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE
+
+
+class DPAIPTC7901FeedParser(IPTC7901FeedParser):
+
+    NAME = 'dpa_iptc7901'
+
+    def parse(self, file_path, provider=None):
+        item = super().parse(file_path, provider)
+        item = self.dpa_derive_dateline(item)
+        # Markup the text and set the content type
+        item['body_html'] = '<p>' + item['body_html'].replace('\r\n', ' ').replace('\n', '</p><p>') + '</p>'
+        item[ITEM_TYPE] = CONTENT_TYPE.TEXT
+        return item
+
+    def dpa_derive_dateline(self, item):
+        """
+        This function attempts to parse a dateline from the first few lines of
+        the item body and populate the dataline location, it also populates the dateline source.
+        If a dateline is matched the coresponding string is removed from the article text.
+        :param item:
+        :return:
+        """
+        lines = item['body_html'].splitlines()
+        if lines:
+            # expect the dateline in the first 5 lines, sometimes there is what appears to be a headline preceeding it.
+            for line_num in range(0, min(len(lines), 5)):
+                city, source, the_rest = lines[line_num].partition(' (dpa) - ')
+                # test if we found a candidate and ensure that the city starts the line and is not crazy long
+                if source and lines[line_num].find(city) == 0 and len(city) < 20:
+                    cities = find_cities()
+                    located = [c for c in cities if c['city'].lower() == city.lower()]
+                    if 'dateline' not in item:
+                        item['dateline'] = {}
+                    item['dateline']['located'] = located[0] if len(located) > 0 else {'city_code': city, 'city': city,
+                                                                                       'tz': 'UTC', 'dateline': 'city'}
+                    item['dateline']['source'] = 'dpa'
+                    item['dateline']['text'] = city
+                    item['body_html'] = item['body_html'].replace(city + source, '', 1)
+                    break
+        return item
+
+register_feed_parser(DPAIPTC7901FeedParser.NAME, DPAIPTC7901FeedParser())

--- a/superdesk/io/feed_parsers/dpa_iptc7901.py
+++ b/superdesk/io/feed_parsers/dpa_iptc7901.py
@@ -41,15 +41,16 @@ class DPAIPTC7901FeedParser(IPTC7901FeedParser):
             for line_num in range(0, min(len(lines), 5)):
                 city, source, the_rest = lines[line_num].partition(' (dpa) - ')
                 # test if we found a candidate and ensure that the city starts the line and is not crazy long
-                if source and lines[line_num].find(city) == 0 and len(city) < 20:
+                if source and lines[line_num].find(city) == 0 and len(city.strip()) < 20:
                     cities = find_cities()
-                    located = [c for c in cities if c['city'].lower() == city.lower()]
+                    located = [c for c in cities if c['city'].lower() == city.strip().lower()]
                     if 'dateline' not in item:
                         item['dateline'] = {}
-                    item['dateline']['located'] = located[0] if len(located) > 0 else {'city_code': city, 'city': city,
+                    item['dateline']['located'] = located[0] if len(located) > 0 else {'city_code': city.strip(),
+                                                                                       'city': city.strip(),
                                                                                        'tz': 'UTC', 'dateline': 'city'}
                     item['dateline']['source'] = 'dpa'
-                    item['dateline']['text'] = city
+                    item['dateline']['text'] = city.strip()
                     item['body_html'] = item['body_html'].replace(city + source, '', 1)
                     break
         return item

--- a/superdesk/io/feeding_services/file_service.py
+++ b/superdesk/io/feeding_services/file_service.py
@@ -13,7 +13,7 @@ import os
 import shutil
 from datetime import timedelta, datetime
 
-from superdesk import etree
+from xml.etree import ElementTree
 from superdesk.errors import IngestFileError, ParserError, ProviderError
 from superdesk.io import register_feeding_service
 from superdesk.io.feed_parsers import XMLFeedParser
@@ -58,10 +58,10 @@ class FileFeedingService(FeedingService):
 
                     if self.is_latest_content(last_updated, provider.get('last_updated')):
                         if isinstance(registered_parser, XMLFeedParser):
-                            with open(file_path, 'r') as f:
-                                xml_string = etree.fromstring(f.read())
-                                parser = self.get_feed_parser(provider, xml_string)
-                                item = parser.parse(xml_string, provider)
+                            with open(file_path, 'rt') as f:
+                                xml = ElementTree.parse(f)
+                                parser = self.get_feed_parser(provider, xml.getroot())
+                                item = parser.parse(xml, provider)
                         else:
                             parser = self.get_feed_parser(provider, file_path)
                             item = parser.parse(file_path, provider)

--- a/superdesk/io/ingest_provider_model.py
+++ b/superdesk/io/ingest_provider_model.py
@@ -48,6 +48,7 @@ class IngestProviderResource(Resource):
             },
             'feed_parser': {
                 'type': 'string',
+                'nullable': True,
                 'allowed': allowed_feed_parsers
             },
             'content_types': {

--- a/tests/io/feed_parsers/anpa_tests.py
+++ b/tests/io/feed_parsers/anpa_tests.py
@@ -10,7 +10,7 @@
 
 
 import os
-import unittest
+from superdesk.tests import TestCase
 
 from superdesk.io.feed_parsers.anpa import ANPAFeedParser
 
@@ -20,12 +20,13 @@ def fixture(filename):
     return os.path.normpath(os.path.join(dirname, '../fixtures', filename))
 
 
-class ANPATestCase(unittest.TestCase):
+class ANPATestCase(TestCase):
 
     parser = ANPAFeedParser()
 
     def open(self, filename):
-        return self.parser.parse(fixture(filename))
+        provider = {'name': 'Test'}
+        return self.parser.parse(fixture(filename), provider)
 
     def test_open_anpa_file(self):
         item = self.open('anpa-1.tst')
@@ -37,7 +38,7 @@ class ANPATestCase(unittest.TestCase):
         self.assertEqual(1049, item['word_count'])
         self.assertEqual('For Argentine chemo patients, mirrors can hurt', item['headline'])
         self.assertEqual('By PAUL BYRNE and ALMUDENA CALATRAVA', item['byline'])
-        self.assertRegex(item['body_text'], '^BUENOS')
+        self.assertRegex(item['body_html'], '^<p>BUENOS')
         self.assertEqual('Argentina-Cancer', item['slugline'])
         self.assertEqual('2013-11-13T15:09:00+00:00', item['firstcreated'].isoformat())
 

--- a/tests/io/feed_parsers/dpa_test.py
+++ b/tests/io/feed_parsers/dpa_test.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+
+import os
+
+from superdesk.io.feed_parsers.dpa_iptc7901 import DPAIPTC7901FeedParser
+from superdesk.tests import TestCase
+
+
+def fixture(filename):
+    dirname = os.path.dirname(os.path.realpath(__file__))
+    return os.path.normpath(os.path.join(dirname, '../fixtures', filename))
+
+
+class DPAIptcTestCase(TestCase):
+
+    parser = DPAIPTC7901FeedParser()
+
+    def open(self, filename):
+        provider = {'name': 'Test'}
+        return self.parser.parse(fixture(filename), provider)
+
+    def test_open_iptc7901_file(self):
+        with self.app.app_context():
+            item = self.open('IPTC7901.txt')
+            self.assertEqual('text', item['type'])
+            self.assertEqual('062', item['ingest_provider_sequence'])
+            self.assertEqual('i', item['anpa_category'][0]['qcode'])
+            self.assertEqual(211, item['word_count'])
+            self.assertEqual('Germany Social Democrats: Coalition talks with Merkel could fail =', item['headline'])
+            self.assertRegex(item['body_html'], '^<p></p><p>Negotiations')
+            self.assertEqual('Germany-politics', item['slugline'])
+            self.assertEqual(4, item['priority'])
+            self.assertEqual([{'qcode': 'i'}], item['anpa_category'])
+            self.assertTrue(item['ednote'].find('## Editorial contacts'))
+            self.assertEqual(item['dateline']['source'], 'dpa')
+            self.assertEqual(item['dateline']['located']['city'], 'Berlin')

--- a/tests/io/feed_parsers/nitf_tests.py
+++ b/tests/io/feed_parsers/nitf_tests.py
@@ -84,6 +84,23 @@ class AAPTestCase(NITFTestCase):
         self.assertEqual(349, self.item.get('word_count'))
 
 
+class APExampleTestCase(NITFTestCase):
+
+    filename = 'ap-nitf.xml'
+
+    def test_headline(self):
+        self.assertEqual(self.item.get('headline'), 'Can trading pollution like stocks help fight climate change?')
+
+    def test_byline(self):
+        self.assertEqual(self.item.get('byline'), 'By BERNARD CONDON')
+
+    def test_ednote(self):
+        self.assertEqual(self.item.get('ednote'), 'For global distribution')
+
+    def test_word_count(self):
+        self.assertEqual(1047, self.item.get('word_count'))
+
+
 class IPTCExampleTestCase(NITFTestCase):
 
     filename = 'nitf-fishing.xml'

--- a/tests/io/fixtures/ap-nitf.xml
+++ b/tests/io/fixtures/ap-nitf.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nitf version="-//IPTC//DTD NITF 3.4//EN" change.date="October 18, 2006" change.time="19:30">
+  <head>
+    <docdata>
+      <doc-id regsrc="AP" />
+      <date.issue norm="20151210T191044Z" />
+      <ed-msg info="For global distribution" />
+      <doc.copyright holder="AP" year="2015" />
+    </docdata>
+  </head>
+  <body>
+    <body.head>
+      <hedline>
+        <hl1 id="headline">Can trading pollution like stocks help fight climate change?</hl1>
+        <hl2 id="originalHeadline">Can trading pollution like stocks help fight climate change?</hl2>
+      </hedline>
+      <byline>By BERNARD CONDON<byttl>AP Business Writer</byttl></byline>
+      <distributor>The Associated Press</distributor>
+      <dateline>
+        <location>NEW YORK</location>
+      </dateline>
+    </body.head>
+    <body.content>
+      <block id="Main">
+              <p>NEW YORK (AP) — The gas produced by hog manure at farms across the U.S. punches holes in the ozone layer, overheats the planet, and angers neighbors with its peculiar odor, a mix of rotten egg and ammonia.</p>
+              <p>All that's needed to clear the air is to cover the manure with a system of tarps that captures the gas, but many farms don't do it because it's too expensive.</p>
+              <p>"If you don't give people incentives to come up with solutions, they're not going to do it," says Rudi Roeslein, a wealthy entrepreneur who thinks he's found a fix.</p>
+              <p>His plan: Raise money to help pay for the tarp systems through a greenhouse gas trading market in California, where companies can pay others who are helping the environment so that they can continue to pollute.</p>
+              <p>Widely derided by politicians on the left and the right, once thought dead even by its supporters, the idea of allowing companies to buy and sell pollution "rights" like stocks is now at the fore again as 151 heads of state and government at the Paris climate conference grope for ways to avert environmental havoc.</p>
+              <p>Under such "cap-and-trade" systems, polluters are required to keep emissions below a certain level or hand over money to polluters that have managed to fall below theirs and have surplus pollution permits to sell. To cut greenhouse gases, the levels, or "caps," are gradually lowered, forcing companies to figure out new ways of running their businesses to cut emissions.</p>
+              <p>If all goes well, Roeslein, an Austrian immigrant who made a fortune building metal can factories around the world, hopes to eventually capture gases from five hog farms in Missouri that, left to rise in the atmosphere, would have done the same damage as releasing 850,000 tons of carbon dioxide every year. His project will be like taking 180,000 cars off the road.</p>
+              <p>Roeslein is so convinced the idea will work, maybe enough to turn a profit, he's putting $25 million of his own money behind the venture.</p>
+              <p>California Gov. Jerry Brown, who's created a bit of stir at the Paris talks scheduled to conclude Friday, has been touting his state's emissions trading market as a model to help solve the global climate crisis. One study, from the non-profit Environmental Defense Fund, says emissions from companies in the market fell 11 percent below the "cap" allowed in 2013, according to the latest data available, while economic growth doesn't appear to have been harmed.</p>
+              <p>"It has got nothing to do with do-gooders. It's about the almighty dollar," says Lenny Hochschild, managing director of emissions broker Evolution Markets. "It's about incentivizing people."</p>
+              <p>There are deep concerns about whether these pollution trading systems can cut emissions as much as scientists say is needed, or even if they can work at all.</p>
+              <p>First proposed by economists in the 1960s, a pollution permit market remained mostly an academic idea until President George H. W. Bush championed it as a way of getting power plants to cut emissions of sulfur dioxide, which leads to acid rain. Annual emissions plunged, at much less cost than expected, and the program is widely considered a success.</p>
+              <p>The European Union followed with a carbon dioxide trading program in 2005. In addition to buying surplus permits from cleaner polluters, power plants and factories emitting more than their limit could buy permits from "offsets" around the world, projects capturing methane fumes from hogs, for instance, or chlorofluorocarbons used in refrigeration, another ozone killer.</p>
+              <p>But critics complained some projects got money that didn't appear to help the environment much. In China, companies ramped up chlorofluorocarbon emissions after permits began to trade, leading to accusation of fraud.</p>
+              <p>"They were pumping out more just for the sake of destroying them," says Jeff Cohen, founder of EOS Climate, which helps offset projects involving refrigerants in the U.S. "It was bizarre, upside down."</p>
+              <p>What's more, the European trading system allowed too many permits at the outset, which had the effect of pushing the price to pollute down sharply. Then the global recession hit in 2008 and polluters didn't need as many permits because they were producing less. With supply and demand out of whack, prices to pollute plunged to near zero.</p>
+              <p>One result:  Utilities kept running their coal-fired power plants instead of switching to cleaner burning gas-fired ones.</p>
+              <p>But two newer carbon trading schemes in the U.S., the one in California and another in the Northeast that launched in 2009, learned from some of Europe's mistakes and seem to be working so well they may soon be expanded.</p>
+              <p>The Northeast program, covering nine states, sold permits at an auction rather than give them away. That, plus a few other improvements, appears to have helped. Emissions have fallen 40 percent over 2005 levels.</p>
+              <p>For its trading system launched three years ago, California made even more tweaks, setting a floor and ceiling for buying permits, for instance.</p>
+              <p>Many expect that as U.S. states are forced to comply with a new Environmental Protection Agency regulation aimed at reducing emissions from power plants they will join these programs, leading the U.S. closer to a nationwide carbon trading system.</p>
+              <p>Still, some economists have doubts. They note that heavy regulations and other factors, like plunging gas prices, may explain the drop in emissions in California and elsewhere more than the pollution trading.</p>
+              <p>"Most of the emission cuts from the power sector has come from switching from coal to natural gas because gas prices are incredibly low," says David G. Victor, an economist at the School of International Relations and Pacific Studies at the University of California, San Diego. He says the pollution markets aren't providing much of a push to change how companies behave.</p>
+              <p>For Roeslein, it's clearly helped, though.</p>
+              <p>Roeslein, whose company will start trading permits next month, figures he can generate as much as $7 million a year from selling in the California market. Add in money from sales of methane pulled the gas produced by the manure, and maybe he makes enough of a profit to convince others to try their hand at similar ventures.</p>
+              <p>"It has to be profitable to be repeatable, for other people to follow this model," he says.</p>
+              <p>___</p>
+              <p>Bernard Condon can be reached at http://twitter.com/BernardFCondon . His work can be found at http://www.bigstory.ap.org/content/bernard-condon .</p>
+            </block>
+    </body.content>
+    <body.end />
+  </body>
+</nitf>


### PR DESCRIPTION
Remove the source specific Feeding Services and make specific Feed Parser's, for AFP and DPA.
(The delivery mechanism should not be a function of the feed format where possible)

ANPA and DPA parser's now markup the body_html.
 
Add AP NITF sample, test and make it work.

The PR is dependent on a PR to the Superdesk repo.