### PR TITLE
stop testing on travis python 3.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 
 python:
     - "3.4"
-    - "3.5"
 
 services:
     - elasticsearch


### PR DESCRIPTION
that version is not in any distro, so it's only slowing down travis