### PR TITLE
Ninjs: keeps `copyrightnotice` field

### DIFF
--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -42,7 +42,7 @@ class NINJSFormatter(Formatter):
     """
     NINJS Formatter
     """
-    direct_copy_properties = ('versioncreated', 'usageterms', 'language', 'headline',
+    direct_copy_properties = ('versioncreated', 'usageterms', 'language', 'headline', 'copyrightnotice',
                               'urgency', 'pubstatus', 'mimetype', 'place', 'copyrightholder',
                               'body_text', 'body_html', 'profile', 'slugline', 'keywords')
 
@@ -78,6 +78,9 @@ class NINJSFormatter(Formatter):
         for copy_property in self.direct_copy_properties:
             if article.get(copy_property) is not None:
                 ninjs[copy_property] = article[copy_property]
+
+        if 'body_text' not in article and 'alt_text' in article:
+            ninjs['body_text'] = article['alt_text']
 
         if 'title' in article:
             ninjs['headline'] = article['title']

--- a/tests/publish/ninjs_formatter_test.py
+++ b/tests/publish/ninjs_formatter_test.py
@@ -332,6 +332,10 @@ class NinjsFormatterTest(TestCase):
             'associations': {
                 "embedded5346670761": {
                     "uri": "56ba77bde4b0568f54a1ce68",
+                    "alt_text": "alternative",
+                    "copyrightholder": "Edouard",
+                    "copyrightnotice": "Edited with Gimp",
+                    "usageterms": "indefinite-usage",
                     "type": "video",
                     "title": "Embed title",
                     "company": "Press Association",
@@ -359,6 +363,10 @@ class NinjsFormatterTest(TestCase):
                     "type": "video",
                     "version": "1",
                     "priority": 5,
+                    "body_text": "alternative",
+                    "copyrightholder": "Edouard",
+                    "copyrightnotice": "Edited with Gimp",
+                    "usageterms": "indefinite-usage",
                     "headline": "Embed title",
                     "organisation": [{"name": "Press Association"}],
                     "renditions": {


### PR DESCRIPTION
and publish `alt_text` field as `body_text`

SDPA-458