### PR TITLE
fix(expiry): fix expiry of items created from template

### DIFF
--- a/apps/archive/commands.py
+++ b/apps/archive/commands.py
@@ -110,6 +110,9 @@ class RemoveExpiredContent(superdesk.Command):
         # Step 3: Processing items to expire
         for item in not_killed_items:
             item_id = item.get(config.ID_FIELD)
+            item.setdefault(config.VERSION, 1)
+            item.setdefault('expiry', expiry_datetime)
+            item.setdefault('unique_name', '')
             expiry_msg = log_msg_format.format(**item)
             logger.info('{} Processing expired item. {}'.format(log_msg, expiry_msg))
 

--- a/features/steps/template_steps.py
+++ b/features/steps/template_steps.py
@@ -1,5 +1,6 @@
 
 from datetime import datetime, timedelta
+from superdesk.tests import set_placeholder
 from steps import when, then, get_json_data, parse_date  # @UnresolvedImport
 
 
@@ -8,7 +9,9 @@ def when_we_run_create_content_task(context):
     from apps.templates import create_scheduled_content
     now = datetime.now() + timedelta(days=8)
     with context.app.app_context():
-        create_scheduled_content(now)
+        items = create_scheduled_content(now)
+        for item in items:
+            set_placeholder(context, 'ITEM_ID', str(item['_id']))
 
 
 @then('next run is on monday "{time}"')

--- a/features/templates.feature
+++ b/features/templates.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Templates
 
     @auth
@@ -88,8 +87,18 @@ Feature: Templates
         And we get "/archive"
         Then we get list with 1 items
         """
-        {"_items": [{"headline": "test", "firstcreated": "__now__", "versioncreated": "__now__"}]}
+        {"_items": [{
+            "headline": "test",
+            "firstcreated": "__now__",
+            "versioncreated": "__now__",
+            "_updated": "__now__",
+            "_created": "__now__",
+            "_current_version": 1,
+            "_etag": "__any_value__"
+        }]}
         """
+        When we get "/archive/#ITEM_ID#?version=all"
+        Then we get list with 1 items
 
     @auth
     Scenario: Apply template to an item
@@ -143,7 +152,6 @@ Feature: Templates
         }
         """
 
-    @wip
     @auth
     Scenario: For kill Template Dateline, Schedule and Desk settings should be null.
     Given "desks"


### PR DESCRIPTION
those items were missing current version field which caused
an exception in expiry task and thus preventing other items
from being removed.

SD-3912