### PR TITLE
fix(WENN parser) handle ftp retrieve errors and markup body

### DIFF
--- a/superdesk/io/feed_parsers/scoop_newsml_2_0.py
+++ b/superdesk/io/feed_parsers/scoop_newsml_2_0.py
@@ -18,6 +18,7 @@ from superdesk.metadata.item import ITEM_TYPE
 from superdesk.io.iptc import subject_codes
 from superdesk.etree import get_word_count
 
+
 class ScoopNewsMLTwoFeedParser(NewsMLTwoFeedParser):
 
     NAME = 'scoop_newsml2'

--- a/superdesk/io/feed_parsers/wenn_parser.py
+++ b/superdesk/io/feed_parsers/wenn_parser.py
@@ -44,6 +44,8 @@ class WENNFeedParser(XMLFeedParser):
                 self.parse_content_management(item, entry)
                 self.parse_news_management(item, entry)
                 item['body_html'] = self.get_elem_content(entry.find(self.qname('content', self.ATOM_NS)))
+                item['body_html'] = item['body_html'].replace('\n\n  ', '</p><p>').replace('\n', '<br>')
+                item['body_html'] = '<p>' + item['body_html'] + '</p>'
                 itemList.append(item)
             return itemList
 

--- a/tests/io/feed_parsers/wenn_parser_test.py
+++ b/tests/io/feed_parsers/wenn_parser_test.py
@@ -62,8 +62,8 @@ class WENNTestCase(unittest.TestCase):
                                                                                 minute=40, second=56, tzinfo=utc))
 
     def test_body(self):
-        self.assertEqual(self.items[0].get('body_html'), 'This is body content1.')
-        self.assertEqual(self.items[1].get('body_html'), 'This is body content2.')
+        self.assertEqual(self.items[0].get('body_html'), '<p>This is body content1.</p>')
+        self.assertEqual(self.items[1].get('body_html'), '<p>This is body content2.</p>')
 
     def test_item_defaults(self):
         self.assertEqual(self.items[0].get('pubstatus'), 'usable')


### PR DESCRIPTION
The FTP retrbinary sometimes throws an exception, since the file has been opened, an empty file is created and there is never another attempt to retrieve it.