### PR TITLE
[SD-4827] - Concurrency issues

### DIFF
--- a/apps/archive/__init__.py
+++ b/apps/archive/__init__.py
@@ -112,6 +112,6 @@ def init_app(app):
     superdesk.intrinsic_privilege(ArchiveLinkResource.endpoint_name, method=['POST'])
 
 
-@celery.task()
+@celery.task(soft_time_limit=600)
 def content_expiry():
     RemoveExpiredContent().run()

--- a/apps/archive/commands.py
+++ b/apps/archive/commands.py
@@ -22,7 +22,6 @@ from superdesk.metadata.item import ITEM_STATE, CONTENT_STATE, ITEM_TYPE, CONTEN
 from superdesk.metadata.packages import PACKAGE_TYPE, TAKES_PACKAGE
 from superdesk.lock import lock, unlock
 from superdesk import get_resource_service
-
 logger = logging.getLogger(__name__)
 
 
@@ -34,14 +33,15 @@ class RemoveExpiredContent(superdesk.Command):
         self.log_msg = 'Expiry Time: {}.'.format(now)
         logger.info('{} Starting to remove expired content at.'.format(self.log_msg))
         lock_name = get_lock_id('archive', 'remove_expired')
-        if not lock(lock_name, '', expire=600):
+
+        if not lock(lock_name, expire=610):
             logger.info('{} Remove expired content task is already running.'.format(self.log_msg))
             return
         try:
             logger.info('{} Removing expired content for expiry.'.format(self.log_msg))
             self._remove_expired_items(now)
         finally:
-            unlock(lock_name, '')
+            unlock(lock_name)
 
         push_notification('content:expired')
         logger.info('{} Completed remove expired content.'.format(self.log_msg))

--- a/apps/item_lock/components/item_lock.py
+++ b/apps/item_lock/components/item_lock.py
@@ -20,7 +20,6 @@ from eve.utils import config
 from apps.common.components.base_component import BaseComponent
 from apps.common.models.utils import get_model
 from apps.content import push_content_notification
-
 from ..models.item import ItemModel
 
 
@@ -51,7 +50,7 @@ class ItemLock(BaseComponent):
             raise SuperdeskApiError.notFoundError()
 
         # get the lock it not raise forbidden exception
-        if not lock(lock_id, "", 5):
+        if not lock(lock_id, expire=5):
             raise SuperdeskApiError.forbiddenError(message="Item is locked by another user.")
 
         try:

--- a/apps/legal_archive/__init__.py
+++ b/apps/legal_archive/__init__.py
@@ -35,11 +35,11 @@ def init_app(app):
     privilege(name=LEGAL_ARCHIVE_NAME, label='Legal Archive', description='Read from legal archive')
 
 
-@celery.task
+@celery.task(soft_time_limit=300)
 def import_legal_publish_queue():
     ImportLegalPublishQueueCommand().run()
 
 
-@celery.task
+@celery.task(soft_time_limit=1800)
 def import_legal_archive():
     ImportLegalArchiveCommand().run()

--- a/apps/legal_archive/commands.py
+++ b/apps/legal_archive/commands.py
@@ -332,12 +332,12 @@ class ImportLegalPublishQueueCommand(superdesk.Command):
     def run(self):
         logger.info('Import to Legal Publish Queue')
         lock_name = get_lock_id('legal_archive', 'import_legal_publish_queue')
-        if not lock(lock_name, '', expire=600):
+        if not lock(lock_name, expire=310):
             return
         try:
             LegalArchiveImport().import_legal_publish_queue()
         finally:
-            unlock(lock_name, '')
+            unlock(lock_name)
 
 
 class ImportLegalArchiveCommand(superdesk.Command):
@@ -358,7 +358,7 @@ class ImportLegalArchiveCommand(superdesk.Command):
         logger.info('Import to Legal Archive')
         lock_name = get_lock_id('legal_archive', 'import_to_legal_archive')
         page_size = int(page_size) if page_size else self.default_page_size
-        if not lock(lock_name, '', expire=1800):
+        if not lock(lock_name, expire=1810):
             return
         try:
             legal_archive_import = LegalArchiveImport()
@@ -384,7 +384,7 @@ class ImportLegalArchiveCommand(superdesk.Command):
         except:
             logger.exception('Failed to import into legal archive.')
         finally:
-            unlock(lock_name, '')
+            unlock(lock_name)
 
     def get_expired_items(self, page_size):
         """

--- a/superdesk/io/__init__.py
+++ b/superdesk/io/__init__.py
@@ -103,6 +103,6 @@ def update_ingest():
     UpdateIngest().run()
 
 
-@celery.task
+@celery.task(soft_time_limit=600)
 def gc_ingest():
     RemoveExpiredContent().run()

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -18,7 +18,7 @@ from werkzeug.exceptions import HTTPException
 import superdesk
 from superdesk.activity import ACTIVITY_EVENT, notify_and_add_activity
 from superdesk.celery_app import celery
-from superdesk.celery_task_utils import get_lock_id, get_host_id
+from superdesk.celery_task_utils import get_lock_id
 from superdesk.errors import ProviderError
 from superdesk.io.register import registered_feeding_services, registered_feed_parsers
 from superdesk.io.iptc import subject_codes
@@ -215,9 +215,8 @@ def update_provider(self, provider, rule_set=None, routing_scheme=None):
     """
 
     lock_name = get_lock_id('ingest', provider['name'], provider[superdesk.config.ID_FIELD])
-    host_name = get_host_id(self)
 
-    if not lock(lock_name, host_name, expire=1800):
+    if not lock(lock_name, expire=1810):
         return
 
     try:
@@ -251,7 +250,7 @@ def update_provider(self, provider, rule_set=None, routing_scheme=None):
         if LAST_ITEM_UPDATE in update:  # Only push a notification if there has been an update
             push_notification('ingest:update', provider_id=str(provider[superdesk.config.ID_FIELD]))
     finally:
-        unlock(lock_name, host_name)
+        unlock(lock_name)
 
 
 def process_anpa_category(item, provider):

--- a/superdesk/lock.py
+++ b/superdesk/lock.py
@@ -5,6 +5,7 @@ import mongolock
 from werkzeug.local import LocalProxy
 from flask import current_app as app
 from superdesk.logging import logger
+import socket
 
 
 _lock_resource_settings = {
@@ -23,7 +24,7 @@ _lock = LocalProxy(_get_lock)
 
 
 def get_host():
-    return 'pid:{pid}'.format(pid=os.getpid())
+    return 'hostid:{} pid:{}'.format(socket.gethostname(), os.getpid())
 
 
 def lock(task, host=None, expire=300, timeout=None):

--- a/tests/publish/publish_content_tests.py
+++ b/tests/publish/publish_content_tests.py
@@ -112,7 +112,6 @@ class TransmitItemsTestCase(TestCase):
     def test_logs_error_even_when_marking_failed_items_fails(self, *mocks):
         fake_get_service = mocks[0]
         fake_get_service().patch.side_effect = Exception('Error patching item')
-        fake_get_service().find_one.return_value = MagicMock(name='orig_item')
         fake_get_service().system_update.side_effect = Exception('Update error')
 
         item_1 = {
@@ -126,6 +125,7 @@ class TransmitItemsTestCase(TestCase):
         }
         queue_items = [item_1]
 
+        fake_get_service().find_one.return_value = item_1
         self.func_under_test(queue_items)
         fake_logger = mocks[1]
         expected_msg = 'Failed to set the state for failed publish queue item item_1.'


### PR DESCRIPTION
We have been observing occasional duplicate queue entries for the published stories and duplicate transmissions of the same queue item. Changed locks for enqueue and transmit workers to have the same lock across the hosts

`transmit_subscriber_items` function requires a refactoring. The list of same queue items could be retrieved by multiple workers before the lock is created. That's why we see multiple transmissions.
 
As a quick fix we have created a second check for the status of published and queue items before processing them which looks like solved the immediate problem.. 

