### PR TITLE
[SD-4785] (fix) Refactor Expiry of items and legal archive process.

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -662,11 +662,12 @@ class ArchiveService(BaseService):
         if updates.get('force_unlock', False):
             del updates['force_unlock']
 
-    def get_expired_items(self, expiry_datetime):
+    def get_expired_items(self, expiry_datetime, invalid_only=False):
         """
         Get the expired items where content state is not scheduled
         and
         :param datetime expiry_datetime: expiry datetime
+        :param bool invalid_only: True only invalid items
         :return pymongo.cursor: expired non published items.
         """
         query = {
@@ -678,6 +679,11 @@ class ArchiveService(BaseService):
                 ]}
             ]
         }
+
+        if invalid_only:
+            query['$and'].append({'expiry_status': 'invalid'})
+        else:
+            query['$and'].append({'expiry_status': {'$ne': 'invalid'}})
 
         req = ParsedRequest()
         req.max_results = config.MAX_EXPIRY_QUERY_LIMIT

--- a/apps/archive/archive_test.py
+++ b/apps/archive/archive_test.py
@@ -429,13 +429,22 @@ class ExpiredArchiveContentTestCase(SuperdeskTestCase):
             self.app.data.insert('publish_queue', self.queue_items)
 
     def test_items_moved_to_legal_success(self):
-        result = self.class_under_test().check_if_items_imported_to_legal_archive(['item1', 'item2'])
-        self.assertEqual(result, True)
+        test_items = dict()
+        test_items['item1'] = self.published_items[0]
+        test_items['item2'] = self.published_items[1]
+        result = self.class_under_test().check_if_items_imported_to_legal_archive(test_items)
+        self.assertDictEqual(result, {})
 
     def test_items_moved_to_legal_fail_if_published_item_not_moved(self):
-        result = self.class_under_test().check_if_items_imported_to_legal_archive(['item2', 'item3'])
-        self.assertEqual(result, False)
+        test_items = dict()
+        test_items['item2'] = self.published_items[1]
+        test_items['item3'] = self.published_items[2]
+        result = self.class_under_test().check_if_items_imported_to_legal_archive(test_items)
+        self.assertIn('item3', result)
 
     def test_items_moved_to_legal_fail_if_published_queue_item_not_moved(self):
-        result = self.class_under_test().check_if_items_imported_to_legal_archive(['item1', 'item4'])
-        self.assertEqual(result, False)
+        test_items = dict()
+        test_items['item2'] = self.published_items[1]
+        test_items['item3'] = self.published_items[3]
+        result = self.class_under_test().check_if_items_imported_to_legal_archive(test_items)
+        self.assertIn('item3', result)

--- a/apps/archive/commands.py
+++ b/apps/archive/commands.py
@@ -13,7 +13,7 @@ from apps.content import push_expired_notification
 import superdesk
 import logging
 from eve.utils import config
-
+from copy import deepcopy
 from apps.packages import PackageService
 from superdesk.celery_task_utils import get_lock_id
 from superdesk.utc import utcnow
@@ -55,6 +55,9 @@ class RemoveExpiredContent(superdesk.Command):
         logger.info('{} Starting to remove published expired items.'.format(self.log_msg))
         archive_service = get_resource_service(ARCHIVE)
         published_service = get_resource_service('published')
+        items_to_remove = set()
+        items_to_be_archived = dict()
+        items_having_issues = dict()
 
         expired_items = list(archive_service.get_expired_items(expiry_datetime))
         if len(expired_items) == 0:
@@ -65,53 +68,78 @@ class RemoveExpiredContent(superdesk.Command):
         self.delete_spiked_items(expired_items)
 
         # get killed items
-        killed_items = [item for item in expired_items if item.get(ITEM_STATE) in {CONTENT_STATE.KILLED}]
+        killed_items = {item.get(config.ID_FIELD): item
+                        for item in expired_items if item.get(ITEM_STATE) in {CONTENT_STATE.KILLED}}
 
-        items_to_remove = set()
-        items_to_be_archived = set()
+        # check if killed items imported to legal
+        items_having_issues.update(self.check_if_items_imported_to_legal_archive(killed_items))
+
+        # filter out the killed items not imported to legal.
+        killed_items = {item_id: item for item_id, item in killed_items
+                        if item_id not in items_having_issues}
 
         # Get the not killed and spiked items
-        not_killed_items = [item for item in expired_items
-                            if item.get(ITEM_STATE) not in {CONTENT_STATE.KILLED, CONTENT_STATE.SPIKED}]
+        not_killed_items = {item.get(config.ID_FIELD): item for item in expired_items
+                            if item.get(ITEM_STATE) not in {CONTENT_STATE.KILLED, CONTENT_STATE.SPIKED}}
 
         log_msg_format = "{{'_id': {_id}, 'unique_name': {unique_name}, 'version': {_current_version}, " \
                          "'expired_on': {expiry}}}."
 
         # Processing items to expire
-        for item in not_killed_items:
-            item_id = item.get(config.ID_FIELD)
+        for item_id, item in not_killed_items.items():
             item.setdefault(config.VERSION, 1)
             item.setdefault('expiry', expiry_datetime)
             item.setdefault('unique_name', '')
             expiry_msg = log_msg_format.format(**item)
             logger.info('{} Processing expired item. {}'.format(self.log_msg, expiry_msg))
 
-            processed_items = set()
-            if item_id not in items_to_be_archived and self._can_remove_item(item, processed_items):
+            processed_items = dict()
+            if item_id not in items_to_be_archived and item_id not in items_having_issues and \
+                    self._can_remove_item(item, processed_items):
                 # item can be archived and removed from the database
                 logger.info('{} Removing item. {}'.format(self.log_msg, expiry_msg))
                 logger.info('{} Items to be removed. {}'.format(self.log_msg, processed_items))
-                items_to_be_archived = items_to_be_archived | processed_items
+                issues = self.check_if_items_imported_to_legal_archive(processed_items)
+                if issues:
+                    items_having_issues.update(issues)
+                else:
+                    items_to_be_archived.update(processed_items)
 
-        items_to_expire = items_to_be_archived | set([item.get(config.ID_FIELD) for item in killed_items
-                                                      if item.get(ITEM_STATE) == CONTENT_STATE.KILLED])
+        # all items to expire
+        items_to_expire = deepcopy(items_to_be_archived)
 
-        if not self.check_if_items_imported_to_legal_archive(list(items_to_expire)):
-            logger.exception('{} CANNOT EXPIRE ITEMS AS ITEMS ARE NOT MOVE TO LEGAL ARCHIVE.'.format(self.log_msg))
-            return
+        # check once again in items imported to legal
+        items_having_issues.update(self.check_if_items_imported_to_legal_archive(items_to_expire))
+        if items_having_issues:
+            # remove items not imported to legal
+            items_to_expire = {item_id: item for item_id, item in items_to_expire.items()
+                               if item_id not in items_having_issues}
+
+            # remove items not imported to legal from archived items
+            items_to_be_archived = {item_id: item for item_id, item in items_to_be_archived.items()
+                                    if item_id not in items_having_issues}
+
+            # items_to_be_archived might contain killed items
+            for item_id, item in items_to_be_archived.items():
+                if item.get(ITEM_STATE) == CONTENT_STATE.KILLED:
+                    killed_items[item_id] = item
+
+            # remove killed items from the items_to_be_archived
+            items_to_be_archived = {item_id: item for item_id, item in items_to_be_archived.items()
+                                    if item.get(ITEM_STATE) != CONTENT_STATE.KILLED}
 
         # move to archived collection
         logger.info('{} Archiving items.'.format(self.log_msg))
-        for item in items_to_be_archived:
-            self._move_to_archived(item)
+        for item_id, item in items_to_be_archived.items():
+            self._move_to_archived(item_id)
 
-        for item in killed_items:
+        for item_id, item in killed_items.items():
             # delete from the published collection and queue
             msg = log_msg_format.format(**item)
             try:
-                published_service.delete_by_article_id(item.get(config.ID_FIELD))
+                published_service.delete_by_article_id(item_id)
                 logger.info('{} Deleting killed item from published. {}'.format(self.log_msg, msg))
-                items_to_remove.add(item.get(config.ID_FIELD))
+                items_to_remove.add(item_id)
             except:
                 logger.exception('{} Failed to delete killed item from published. {}'.format(self.log_msg, msg))
 
@@ -120,6 +148,14 @@ class RemoveExpiredContent(superdesk.Command):
             archive_service.delete_by_article_ids(list(items_to_remove))
 
         push_expired_notification(items_to_expire)
+
+        for item_id, item in items_having_issues.items():
+            msg = log_msg_format.format(**item)
+            try:
+                archive_service.system_update(item.get(config.ID_FIELD), {'expiry_status': 'invalid'}, item)
+                logger.info('{} Setting item expiry status. {}'.format(self.log_msg, msg))
+            except:
+                logger.exception('{} Failed to set expiry status for item. {}'.format(self.log_msg, msg))
 
         logger.info('{} Deleting killed from archive.'.format(self.log_msg))
 
@@ -132,7 +168,7 @@ class RemoveExpiredContent(superdesk.Command):
         """
 
         if processed_item is None:
-            processed_item = set()
+            processed_item = dict()
 
         item_refs = []
         package_service = PackageService()
@@ -149,6 +185,12 @@ class RemoveExpiredContent(superdesk.Command):
             # If included in a package then check the package expiry.
             item_refs.extend([broadcast_item.get(config.ID_FIELD) for broadcast_item in broadcast_items])
 
+            if item.get('rewrite_of'):
+                item_refs.append(item.get('rewrite_of'))
+
+            if item.get('rewritten_by'):
+                item_refs.append(item.get('rewritten_by'))
+
         # get item reference where this referred
         item_refs.extend(package_service.get_linked_in_package_ids(item))
 
@@ -160,7 +202,7 @@ class RemoveExpiredContent(superdesk.Command):
             if item.get(config.ID_FIELD) in processed_item:
                 return is_expired
 
-            processed_item.add(item.get(config.ID_FIELD))
+            processed_item[item.get(config.ID_FIELD)] = item
             if item_refs:
                 archive_items = archive_service.get_from_mongo(req=None, lookup={'_id': {'$in': item_refs}})
                 for archive_item in archive_items:
@@ -170,26 +212,26 @@ class RemoveExpiredContent(superdesk.Command):
 
         return is_expired
 
-    def _move_to_archived(self, _id):
+    def _move_to_archived(self, item_id):
         """
         Moves all the published version of an article to archived.
         Deletes all published version of an article in the published collection
-        :param str _id: id of the document to be moved
+        :param str item_id: item_id of the document
         """
         published_service = get_resource_service('published')
         archived_service = get_resource_service('archived')
         archive_service = get_resource_service('archive')
 
-        published_items = list(published_service.get_from_mongo(req=None, lookup={'item_id': _id}))
+        published_items = list(published_service.get_from_mongo(req=None, lookup={'item_id': item_id}))
 
         try:
             if published_items:
                 archived_service.post(published_items)
                 logger.info('{} Archived published item'.format(self.log_msg))
-                published_service.delete_by_article_id(_id)
+                published_service.delete_by_article_id(item_id)
                 logger.info('{} Deleted published item.'.format(self.log_msg))
 
-            archive_service.delete_by_article_ids([_id])
+            archive_service.delete_by_article_ids([item_id])
             logger.info('{} Delete archive item.'.format(self.log_msg))
         except:
             failed_items = [item.get(config.ID_FIELD) for item in published_items]
@@ -207,46 +249,45 @@ class RemoveExpiredContent(superdesk.Command):
             if spiked_ids:
                 logger.warning('{} deleting spiked items: {}.'.format(self.log_msg, spiked_ids))
                 get_resource_service('archive').delete_by_article_ids(spiked_ids)
-            logger.info('{} deleted spiked items.'.format(self.log_msg))
+            logger.info('{} deleted spiked items. Count: {}.'.format(self.log_msg, len(spiked_ids)))
         except:
             logger.exception('{} Failed to delete spiked items.'.format(self.log_msg))
 
-    def check_if_items_imported_to_legal_archive(self, item_ids):
+    def check_if_items_imported_to_legal_archive(self, items_to_expire):
         """
         Checks if all items are moved to legal or not
-        :param list item_ids: list of item id to be verified
-        :param str log_msg: log message
-        :return bool: True if items in legal archive else false
+        :param dict items_to_expire:
+        :return dict: dict of items having issues.
         """
-        logger.info('{} checking for items in legal archive. Items: {}'.format(self.log_msg, item_ids))
+        logger.info('{} checking for items in legal archive. Items: {}'.format(self.log_msg,
+                                                                               items_to_expire.keys()))
 
         items_not_moved_to_legal = get_resource_service('published').\
-            get_published_items_by_moved_to_legal(item_ids, False)
+            get_published_items_by_moved_to_legal(list(items_to_expire.keys()), False)
 
+        items_not_moved = dict()
         if len(items_not_moved_to_legal) > 0:
-            logger.warning('{} Items are not moved to legal archive {}.'.format(self.log_msg,
-                                                                                set([item.get('item_id')
-                                                                                     for item in
-                                                                                     items_not_moved_to_legal])))
-            return False
+            publish_items = set([item.get('item_id') for item in items_not_moved_to_legal])
+            items_not_moved = {item_id: items_to_expire[item_id] for item_id in publish_items}
+            logger.warning('{} Items are not moved to legal archive {}.'.format(self.log_msg, publish_items))
 
+        # get all the
         lookup = {
             '$and': [
-                {'item_id': {'$in': item_ids}},
-                {'moved_to_legal': False},
+                {'item_id': {'$in': list(items_to_expire.keys())}},
+                {'moved_to_legal': False}
             ]
         }
 
         items_not_moved_to_legal = list(get_resource_service('publish_queue').get(req=None, lookup=lookup))
 
         if len(items_not_moved_to_legal) > 0:
+            publish_queue_items = set([item.get('item_id') for item in items_not_moved_to_legal])
+            items_not_moved.update({item_id: items_to_expire[item_id] for item_id in publish_queue_items})
             logger.warning('{} Items are not moved to legal publish queue {}.'.format(self.log_msg,
-                                                                                      set([item.get('item_id')
-                                                                                           for item in
-                                                                                           items_not_moved_to_legal])))
-            return False
+                                                                                      publish_queue_items))
 
-        return True
+        return items_not_moved
 
 
 superdesk.command('archive:remove_expired', RemoveExpiredContent())

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -144,6 +144,11 @@ ARCHIVE_SCHEMA_FIELDS = {
                 'security_exchange': not_analyzed
             }
         }
+    },
+    'expiry_status': {
+        'type': 'string',
+        'mapping': not_analyzed,
+        'nullable': True
     }
 }
 

--- a/apps/content_filters/content_filter/content_filter_resource.py
+++ b/apps/content_filters/content_filter/content_filter_resource.py
@@ -43,6 +43,10 @@ class ContentFilterResource(Resource):
         'is_global': {
             'type': 'boolean',
             'default': False
+        },
+        'is_archived_filter': {
+            'type': 'boolean',
+            'default': False
         }
     }
 

--- a/apps/publish/published_item.py
+++ b/apps/publish/published_item.py
@@ -35,8 +35,9 @@ logger = logging.getLogger(__name__)
 PUBLISHED = 'published'
 LAST_PUBLISHED_VERSION = 'last_published_version'
 QUEUE_STATE = 'queue_state'
-queue_states = ['pending', 'in_progress', 'queued']
-PUBLISH_STATE = namedtuple('PUBLISH_STATE', ['PENDING', 'IN_PROGRESS', 'QUEUED'])(*queue_states)
+queue_states = ['pending', 'in_progress', 'queued', 'queued_not_transmitted']
+PUBLISH_STATE = namedtuple('PUBLISH_STATE', ['PENDING', 'IN_PROGRESS', 'QUEUED',
+                                             'QUEUED_NOT_TRANSMITTED'])(*queue_states)
 
 published_item_fields = {
     'item_id': {

--- a/features/archived_kill.feature
+++ b/features/archived_kill.feature
@@ -80,6 +80,9 @@ Feature: Kill a content item in the (dusty) archive
     When we enqueue published
     And we get "/publish_queue"
     Then we get list with 1 items
+    When run import legal publish queue
+    And we get "/legal_publish_queue"
+    Then we get list with 0 items
     When we transmit items
     And run import legal publish queue
     And we expire items

--- a/features/content_filter.feature
+++ b/features/content_filter.feature
@@ -34,8 +34,8 @@ Feature: Content Filter
     """
 
   @auth
-  @vocabulary
-  Scenario: Add a new content filter without global filter value
+  @vocabulary @test
+  Scenario: Add a new content filter without global filter value but with archived flag
     Given empty "filter_conditions"
     When we post to "/filter_conditions" with success
     """
@@ -54,7 +54,23 @@ Feature: Content Filter
     {
       "_items":
         [
-          {"is_global": false}
+          {"name": "soccer", "is_global": false, "is_archived_filter": false}
+        ]
+    }
+    """
+    When we post to "/content_filters" with success
+    """
+    [{"content_filter": [{"expression": {"fc": ["#filter_conditions._id#"]}}],
+      "name": "soccer archived", "is_archived_filter": true}]
+    """
+    And we get "/content_filters"
+    Then we get list with 2 items
+    """
+    {
+      "_items":
+        [
+          {"name": "soccer", "is_global": false, "is_archived_filter": false},
+          {"name": "soccer archived", "is_global": false, "is_archived_filter": true}
         ]
     }
     """

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -2101,3 +2101,18 @@ def we_get_text_in_field(context, text, field):
 @then('we reset priority flag for updated articles')
 def we_get_reset_default_priority_for_updated_articles(context):
     context.app.config['RESET_PRIORITY_VALUE_FOR_UPDATE_ARTICLES'] = True
+
+
+@then('we mark the items not moved to legal')
+def we_mark_the_items_not_moved_to_legal(context):
+    with context.app.test_request_context(context.app.config['URL_PREFIX']):
+        ids = json.loads(apply_placeholders(context, context.text))
+        for item_id in ids:
+            get_resource_service('published').update_published_items(item_id, 'moved_to_legal', False)
+
+
+@when('we run import legal archive command')
+def we_run_import_legal_archive_command(context):
+    with context.app.test_request_context(context.app.config['URL_PREFIX']):
+        from apps.legal_archive.commands import ImportLegalArchiveCommand
+        ImportLegalArchiveCommand().run()


### PR DESCRIPTION
- Mark items with expiry_status="invalid" if items are not moved to legal.
- Currently, the process rejects whole batch if items are not moved to legal. Modify the process so that items that moved to legal are expired and the items that are moved to legal are marked with expiry_status="invalid"
- Modify the `ImportLegalArchiveCommand` to handle items with expiry_status="invalid"
- Archive content based on the content filter.