### PR TITLE
[SD-4270] - Auto publish should not be visible on frontend

### DIFF
--- a/apps/macros/macro_register.py
+++ b/apps/macros/macro_register.py
@@ -53,7 +53,8 @@ def register_macros():
     for macro_module in macro_modules:
         kwargs = {'name': macro_module.name,
                   'callback': macro_module.callback,
-                  'access_type': macro_module.access_type}
+                  'access_type': macro_module.access_type,
+                  'action_type': macro_module.action_type}
 
         if hasattr(macro_module, 'label'):
             kwargs['label'] = macro_module.label

--- a/apps/macros/macros.py
+++ b/apps/macros/macros.py
@@ -24,13 +24,14 @@ class MacrosService(superdesk.Service):
     def get(self, req, lookup):
         """Return all registered macros."""
         desk = getattr(req, 'args', {}).get('desk')
-        frontend_macros = self.get_frontend_macros()
+        include_backend = getattr(req, 'args', {}).get('backend') == 'true'
+        all_macros = self.get_macros(include_backend)
 
         if desk:
-            return ListCursor([get_public_props(macro) for macro in frontend_macros if
+            return ListCursor([get_public_props(macro) for macro in all_macros if
                                desk.upper() in macro.get('desks', []) or macro.get('desks') is None])
         else:
-            return ListCursor([get_public_props(macro) for macro in frontend_macros])
+            return ListCursor([get_public_props(macro) for macro in all_macros])
 
     def create(self, docs, **kwargs):
         try:
@@ -59,8 +60,11 @@ class MacrosService(superdesk.Service):
         macro = self.get_macro_by_name(macro_name)
         return macro['callback'](doc)
 
-    def get_frontend_macros(self):
-        return [m for m in macros if m.get('access_type') == 'frontend']
+    def get_macros(self, include_backend):
+        if include_backend:
+            return macros
+        else:
+            return [m for m in macros if m.get('access_type') == 'frontend']
 
 
 class MacrosResource(superdesk.Resource):

--- a/features/steps/fixtures/behave_macro.py
+++ b/features/steps/fixtures/behave_macro.py
@@ -21,3 +21,4 @@ shortcut = 'w'
 callback = update_fields
 desks = ['POLITICS']
 access_type = 'frontend'
+action_type = 'direct'

--- a/features/steps/fixtures/validate_headline_macro.py
+++ b/features/steps/fixtures/validate_headline_macro.py
@@ -22,3 +22,4 @@ shortcut = 'w'
 callback = validate
 desks = ['POLITICS']
 access_type = 'backend'
+action_type = 'direct'

--- a/superdesk/macros/abstract_populator.py
+++ b/superdesk/macros/abstract_populator.py
@@ -37,3 +37,4 @@ shortcut = 'a'
 callback = populate
 desks = ['POLITICS']
 access_type = 'frontend'
+action_type = 'direct'

--- a/superdesk/macros/auto_publish.py
+++ b/superdesk/macros/auto_publish.py
@@ -15,7 +15,7 @@ from superdesk.metadata.item import ITEM_STATE, CONTENT_STATE
 def auto_publish(item, **kwargs):
     """
     Publish the passed item. The macro must be called as an on stage macro as publishing an item that is in transit
-    i.e. an incomming or outgoing macro will fail.
+    i.e. an incoming or outgoing macro will fail.
     :param item:
     :param kwargs:
     :return:
@@ -28,4 +28,5 @@ def auto_publish(item, **kwargs):
 name = 'Auto Publish'
 label = 'Auto Publish'
 callback = auto_publish
-access_type = 'frontend'
+access_type = 'backend'
+action_type = 'direct'

--- a/superdesk/macros/clean_keywords.py
+++ b/superdesk/macros/clean_keywords.py
@@ -38,3 +38,4 @@ def clean_keywords(**kwargs):
 name = 'clean_keywords'
 callback = clean_keywords
 access_type = 'backend'
+action_type = 'direct'

--- a/superdesk/macros/currency.py
+++ b/superdesk/macros/currency.py
@@ -38,3 +38,4 @@ label = 'Convert USD to AUD'
 shortcut = 'c'
 callback = usd_to_aud
 access_type = 'frontend'
+action_type = 'interactive'

--- a/superdesk/macros/currency_usd_to_cad.py
+++ b/superdesk/macros/currency_usd_to_cad.py
@@ -38,3 +38,4 @@ label = 'Convert USD to CAD'
 shortcut = 'd'
 callback = usd_to_cad
 access_type = 'frontend'
+action_type = 'interactive'

--- a/superdesk/macros/dollar_AUD_character_replace.py
+++ b/superdesk/macros/dollar_AUD_character_replace.py
@@ -29,3 +29,4 @@ label = '$ -> AUD'
 shortcut = '$'
 callback = find_and_replace
 access_type = 'frontend'
+action_type = 'direct'

--- a/superdesk/macros/dpa_derive_dateline.py
+++ b/superdesk/macros/dpa_derive_dateline.py
@@ -45,3 +45,4 @@ def dpa_derive_dateline(item, **kwargs):
 name = 'Derive dateline from article text for DPA'
 callback = dpa_derive_dateline
 access_type = 'backend'
+action_type = 'direct'

--- a/superdesk/macros/noise11_derive_metadata.py
+++ b/superdesk/macros/noise11_derive_metadata.py
@@ -55,3 +55,4 @@ def noise11_derive_metadata(item, **kwargs):
 name = 'Derive metadata for Noise11'
 callback = noise11_derive_metadata
 access_type = 'backend'
+action_type = 'direct'

--- a/superdesk/macros/rename_genre_value.py
+++ b/superdesk/macros/rename_genre_value.py
@@ -46,3 +46,4 @@ def rename_genre_value(**kwargs):
 name = 'rename_genre_value'
 callback = rename_genre_value
 access_type = 'backend'
+action_type = 'background-thread'

--- a/superdesk/macros/replace_words.py
+++ b/superdesk/macros/replace_words.py
@@ -54,3 +54,4 @@ label = 'Replace American Words'
 shortcut = 'a'
 callback = find_and_replace
 access_type = 'frontend'
+action_type = 'interactive'

--- a/superdesk/macros/reuters_derive_dateline.py
+++ b/superdesk/macros/reuters_derive_dateline.py
@@ -69,3 +69,4 @@ def reuters_derive_dateline(item, **kwargs):
 name = 'Derive dateline from article text for Reuters'
 callback = reuters_derive_dateline
 access_type = 'backend'
+action_type = 'direct'

--- a/superdesk/macros/take_key_validator.py
+++ b/superdesk/macros/take_key_validator.py
@@ -22,3 +22,4 @@ name = 'take_key_validator'
 label = 'validate take key'
 callback = validate
 access_type = 'frontend'
+action_type = 'direct'

--- a/superdesk/macros/update_to_pass_validation.py
+++ b/superdesk/macros/update_to_pass_validation.py
@@ -54,3 +54,4 @@ def update_to_pass_validation(item, **kwargs):
 name = 'update to pass validation'
 callback = update_to_pass_validation
 access_type = 'backend'
+action_type = 'direct'

--- a/superdesk/macros/validate_for_publish.py
+++ b/superdesk/macros/validate_for_publish.py
@@ -26,3 +26,4 @@ name = 'Validate for Publish'
 label = 'Validate for Publish'
 callback = validate_for_publish
 access_type = 'frontend'
+action_type = 'direct'


### PR DESCRIPTION
1. Created a new attribute: `action_type` to differentiate the return type of the macros
  1. `interactive`: macro returns a diff
  2. `direct`: story is updated directly
  3. `background-thread` is where the macro can run and no response is expected

2. Modified the `get` function to accept parameter to return `backend` macros