### PR TITLE
(fix)[SD-3921] For serialization with place field.

### DIFF
--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -293,10 +293,7 @@ metadata_schema = {
     # aka Locator as per NewML Specification
     'place': {
         'type': 'list',
-        'nullable': True,
-        'schema': {
-            'type': 'dict'
-        }
+        'nullable': True
     },
 
     # Not Categorized


### PR DESCRIPTION
`place` is a `nullable` field and when the payload contains `null` the serialization fails at line https://github.com/nicolaiarocci/eve/blob/master/eve/methods/common.py#L338 and any fields in the payload after `place` won't get serialize. For example, `datetime` field won't get serialize as `datetime` and remain as `str`. This causes datetime validation to fail even though the datetime supplied in the payload is correct.

Note: Need to fix eve as well so that it does not throw exception as L338.

