### PR TITLE
[SD-3936] Items missing from Reuters ingest

### DIFF
--- a/apps/io/fixtures/channel1
+++ b/apps/io/fixtures/channel1
@@ -1,0 +1,19 @@
+<results>
+    <result>
+        <id>tag:reuters.com,0000:newsml_L3N15V1FU:1147689808</id>
+        <guid>tag:reuters.com,0000:newsml_L3N15V1FU</guid>
+        <version>1147689808</version>
+    </result>
+    <result>
+        <id>tag:reuters.com,0000:newsml_L3N15V181:779851386</id>
+        <guid>tag:reuters.com,0000:newsml_L3N15V181</guid>
+        <version>779851386</version>
+    </result>
+    <result>
+        <id>tag:reuters.com,0000:newsml_L3N15O2J0:1353575241</id>
+        <guid>tag:reuters.com,0000:newsml_L3N15O2J0</guid>
+        <version>1353575241</version>
+    </result>
+    <pollToken>ExwaY31kfnR2Z2J1cWZ2YnxoYH9kfw==</pollToken>
+    <status code="10"/>
+</results>

--- a/apps/io/reuters_mock.py
+++ b/apps/io/reuters_mock.py
@@ -24,7 +24,10 @@ def item_request(url, request):
     try:
         params = parse_qs(url.query, keep_blank_values=True)
         fixtures = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'fixtures')
-        file = os.path.join(fixtures, params['id'][0].replace(':', '_version_'))
+        if 'channel' in params:
+            file = os.path.join(fixtures, params['channel'][0])
+        else:
+            file = os.path.join(fixtures, params['id'][0].replace(':', '_version_'))
         with open(file, "r") as stored_response:
             content = stored_response.read()
             return {'status_code': 200, 'content': content}

--- a/apps/io/update_ingest_tests.py
+++ b/apps/io/update_ingest_tests.py
@@ -499,6 +499,6 @@ class UpdateIngestTest(SuperdeskTestCase):
         provider_service.provider = provider
         provider_service.URL = provider.get('config', {}).get('url')
         ids = provider_service._get_article_ids('channel1', utcnow(), utcnow() + timedelta(minutes=-10))
-        self.assertEqual(len(ids),3)
+        self.assertEqual(len(ids), 3)
         provider = get_resource_service('ingest_providers').find_one(name=provider_name, req=None)
         self.assertEqual(provider['tokens']['poll_tokens']['channel1'], 'ExwaY31kfnR2Z2J1cWZ2YnxoYH9kfw==')

--- a/apps/io/update_ingest_tests.py
+++ b/apps/io/update_ingest_tests.py
@@ -491,3 +491,14 @@ class UpdateIngestTest(SuperdeskTestCase):
         self.assertEqual(elastic_item['headline'], 'Updated headline')
         self.assertEqual(elastic_item['unique_id'], 1)
         self.assertEqual(elastic_item['unique_name'], '#1')
+
+    def test_get_article_ids(self):
+        provider_name = 'reuters'
+        provider = self._get_provider(provider_name)
+        provider_service = self._get_provider_service(provider)
+        provider_service.provider = provider
+        provider_service.URL = provider.get('config', {}).get('url')
+        ids = provider_service._get_article_ids('channel1', utcnow(), utcnow() + timedelta(minutes=-10))
+        self.assertEqual(len(ids),3)
+        provider = get_resource_service('ingest_providers').find_one(name=provider_name, req=None)
+        self.assertEqual(provider['tokens']['poll_tokens']['channel1'], 'ExwaY31kfnR2Z2J1cWZ2YnxoYH9kfw==')

--- a/superdesk/io/feeding_services/http_service.py
+++ b/superdesk/io/feeding_services/http_service.py
@@ -48,11 +48,11 @@ class HTTPFeedingService(FeedingService, metaclass=ABCMeta):
         :return: Authentication Token
         :rtype: str
         """
-        token = {'token': self._generate_auth_token(provider), 'created': utcnow()}
-        get_resource_service('ingest_providers').system_update(provider[config.ID_FIELD], updates={'token': token},
+        token = {'auth_token': self._generate_auth_token(provider), 'created': utcnow()}
+        get_resource_service('ingest_providers').system_update(provider[config.ID_FIELD], updates={'tokens': token},
                                                                original=provider)
 
-        return token['token']
+        return token['auth_token']
 
     def _generate_auth_token(self, provider):
         """
@@ -114,9 +114,9 @@ class HTTPFeedingService(FeedingService, metaclass=ABCMeta):
         :return: Authentication Token
         :rtype: str
         """
-        token = provider.get('token')
+        token = provider.get('tokens')
         if token and self._is_valid_token(token):
-            return token.get('token')
+            return token.get('auth_token')
 
         return self._generate_token_and_update_provider(provider) if update else ''
 

--- a/superdesk/io/ingest_provider_model.py
+++ b/superdesk/io/ingest_provider_model.py
@@ -69,7 +69,7 @@ class IngestProviderResource(Resource):
             'accepted_count': {
                 'type': 'integer'
             },
-            'token': {
+            'tokens': {
                 'type': 'dict'
             },
             'is_closed': {

--- a/tests/io/feeding_services/http_tests.py
+++ b/tests/io/feeding_services/http_tests.py
@@ -26,8 +26,8 @@ def setup_provider(token, hours):
         'feeding_service': 'test',
         'feed_parser': 'newsml2',
         'content_expiry': 2880,
-        'token': {
-            'token': token,
+        'tokens': {
+            'auth_token': token,
             'created': utcnow() - timedelta(hours=hours),
         }
     }
@@ -72,7 +72,7 @@ class GetTokenTestCase(TestCase):
         if provider['config']['username']:
             token = TestFeedingService()._generate_auth_token(provider, update=True)
             self.assertNotEquals('', token)
-            self.assertEquals(token, provider['token']['token'])
+            self.assertEquals(token, provider['tokens']['auth_token'])
 
             dbprovider = superdesk.get_resource_service('ingest_providers').find_one(name='test http', req=None)
-            self.assertEquals(token, dbprovider['token']['token'])
+            self.assertEquals(token, dbprovider['tokens']['auth_token'])


### PR DESCRIPTION
Changes the Reuters ingest to :- 

- keep the pollToken rather than relying on times to identify new content. 

- Request the content id's rather than guids (guids exclude the version component)
