### PR TITLE
fix(templates): remove html from headline in items created from template

### DIFF
--- a/apps/templates/content_templates_test.py
+++ b/apps/templates/content_templates_test.py
@@ -110,3 +110,12 @@ class RenderTemplateTestCase(SuperdeskTestCase):
         self.assertEqual(updates['body_html'], 'This article has slugline: Testing and dateline: '
                                                'hello world at 02 Jun 2015 08:53 AEST')
         self.assertListEqual(updates['place'], ['Australia'])
+
+    def test_headline_strip_tags(self):
+        template = {'data': {'headline': ' test\nit<br>'}}
+
+        updates = render_content_template({}, template)
+        self.assertEqual('test it', updates['headline'])
+
+        item = get_item_from_template(template)
+        self.assertEqual('test it', item['headline'])

--- a/superdesk/utils.py
+++ b/superdesk/utils.py
@@ -17,6 +17,7 @@ from bson import ObjectId
 from enum import Enum
 from importlib import import_module
 from eve.utils import config
+from bs4 import BeautifulSoup
 
 
 required_string = {'type': 'string', 'required': True, 'nullable': False, 'empty': False}
@@ -168,3 +169,10 @@ def sha(text):
     :param text: text str
     """
     return hashlib.sha256(text.encode()).hexdigest()
+
+
+def plaintext_filter(value):
+    """Filter out html from value."""
+    soup = BeautifulSoup(value, 'html.parser')
+    text = soup.get_text()
+    return text.replace('\n', ' ').strip()


### PR DESCRIPTION
if you copy&paste in headline, line breaks can get there, so make sure
it doesn't make it to item which is created from template.

SD-3999