### PR TITLE
[SD-4838] (fix) Modified the headline maxlength validation to 42 characters.

### DIFF
--- a/apps/prepopulate/data_initialization/validators.json
+++ b/apps/prepopulate/data_initialization/validators.json
@@ -9,7 +9,7 @@
                 "required": true,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -84,7 +84,7 @@
                 "required": true,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -159,7 +159,7 @@
                 "required": true,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -229,7 +229,7 @@
                 "required": true,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -299,7 +299,7 @@
                 "required": true,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -369,7 +369,7 @@
                 "required": true,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -439,7 +439,7 @@
                 "required": true,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -529,7 +529,7 @@
                 "required": true,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -619,7 +619,7 @@
                 "required": false,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -703,7 +703,7 @@
                 "required": false,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -779,7 +779,7 @@
                 "required": false,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -855,7 +855,7 @@
                 "required": false,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -931,7 +931,7 @@
                 "required": false,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -1007,7 +1007,7 @@
                 "required": false,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -1083,7 +1083,7 @@
                 "required": false,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -1159,7 +1159,7 @@
                 "required": false,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "type": {
                 "type": "string",
@@ -1214,7 +1214,7 @@
                 "required": false,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "type": {
                 "type": "string",
@@ -1269,7 +1269,7 @@
                 "required": false,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "type": {
                 "type": "string",
@@ -1405,7 +1405,7 @@
                 "required": true,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",
@@ -1467,7 +1467,7 @@
                 "required": true,
                 "nullable": false,
                 "empty": false,
-                "maxlength": 64
+                "maxlength": 42
             },
             "abstract": {
                 "type": "string",


### PR DESCRIPTION
If validators update is required for any instance. Please run the following command.

`app:initialize_data --entity-name=validators --file<location>`
where `location` points to the `validators.json file` in the folder `server/data`

This depends on https://github.com/superdesk/superdesk-client-core/pull/656