### PR TITLE
fix(utc): fix local_to_utc method

### DIFF
--- a/features/content_publish.feature
+++ b/features/content_publish.feature
@@ -609,7 +609,7 @@ Feature: Content Publishing
         "_items":
           [
             {"publish_schedule":  "2020-02-13T22:46:19+0000",
-             "schedule_settings":  {"utc_publish_schedule": "2020-02-13T12:41:19+0000"}
+             "schedule_settings":  {"utc_publish_schedule": "2020-02-13T11:46:19+0000"}
             }
           ]
       }
@@ -623,7 +623,7 @@ Feature: Content Publishing
       Then we get existing resource
       """
       {"publish_schedule":  "2020-03-13T22:46:19+0000",
-       "schedule_settings":  {"utc_publish_schedule": "2020-03-13T12:41:19+0000"}
+       "schedule_settings":  {"utc_publish_schedule": "2020-03-13T11:46:19+0000"}
       }
       """
       When we patch "/archive/123"

--- a/features/embargo.feature
+++ b/features/embargo.feature
@@ -70,7 +70,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
       "_items":
         [
           {"embargo":  "2020-02-13T22:46:19+0000",
-           "schedule_settings":  {"utc_embargo": "2020-02-13T12:41:19+0000"}
+           "schedule_settings":  {"utc_embargo": "2020-02-13T11:46:19+0000"}
           }
         ]
     }
@@ -100,7 +100,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     Then we get existing resource
     """
     {"embargo":  "2020-02-13T22:46:19+0000",
-     "schedule_settings":  {"utc_embargo": "2020-02-13T12:41:19+0000"}
+     "schedule_settings":  {"utc_embargo": "2020-02-13T11:46:19+0000"}
     }
     """
     When we patch "/archive/123"
@@ -112,7 +112,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     Then we get existing resource
     """
     {"embargo":  "2020-03-13T22:46:19+0000",
-     "schedule_settings":  {"utc_embargo": "2020-03-13T12:41:19+0000"}
+     "schedule_settings":  {"utc_embargo": "2020-03-13T11:46:19+0000"}
     }
     """
     When we patch "/archive/123"

--- a/features/steps/template_steps.py
+++ b/features/steps/template_steps.py
@@ -21,4 +21,4 @@ def then_next_run_is_on_monday(context, time):
     next_run = parse_date(data.get('next_run'))
     assert isinstance(next_run, datetime)
     assert next_run.weekday() == 0
-    assert next_run.strftime('%H:%M:%S') == time
+    assert next_run.strftime('%H:%M:%S') == time, 'it is %s' % (next_run, )

--- a/features/templates.feature
+++ b/features/templates.feature
@@ -120,13 +120,13 @@ Feature: Templates
          "template_desk": "#desks._id#", "template_stage": "#stages._id#"}
         """
         Then we get new resource
-        And next run is on monday "22:10:00"
+        And next run is on monday "22:15:00"
 
         When we patch latest
         """
         {"schedule": {"day_of_week": ["MON"], "create_at": "09:15:00", "is_active": true}}
         """
-        Then next run is on monday "23:10:00"
+        Then next run is on monday "23:15:00"
 
         When we run create content task
         And we get "/archive"

--- a/superdesk/utc.py
+++ b/superdesk/utc.py
@@ -56,7 +56,7 @@ def local_to_utc(local_tz_name, local_datetime):
     """
     if local_datetime:
         local_tz = pytz.timezone(local_tz_name)
-        utc_dat = local_datetime.replace(tzinfo=local_tz).astimezone(pytz.utc)
+        utc_dat = local_tz.localize(local_datetime.replace(tzinfo=None))
         return pytz.utc.normalize(utc_dat)
 
 

--- a/tests/utc_tests.py
+++ b/tests/utc_tests.py
@@ -9,15 +9,15 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
+import pytz
+import unittest
 from datetime import datetime, timedelta
-from superdesk.tests import TestCase
 from superdesk.utc import get_date, utcnow, get_expiry_date, local_to_utc, utc_to_local, set_time
 from pytz import utc, timezone # flake8: noqa
 from nose.tools import assert_raises
-import pytz
 
 
-class UTCTestCase(TestCase):
+class UTCTestCase(unittest.TestCase):
 
     def test_get_date(self):
         self.assertIsInstance(get_date('2012-12-12'), datetime)
@@ -76,12 +76,15 @@ class UTCTestCase(TestCase):
     def test_local_to_utc(self):
         # with day light saving on
         local_tz = pytz.timezone('Australia/Sydney')
-        local_dt = datetime(2015, 2, 8, 8, 0, 0, 0, local_tz)
+        local_dt = datetime(2015, 2, 8, 18, 0, 0, 0, local_tz)
         utc_dt = local_to_utc('Australia/Sydney', local_dt)
-        self.assertEqual(utc_dt.hour - local_dt.hour, 13)
+        self.assertEqual(local_dt.hour - utc_dt.hour, 11)
 
         # without day light saving
-        local_dt = local_tz.normalize(datetime(2015, 2, 8, 8, 0, 0, 0).replace(tzinfo=local_tz))
+        local_dt = local_tz.normalize(datetime(2015, 6, 8, 18, 0, 0, 0).replace(tzinfo=local_tz))
         utc_dt = local_to_utc('Australia/Sydney', local_dt)
-        self.assertEqual(utc_dt.hour - local_dt.hour, 14)
+        self.assertEqual(local_dt.hour - utc_dt.hour, 10)
 
+    def test_local_to_utc_europe(self):
+        utc_dt = local_to_utc('Europe/Prague', datetime(2016, 4, 19, 15, 8, 0))
+        self.assertEqual('2016-04-19T13:08:00+00:00', utc_dt.isoformat())


### PR DESCRIPTION
it was using local datetime as if it was utc

goes together with https://github.com/superdesk/superdesk-client-core/pull/348 and replaces https://github.com/superdesk/superdesk-core/pull/306