### PR TITLE
feat(desks): add content profiles setting to desk

### DIFF
--- a/apps/desks.py
+++ b/apps/desks.py
@@ -86,6 +86,12 @@ desks_schema = {
     'desk_metadata': {
         'type': 'dict',
     },
+
+    'content_profiles': {
+        'type': 'dict',
+    },
+
+    'default_content_profile': Resource.rel('content_types', type='string', nullable=True),
 }
 
 

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -89,6 +89,9 @@ def send_to(doc, update=None, desk_id=None, stage_id=None, user_id=None, default
             task['stage'] = desk.get(default_stage)
             destination_stage = get_resource_service('stages').find_one(req=None, _id=desk.get(default_stage))
 
+        if desk.get('default_content_profile'):
+            doc.setdefault('profile', desk['default_content_profile'])
+
     if stage_id:
         destination_stage = get_resource_service('stages').find_one(req=None, _id=stage_id)
         if not destination_stage:

--- a/features/desks.feature
+++ b/features/desks.feature
@@ -368,3 +368,28 @@ Feature: Desks
         """
         {"slugline": "x", "headline": "sports", "anpa_category": [{"qcode": "sport"}]}
         """
+
+    @auth
+    Scenario: Associate content profiles to desks
+        Given "ingest"
+        """
+        [{"_id": "ingest1", "type": "text"}]
+        """
+        And "content_types"
+        """
+        [{"_id": "foo"}]
+        """
+        When we post to "/desks"
+        """
+        {"name": "sports", "default_content_profile": "foo", "content_profiles": {"foo": 1}}
+        """
+        Then we get new resource
+
+        When we post to "/ingest/ingest1/fetch"
+        """
+        {"desk": "#desks._id#"}
+        """
+        Then we get new resource
+        """
+        {"profile": "foo"}
+        """


### PR DESCRIPTION
you can specify what content profiles should be available
when creating an item on a desk plus set what is default
content profile for items sent to/fetched to desk.

SD-4569