### PR TITLE
feat(sign-off): Map signoff and add edit signoff for item(SDNTB-24, S…

### DIFF
--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -186,6 +186,7 @@ def set_sign_off(updates, original=None, repo_type=ARCHIVE, user=None):
     Set sign_off on updates object. Rules:
         1. updates['sign_off'] = original['sign_off'] + sign_off of the user performing operation.
         2. If the last modified user and the user performing operation are same then sign_off shouldn't change
+        3. If sign_off is received on updates, this value will be preserved
     """
 
     if repo_type != ARCHIVE:
@@ -195,6 +196,8 @@ def set_sign_off(updates, original=None, repo_type=ARCHIVE, user=None):
     if not user:
         return
 
+    if SIGN_OFF in updates:
+        return
     sign_off = get_sign_off(user)
     current_sign_off = '' if original is None else original.get(SIGN_OFF, '')
 

--- a/apps/duplication/archive_move.py
+++ b/apps/duplication/archive_move.py
@@ -18,7 +18,7 @@ from apps.tasks import send_to, apply_onstage_rule
 from apps.desks import DeskTypes
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
-from superdesk.metadata.item import ITEM_STATE, CONTENT_STATE
+from superdesk.metadata.item import ITEM_STATE, CONTENT_STATE, SIGN_OFF
 from superdesk.resource import Resource
 from superdesk.services import BaseService
 from superdesk.metadata.utils import item_url
@@ -92,6 +92,7 @@ class MoveService(BaseService):
 
         # set the change in desk type when content is moved.
         self.set_change_in_desk_type(archived_doc, original)
+        archived_doc.pop(SIGN_OFF, None)
         set_sign_off(archived_doc, original=original)
         convert_task_attributes_to_objectId(archived_doc)
         resolve_document_version(archived_doc, ARCHIVE, 'PATCH', original)

--- a/features/archive.feature
+++ b/features/archive.feature
@@ -54,6 +54,28 @@ Feature: News Items Archive
         Then we get list with 3 items
 
     @auth
+    Scenario: Force update sign-off
+        Given "archive"
+        """
+        [{"_id": "xyz", "guid": "testid", "headline": "test"}]
+        """
+
+        When we patch given
+        """
+        {"headline": "TEST 2", "sign_off": "abc"}
+        """
+
+        And we patch latest
+        """
+        {"headline": "TEST 3", "sign_off": "123"}
+        """
+
+        Then we get updated response
+        """
+        {"headline": "TEST 3", "sign_off": "123"}
+        """
+
+    @auth
     Scenario: Update item and keep version
         Given "archive"
         """

--- a/superdesk/users/services.py
+++ b/superdesk/users/services.py
@@ -98,7 +98,10 @@ def set_sign_off(user):
     """
 
     if SIGN_OFF not in user:
-        if 'first_name' not in user or 'last_name' not in user:
+        signOffMapping = app.config.get('SIGN_OFF_MAPPING', None)
+        if signOffMapping and signOffMapping in user:
+            user[SIGN_OFF] = user[signOffMapping]
+        elif 'first_name' not in user or 'last_name' not in user:
             user[SIGN_OFF] = user['username'][:3].upper()
         else:
             user[SIGN_OFF] = '{first_name[0]}{last_name[0]}'.format(**user)

--- a/superdesk/users/users.py
+++ b/superdesk/users/users.py
@@ -96,7 +96,7 @@ class UsersResource(Resource):
             'desk': Resource.rel('desks'),  # Default desk of the user, which would be selected when logged-in.
             SIGN_OFF: {  # Used for putting a sign-off on the content when it's created/updated except kill
                 'type': 'string',
-                'required': True,
+                'required': False,
                 'regex': '^[a-zA-Z0-9]+$'
             },
             BYLINE: {


### PR DESCRIPTION
…D-NTB-25)

Those changes are available only if sign_off mapping is set on
settings.py and index.html
When an user is added/edited, the sign-off is not shown and is set to
mapped value
On authoring the user is able to set a new value for sign-off by
selecting only one user from user list