### PR TITLE
SDPA-456 : Increase soft time limit for emails

### DIFF
--- a/superdesk/emails/__init__.py
+++ b/superdesk/emails/__init__.py
@@ -22,7 +22,7 @@ from superdesk import get_resource_service
 EMAIL_TIMESTAMP_RESOURCE = 'email_timestamps'
 
 
-@celery.task(bind=True, max_retries=3, soft_time_limit=10)
+@celery.task(bind=True, max_retries=3, soft_time_limit=100)
 def send_email(self, subject, sender, recipients, text_body, html_body):
     msg = Message(subject, sender=sender, recipients=recipients)
     msg.body = text_body


### PR DESCRIPTION
[32m15:55:33 work.1 | [0mSoftTimeLimitExceeded() level=ERROR process=Worker-2
[32m15:55:33 work.1 | [0mTraceback (most recent call last):
[32m15:55:33 work.1 | [0m  File "/opt/superdesk/env/lib64/python3.4/site-packages/celery/app/trace.py", line 240, in trace_task
[32m15:55:33 work.1 | [0m    R = retval = fun(*args, **kwargs)
[32m15:55:33 work.1 | [0m  File "/opt/superdesk/env/lib64/python3.4/site-packages/superdesk/celery_app.py", line 113, in __call__
[32m15:55:33 work.1 | [0m    return super().__call__(*args, **kwargs)
[32m15:55:33 work.1 | [0m  File "/opt/superdesk/env/lib64/python3.4/site-packages/celery/app/trace.py", line 438, in __protected_call__
[32m15:55:33 work.1 | [0m    return self.run(*args, **kwargs)
[32m15:55:33 work.1 | [0m  File "/opt/superdesk/env/lib64/python3.4/site-packages/superdesk/emails/__init__.py", line 30, in send_email
[32m15:55:33 work.1 | [0m    return app.mail.send(msg)
[32m15:55:33 work.1 | [0m  File "/opt/superdesk/env/lib64/python3.4/site-packages/flask_mail.py", line 491, in send
[32m15:55:33 work.1 | [0m    with self.connect() as connection:
[32m15:55:33 work.1 | [0m  File "/opt/superdesk/env/lib64/python3.4/site-packages/flask_mail.py", line 144, in __enter__
[32m15:55:33 work.1 | [0m    self.host = self.configure_host()
[32m15:55:33 work.1 | [0m  File "/opt/superdesk/env/lib64/python3.4/site-packages/flask_mail.py", line 158, in configure_host
[32m15:55:33 work.1 | [0m    host = smtplib.SMTP(self.mail.server, self.mail.port)
[32m15:55:33 work.1 | [0m  File "/opt/rh/rh-python34/root/usr/lib64/python3.4/smtplib.py", line 242, in __init__
[32m15:55:33 work.1 | [0m    (code, msg) = self.connect(host, port)
[32m15:55:33 work.1 | [0m  File "/opt/rh/rh-python34/root/usr/lib64/python3.4/smtplib.py", line 321, in connect
[32m15:55:33 work.1 | [0m    self.sock = self._get_socket(host, port, self.timeout)
[32m15:55:33 work.1 | [0m  File "/opt/rh/rh-python34/root/usr/lib64/python3.4/smtplib.py", line 292, in _get_socket
[32m15:55:33 work.1 | [0m    self.source_address)
[32m15:55:33 work.1 | [0m  File "/opt/rh/rh-python34/root/usr/lib64/python3.4/socket.py", line 500, in create_connection
[32m15:55:33 work.1 | [0m    sock.connect(sa)
[32m15:55:33 work.1 | [0m  File "/opt/superdesk/env/lib64/python3.4/site-packages/billiard/pool.py", line 235, in soft_timeout_sighandler
[32m15:55:33 work.1 | [0m    raise SoftTimeLimitExceeded()
[32m15:55:33 work.1 | [0mbilliard.exceptions.SoftTimeLimitExceeded: SoftTimeLimitExceeded()
[32m15:55:33 work.1 | [0mTask superdesk.emails.send_email[5b130ef2-d99c-4bc9-a407-3a6c93d245b2] raised unexpected: SoftTimeLimitExceeded() level=ERROR process=MainProcess
[32m15:55:33 work.1 | [0mTraceback (most recent call last):