### PR TITLE
fix(schedule): fix publish scheduling

### DIFF
--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -460,13 +460,12 @@ def update_schedule_settings(updates, field_name, value):
 
     schedule_settings = updates.get(SCHEDULE_SETTINGS, {}) or {}
 
-    if field_name:
+    if field_name and value:
         tz_name = schedule_settings.get('time_zone')
-        if tz_name:
+        if tz_name and not value.tzinfo:
             schedule_settings['utc_{}'.format(field_name)] = local_to_utc(tz_name, value)
         else:
             schedule_settings['utc_{}'.format(field_name)] = value
-            schedule_settings['time_zone'] = None
 
     updates[SCHEDULE_SETTINGS] = schedule_settings
 

--- a/apps/publish/publish_content_tests.py
+++ b/apps/publish/publish_content_tests.py
@@ -131,3 +131,19 @@ class PublishContentTests(SuperdeskTestCase):
         ]
         enqueue_items(queue_items)
         fake_enqueue_item.assert_called_with(queue_items[0])
+
+    @mock.patch('apps.publish.enqueue.enqueue_item')
+    def test_enqueue_item_scheduled_with_timezone(self, *mocks):
+        fake_enqueue_item = mocks[0]
+        queue_items = [
+            {
+                '_id': '1', 'item_id': 'item_1', 'queue_state': 'pending',
+                'state': 'scheduled',
+                'publish_schedule': utcnow() + timedelta(minutes=5),
+                'schedule_settings': {
+                    'time_zone': 'Pacific/Fiji'  # something far east
+                }
+            }
+        ]
+        enqueue_items(queue_items)
+        assert not fake_enqueue_item.called, 'not scheduled yet %s' % (queue_items[0]['publish_schedule'], )


### PR DESCRIPTION
it was using datetime in utc as if it was naive, but it gets
utc datetime from client.

SD-4377