### PR TITLE
(fix)Fixing the embargo and scheduled publishing.

### DIFF
--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -459,13 +459,13 @@ def update_schedule_settings(updates, field_name, value):
     """
 
     schedule_settings = updates.get(SCHEDULE_SETTINGS, {}) or {}
-
+    utc_field_name = 'utc_{}'.format(field_name)
     if field_name:
         tz_name = schedule_settings.get('time_zone')
         if tz_name:
-            schedule_settings['utc_{}'.format(field_name)] = local_to_utc(tz_name, value)
+            schedule_settings[utc_field_name] = local_to_utc(tz_name, value)
         else:
-            schedule_settings['utc_{}'.format(field_name)] = value
+            schedule_settings[utc_field_name] = value
             schedule_settings['time_zone'] = None
 
     updates[SCHEDULE_SETTINGS] = schedule_settings
@@ -478,13 +478,13 @@ def get_utc_schedule(doc, field_name):
     :param field_name: Name of he field: either publish_schedule or embargo
     :return: the utc value of the field
     """
-
+    utc_field_name = 'utc_{}'.format(field_name)
     if SCHEDULE_SETTINGS not in doc or \
             not doc.get(SCHEDULE_SETTINGS) or \
-            field_name not in doc.get(SCHEDULE_SETTINGS, {}):
+            utc_field_name not in doc.get(SCHEDULE_SETTINGS, {}):
         update_schedule_settings(doc, field_name, doc.get(field_name))
 
-    return doc.get(SCHEDULE_SETTINGS, {}).get('utc_{}'.format(field_name))
+    return doc.get(SCHEDULE_SETTINGS, {}).get(utc_field_name)
 
 
 def item_schema(extra=None):

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -134,7 +134,7 @@ class BasePublishService(BaseService):
                 if self.published_state != CONTENT_STATE.KILLED:
                     self._process_takes_package(original, updated, updates)
 
-                self._update_archive(original, updated, should_insert_into_versions=auto_publish)
+                self._update_archive(original, updates, should_insert_into_versions=auto_publish)
                 self.update_published_collection(published_item_id=original[config.ID_FIELD], updated=updated)
 
             from apps.publish.enqueue import enqueue_published
@@ -168,6 +168,8 @@ class BasePublishService(BaseService):
                 '''
                 package_id = self.takes_package_service.package_story_as_a_take(updated, {}, None)
                 package = get_resource_service(ARCHIVE).find_one(req=None, _id=package_id)
+                updates[LINKED_IN_PACKAGES] = updated[LINKED_IN_PACKAGES]
+
             package_id = package[config.ID_FIELD]
 
             package_updates = self.process_takes(updates_of_take_to_be_published=updates,
@@ -207,10 +209,12 @@ class BasePublishService(BaseService):
                 raise PublishQueueError.previous_take_not_published_error(
                     Exception("Previous takes are not published."))
 
-            validate_schedule(updated.get(PUBLISH_SCHEDULE), takes_package.get(SEQUENCE, 1) if takes_package else 1)
             update_schedule_settings(updated, PUBLISH_SCHEDULE, updated.get(PUBLISH_SCHEDULE))
+            validate_schedule(updated.get(SCHEDULE_SETTINGS, {}).get('utc_{}'.format(PUBLISH_SCHEDULE)),
+                              takes_package.get(SEQUENCE, 1) if takes_package else 1)
 
             if original[ITEM_TYPE] != CONTENT_TYPE.COMPOSITE and updates.get(EMBARGO):
+                update_schedule_settings(updated, EMBARGO, updated.get(EMBARGO))
                 get_resource_service(ARCHIVE).validate_embargo(updated)
 
         if self.publish_type in [ITEM_CORRECT, ITEM_KILL]:
@@ -347,7 +351,7 @@ class BasePublishService(BaseService):
                 package_updates['body_html'] = body_html
 
             metadata_tobe_copied = self.takes_package_service.fields_for_creating_take.copy()
-            metadata_tobe_copied.extend([PUBLISH_SCHEDULE, SCHEDULE_SETTINGS, 'byline'])
+            metadata_tobe_copied.extend([PUBLISH_SCHEDULE, SCHEDULE_SETTINGS, 'byline', EMBARGO])
             updated_take = original_of_take_to_be_published.copy()
             updated_take.update(updates_of_take_to_be_published)
             metadata_from = updated_take

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -213,14 +213,15 @@ class BasePublishService(BaseService):
             validate_schedule(updated.get(SCHEDULE_SETTINGS, {}).get('utc_{}'.format(PUBLISH_SCHEDULE)),
                               takes_package.get(SEQUENCE, 1) if takes_package else 1)
 
-            if original[ITEM_TYPE] != CONTENT_TYPE.COMPOSITE and updates.get(EMBARGO):
-                update_schedule_settings(updated, EMBARGO, updated.get(EMBARGO))
-                get_resource_service(ARCHIVE).validate_embargo(updated)
+        if original[ITEM_TYPE] != CONTENT_TYPE.COMPOSITE and updates.get(EMBARGO):
+            update_schedule_settings(updated, EMBARGO, updated.get(EMBARGO))
+            get_resource_service(ARCHIVE).validate_embargo(updated)
 
         if self.publish_type in [ITEM_CORRECT, ITEM_KILL]:
-            if updates.get(EMBARGO):
+            if updates.get(EMBARGO) and not original.get(EMBARGO):
                 raise SuperdeskApiError.badRequestError("Embargo can't be set after publishing")
 
+        if self.publish_type in [ITEM_CORRECT, ITEM_KILL]:
             if updates.get('dateline'):
                 raise SuperdeskApiError.badRequestError("Dateline can't be modified after publishing")
 

--- a/apps/publish/content/kill.py
+++ b/apps/publish/content/kill.py
@@ -11,7 +11,8 @@
 from eve.versioning import resolve_document_version
 from .common import BasePublishService, BasePublishResource, ITEM_KILL
 from eve.utils import config
-from superdesk.metadata.item import CONTENT_STATE, ITEM_STATE, GUID_FIELD, PUB_STATUS
+from superdesk.metadata.item import CONTENT_STATE, ITEM_STATE, GUID_FIELD, PUB_STATUS, EMBARGO, SCHEDULE_SETTINGS, \
+    PUBLISH_SCHEDULE
 from superdesk.metadata.packages import PACKAGE_TYPE
 from superdesk import get_resource_service
 from superdesk.utc import utcnow
@@ -50,6 +51,7 @@ class KillPublishService(BasePublishService):
 
         updates['pubstatus'] = PUB_STATUS.CANCELED
         updates['versioncreated'] = utcnow()
+
         super().on_update(updates, original)
         updates[ITEM_OPERATION] = ITEM_KILL
         self.takes_package_service.process_killed_takes_package(original)
@@ -83,6 +85,10 @@ class KillPublishService(BasePublishService):
         'body_html':<p>Please kill story slugged test2 ex London, PA May 5 at 05 May 2016 10:00 AEDT<p>
                     <p>Story killed due to legal reason.</p>
         """
+        # kill cannot be scheduled and embargoed.
+        updates[EMBARGO] = None
+        updates[PUBLISH_SCHEDULE] = None
+        updates[SCHEDULE_SETTINGS] = {}
         self.broadcast_kill_email(original)
         updates_copy = deepcopy(updates)
         original_copy = deepcopy(original)

--- a/apps/publish/content/publish.py
+++ b/apps/publish/content/publish.py
@@ -10,7 +10,7 @@
 
 import logging
 from superdesk.errors import SuperdeskApiError
-from superdesk.metadata.item import CONTENT_TYPE, ITEM_TYPE, ITEM_STATE, CONTENT_STATE, PUBLISH_SCHEDULE
+from superdesk.metadata.item import CONTENT_TYPE, ITEM_TYPE, ITEM_STATE, CONTENT_STATE, PUBLISH_SCHEDULE, EMBARGO
 
 from apps.archive.common import set_sign_off, ITEM_OPERATION
 
@@ -52,5 +52,7 @@ class ArchivePublishService(BasePublishService):
         updates.setdefault(ITEM_OPERATION, ITEM_PUBLISH)
         if original.get(PUBLISH_SCHEDULE) or updates.get(PUBLISH_SCHEDULE):
             updates[ITEM_STATE] = CONTENT_STATE.SCHEDULED
+        elif original.get(EMBARGO) or updates.get(EMBARGO):
+            updates[ITEM_STATE] = CONTENT_STATE.PUBLISHED
         else:
             super().set_state(original, updates)

--- a/apps/publish/enqueue/enqueue_service.py
+++ b/apps/publish/enqueue/enqueue_service.py
@@ -369,7 +369,7 @@ class EnqueueService:
             if not package_item_takes_package:
                 # this item has not been published to digital subscribers so
                 # the list of subscribers are empty
-                return []
+                return [], {}
 
             query = {'$and': [{'item_id': package_item_takes_package[config.ID_FIELD]},
                               {'publishing_action': package_item_takes_package[ITEM_STATE]}]}

--- a/features/content_crop.feature
+++ b/features/content_crop.feature
@@ -109,7 +109,7 @@ Feature: Cropping the Image Articles
 
 
     @auth
-    @vocabulary @test
+    @vocabulary
     Scenario: Correct a picture with the crops succeeds
       Given the "validators"
       """

--- a/features/content_expire_not_published.feature
+++ b/features/content_expire_not_published.feature
@@ -18,7 +18,7 @@ Feature: Content Expiry Not Published Items
     {"_current_version": 1, "state": "fetched", "task":{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}
     """
 
-  @auth @test
+  @auth
   Scenario: Item on a desk and not part of any package is expired .
     When we expire items
     """

--- a/features/content_fetch.feature
+++ b/features/content_fetch.feature
@@ -86,7 +86,6 @@ Feature: Fetch Items from Ingest
 
     @auth
     @provider
-    @test
     Scenario: Fetch a package and validate metadata set by API
       Given empty "ingest"
       And "desks"

--- a/features/content_link.feature
+++ b/features/content_link.feature
@@ -742,7 +742,7 @@ Feature: Link content in takes
         }
         """
 
-    @auth @test
+    @auth
     Scenario: If the user is the member of a desk then New Take on a desk is allowed
         Given "desks"
         """

--- a/features/embargo.feature
+++ b/features/embargo.feature
@@ -275,6 +275,61 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     Then we validate the published item expiry to be after publish expiry set in desk settings 4320
 
   @auth
+  Scenario: Publish an article with Embargo and change embargo in correction
+    When we patch "/archive/123"
+    """
+    {"embargo": "#DATE+2#"}
+    """
+    And we publish "#archive._id#" with "publish" type and "published" state
+    Then we get OK response
+    And we get existing resource
+    """
+    {"_current_version": 3, "state": "published", "task":{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}
+    """
+    And we get expiry for schedule and embargo content 4320 minutes after "#archive_publish.embargo#"
+    And we check if article has Embargo and Ed. Note of the article has embargo indication
+    When we get "/published"
+    Then we get existing resource
+    """
+    {"_items" : [{"_id": "123", "guid": "123", "headline": "test", "_current_version": 3, "state": "published",
+      "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}]}
+    """
+    And we check if article has Embargo and Ed. Note of the article has embargo indication
+    When we enqueue published
+    When we get "/publish_queue"
+    Then we get list with 1 items
+    """
+    {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}}]}
+    """
+    When we publish "#archive._id#" with "correct" type and "corrected" state
+    """
+    {"embargo": "#DATE+3#"}
+    """
+    Then we get OK response
+    When we enqueue published
+    When we get "/publish_queue"
+    Then we get list with 2 items
+    """
+    {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}},
+                {"subscriber_id": "123", "publishing_action": "corrected", "content_type": "text", "destination":{"name":"email"}}]}
+    """
+    When we get "/published"
+    Then we validate the published item expiry to be after publish expiry set in desk settings 4320
+    And we check if article has Embargo and Ed. Note of the article has embargo indication
+    When we publish "#archive._id#" with "correct" type and "corrected" state
+    """
+    {"embargo": null}
+    """
+    Then we get OK response
+    When we enqueue published
+    When we get "/published"
+    Then we validate the published item expiry to be after publish expiry set in desk settings 4320
+    When we get "/archive/#archive.123.take_package#"
+    """
+    {"ednote": ""}
+    """
+
+  @auth
   Scenario: Creating/Updating an item without a future Embargo should fail
     When we post to "/archive"
     """

--- a/features/embargo.feature
+++ b/features/embargo.feature
@@ -215,7 +215,6 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     """
     {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}}]}
     """
-    When embargo lapses for "#archive._id#"
     When we enqueue published
     And we publish "#archive._id#" with "correct" type and "corrected" state
     Then we get OK response
@@ -232,10 +231,54 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     Then we validate the published item expiry to be after publish expiry set in desk settings 4320
 
   @auth
+  Scenario: Publish an article with Embargo and embargo lapses
+    When we patch "/archive/123"
+    """
+    {"embargo": "#DATE+2#"}
+    """
+    And we publish "#archive._id#" with "publish" type and "published" state
+    Then we get OK response
+    And we get existing resource
+    """
+    {"_current_version": 3, "state": "published", "task":{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}
+    """
+    And we get expiry for schedule and embargo content 4320 minutes after "#archive_publish.embargo#"
+    And we check if article has Embargo and Ed. Note of the article has embargo indication
+    When we get "/published"
+    Then we get existing resource
+    """
+    {"_items" : [{"_id": "123", "guid": "123", "headline": "test", "_current_version": 3, "state": "published",
+      "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}]}
+    """
+    And we check if article has Embargo and Ed. Note of the article has embargo indication
+    When we enqueue published
+    When we get "/publish_queue"
+    Then we get list with 1 items
+    """
+    {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}}]}
+    """
+    When embargo lapses for "#archive._id#"
+    And we publish "#archive._id#" with "correct" type and "corrected" state
+    Then we get OK response
+    When we enqueue published
+    When we get "/publish_queue"
+    Then we get list with 2 items
+    """
+    {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}},
+                {"subscriber_id": "123", "publishing_action": "corrected", "content_type": "text", "destination":{"name":"email"}}]}
+    """
+    When we get "/archive/#archive.123.take_package#"
+    """
+    {"ednote": ""}
+    """
+    When we get "/published"
+    Then we validate the published item expiry to be after publish expiry set in desk settings 4320
+
+  @auth
   Scenario: Creating/Updating an item without a future Embargo should fail
     When we post to "/archive"
     """
-    [{"guid": "text-article-with-embargo", "type": "text", "embargo": "#DATE-1#"}]
+    [{"guid": "text-article-with-embargo", "type": "text", "embargo": "#DATE-2#"}]
     """
     Then we get error 400
     """

--- a/features/groups.feature
+++ b/features/groups.feature
@@ -61,7 +61,7 @@ Feature: Groups
         Then we get deleted response
 
 
-    @auth @test
+    @auth
     Scenario: Unique name for group
       Given empty "groups"
       When we post to "/groups"

--- a/features/package_publish.feature
+++ b/features/package_publish.feature
@@ -747,7 +747,7 @@ Feature: Package Publishing
 
 
       @auth
-      @notification
+      @notification @test
       Scenario: Publish a package with two text stories and one digital subscriber
       Given empty "archive"
       Given "desks"

--- a/features/package_publish.feature
+++ b/features/package_publish.feature
@@ -747,7 +747,7 @@ Feature: Package Publishing
 
 
       @auth
-      @notification @test
+      @notification
       Scenario: Publish a package with two text stories and one digital subscriber
       Given empty "archive"
       Given "desks"

--- a/features/routing_rules.feature
+++ b/features/routing_rules.feature
@@ -238,7 +238,7 @@ Feature: Routing Scheme and Routing Rules
       Then we get response code 400
 
 
-    @auth @test
+    @auth
     Scenario: Create a valid Routing Scheme with an empty filter
       Given empty "desks"
 

--- a/features/user.feature
+++ b/features/user.feature
@@ -68,7 +68,7 @@ Feature: User Resource
         ["bar", "foo"]
         """
 
-    @auth @test
+    @auth
     Scenario: Fetch single user
         Given "users"
         """


### PR DESCRIPTION
- For `publish_schedule` and `embargo` validation is done using utc dates.
- Moved `deschedule` to `update` method so that correct state of `schedule_settings` are stored.
- `Embargo` can be modified while correcting the story.
- Remove `embargo` setting if embargo as lapsed or killed.