### PR TITLE
[SD-4683] - Remove mark-up from fields before validating the length

### DIFF
--- a/apps/validate/validate.py
+++ b/apps/validate/validate.py
@@ -11,6 +11,7 @@
 import logging
 import cerberus
 import superdesk
+from bs4 import BeautifulSoup
 from superdesk.metadata.item import ITEM_TYPE
 
 logger = logging.getLogger(__name__)
@@ -82,12 +83,27 @@ class ValidateService(superdesk.Service):
         lookup = {'act': doc['act'], 'type': doc[ITEM_TYPE]}
         return superdesk.get_resource_service('validators').get(req=None, lookup=lookup)
 
+    def _sanitize_fields(self, doc, validator):
+        '''
+        If maxlength or minlength is specified in the validator then
+        remove any markups from that field
+        :param doc: Article to be validated
+        :param validator: Validation rule
+        :return: updated article
+        '''
+        fields_to_check = ['minlength', 'maxlength']
+        schema = validator.get('schema', {})
+        for field in schema:
+            if doc.get(field) and any(k in schema[field] for k in fields_to_check):
+                doc[field] = BeautifulSoup(doc[field], 'html.parser').get_text()
+
     def _validate(self, doc, **kwargs):
         lookup = {'act': doc['act'], 'type': doc[ITEM_TYPE]}
         use_headline = kwargs and 'headline' in kwargs
         validators = superdesk.get_resource_service('validators').get(req=None, lookup=lookup)
         validators = self._get_validators(doc)
         for validator in validators:
+            self._sanitize_fields(doc['validate'], validator)
             v = SchemaValidator()
             v.allow_unknown = True
             v.validate(doc['validate'], validator['schema'])
@@ -96,7 +112,7 @@ class ValidateService(superdesk.Service):
             for e in error_list:
                 if error_list[e] == 'required field' or type(error_list[e]) is dict:
                     message = '{} is a required field'.format(e.upper())
-                elif 'min length is 1' in error_list[e]:
+                elif 'min length is 1' == error_list[e]:
                     message = '{} is a required field'.format(e.upper())
                 elif 'min length is' in error_list[e]:
                     message = '{} is too short'.format(e.upper())

--- a/features/validate.feature
+++ b/features/validate.feature
@@ -28,7 +28,7 @@ Feature: Validate
       """
     Then we get existing resource
     """
-    {"errors": "__any_value__"}
+    {"errors": []}
     """
 
   @auth
@@ -49,7 +49,14 @@ Feature: Validate
   Scenario: Validate field length short
     Given the "validators"
       """
-      [{"_id": "publish", "act": "publish", "type": "text", "schema":{"headline": {"type": "string", "minlength": 2, "maxlength": 55}}}]
+      [{"_id": "publish",
+        "act": "publish",
+        "type": "text",
+        "schema":{
+          "headline": {
+            "type": "string",
+            "minlength": 2,
+            "maxlength": 55}}}]
       """
     When we post to "/validate"
       """
@@ -58,6 +65,50 @@ Feature: Validate
     Then we get existing resource
     """
     {"errors": ["HEADLINE is too short"]}
+    """
+
+  @auth
+  Scenario: Validate field minimum length fails
+    Given the "validators"
+      """
+      [{"_id": "publish",
+        "act": "publish",
+        "type": "text",
+        "schema":{
+          "headline": {
+            "type": "string",
+            "minlength": 2,
+            "required": true,
+            "maxlength": 55}}}]
+      """
+    When we post to "/validate"
+      """
+      {"act": "publish", "type": "text", "validate": {"headline": "<p></p>"}}
+      """
+    Then we get existing resource
+    """
+    {"errors": ["HEADLINE is too short"]}
+    """
+
+  @auth
+  Scenario: Validate field maximum length passes
+    Given the "validators"
+      """
+      [{"_id": "publish",
+        "act": "publish",
+        "type": "text",
+        "schema":{
+          "headline": {
+            "type": "string",
+            "maxlength": 9}}}]
+      """
+    When we post to "/validate"
+      """
+      {"act": "publish", "type": "text", "validate": {"headline": "<p>123456789</p>"}}
+      """
+    Then we get existing resource
+    """
+    {"errors": []}
     """
 
   @auth
@@ -101,7 +152,7 @@ Feature: Validate
       """
     Then we get existing resource
     """
-    {"errors": "__any_value__"}
+    {"errors": []}
     """
   @auth
   Scenario: Missing validator


### PR DESCRIPTION
- Client side character count ignores html markup
- Server side validation now will remove markup if length is checked 