### PR TITLE
fix(publish): trigger enqueue publish after publishing

### DIFF
--- a/apps/prepopulate/app_prepopulate.py
+++ b/apps/prepopulate/app_prepopulate.py
@@ -147,12 +147,7 @@ class PrepopulateService(BaseService):
             if doc.get('remove_first'):
                 drop_elastic(superdesk.app)
                 drop_mongo(superdesk.app)
-                # call the create index with settings
-                superdesk.app.data.elastic.create_index(
-                    superdesk.app.config['ELASTICSEARCH_INDEX'],
-                    superdesk.app.config['ELASTICSEARCH_SETTINGS']
-                )
-                superdesk.app.data.elastic.put_mapping(superdesk.app)
+                app.data.elastic.init_app(superdesk.app)
 
             user = get_resource_service('users').find_one(username=get_default_user()['username'], req=None)
             if not user:

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -156,6 +156,9 @@ class BasePublishService(BaseService):
                 self._update_archive(original, updated, should_insert_into_versions=auto_publish)
                 self.update_published_collection(published_item_id=original[config.ID_FIELD], updated=updated)
 
+                from apps.publish.enqueue import enqueue_published
+                enqueue_published.apply_async()
+
             push_notification('item:publish', item=str(id), unique_name=original['unique_name'],
                               desk=str(original.get('task', {}).get('desk', '')),
                               user=str(user.get(config.ID_FIELD, '')))

--- a/superdesk/factory/default_settings.py
+++ b/superdesk/factory/default_settings.py
@@ -155,7 +155,11 @@ CELERY_ROUTES = {
     'apps.archive.remove_scheduled': {
         'queue': 'publish',
         'routing_key': 'publish.remove_scheduled'
-    }
+    },
+    'apps.publish.enqueue.enqueue_published': {
+        'queue': 'publish',
+        'routing_key': 'publish.enqueue'
+    },
 }
 
 
@@ -194,7 +198,11 @@ CELERYBEAT_SCHEDULE = {
     'legal:import_publish_queue': {
         'task': 'apps.legal_archive.import_legal_publish_queue',
         'schedule': timedelta(minutes=5)
-    }
+    },
+    'publish:enqueue': {
+        'task': 'apps.publish.enqueue.enqueue_published',
+        'schedule': timedelta(seconds=10)
+    },
 }
 
 SENTRY_DSN = env('SENTRY_DSN')


### PR DESCRIPTION
@mugurrus seems like the issue publishing e2e was missing `enqueue_published` call.
I've added it to publishing handler - not sure if it could be an issue - this way it reacts faster and e2e tests work without any changes. otherwise it would have to wait for the queue. what do you think?