### PR TITLE
chore(eve): update eve to 0.6.3

### DIFF
--- a/apps/apps_tests.py
+++ b/apps/apps_tests.py
@@ -14,6 +14,7 @@ from apps.preferences import PreferencesService
 
 class Preference_Tests(SuperdeskTestCase):
     def setUp(self):
+        super().setUp()
         self._default_user_settings = {
             "archive:view": {
                 "default": "mgrid",

--- a/apps/archive/archive_test.py
+++ b/apps/archive/archive_test.py
@@ -9,8 +9,9 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
-from bson import ObjectId
+import unittest
 
+from bson import ObjectId
 from unittest.mock import MagicMock
 from superdesk import get_resource_service
 from test_factory import SuperdeskTestCase
@@ -206,15 +207,12 @@ class RemoveSpikedContentTestCase(SuperdeskTestCase):
         archive_service = get_resource_service(ARCHIVE)
         archive_service.on_delete = MagicMock()
         archive_service.delete_by_article_ids(ids)
-        self.assertTrue(self.app.data.elastic.is_empty(ARCHIVE))
         self.assertTrue(self.app.data.mongo.is_empty(ARCHIVE))
+        self.assertTrue(self.app.data.elastic.is_empty(ARCHIVE))
         self.assertEqual(len(self.articles), archive_service.on_delete.call_count)
 
 
 class ArchiveTestCase(SuperdeskTestCase):
-    def setUp(self):
-        super().setUp()
-
     def test_validate_schedule(self):
         validate_schedule(utcnow() + timedelta(hours=2))
 
@@ -328,10 +326,7 @@ class ArchiveTestCase(SuperdeskTestCase):
         self.assertEqual(doc['dateline']['text'], 'SYDNEY %s %s -' % (formatted_date, source))
 
 
-class ArchiveCommonTestCase(SuperdeskTestCase):
-
-    def setUp(self):
-        super().setUp()
+class ArchiveCommonTestCase(unittest.TestCase):
 
     def test_broadcast_content(self):
         content = {

--- a/features/content_lock.feature
+++ b/features/content_lock.feature
@@ -352,3 +352,25 @@ Feature: Content Locking
         """
         {"_id": "item-1", "linked_in_packages": [{"package": "package-2"}]}
         """
+
+    @auth
+    Scenario: Unlocking an item that expired in mongo (bug)
+        Given "archive"
+        """
+        [{"_id": "item-1", "guid": "item-1", "headline": "test", "_current_version": 1}]
+        """
+        When we post to "/archive/item-1/lock"
+        """
+        {}
+        """
+
+        When we remove item "item-1" from mongo
+
+        And we post to "/archive/item-1/unlock"
+        """
+        {}
+        """
+        Then we get error 404
+
+        When we get "/workqueue"
+        Then we get list with 0 items

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 LONG_DESCRIPTION = "Superdesk Server Core"
 
 install_requires = [
-    'eve>=0.6,<0.6.2',
+    'eve>=0.6,<0.7',
     'eve-elastic>=0.3.6,<0.4',
     'elasticsearch==1.9.0',
     'flask>=0.10',

--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -44,6 +44,7 @@ def get_app(config=None, media_storage=None, config_object=None):
     app_config.from_object('superdesk.factory.default_settings')
     app_config.setdefault('APP_ABSPATH', abs_path)
     app_config.setdefault('DOMAIN', {})
+    app_config.setdefault('SOURCES', {})
 
     if config_object:
         app_config.from_object(config_object)

--- a/superdesk/io/feeding_services/http_service.py
+++ b/superdesk/io/feeding_services/http_service.py
@@ -51,7 +51,7 @@ class HTTPFeedingService(FeedingService, metaclass=ABCMeta):
         token = {'auth_token': self._generate_auth_token(provider), 'created': utcnow()}
         get_resource_service('ingest_providers').system_update(provider[config.ID_FIELD], updates={'tokens': token},
                                                                original=provider)
-
+        provider['tokens'] = token
         return token['auth_token']
 
     def _generate_auth_token(self, provider):

--- a/superdesk/lock.py
+++ b/superdesk/lock.py
@@ -7,9 +7,16 @@ from flask import current_app as app
 from superdesk.logging import logger
 
 
+_lock_resource_settings = {
+    'internal_resource': True,
+    'versioning': False,
+}
+
+
 def _get_lock():
     """Get mongolock instance using app mongodb."""
-    return mongolock.MongoLock(client=app.data.mongo.pymongo().db)
+    app.register_resource('_lock', _lock_resource_settings)  # setup dummy resource for locks
+    return mongolock.MongoLock(client=app.data.mongo.pymongo('_lock').db)
 
 
 _lock = LocalProxy(_get_lock)

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -2054,3 +2054,9 @@ def expire_content(context):
     with context.app.test_request_context(context.app.config['URL_PREFIX']):
         from superdesk.publish.publish_content import PublishContent
         PublishContent().run()
+
+
+@when('we remove item "{_id}" from mongo')
+def remove_item_from_mongo(context, _id):
+    with context.app.app_context():
+        context.app.data.mongo.remove('archive', {'_id': _id})

--- a/test_factory.py
+++ b/test_factory.py
@@ -76,7 +76,3 @@ class SuperdeskTestCase(TestCase):
         setup(self, app_factory=get_app)
         self.ctx = self.app.app_context()
         self.ctx.push()
-
-    def tearDown(self):
-        if hasattr(self, 'ctx'):
-            self.ctx.pop()

--- a/tests/io/feeding_services/rss_test.py
+++ b/tests/io/feeding_services/rss_test.py
@@ -51,6 +51,7 @@ class RssIngestServiceTest(TestCase):
     """Base class for RSSFeedingService tests."""
 
     def setUp(self):
+        super().setUp()
         try:
             from superdesk.io.feeding_services.rss import RSSFeedingService
         except ImportError:

--- a/tests/storage/gridfs_media_storage_test.py
+++ b/tests/storage/gridfs_media_storage_test.py
@@ -1,7 +1,7 @@
 
 import io
+import eve
 import bson
-import flask
 import unittest
 from unittest.mock import Mock
 from superdesk.upload import bp
@@ -12,7 +12,7 @@ from superdesk.storage.desk_media_storage import SuperdeskGridFSMediaStorage
 class GridFSMediaStorageTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.app = flask.Flask(__name__)
+        self.app = eve.Eve(__name__, {'DOMAIN': {}})
         self.app.config['SERVER_NAME'] = 'localhost'
         self.app.config['DOMAIN'] = {'upload': {}}
         self.app.config['MONGO_DBNAME'] = 'sptests'


### PR DESCRIPTION
it raises now `OriginalChanged` error when there is no update done in db,
which could be the case with system update (other updates change etag).

this case is now handled in eve backend layer.