### PR TITLE
fix(expiry): fix check if item is expired

### DIFF
--- a/apps/archive/commands.py
+++ b/apps/archive/commands.py
@@ -150,7 +150,7 @@ class RemoveExpiredContent(superdesk.Command):
         item_refs.extend(package_service.get_linked_in_package_ids(item))
 
         # check item refs in the ids to remove set
-        is_expired = 'expiry' in item and item.get('expiry') < utcnow()
+        is_expired = item.get('expiry') and item.get('expiry') < utcnow()
 
         if is_expired:
             # now check recursively for all references

--- a/apps/archive/commands_test.py
+++ b/apps/archive/commands_test.py
@@ -1,0 +1,11 @@
+
+from superdesk.tests import TestCase
+from apps.archive.commands import RemoveExpiredContent
+
+
+class RemoveExpiredContentTestCase(TestCase):
+
+    def test_is_expired(self):
+        command = RemoveExpiredContent()
+        item = {'expiry': None, '_id': 'foo'}
+        self.assertFalse(command._can_remove_item(item))


### PR DESCRIPTION
there are items with `expiry` set to `None`, not sure how.
atm remove expired command fails on master, this should fix it.