### PR TITLE
[ingest] fixed ingestion post processing when qcode is not a number

### DIFF
--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -308,7 +308,7 @@ def process_iptc_codes(item, provider):
             return False
 
         for subject in item['subject']:
-            if 'qcode' in subject and len(subject['qcode']) == 8:
+            if 'qcode' in subject and len(subject['qcode']) == 8 and subject['qcode'].isdigit():
                 top_qcode = subject['qcode'][:2] + '000000'
                 if not iptc_already_exists(top_qcode):
                     item['subject'].append({'qcode': top_qcode, 'name': subject_codes[top_qcode]})


### PR DESCRIPTION
In some cases, qcode may not be a number. This happen for NTB NITF
parser because the requested behaviour imply that category is stored in
item['subject'] with its name as qcode.
If the name is 8 characters long (e.g. "Utenriks") the post processing
is crashing, trying to find a unexisting key.

This commit check that the qcode is actually a number to avoid this
crash.

SDNTB-219