### PR TITLE
(fix)[SD-4068] Transfer Kill Text from take to other takes and broadcast

### DIFF
--- a/apps/archive_broadcast/broadcast.py
+++ b/apps/archive_broadcast/broadcast.py
@@ -349,6 +349,7 @@ class ArchiveBroadcastService(BaseService):
                         if refs:
                             correct_service.patch(package.get(config.ID_FIELD), package_updates)
                         else:
+                            package_updates['body_html'] = updates.get('body_html', '')
                             kill_service.patch(package.get(config.ID_FIELD), package_updates)
 
                         processed_packages.add(package.get(config.ID_FIELD))
@@ -362,4 +363,4 @@ class ArchiveBroadcastService(BaseService):
                         item_id, package.get(config.ID_FIELD)
                     ))
 
-            kill_service.kill_item(item)
+            kill_service.kill_item(updates, item)

--- a/apps/templates/content_templates.py
+++ b/apps/templates/content_templates.py
@@ -238,6 +238,22 @@ class ContentTemplatesApplyService(Service):
         return [docs[0].get(config.ID_FIELD)]
 
 
+def render_content_template_by_name(item, template_name):
+    """
+    Apply template by name
+    :param dict item: item on which template is applied
+    :param str template_name: template name
+    :return dict: updates to the item
+    """
+    # get the kill template
+    template = superdesk.get_resource_service('content_templates').get_template_by_name(template_name)
+    if not template:
+        SuperdeskApiError.badRequestError(message='{} Template missing.'.format(template_name))
+
+    # apply the kill template
+    return render_content_template(item, template)
+
+
 def render_content_template(item, template):
     """
     Render the template.

--- a/features/archived_kill.feature
+++ b/features/archived_kill.feature
@@ -36,7 +36,7 @@ Feature: Kill a content item in the (dusty) archive
     When we post to "content_templates"
     """
     {"template_name": "kill", "template_type": "kill",
-     "data": {"body_html": "<p>Please kill story slugged {{ item.slugline }} ex {{ item.dateline['text'] }}.<\/p>",
+     "data": {"body_html": "<p>Story killed due to court case. Please remove the story from your archive.<\/p>",
               "type": "text", "abstract": "This article has been removed", "headline": "Kill\/Takedown notice ~~~ Kill\/Takedown notice",
               "urgency": 1, "priority": 1,  "anpa_take_key": "KILL\/TAKEDOWN"}
     }
@@ -46,7 +46,7 @@ Feature: Kill a content item in the (dusty) archive
   Scenario: Kill a Text Article in the Dusty Archive
     When we post to "/archive" with success
     """
-    [{"guid": "123", "type": "text", "state": "fetched", "slugline": "slugline",
+    [{"guid": "123", "type": "text", "state": "fetched", "slugline": "archived",
       "headline": "headline", "anpa_category" : [{"qcode" : "e", "name" : "Entertainment"}],
       "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
       "subject":[{"qcode": "17004000", "name": "Statistics"}], "targeted_for": [{"name": "Digital", "allow": false}],
@@ -100,7 +100,7 @@ Feature: Kill a content item in the (dusty) archive
     Then we get list with 1 items
     When we patch "/archived/123:2"
     """
-    {}
+    {"body_html": "Killed body."}
     """
     Then we get OK response
     And we get 1 emails
@@ -119,6 +119,10 @@ Feature: Kill a content item in the (dusty) archive
         {"item_id": "123", "content_type": "text", "item_version": 3, "publishing_action": "killed"}
      ]}
     """
+    When we get "/archive/123"
+    Then we get OK response
+    And we get text "Please kill story slugged archived" in response field "body_html"
+    And we get text "Killed body" in response field "body_html"
     When we get "/archived/123:2"
     Then we get error 404
     When we get "/archived"
@@ -214,7 +218,7 @@ Feature: Kill a content item in the (dusty) archive
     Then we get list with 2 items
     When we patch "/archived/123:2"
     """
-    {}
+    {"body_html": "Killed body"}
     """
     Then we get OK response
     And we get 2 emails
@@ -222,6 +226,14 @@ Feature: Kill a content item in the (dusty) archive
     Then we get list with 2 items
     When we get "/publish_queue"
     Then we get list with 2 items
+    When we get "/archive/123"
+    Then we get OK response
+    And we get text "Please kill story slugged slugline" in response field "body_html"
+    And we get text "Killed body" in response field "body_html"
+    When we get "/archive/#archive.123.take_package#"
+    Then we get OK response
+    And we get text "Please kill story slugged slugline" in response field "body_html"
+    And we get text "Killed body" in response field "body_html"
     When we get "/archived"
     Then we get list with 0 items
     When we transmit items

--- a/features/takes_publish.feature
+++ b/features/takes_publish.feature
@@ -298,6 +298,21 @@ Feature: Take Package Publishing
         "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}]
       }]
       """
+      And we post to "content_templates"
+        """
+          {
+            "data": {
+              "body_html": "<p>This is test story.<\/p>",
+              "type": "text",
+              "abstract": "This article has been removed",
+              "headline": "Kill\/Takedown notice ~~~ Kill\/Takedown notice",
+              "urgency": 1, "priority": 1,
+              "anpa_take_key": "KILL\/TAKEDOWN"
+            },
+            "template_name": "kill",
+            "template_type": "kill"
+          }
+        """
       When we post to "archive" with success
       """
       [{
@@ -340,7 +355,7 @@ Feature: Take Package Publishing
       """
       When we patch "/archive/#TAKE2#"
       """
-      {"body_html": "Take-2", "abstract": "Take-2 Abstract"}
+      {"body_html": "Take-2", "abstract": "Take-2 Abstract", "slugline": "Take-2 slugline"}
       """
       And we post to "/archive/#TAKE2#/move"
       """
@@ -355,7 +370,7 @@ Feature: Take Package Publishing
       {
           "type": "text",
           "headline": "Take-1 headline",
-          "slugline": "Take-1 slugline",
+          "slugline": "Take-2 slugline",
           "anpa_take_key": "Take=3",
           "state": "draft",
           "original_creator": "#CONTEXT_USER_ID#"
@@ -363,7 +378,7 @@ Feature: Take Package Publishing
       """
       When we patch "/archive/#TAKE3#"
       """
-      {"body_html": "Take-3", "abstract": "Take-3 Abstract"}
+      {"body_html": "Take-3", "abstract": "Take-3 Abstract", "slugline": "Take-3 slugline"}
       """
       And we post to "/archive/#TAKE3#/move"
       """
@@ -416,7 +431,7 @@ Feature: Take Package Publishing
       """
       When we publish "#TAKE2#" with "kill" type and "killed" state
       """
-      {"body_html": "Killed", "headline": "Story is Killed", "slugline": "killed"}
+      {"body_html": "Killed Story", "headline": "Kill/Takedown notice ~~~ Kill/Takedown notice"}
       """
       Then we get OK response
       When we get "/published"
@@ -477,27 +492,24 @@ Feature: Take Package Publishing
                   "_current_version": 4,
                   "state": "killed",
                   "last_published_version": true,
-                  "body_html": "Killed",
-                  "headline": "Story is Killed",
-                  "slugline": "killed"
+                  "headline": "Kill/Takedown notice ~~~ Kill/Takedown notice",
+                  "slugline": "Take-1 slugline"
               },
               {
                   "_id": "#TAKE2#",
                   "_current_version": 5,
                   "state": "killed",
                   "last_published_version": true,
-                  "body_html": "Killed",
-                  "headline": "Story is Killed",
-                  "slugline": "killed"
+                  "headline": "Kill/Takedown notice ~~~ Kill/Takedown notice",
+                  "slugline": "Take-2 slugline"
               },
               {
                   "_id": "#TAKE3#",
                   "_current_version": 5,
                   "state": "killed",
                   "last_published_version": true,
-                  "body_html": "Killed",
-                  "headline": "Story is Killed",
-                  "slugline": "killed"
+                  "headline": "Kill/Takedown notice ~~~ Kill/Takedown notice",
+                  "slugline": "Take-3 slugline"
               },
               {
                   "_id": "#archive.123.take_package#",
@@ -505,9 +517,8 @@ Feature: Take Package Publishing
                   "state": "killed",
                   "type": "composite",
                   "package_type": "takes",
-                  "body_html": "Killed",
-                  "headline": "Story is Killed",
-                  "slugline": "killed",
+                  "headline": "Kill/Takedown notice ~~~ Kill/Takedown notice",
+                  "slugline": "Take-2 slugline",
                   "last_published_version": true,
                   "groups": [
                     {"refs": [{"idRef" : "main"}], "id": "root"},
@@ -522,6 +533,13 @@ Feature: Take Package Publishing
           ]
       }
       """
+      When we get "/archive/123"
+      Then we get text "Please kill story slugged Take-1 slugline" in response field "body_html"
+      When we get "/archive/#TAKE2#"
+      Then we get text "Please kill story slugged Take-2 slugline" in response field "body_html"
+      When we get "/archive/#TAKE3#"
+      Then we get text "Please kill story slugged Take-3 slugline" in response field "body_html"
+
 
     @auth @vocabulary
     Scenario: Publish subsequent takes to same wire clients as published before.

--- a/superdesk/templates/article_killed_override.json
+++ b/superdesk/templates/article_killed_override.json
@@ -1,0 +1,3 @@
+{
+    "body_html": "<p>Please kill story slugged {{ item.slugline }} ex {{ item.dateline['text'] }} at {{item.versioncreated | format_datetime('Australia/Sydney', '%d %b %Y %H:%S %Z')}}.</p>{{item.body_html | escape}}"
+}

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -2060,3 +2060,14 @@ def expire_content(context):
 def remove_item_from_mongo(context, _id):
     with context.app.app_context():
         context.app.data.mongo.remove('archive', {'_id': _id})
+
+
+@then('we get text "{text}" in response field "{field}"')
+def we_get_text_in_field(context, text, field):
+    with context.app.test_request_context(context.app.config['URL_PREFIX']):
+        resp = parse_json_response(context.response)
+        assert field in resp, 'Field {} not found in response.'.format(field)
+        assert isinstance(resp.get(field), str), 'Invalid type'
+        assert text in resp.get(field, ''), '{} contains text: {}. Text To find: {}'.format(field,
+                                                                                            resp.get(field, ''),
+                                                                                            text)


### PR DESCRIPTION
 Kill for multiple items is triggered
- for all takes and takes_package if one of the take is killed.
- for broadcast items if master item is killed.

In case of the multiple items the kill header text will be different but rest of the body_html will be same.
For example:

If there are 2 takes and Take1 is killed and `body_html` of the take1 is `Story killed due to legal reason.`
Take1: {'slugline': 'test1', 'versioncreated': '2016-04-04T00:00:00+0000',  'dateline': {'text': 'London, PA May 4'}}

Take2: {'slugline': 'test2', 'versioncreated': '2016-04-05T00:00:00+0000', 'dateline': {'text': 'London, PA May 5'}}

Th `body_html` for `Take1` will be:
```
`body_html`:<p>Please kill story slugged test1 ex London, PA May 4 at 04 May 2016 10:00 AEDT<p>
                   <p>Story killed due to legal reason.</p>
```
The `body_html` for `Take2` will be:
```
`body_html`:<p>Please kill story slugged test2 ex London, PA May 5 at 05 May 2016 10:00 AEDT<p>
                   <p>Story killed due to legal reason.</p>
```
