### PR TITLE
[SD-4784] Remove take key validator macro

### DIFF
--- a/superdesk/macros/take_key_validator.py
+++ b/superdesk/macros/take_key_validator.py
@@ -21,5 +21,5 @@ def validate(item, **kwargs):
 name = 'take_key_validator'
 label = 'validate take key'
 callback = validate
-access_type = 'frontend'
+access_type = 'backend'
 action_type = 'direct'


### PR DESCRIPTION
Make it a backend macro so it doesn't appear in the UI, but it is still available for tests