### PR TITLE
fix(anpa): fix formatting  for empty dateline.text

### DIFF
--- a/apps/publish/formatters/anpa_formatter.py
+++ b/apps/publish/formatters/anpa_formatter.py
@@ -95,7 +95,7 @@ class AAPAnpaFormatter(Formatter):
                     anpa.append(article.get(BYLINE).encode('ascii', 'ignore'))
                     anpa.append(b'\x0D\x0A')
 
-                if 'dateline' in article and 'text' in article['dateline']:
+                if article.get('dateline', {}).get('text'):
                     anpa.append(article.get('dateline').get('text').encode('ascii', 'ignore'))
 
                 body = self.append_body_footer(article)

--- a/apps/publish/formatters/anpa_formatter_test.py
+++ b/apps/publish/formatters/anpa_formatter_test.py
@@ -214,3 +214,10 @@ class ANPAFormatterTest(SuperdeskTestCase):
         self.assertEqual('r', map_priority(None))
         self.assertEqual('r', map_priority(7))
         self.assertEqual('r', map_priority(''))
+
+    def test_dateline_with_empty_text(self):
+        f = AAPAnpaFormatter()
+        subscriber = self.app.data.find('subscribers', None, None)[0]
+        item = self.article.copy()
+        item.update({'dateline': {'text': None}})
+        seq, out = f.format(item, subscriber)[0]


### PR DESCRIPTION
it was checking if text was set but it could be set to null

SD-3469