### PR TITLE
fix(service): fix delete by multiple ids

### DIFF
--- a/apps/archive/archive_test.py
+++ b/apps/archive/archive_test.py
@@ -11,6 +11,7 @@
 
 from bson import ObjectId
 
+from unittest.mock import MagicMock
 from superdesk import get_resource_service
 from test_factory import SuperdeskTestCase
 from eve.utils import date_to_str
@@ -221,6 +222,15 @@ class RemoveSpikedContentTestCase(SuperdeskTestCase):
         now = date_to_str(utcnow())
         overdue_items = get_overdue_scheduled_items(now, 'archive')
         self.assertEquals(1, overdue_items.count())
+
+    def test_delete_by_ids(self):
+        ids = self.app.data.insert(ARCHIVE, self.articles)
+        archive_service = get_resource_service(ARCHIVE)
+        archive_service.on_delete = MagicMock()
+        archive_service.delete_by_article_ids(ids)
+        self.assertTrue(self.app.data.elastic.is_empty(ARCHIVE))
+        self.assertTrue(self.app.data.mongo.is_empty(ARCHIVE))
+        self.assertEqual(len(self.articles), archive_service.on_delete.call_count)
 
 
 class ArchiveTestCase(SuperdeskTestCase):

--- a/superdesk/services.py
+++ b/superdesk/services.py
@@ -135,13 +135,13 @@ class BaseService():
     def delete_action(self, lookup=None):
         if lookup is None:
             lookup = {}
-
-        if lookup:
-            doc = self.find_one(req=None, **lookup)
+            docs = []
+        else:
+            docs = self.get_from_mongo(None, lookup)
+        for doc in docs:
             self.on_delete(doc)
         res = self.delete(lookup)
-
-        if lookup and doc:
+        for doc in docs:
             self.on_deleted(doc)
         return res
 


### PR DESCRIPTION
it was using mongo query when doing elastic find_one,
which was failing on master instance.

also as long as you removed more than 1 item it wasn't calling
on_update/on_updated methods for removed items.

fixes SD-4005 I hope