### PR TITLE
[SD-3952] Modify websocket notification to use broker for HA.

### DIFF
--- a/superdesk/factory/default_settings.py
+++ b/superdesk/factory/default_settings.py
@@ -326,6 +326,7 @@ RENDITIONS = {
 
 SERVER_DOMAIN = 'localhost'
 
+
 BCRYPT_GENSALT_WORK_FACTOR = 12
 RESET_PASSWORD_TOKEN_TIME_TO_LIVE = int(env('RESET_PASS_TTL', 1))  # The number of days a token is valid
 # The number of days an activation token is valid

--- a/superdesk/notification.py
+++ b/superdesk/notification.py
@@ -61,12 +61,12 @@ def push_notification(name, **kwargs):
         init_app(app)
 
     if not app.notification_client.open:
-        logger.info('No connection to broker. Dropping event %s' % name)
+        logger.warning('No connection to broker. Dropping event %s' % name)
         return
 
     try:
         message = _create_socket_message(event=name, extra=kwargs)
-        logger.info('Sending the message to the broker...')
+        logger.debug('Sending the message: {} to the broker.'.format(message))
         app.notification_client.send(message)
     except Exception as err:
         logger.exception(err)

--- a/superdesk/notification.py
+++ b/superdesk/notification.py
@@ -10,21 +10,23 @@
 
 """Superdesk push notifications"""
 
-import os
 import logging
-import asyncio
-import websockets
+import os
+import json
 
-from flask import current_app as app, json
 from datetime import datetime
+from flask import current_app as app
 from superdesk.utils import json_serialize_datetime_objectId
+from superdesk.websockets_comms import SocketMessageProducer
+
 
 logger = logging.getLogger(__name__)
+exchange_name = 'socket_notification'
 
 
 class ClosedSocket():
     """Mimic closed socket to simplify logic when connection
-    can't be estabilished at first place.
+    can't be established at first place.
     """
     def __init__(self):
         self.open = False
@@ -34,57 +36,37 @@ class ClosedSocket():
 
 
 def init_app(app):
-    """Create websocket connection and put it on app object."""
-    host = app.config['WS_HOST']
-    port = app.config['WS_PORT']
     try:
-        try:
-            loop = asyncio.get_event_loop()
-        except:
-            loop = asyncio.new_event_loop()
-
-        app.notification_client = loop.run_until_complete(websockets.connect('ws://%s:%s/server' % (host, port)))
-        logger.info('websocket connected on=%s:%s' % app.notification_client.local_address)
+        app.notification_client = SocketMessageProducer(app.config['BROKER_URL'])
     except (RuntimeError, OSError):
         # not working now, but we can try later when actually sending something
         app.notification_client = ClosedSocket()
 
 
-def _notify(**kwargs):
+def _create_socket_message(**kwargs):
     """Send out all kwargs as json string."""
     kwargs.setdefault('_created', datetime.utcnow().isoformat())
     kwargs.setdefault('_process', os.getpid())
-    message = json.dumps(kwargs, default=json_serialize_datetime_objectId)
-
-    @asyncio.coroutine
-    def send_message():
-        yield from app.notification_client.send(message)
-
-    try:
-        loop = asyncio.get_event_loop()
-    except:
-        loop = asyncio.new_event_loop()
-    loop.run_until_complete(send_message())
+    return json.dumps(kwargs, default=json_serialize_datetime_objectId)
 
 
 def push_notification(name, **kwargs):
-    """Push notification to websocket.
-
-    In case socket is closed it will try to reconnect.
-
+    """Push notification to broker.
+    In case connection is closed it will try to reconnect.
     :param name: event name
     """
     logger.info('pushing event {0} ({1})'.format(name, json.dumps(kwargs, default=json_serialize_datetime_objectId)))
-
     if not app.notification_client.open:
         app.notification_client.close()
         init_app(app)
 
     if not app.notification_client.open:
-        logger.info('No connection to websocket server. Dropping event %s' % name)
+        logger.info('No connection to broker. Dropping event %s' % name)
         return
 
     try:
-        _notify(event=name, extra=kwargs)
+        message = _create_socket_message(event=name, extra=kwargs)
+        logger.info('Sending the message to the broker...')
+        app.notification_client.send(message)
     except Exception as err:
         logger.exception(err)

--- a/superdesk/notification_mock.py
+++ b/superdesk/notification_mock.py
@@ -9,9 +9,6 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
-import asyncio
-
-
 class ClientMock:
 
     def __init__(self):
@@ -19,10 +16,8 @@ class ClientMock:
         self.client = None
         self.open = True
 
-    @asyncio.coroutine
     def send(self, message):
         self.messages.append(message)
-        yield from asyncio.sleep(0)
 
     def reset(self):
         self.messages = []

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+
+import logging
+import asyncio
+import websockets
+import signal
+
+from threading import Thread
+from kombu import Queue, Exchange, Connection
+from kombu.mixins import ConsumerMixin
+from kombu.pools import producers
+from superdesk.utils import get_random_string
+from flask import json
+
+
+logger = logging.getLogger(__name__)
+exchange_name = 'socket_notification'
+
+
+class SocketBrokerClient:
+    """
+    Base class for web socket notification using broker (redis or rabbitmq)
+
+    """
+    connection = None
+
+    def __init__(self, url):
+        self.url = url
+        self.connect()
+        self.channel = self.connection.channel()
+        self.socket_exchange = Exchange(exchange_name, type='fanout', channel=self.channel)
+        self.socket_exchange.declare()
+
+    def open(self):
+        """
+        True if connected else false
+        :return bool:
+        """
+        return self.connection and self.connection.connected
+
+    def connect(self):
+        self._close()
+        logger.info('Connecting to broker {}'.format(self.url))
+        self.connection = Connection(self.url)
+        self.connection.connect()
+        logger.info('Connected to broker {}'.format(self.url))
+
+    def _close(self):
+        if hasattr(self, 'connection') and self.connection:
+            logger.info('Closing connecting to broker {}'.format(self.url))
+            self.connection.release()
+            self.connection = None
+            logger.info('Connection closed to broker {}'.format(self.url))
+
+    def close(self):
+        self._close()
+
+
+class SocketMessageProducer(SocketBrokerClient):
+    """
+    Publishes messages to a exchange (fanout).
+    """
+    def __init__(self, url):
+        super().__init__(url)
+
+    def send(self, message):
+        """
+        Publishes the message to an exchange
+        :param string message: message to publish
+        """
+        try:
+            with producers[self.connection].acquire(block=True) as producer:
+                producer.publish(message, exchange=self.socket_exchange)
+                logger.debug('message:{} published to broker:{}.'.format(message, self.url))
+        except:
+            logger.exception('Failed to publish message {} to broker.'.format(message))
+
+
+class SocketMessageConsumer(SocketBrokerClient, ConsumerMixin):
+    """
+    Consumer of the message.
+    """
+    def __init__(self, url, callback):
+        """
+        :param string url: Broker URL
+        :param string host: host name running the websocket server
+        :param callback: callback function to call on message arrival
+        """
+        super().__init__(url)
+        self.callback = callback
+        self.queue_name = 'socket_consumer_{}'.format(get_random_string())
+        # expire message after 10 seconds and queue after 60 seconds
+        self.queue = Queue(self.queue_name, exchange=self.socket_exchange,
+                           channel=self.channel,
+                           queue_arguments={'x-message-ttl': 10000, 'x-expires': 60000})
+
+    def get_consumers(self, Consumer, channel):
+        return [Consumer(queues=[self.queue], callbacks=[self.on_message])]
+
+    def on_message(self, body, message):
+        """
+        Event fired when message is received by the queue
+        :param str body:
+        :param kombu.Message message: Message object
+        """
+        try:
+            try:
+                loop = asyncio.get_event_loop()
+            except:
+                loop = asyncio.new_event_loop()
+
+            logger.info('Queue: {}. Broadcasting message {}'.format(self.queue_name, body))
+            loop.run_until_complete(self.callback(body))
+        except:
+            logger.exception('Dropping event. Failed to send message {}.'.format(body))
+        try:
+            message.ack()
+        except:
+            logger.exception('Failed to ack message {} on queue {}.'.format(body, self.queue_name))
+
+    def close(self):
+        """
+        Closing the consumer.
+        :return:
+        """
+        logger.info('closing consumer')
+        self.should_stop = True
+        super().close()
+        logger.info('consumer terminated successfully')
+
+
+class SocketCommunication:
+    """
+    Responsible for websocket comms.
+    """
+    clients = set()
+
+    def __init__(self, host, port, broker_url):
+        self.host = host
+        self.port = port
+        self.broker_url = broker_url
+
+    @asyncio.coroutine
+    def _client_loop(self, websocket):
+        """Client loop - send it ping every `beat_delay` seconds to keep it alive.
+
+        Nginx would close the connection after 2 minutes of inactivity, that's why.
+
+        Also it does the health check - if socket was closed by client it will
+        break the loop and let server deregister the client.
+
+        :param websocket: websocket protocol instance
+        """
+        pings = 0
+        while True:
+            yield from asyncio.sleep(5)
+            if not websocket.open:
+                break
+            pings += 1
+            yield from websocket.send(json.dumps({'ping': pings, 'clients': len(websocket.ws_server.websockets)}))
+
+    @asyncio.coroutine
+    def broadcast(self, message):
+        """Broadcast message to all clients.
+
+        :param message: message as it was received - no encoding/decoding.
+        """
+        logger.debug('broadcast %s' % message)
+        for websocket in self.clients.copy():
+            try:
+                if websocket.open:
+                    yield from websocket.send(message)
+            except:
+                yield
+
+    @asyncio.coroutine
+    def _server_loop(self, websocket):
+        """Server loop - wait for message and broadcast it.
+
+        When message is none it means the socket is closed
+        and there will be no messages so we break the loop.
+
+        :param websocket: websocket protocol instance
+        """
+        while True:
+            message = yield from websocket.recv()
+            if message is None:
+                break
+            yield from self.broadcast(message)
+
+    def _log(self, message, websocket):
+        """Log message with some websocket data like address.
+
+        :param message: message string
+        :param websocket: websocket protocol instance
+        """
+        host, port = websocket.remote_address
+        logger.info('%s address=%s:%s' % (message, host, port))
+
+    @asyncio.coroutine
+    def _connection_handler(self, websocket, path):
+        """Handle incomming connections.
+
+        When this function returns the session is over and it closes the socket,
+        so there must be some loops..
+
+        :param websocket: websocket protocol instance
+        :param path: url path used by client - used to identify client/server connections
+        """
+        if 'server' in path:
+            self._log('server open', websocket)
+            yield from self._server_loop(websocket)
+            self._log('server done', websocket)
+        else:
+            self._log('client open', websocket)
+            self.clients.add(websocket)
+            yield from self._client_loop(websocket)
+            self.clients.remove(websocket)
+            self._log('client done', websocket)
+
+    def run_server(self):
+        """Create websocket server and run it until it gets Ctrl+C or SIGTERM.
+        :param config: config dictionary
+        """
+        try:
+            loop = asyncio.get_event_loop()
+            server = loop.run_until_complete(websockets.serve(self._connection_handler,
+                                                              self.host, self.port))
+            loop.add_signal_handler(signal.SIGTERM, loop.stop)
+            logger.info('listening on %s:%s' % (self.host, self.port))
+            consumer = None
+            # create socket message consumer
+            consumer = SocketMessageConsumer(self.broker_url, self.broadcast)
+            consumer_thread = Thread(target=consumer.run)
+            consumer_thread.start()
+            loop.run_forever()
+        except KeyboardInterrupt:
+            pass
+        finally:
+            logger.info('closing server')
+            server.close()
+            loop.run_until_complete(server.wait_closed())
+            loop.stop()
+            loop.run_forever()
+            loop.close()
+            if consumer:
+                consumer.close()

--- a/superdesk/ws.py
+++ b/superdesk/ws.py
@@ -10,126 +10,30 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
-import json
-import signal
-import asyncio
 import logging
-import websockets
 import logging.handlers
-
-beat_delay = 5
-clients = set()
+from superdesk.websockets_comms import SocketCommunication
 
 logger = logging.getLogger(__name__)
 
 
-@asyncio.coroutine
-def client_loop(websocket):
-    """Client loop - send it ping every `beat_delay` seconds to keep it alive.
-
-    Nginx would close the connection after 2 minutes of inactivity, that's why.
-
-    Also it does the health check - if socket was closed by client it will
-    break the loop and let server deregister the client.
-
-    :param websocket: websocket protocol instance
-    """
-    pings = 0
-    while True:
-        yield from asyncio.sleep(beat_delay)
-        if not websocket.open:
-            break
-        pings += 1
-        yield from websocket.send(json.dumps({'ping': pings, 'clients': len(websocket.ws_server.websockets)}))
-
-
-@asyncio.coroutine
-def broadcast(message):
-    """Broadcast message to all clients.
-
-    :param message: message as it was received - no encoding/decoding.
-    """
-    logger.debug('broadcast %s' % message)
-    for websocket in clients:
-        if websocket.open:
-            yield from websocket.send(message)
-
-
-@asyncio.coroutine
-def server_loop(websocket):
-    """Server loop - wait for message and broadcast it.
-
-    When message is none it means the socket is closed
-    and there will be no messages so we break the loop.
-
-    :param websocket: websocket protocol instance
-    """
-    while True:
-        message = yield from websocket.recv()
-        if message is None:
-            break
-        yield from broadcast(message)
-
-
-def log(message, websocket):
-    """Log message with some websocket data like address.
-
-    :param message: message string
-    :param websocket: websocket protocol instance
-    """
-    host, port = websocket.remote_address
-    logger.info('%s address=%s:%s' % (message, host, port))
-
-
-@asyncio.coroutine
-def connection_handler(websocket, path):
-    """Handle incomming connections.
-
-    When this function returns the session is over and it closes the socket,
-    so there must be some loops..
-
-    :param websocket: websocket protocol instance
-    :param path: url path used by client - used to identify client/server connections
-    """
-    if 'server' in path:
-        log('server open', websocket)
-        yield from server_loop(websocket)
-        log('server done', websocket)
-    else:
-        log('client open', websocket)
-        clients.add(websocket)
-        yield from client_loop(websocket)
-        clients.remove(websocket)
-        log('client done', websocket)
-
-
 def create_server(config):
     """Create websocket server and run it until it gets Ctrl+C or SIGTERM.
-
     :param config: config dictionary
     """
     try:
         host = config['WS_HOST']
         port = int(config['WS_PORT'])
-        loop = asyncio.get_event_loop()
-        server = loop.run_until_complete(websockets.serve(connection_handler, host, port))
-        loop.add_signal_handler(signal.SIGTERM, loop.stop)
-        logger.info('listening on %s:%s' % (host, port))
-        loop.run_forever()
-    except KeyboardInterrupt:
-        pass
-    finally:
-        logger.info('closing server')
-        server.close()
-        loop.run_until_complete(server.wait_closed())
-        loop.stop()
-        loop.run_forever()
-        loop.close()
-
+        broker_url = config['BROKER_URL']
+        comms = SocketCommunication(host, port, broker_url)
+        comms.run_server()
+    except:
+        logger.exception('Failed to start the WebSocket server.')
 
 if __name__ == '__main__':
     config = {
         'WS_HOST': '0.0.0.0',
         'WS_PORT': '5100',
+        'BROKER_URL': 'redis://localhost:6379'
     }
     create_server(config)


### PR DESCRIPTION
If `USE_PUB_SUB_FOR_WEBSOCKETS` is set then socket notification are sent to broker (RabbitMQ/Redis). The `ws.py` process is the consumer of the messages delivered by the exchange and then the `ws.py` process broadcast the message to all connected websockets. 

@petrjasek

**This PR would require change superdesk repo in `ws.py` [Superdesk PR 1906](https://github.com/superdesk/superdesk/pull/1906).