### PR TITLE
Replaced use of deprecated 'filtered', 'and', 'not' and 'query' filter (needed for SD-4323)

### DIFF
--- a/apps/archive/user_content.py
+++ b/apps/archive/user_content.py
@@ -25,10 +25,12 @@ class UserContentResource(Resource):
         'source': 'archive',
         'aggregations': aggregations,
         'elastic_filter': {
-            'and': [
-                {'not': {'exists': {'field': 'task.desk'}}},
-                {'not': {'term': {'version': 0}}},
-            ]
+            'bool': {
+                'must_not': [
+                    {'exists': {'field': 'task.desk'}},
+                    {'term': {'version': 0}},
+                ]
+            }
         }
     }
     resource_methods = ['GET', 'POST']

--- a/apps/archive_broadcast/broadcast.py
+++ b/apps/archive_broadcast/broadcast.py
@@ -127,7 +127,7 @@ class ArchiveBroadcastService(BaseService):
         """
         query = {
             'query': {
-                'filtered': {
+                'bool': {
                     'filter': {
                         'bool': {
                             'must': {'term': {'genre.name': BROADCAST_GENRE}},
@@ -248,9 +248,9 @@ class ArchiveBroadcastService(BaseService):
 
         query = {
             'query': {
-                'filtered': {
+                'bool': {
                     'filter': {
-                        'and': [
+                        'must': [
                             {'term': {'genre.name': BROADCAST_GENRE}},
                             {'term': {'broadcast.rewrite_id': item.get(config.ID_FIELD)}}
                         ]

--- a/apps/content_filters/content_filter.py
+++ b/apps/content_filters/content_filter.py
@@ -212,10 +212,10 @@ class ContentFilterService(BaseService):
             return expressions[0]
 
     def build_elastic_query(self, doc):
-        return {'query': {'filtered': {'query': self._get_elastic_query(doc)}}}
+        return {'query': {'bool': {'must': self._get_elastic_query(doc)}}}
 
     def build_elastic_not_filter(self, doc):
-        return {'query': {'filtered': {'query': self._get_elastic_query(doc, matching=False)}}}
+        return {'query': {'bool': {'must': self._get_elastic_query(doc, matching=False)}}}
 
     def _get_elastic_query(self, doc, matching=True):
         expressions_list = []

--- a/apps/content_filters/content_filter_tests.py
+++ b/apps/content_filters/content_filter_tests.py
@@ -221,7 +221,7 @@ class RetrievingDataTests(ContentFilterTests):
     def test_build_elastic_query_using_like_filter_single_filter_condition(self):
         doc = {'content_filter': [{"expression": {"fc": [1]}}], 'name': 'pf-1'}
         with self.app.app_context():
-            query = {'query': {'filtered': {'query': self.f._get_elastic_query(doc)}}}
+            query = {'query': {'bool': {'must': self.f._get_elastic_query(doc)}}}
             self.req.args = {'source': json.dumps(query)}
             docs = superdesk.get_resource_service('archive').get(req=self.req, lookup=None)
             doc_ids = [d['_id'] for d in docs]
@@ -233,7 +233,7 @@ class RetrievingDataTests(ContentFilterTests):
     def test_build_elastic_query_using_like_filter_single_content_filter(self):
         doc = {'content_filter': [{"expression": {"pf": [1]}}], 'name': 'pf-1'}
         with self.app.app_context():
-            query = {'query': {'filtered': {'query': self.f._get_elastic_query(doc)}}}
+            query = {'query': {'bool': {'must': self.f._get_elastic_query(doc)}}}
             self.req.args = {'source': json.dumps(query)}
             docs = superdesk.get_resource_service('archive').get(req=self.req, lookup=None)
             doc_ids = [d['_id'] for d in docs]
@@ -245,7 +245,7 @@ class RetrievingDataTests(ContentFilterTests):
     def test_build_elastic_query_using_like_filter_multi_filter_condition(self):
         doc = {'content_filter': [{"expression": {"fc": [1]}}, {"expression": {"fc": [2]}}], 'name': 'pf-1'}
         with self.app.app_context():
-            query = {'query': {'filtered': {'query': self.f._get_elastic_query(doc)}}}
+            query = {'query': {'bool': {'must': self.f._get_elastic_query(doc)}}}
             self.req.args = {'source': json.dumps(query)}
             docs = superdesk.get_resource_service('archive').get(req=self.req, lookup=None)
             doc_ids = [d['_id'] for d in docs]
@@ -258,7 +258,7 @@ class RetrievingDataTests(ContentFilterTests):
     def test_build_mongo_query_using_like_filter_multi_content_filter(self):
         doc = {'content_filter': [{"expression": {"pf": [1]}}, {"expression": {"fc": [2]}}], 'name': 'pf-1'}
         with self.app.app_context():
-            query = {'query': {'filtered': {'query': self.f._get_elastic_query(doc)}}}
+            query = {'query': {'bool': {'must': self.f._get_elastic_query(doc)}}}
             self.req.args = {'source': json.dumps(query)}
             docs = superdesk.get_resource_service('archive').get(req=self.req, lookup=None)
             doc_ids = [d['_id'] for d in docs]
@@ -271,7 +271,7 @@ class RetrievingDataTests(ContentFilterTests):
     def test_build_elastic_query_using_like_filter_multi_filter_condition2(self):
         doc = {'content_filter': [{"expression": {"fc": [3, 4]}}, {"expression": {"fc": [1, 2]}}], 'name': 'pf-1'}
         with self.app.app_context():
-            query = {'query': {'filtered': {'query': self.f._get_elastic_query(doc)}}}
+            query = {'query': {'bool': {'must': self.f._get_elastic_query(doc)}}}
             self.req.args = {'source': json.dumps(query)}
             docs = superdesk.get_resource_service('archive').get(req=self.req, lookup=None)
             doc_ids = [d['_id'] for d in docs]
@@ -282,7 +282,7 @@ class RetrievingDataTests(ContentFilterTests):
         doc = {'content_filter': [{"expression": {"fc": [4, 3]}},
                                   {"expression": {"pf": [1], "fc": [2]}}], 'name': 'pf-1'}
         with self.app.app_context():
-            query = {'query': {'filtered': {'query': self.f._get_elastic_query(doc)}}}
+            query = {'query': {'bool': {'must': self.f._get_elastic_query(doc)}}}
             self.req.args = {'source': json.dumps(query)}
             docs = superdesk.get_resource_service('archive').get(req=self.req, lookup=None)
             doc_ids = [d['_id'] for d in docs]
@@ -292,7 +292,7 @@ class RetrievingDataTests(ContentFilterTests):
     def test_build_elastic_query_using_like_filter_multi_content_filter3(self):
         doc = {'content_filter': [{"expression": {"pf": [2]}}, {"expression": {"pf": [1], "fc": [2]}}], 'name': 'pf-1'}
         with self.app.app_context():
-            query = {'query': {'filtered': {'query': self.f._get_elastic_query(doc)}}}
+            query = {'query': {'bool': {'must': self.f._get_elastic_query(doc)}}}
             self.req.args = {'source': json.dumps(query)}
             docs = superdesk.get_resource_service('archive').get(req=self.req, lookup=None)
             doc_ids = [d['_id'] for d in docs]
@@ -302,17 +302,17 @@ class RetrievingDataTests(ContentFilterTests):
     def test_build_elastic_query_using_like_filter_multi_content_filter4(self):
         doc = {'content_filter': [{"expression": {"pf": [2]}}, {"expression": {"pf": [3]}}], 'name': 'pf-1'}
         with self.app.app_context():
-            query = {'query': {'filtered': {'query': self.f._get_elastic_query(doc)}}}
+            query = {'query': {'bool': {'must': self.f._get_elastic_query(doc)}}}
             self.req.args = {'source': json.dumps(query)}
             docs = superdesk.get_resource_service('archive').get(req=self.req, lookup=None)
             doc_ids = [d['_id'] for d in docs]
             self.assertEqual(1, docs.count())
             self.assertTrue('3' in doc_ids)
 
-    def test_build_elastic_query_using_like_filter_multi_content_filter4(self):
+    def test_build_elastic_query_using_like_filter_multi_content_filter5(self):
         doc = {'content_filter': [{"expression": {"pf": [4], "fc": [4]}}], 'name': 'pf-1'}
         with self.app.app_context():
-            query = {'query': {'filtered': {'query': self.f._get_elastic_query(doc)}}}
+            query = {'query': {'bool': {'must': self.f._get_elastic_query(doc)}}}
             self.req.args = {'source': json.dumps(query)}
             docs = superdesk.get_resource_service('archive').get(req=self.req, lookup=None)
             doc_ids = [d['_id'] for d in docs]

--- a/apps/content_filters/filter_condition_tests.py
+++ b/apps/content_filters/filter_condition_tests.py
@@ -84,7 +84,7 @@ class FilterConditionTests(SuperdeskTestCase):
             self.req.args = {'source': json.dumps({'query': {'bool': {'must_not': [elastic_translation]}}})}
         elif search_type == 'filter':
             self.req.args = {'source': json.dumps({'query': {
-                                                   'filtered': {
+                                                   'bool': {
                                                        'filter': {
                                                            'bool': {
                                                                'should': [elastic_translation]}}}}})}

--- a/apps/desks.py
+++ b/apps/desks.py
@@ -292,10 +292,11 @@ class SluglineDesksResource(Resource):
     datasource = {'source': 'published',
                   'search_backend': 'elastic',
                   'default_sort': [('slugline.phrase', 1), ("versioncreated", 0)],
-                  'elastic_filter': {"and": [{"range": {"versioncreated": {"gte": "now-24H"}}},
+                  'elastic_filter': {"bool": {
+                                     "must": [{"range": {"versioncreated": {"gte": "now-24H"}}},
                                              {"term": {"last_published_version": True}},
                                              {"term": {"type": "text"}}
-                                             ]}}
+                                             ]}}}
     resource_methods = ['GET']
     item_methods = []
 
@@ -409,12 +410,14 @@ class SluglineDeskService(BaseService):
         req = ParsedRequest()
         query = {
             'query': {
-                'filtered': {
+                'bool': {
                     'filter': {
-                        'and': [
-                            {'term': {'family_id': family_id}},
-                            {'term': {'task.desk': desk_id}},
-                        ]
+                        'bool': {
+                            'must:'[
+                                {'term': {'family_id': family_id}},
+                                {'term': {'task.desk': desk_id}},
+                            ]
+                        }
                     }
                 }
             }

--- a/apps/highlights/service.py
+++ b/apps/highlights/service.py
@@ -25,10 +25,10 @@ def get_highlighted_items(highlights_id):
     highlight = get_resource_service('highlights').find_one(req=None, _id=highlights_id)
     query = {
         'query': {
-            'filtered': {'filter': {'and': [
+            'bool': {'filter': {'bool': {'must': [
                 {'range': {'versioncreated': {'gte': highlight.get('auto_insert', 'now/d')}}},
                 {'term': {'highlights': str(highlights_id)}},
-            ]}}
+            ]}}}
         },
         'sort': [
             {'versioncreated': 'desc'},
@@ -58,7 +58,7 @@ class HighlightsService(BaseService):
     def on_delete(self, doc):
         service = get_resource_service('archive')
         highlights_id = str(doc['_id'])
-        query = {'query': {'filtered': {'filter': {'term': {'highlights': highlights_id}}}}}
+        query = {'query': {'bool': {'filter': {'term': {'highlights': highlights_id}}}}}
         req = init_parsed_request(query)
         proposedItems = service.get(req=req, lookup=None)
         for item in proposedItems:

--- a/apps/io/search_ingest.py
+++ b/apps/io/search_ingest.py
@@ -110,5 +110,5 @@ class SearchIngestService(superdesk.Service):
 
     def _get_query(self, req):
         args = getattr(req, 'args', {})
-        query = json.loads(args.get('source')) if args.get('source') else {'query': {'filtered': {}}}
+        query = json.loads(args.get('source')) if args.get('source') else {'query': {'bool': {}}}
         return query

--- a/apps/legal_archive/commands.py
+++ b/apps/legal_archive/commands.py
@@ -393,13 +393,15 @@ class ImportLegalArchiveCommand(superdesk.Command):
         """
         query = {
             'query': {
-                'filtered': {
+                'bool': {
                     'filter': {
-                        'and': [
-                            {'range': {'expiry': {'lt': 'now'}}},
-                            {'term': {'moved_to_legal': False}},
-                            {'not': {'term': {'state': CONTENT_STATE.SCHEDULED}}}
-                        ]
+                        'bool': {
+                            'must': [
+                                {'range': {'expiry': {'lt': 'now'}}},
+                                {'term': {'moved_to_legal': False}}
+                            ],
+                            'must_not': {'term': {'state': CONTENT_STATE.SCHEDULED}}
+                        }
                     }
                 }
             }

--- a/apps/packages/takes_package_service.py
+++ b/apps/packages/takes_package_service.py
@@ -274,7 +274,7 @@ class TakesPackageService():
             takes = [ref.get(RESIDREF) for ref in refs if ref.get(SEQUENCE) < sequence]
             # elastic filter for the archive resource filters out the published items
             archive_service = get_resource_service(ARCHIVE)
-            query = {'query': {'filtered': {'filter': {'terms': {'_id': takes}}}}}
+            query = {'query': {'bool': {'filter': {'terms': {'_id': takes}}}}}
             request = ParsedRequest()
             request.args = {'source': json.dumps(query)}
             items = archive_service.get(req=request, lookup=None)

--- a/apps/publish/content/tests.py
+++ b/apps/publish/content/tests.py
@@ -677,9 +677,9 @@ class ArchivePublishTestCase(SuperdeskTestCase):
 
     def test_maintain_latest_version_for_published(self):
         def get_publish_items(item_id, last_version):
-            query = {'query': {'filtered': {'filter': {'and': [
+            query = {'query': {'bool': {'filter': {'bool': {'must':[
                     {'term': {'item_id': item_id}}, {'term': {LAST_PUBLISHED_VERSION: last_version}}
-            ]}}}}
+            ]}}}}}
             request = ParsedRequest()
             request.args = {'source': json.dumps(query), 'aggregations': 0}
             return self.app.data.find(PUBLISHED, req=request, lookup=None)

--- a/apps/publish/enqueue/enqueue_service.py
+++ b/apps/publish/enqueue/enqueue_service.py
@@ -110,8 +110,8 @@ class EnqueueService:
         """
         published_service = get_resource_service('published')
         req = ParsedRequest()
-        query = {'query': {'filtered': {'filter': {'and': [{'term': {QUEUE_STATE: PUBLISH_STATE.QUEUED}},
-                                                           {'term': {'item_id': package['item_id']}}]}}},
+        query = {'query': {'bool': {'filter': {'bool': {"must": [{'term': {QUEUE_STATE: PUBLISH_STATE.QUEUED}},
+                                                           {'term': {'item_id': package['item_id']}}]}}}},
                  'sort': [{'publish_sequence_no': 'desc'}]}
         req.args = {'source': json.dumps(query)}
         req.max_results = 1000

--- a/apps/publish/published_item.py
+++ b/apps/publish/published_item.py
@@ -230,7 +230,7 @@ class PublishedItemService(BaseService):
 
     def get_other_published_items(self, _id):
         try:
-            query = {'query': {'filtered': {'filter': {'term': {'item_id': _id}}}}}
+            query = {'query': {'bool': {'filter': {'term': {'item_id': _id}}}}}
             request = ParsedRequest()
             request.args = {'source': json.dumps(query)}
             return super().get(req=request, lookup=None)
@@ -241,7 +241,7 @@ class PublishedItemService(BaseService):
         """ Returns all the published and rewritten take stories for the same event """
         try:
             query = {'query':
-                     {'filtered':
+                     {'bool':
                       {'filter':
                        {'bool':
                         {'must': [
@@ -266,7 +266,7 @@ class PublishedItemService(BaseService):
         """
         try:
             query = {'query':
-                     {'filtered':
+                     {'bool':
                       {'filter':
                        {'bool':
                         {'must': [
@@ -361,12 +361,14 @@ class PublishedItemService(BaseService):
             try:
                 query = {
                     'query': {
-                        'filtered': {
+                        'bool': {
                             'filter': {
-                                'and': [
-                                    {'terms': {'item_id': item_ids}},
-                                    {'term': {'moved_to_legal': move_to_legal}}
-                                ]
+                                'bool': {
+                                    'must': [
+                                        {'terms': {'item_id': item_ids}},
+                                        {'term': {'moved_to_legal': move_to_legal}}
+                                    ]
+                                }
                             }
                         }
                     }

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -1779,12 +1779,14 @@ def validate_routed_item(context, rule_name, is_routed, is_transformed=False):
     def validate_rule(action, state):
         for destination in rule.get('actions', {}).get(action, []):
             query = {
-                'and': [
-                    {'term': {'ingest_id': str(data['ingest'])}},
-                    {'term': {'task.desk': str(destination['desk'])}},
-                    {'term': {'task.stage': str(destination['stage'])}},
-                    {'term': {'state': state}}
-                ]
+                'bool': {
+                    'must': [
+                        {'term': {'ingest_id': str(data['ingest'])}},
+                        {'term': {'task.desk': str(destination['desk'])}},
+                        {'term': {'task.stage': str(destination['stage'])}},
+                        {'term': {'state': state}}
+                    ]
+                }
             }
             item = get_archive_items(query) + get_published_items(query)
 

--- a/tests/elasticsearch_settings_test.py
+++ b/tests/elasticsearch_settings_test.py
@@ -42,8 +42,8 @@ class ElasticSearchSettingsTest(TestCase):
     def test_query_prefix_soccer(self):
         query = {
             'query': {
-                'filtered': {
-                    'query': {
+                'bool': {
+                    'must': {
                         'match_phrase_prefix': {
                             'slugline.phrase': 'soccer'
                         }
@@ -65,8 +65,8 @@ class ElasticSearchSettingsTest(TestCase):
     def test_query_prefix_soccer_england(self):
         query = {
             'query': {
-                'filtered': {
-                    'query': {
+                'bool': {
+                    'must': {
                         'match_phrase_prefix': {
                             'slugline.phrase': 'soccer england'
                         }
@@ -87,8 +87,8 @@ class ElasticSearchSettingsTest(TestCase):
     def test_query_prefix_soccer_england_result_without_forward_slash(self):
         query = {
             'query': {
-                'filtered': {
-                    'query': {
+                'bool': {
+                    'must': {
                         'match_phrase_prefix': {
                             'slugline.phrase': 'soccer-england result'
                         }
@@ -107,8 +107,8 @@ class ElasticSearchSettingsTest(TestCase):
     def test_query_prefix_soccer_england_result_with_forward_slash(self):
         query = {
             'query': {
-                'filtered': {
-                    'query': {
+                'bool': {
+                    'must': {
                         'match_phrase_prefix': {
                             'slugline.phrase': 'soccer england/result'
                         }


### PR DESCRIPTION
The 'bool' query is used to replace them, see
https://www.elastic.co/guide/en/elasticsearch/reference/2.0/breaking_20_query_dsl_changes.html#_literal_filtered_literal_query_and_literal_query_literal_filter_deprecated

SD-3996
SD-4323
