### PR TITLE
feat(content types): Add support for default value on content types

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -42,6 +42,7 @@ from apps.packages import PackageService, TakesPackageService
 from .archive_media import ArchiveMediaService
 from superdesk.utc import utcnow
 import datetime
+from eve.defaults import resolve_default_values
 
 
 logger = logging.getLogger(__name__)
@@ -165,9 +166,7 @@ class ArchiveService(BaseService):
             if doc.get('version') == 0:
                 doc[config.VERSION] = doc['version']
 
-            doc.setdefault('priority', config.DEFAULT_PRIORITY_VALUE_FOR_MANUAL_ARTICLES)
-            doc.setdefault('urgency', config.DEFAULT_URGENCY_VALUE_FOR_MANUAL_ARTICLES)
-
+            self._set_default_values(doc)
             self._add_desk_metadata(doc, {})
 
             convert_task_attributes_to_objectId(doc)
@@ -594,6 +593,24 @@ class ArchiveService(BaseService):
         subject_qcodes = [q['qcode'] for q in updates.get('subject', []) or []]
         if subject_qcodes and len(subject_qcodes) != len(set(subject_qcodes)):
             raise SuperdeskApiError.badRequestError("Duplicate subjects are not allowed")
+
+    def _set_default_values(self, doc):
+        """
+        Set the default values defined on current set profile
+        """
+        defaults = {}
+
+        profile = doc.get('profile', None)
+        if profile:
+            content_type = superdesk.get_resource_service('content_types').find_one(req=None, _id=profile)
+            if content_type:
+                defaults = {name: field.get('default', None)
+                            for (name, field) in content_type.get('schema', {}).items()
+                            if field.get('default', None)}
+
+        defaults.setdefault('priority', config.DEFAULT_PRIORITY_VALUE_FOR_MANUAL_ARTICLES)
+        defaults.setdefault('urgency', config.DEFAULT_URGENCY_VALUE_FOR_MANUAL_ARTICLES)
+        resolve_default_values(doc, defaults)
 
     def _add_system_updates(self, original, updates, user):
         """

--- a/features/archive.feature
+++ b/features/archive.feature
@@ -597,3 +597,31 @@ Feature: News Items Archive
          """
          {"guid": "123", "source": "FOO", "dateline": {"source": "FOO"}}
          """
+
+      @auth
+      Scenario: Create content item based on a content type with default values
+         Given "content_types"
+          """
+          [{"_id": "snap", "schema": {"headline": {"default": "default_headline"}, "priority": {"default": 10}}}]
+          """
+         When we post to "/archive"
+          """
+           [{  "type":"text", "guid": "123",  "profile": "snap" }]
+          """
+         When we get "archive/123"
+         Then we get OK response
+         Then we get existing resource
+         """
+         {"guid": "123", "headline": "default_headline", "priority": 10}
+         """
+
+         When we post to "/archive"
+          """
+           [{  "type":"text", "headline": "test1", "guid": "456",  "priority": 3, "profile": "snap" }]
+          """
+         When we get "archive/456"
+         Then we get OK response
+         Then we get existing resource
+         """
+         {"guid": "456", "headline": "test1", "priority": 3}
+         """


### PR DESCRIPTION
"schema": {
            "priority": {"required": true, "default": 6},
            "urgency": {"required": true, "default": 5},
        },