### PR TITLE
[SD-3996] Running app:prepopulate command fails

### DIFF
--- a/apps/saved_searches/saved_searches.py
+++ b/apps/saved_searches/saved_searches.py
@@ -92,7 +92,8 @@ class AllSavedSearchesService(BaseService):
 class SavedSearchesService(BaseService):
     def on_create(self, docs):
         for doc in docs:
-            doc.setdefault('user', request.view_args.get('user'))
+            if 'user' not in doc and request:
+                doc['user'] = request.view_args.get('user')
             self.process(doc)
 
     def process(self, doc):


### PR DESCRIPTION
When on_create is called with no valid request object (which is the
case when using app:prepopulate command), the "user" key must be
present in the doc dict to avoid calling request.view_args.get('user').

This was implemented by using setdefault, but it was leading to an
evaluation of request.view_args.get('user') during parsing, resulting
in a crash.

Note that the traceback fixed here is not the initial one reported in
the issue, so an other patch may follow.

SD-3996