### PR TITLE
fix(init): use init_index instead of put_mapping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ LONG_DESCRIPTION = "Superdesk Server Core"
 
 install_requires = [
     'eve>=0.6,<0.6.2',
-    'eve-elastic>=0.3.2,<0.4',
+    'eve-elastic>=0.3.3,<0.4',
     'elasticsearch==1.9.0',
     'flask>=0.10',
     'flask-mail>=0.9',

--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -114,7 +114,7 @@ def get_app(config=None, media_storage=None, config_object=None):
         app.jinja_env.filters[name] = jinja_filter
 
     # we can only put mapping when all resources are registered
-    app.data.elastic.put_mapping(app)
+    app.data.elastic.init_index(app)
 
     # instantiate registered provider classes (leave non-classes intact)
     for key, provider in registered_feeding_services.items():

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -120,7 +120,7 @@ def setup(context=None, config=None, app_factory=get_app):
     drop_mongo(app)
 
     # create index again after dropping it
-    app.data.elastic.init_app(app)
+    app.data.elastic.init_index(app)
 
     if context:
         context.app = app


### PR DESCRIPTION
put_mapping would fail in case index is not there,
while init_index can create it if missing.

this was in issue on travis, after a failure when gunicorn
created a new process it could call put_mapping during the time
when index was removed by other gunicorn process, and a failure
in app init stops gunicorn and thus honcho.