### PR TITLE
[SD-4069] Add on stage macro on move and a publishing macro

### DIFF
--- a/apps/duplication/archive_move.py
+++ b/apps/duplication/archive_move.py
@@ -14,7 +14,7 @@ from flask import request
 from copy import deepcopy
 
 import superdesk
-from apps.tasks import send_to
+from apps.tasks import send_to, apply_onstage_rule
 from apps.desks import DeskTypes
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
@@ -102,6 +102,9 @@ class MoveService(BaseService):
         insert_into_versions(id_=original[config.ID_FIELD])
 
         push_content_notification([archived_doc, original])
+
+        # finally apply any on stage rules/macros
+        apply_onstage_rule(archived_doc, original[config.ID_FIELD])
 
         return archived_doc
 

--- a/apps/stages.py
+++ b/apps/stages.py
@@ -72,6 +72,9 @@ class StagesResource(Resource):
         },
         'outgoing_macro': {
             'type': 'string'
+        },
+        'onstage_macro': {
+            'type': 'string'
         }
     }
 

--- a/features/content_publish.feature
+++ b/features/content_publish.feature
@@ -1649,3 +1649,174 @@ Feature: Content Publishing
                     "role" : "grpRole:main", "id" : "main"}]
       }
       """
+
+    @auth
+    Scenario: Publish a user content using macro
+      Given the "validators"
+      """
+        [
+        {
+            "schema": {},
+            "type": "text",
+            "act": "publish",
+            "_id": "publish_text"
+        },
+        {
+            "_id": "publish_composite",
+            "act": "publish",
+            "type": "composite",
+            "schema": {}
+        }
+        ]
+      """
+      And "desks"
+      """
+      [{"name": "Sports", "content_expiry": 60}]
+      """
+      When we post to "/archive" with success
+      """
+      [{"guid": "123", "type": "text", "headline": "test", "state": "fetched",
+        "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
+        "subject":[{"qcode": "17004000", "name": "Statistics"}],
+        "slugline": "test",
+        "body_html": "Test Document body"}]
+      """
+      Then we get OK response
+      And we get existing resource
+      """
+      {"_current_version": 1, "state": "fetched", "task":{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}
+      """
+      When we post to "/subscribers" with "digital" and success
+      """
+      {
+        "name":"Channel 1","media_type":"media", "subscriber_type": "digital", "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
+        "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}]
+      }
+      """
+      When we post to "/subscribers" with "wire" and success
+      """
+      {
+        "name":"Channel 2","media_type":"media", "subscriber_type": "wire", "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
+        "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}]
+      }
+      """
+      When we post to "/macros"
+      """
+      {
+        "macro": "Auto Publish", "item": {"_id": "#archive._id#"}
+      }
+      """
+      Then we get OK response
+      When we get "/published"
+      Then we get existing resource
+      """
+      {"_items" : [{"_id": "123", "guid": "123", "headline": "test", "_current_version": 2, "state": "published",
+        "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}]}
+      """
+      When we get "/legal_archive"
+      Then we get existing resource
+      """
+      {"_items" : [
+        {"_id": "123", "guid": "123", "headline": "test", "_current_version": 2, "state": "published",
+         "task": {"desk": "Sports", "stage": "Incoming Stage", "user": "test_user"},
+         "slugline": "test",
+         "body_html": "Test Document body", "subject":[{"qcode": "17004000", "name": "Statistics"}]},
+        {"headline": "test", "_current_version": 2, "state": "published", "type": "composite",
+         "package_type": "takes", "task": {"desk": "Sports", "stage": "Incoming Stage", "user": "test_user"},
+         "sequence": 1,
+         "slugline": "test",
+         "groups" : [
+            {
+                "id" : "root",
+                "refs" : [
+                    {
+                        "idRef" : "main"
+                    }
+                ],
+                "role" : "grpRole:NEP"
+            },
+            {
+                "id" : "main",
+                "refs" : [
+                    {
+                        "sequence" : 1,
+                        "renditions" : {},
+                        "type" : "text",
+                        "location" : "legal_archive",
+                        "slugline" : "test",
+                        "itemClass" : "icls:text",
+                        "residRef" : "123",
+                        "headline" : "test",
+                        "guid" : "123",
+                        "_current_version" : 2
+                    }
+                ],
+                "role" : "grpRole:main"
+            }
+         ],
+         "body_html": "Test Document body", "subject":[{"qcode": "17004000", "name": "Statistics"}]}
+        ]
+      }
+      """
+      When we get "/legal_archive/123?version=all"
+      Then we get list with 2 items
+      """
+      {"_items" : [
+        {"_id": "123", "headline": "test", "_current_version": 1, "state": "fetched",
+         "task": {"desk": "Sports", "stage": "Incoming Stage", "user": "test_user"}},
+        {"_id": "123", "headline": "test", "_current_version": 2, "state": "published",
+         "task": {"desk": "Sports", "stage": "Incoming Stage", "user": "test_user"}}
+       ]
+      }
+      """
+      When we get "/legal_archive/123?version=all"
+      Then we get list with 2 items
+      """
+      {"_items" : [
+        {"_id": "123", "headline": "test", "_current_version": 1, "state": "fetched",
+         "task": {"desk": "Sports", "stage": "Incoming Stage", "user": "test_user"}},
+        {"_id": "123", "headline": "test", "_current_version": 2, "state": "published",
+         "task": {"desk": "Sports", "stage": "Incoming Stage", "user": "test_user"},
+         "body_html": "Test Document body"}
+       ]
+      }
+      """
+      When we get digital item of "123"
+      When we get "/legal_archive/#archive.123.take_package#?version=all"
+      Then we get list with 1 items
+      """
+      {"_items" : [
+
+        {"_id": "#archive.123.take_package#", "headline": "test", "_current_version": 2,
+         "state": "published", "type": "composite", "package_type": "takes",
+         "task": {"desk": "Sports", "stage": "Incoming Stage", "user": "test_user"}}
+       ]
+      }
+      """
+      When we enqueue published
+      When we get "/publish_queue"
+      Then we get list with 2 items
+      """
+      {
+        "_items": [
+          {"state": "pending", "content_type": "composite",
+          "subscriber_id": "#digital#", "item_id": "#archive.123.take_package#", "item_version": 2},
+          {"state": "pending", "content_type": "text",
+          "subscriber_id": "#wire#", "item_id": "123", "item_version": 2}
+        ]
+      }
+      """
+      When run import legal publish queue
+      When we enqueue published
+      And we get "/legal_publish_queue"
+      Then we get list with 2 items
+      """
+      {
+        "_items": [
+          {"state": "pending", "content_type": "composite",
+          "subscriber_id": "Channel 1", "item_id": "#archive.123.take_package#", "item_version": 2},
+          {"state": "pending", "content_type": "text",
+          "subscriber_id": "Channel 2", "item_id": "123", "item_version": 2}
+        ]
+      }
+      """

--- a/superdesk/macros/auto_publish.py
+++ b/superdesk/macros/auto_publish.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk import get_resource_service, config
+from superdesk.metadata.item import ITEM_STATE, CONTENT_STATE
+
+
+def auto_publish(item, **kwargs):
+    """
+    Publish the passed item. The macro must be called as an on stage macro as publishing an item that is in transit
+    i.e. an incomming or outgoing macro will fail.
+    :param item:
+    :param kwargs:
+    :return:
+    """
+    get_resource_service('archive_publish').patch(id=item[config.ID_FIELD],
+                                                  updates={ITEM_STATE: CONTENT_STATE.PUBLISHED, 'auto_publish': True})
+    return item
+
+
+name = 'Auto Publish'
+label = 'Auto Publish'
+callback = auto_publish
+access_type = 'frontend'

--- a/superdesk/macros/validate_for_publish.py
+++ b/superdesk/macros/validate_for_publish.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk import get_resource_service, config
+from eve.validation import ValidationError
+from apps.publish.content.common import ITEM_PUBLISH
+
+
+def validate_for_publish(item, **kwargs):
+    doc = get_resource_service('archive').find_one(req=None, _id=item[config.ID_FIELD])
+    validate_item = {'act': ITEM_PUBLISH, 'type': doc['type'], 'validate': doc}
+    validation_errors = get_resource_service('validate').post([validate_item])
+    if validation_errors[0]:
+        raise ValidationError(validation_errors)
+    return item
+
+
+name = 'Validate for Publish'
+label = 'Validate for Publish'
+callback = validate_for_publish
+access_type = 'frontend'

--- a/superdesk/macros/validate_for_publish_test.py
+++ b/superdesk/macros/validate_for_publish_test.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from .validate_for_publish import validate_for_publish, ValidationError
+from nose.tools import assert_raises
+from test_factory import SuperdeskTestCase
+
+
+class ValidateForPublishTests(SuperdeskTestCase):
+    validator = {'_id': 'publish_text',
+                 'act': 'publish',
+                 'type': 'text',
+                 'schema': {
+                     'headline': {
+                         'required': True,
+                         'maxlength': 5,
+                         'empty': False,
+                         'nullable': False,
+                         'type': "string"
+                     }
+                 }
+                 }
+
+    def test_validator(self):
+        self.app.data.insert('archive', [{'_id': 1, 'type': 'text', 'headline': '123456'}])
+        self.app.data.insert('validators', [self.validator])
+        with self.app.app_context():
+            with assert_raises(ValidationError):
+                item = {'_id': 1}
+                validate_for_publish(item)


### PR DESCRIPTION
The PO wants to be able to publish content by just moving it to a stage.

The reason for this is that they can transition users who create content to Superdesk and have them use the normal workflow (i.e creating content and moving it to another stage). WITHOUT  having them publish using the normal publishing mechanism.
