### PR TITLE
(fix)Fixing the prepopulate data for spellchecking and template name to be unique

### DIFF
--- a/apps/prepopulate/app_prepopulate_data.json
+++ b/apps/prepopulate/app_prepopulate_data.json
@@ -41,7 +41,7 @@
                     "type" : "bool",
                     "enabled" : true
                 },
-                "spellcheck:status" : {
+                "spellchecker:status" : {
                     "default": true,
                     "type" : "bool",
                     "enabled" : true
@@ -63,7 +63,7 @@
             "username": "admin4",
             "role": "-id Editor role-",
             "user_preferences": {
-                "spellcheck:status" : {
+                "spellchecker:status" : {
                     "default": true,
                     "type" : "bool",
                     "enabled" : true
@@ -85,7 +85,7 @@
             "username": "admin3",
             "role": "-id Writer role-",
             "user_preferences": {
-                "spellcheck:status" : {
+                "spellchecker:status" : {
                     "default": true,
                     "type" : "bool",
                     "enabled" : true
@@ -107,7 +107,7 @@
             "username": "admin2",
             "role": "-id Writer role-",
             "user_preferences": {
-                "spellcheck:status" : {
+                "spellchecker:status" : {
                     "default": true,
                     "type" : "bool",
                     "enabled" : true
@@ -129,7 +129,7 @@
             "username": "admin1",
             "role": "-id Superadmin role-",
             "user_preferences": {
-                "spellcheck:status" : {
+                "spellchecker:status" : {
                     "default": true,
                     "type" : "bool",
                     "enabled" : true

--- a/features/templates.feature
+++ b/features/templates.feature
@@ -265,10 +265,22 @@ Feature: Templates
         Then we get error 400
         """
         {"_error": {"code": 400, "message": "Insertion failure: 1 document(s) contain(s) error(s)"},
-         "_issues": {"template_name": "value 'personal' is not unique"},
+         "_issues": {"template_name": "Template Name is not unique"},
          "_status": "ERR"
         }
         """
+        When we post to "content_templates"
+        """
+        {"template_name": "PERSONAL", "template_type": "create", "template_desk": null, "data": {"body_footer": "test"}}
+        """
+        Then we get error 400
+        """
+        {"_error": {"code": 400, "message": "Insertion failure: 1 document(s) contain(s) error(s)"},
+         "_issues": {"template_name": "Template Name is not unique"},
+         "_status": "ERR"
+        }
+        """
+
 
     @auth
     Scenario: Validate unique name on desk template
@@ -303,7 +315,21 @@ Feature: Templates
         Then we get error 400
         """
         {"_error": {"code": 400, "message": "Insertion failure: 1 document(s) contain(s) error(s)"},
-         "_issues": {"template_name": ["value 'desk' is not unique", "value 'desk' is not unique"]},
+         "_issues": {"is_public": "Template Name is not unique", "template_name": "Template Name is not unique"},
+         "_status": "ERR"
+        }
+        """
+        When we post to "content_templates"
+        """
+        {
+         "template_name": "Desk", "template_type": "create", "data": {"body_footer": "test"},
+         "template_desk": "#desks._id#", "template_stage": "#desks.incoming_stage#", "is_public": true
+         }
+        """
+        Then we get error 400
+        """
+        {"_error": {"code": 400, "message": "Insertion failure: 1 document(s) contain(s) error(s)"},
+         "_issues": {"is_public": "Template Name is not unique", "template_name": "Template Name is not unique"},
          "_status": "ERR"
         }
         """
@@ -346,7 +372,22 @@ Feature: Templates
         """
         Then we get error 400
         """
-        {"_issues": {"template_name": "value 'template' is not unique"},
+        {"_issues": {"is_public": "Template Name is not unique"},
+         "_status": "ERR"
+        }
+        """
+        When we patch "content_templates/#content_templates._id#"
+        """
+        {"template_name": "TEMPLATE"}
+        """
+        Then we get OK response
+        When we patch "content_templates/#content_templates._id#"
+        """
+        {"is_public": true}
+        """
+        Then we get error 400
+        """
+        {"_issues": {"is_public": "Template Name is not unique"},
          "_status": "ERR"
         }
         """

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -53,9 +53,11 @@ DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 def test_json(context):
     try:
         response_data = json.loads(context.response.get_data())
+        print('response', response_data)
     except Exception:
         fail_and_print_body(context.response, 'response is not valid json')
     context_data = json.loads(apply_placeholders(context, context.text))
+    print('context', context_data)
     assert_equal(json_match(context_data, response_data), True,
                  msg=str(context_data) + '\n != \n' + str(response_data))
     return response_data
@@ -813,9 +815,11 @@ def step_impl_then_get_next_take(context, new_take):
 
 @then('we get error {code}')
 def step_impl_then_get_error(context, code):
+    print('*********************')
     expect_status(context.response, int(code))
     if context.text:
         test_json(context)
+    print('*********************')
 
 
 @then('we get list with {total_count} items')

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -53,11 +53,9 @@ DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 def test_json(context):
     try:
         response_data = json.loads(context.response.get_data())
-        print('response', response_data)
     except Exception:
         fail_and_print_body(context.response, 'response is not valid json')
     context_data = json.loads(apply_placeholders(context, context.text))
-    print('context', context_data)
     assert_equal(json_match(context_data, response_data), True,
                  msg=str(context_data) + '\n != \n' + str(response_data))
     return response_data
@@ -815,11 +813,9 @@ def step_impl_then_get_next_take(context, new_take):
 
 @then('we get error {code}')
 def step_impl_then_get_error(context, code):
-    print('*********************')
     expect_status(context.response, int(code))
     if context.text:
         test_json(context)
-    print('*********************')
 
 
 @then('we get list with {total_count} items')

--- a/superdesk/validator.py
+++ b/superdesk/validator.py
@@ -160,4 +160,11 @@ class SuperdeskValidator(Validator):
             _, auth_value = auth_field_and_value(self.resource)
             query = {'user': auth_value, 'is_public': False}
 
-        self._is_value_unique(unique, 'template_name', template_name, query)
+        query['template_name'] = re.compile('^{}$'.format(re.escape(template_name.strip())), re.IGNORECASE)
+
+        if self._id:
+            id_field = config.DOMAIN[self.resource]['id_field']
+            query[id_field] = {'$ne': self._id}
+
+        if superdesk.get_resource_service(self.resource).find_one(req=None, **query):
+            self._error(field, "Template Name is not unique")


### PR DESCRIPTION
@ioanpocol had to change the code so that template name is unique (case insensitive).
Also, depending on the order of the keys in the payload, the behave test "Validate unique name on desk template" used to fail.
i.e. in case of error, if `is_public` field is validated first then response from the server is
```
_issues": {"template_name": "Template Name is not unique"}
```
else the response is:
```
_issues": {"template_name": ["Template Name is not unique", "Template Name is not unique"]}
```
 
