### PR TITLE
Refactor NITF Formatter, Split off AAP specific meta data

### DIFF
--- a/superdesk/publish/formatters/nitf_formatter.py
+++ b/superdesk/publish/formatters/nitf_formatter.py
@@ -10,7 +10,7 @@
 
 import xml.etree.ElementTree as etree
 from xml.etree.ElementTree import SubElement
-
+from flask import current_app as app
 from superdesk.publish.formatters import Formatter
 import superdesk
 from superdesk.errors import FormatterError
@@ -42,7 +42,8 @@ class NITFFormatter(Formatter):
             raise FormatterError.nitfFormatterError(ex, subscriber)
 
     def get_nitf(self, article, destination, pub_seq_num):
-        self._message_attrib.update(self._debug_message_extra)
+        if app.config.get('DEBUG', False):
+            self._message_attrib.update(self._debug_message_extra)
         nitf = etree.Element("nitf", attrib=self._message_attrib)
         head = SubElement(nitf, "head")
         body = SubElement(nitf, "body")

--- a/superdesk/publish/formatters/nitf_formatter.py
+++ b/superdesk/publish/formatters/nitf_formatter.py
@@ -14,7 +14,7 @@ from xml.etree.ElementTree import SubElement
 from superdesk.publish.formatters import Formatter
 import superdesk
 from superdesk.errors import FormatterError
-from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE, EMBARGO, FORMAT, FORMATS, SIGN_OFF
+from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE, EMBARGO, FORMAT, FORMATS
 from apps.archive.common import get_utc_schedule
 from bs4 import BeautifulSoup
 
@@ -142,44 +142,10 @@ class NITFFormatter(Formatter):
             article[ITEM_TYPE] in (CONTENT_TYPE.TEXT, CONTENT_TYPE.PREFORMATTED, CONTENT_TYPE.COMPOSITE)
 
     def _append_meta_priority(self, article, head):
-        SubElement(head, 'meta', {'name': 'aap-priority', 'content': str(article.get('priority', '3'))})
+        pass
 
     def _append_meta(self, article, head, destination, pub_seq_num):
         """
         Appends <meta> elements to <head>
         """
-
-        SubElement(head, 'meta', {'name': 'anpa-sequence', 'content': str(pub_seq_num)})
-        SubElement(head, 'meta', {'name': 'anpa-keyword', 'content': self.append_legal(article)})
-        SubElement(head, 'meta', {'name': 'anpa-takekey', 'content': article.get('anpa_take_key', '') or ''})
-        if 'anpa_category' in article and article['anpa_category'] is not None and len(
-                article.get('anpa_category')) > 0:
-            SubElement(head, 'meta',
-                       {'name': 'anpa-category', 'content': article.get('anpa_category')[0].get('qcode', '')})
-
-        self._append_meta_priority(article, head)
-        original_creator = superdesk.get_resource_service('users').find_one(req=None,
-                                                                            _id=article.get('original_creator', ''))
-        if original_creator:
-            SubElement(head, 'meta', {'name': 'aap-original-creator', 'content': original_creator.get('username')})
-        version_creator = superdesk.get_resource_service('users').find_one(req=None,
-                                                                           _id=article.get('version_creator', ''))
-        if version_creator:
-            SubElement(head, 'meta', {'name': 'aap-version-creator', 'content': version_creator.get('username')})
-
-        if article.get('task', {}).get('desk') is not None:
-            desk = superdesk.get_resource_service('desks').find_one(_id=article.get('task', {}).get('desk'), req=None)
-            SubElement(head, 'meta', {'name': 'aap-desk', 'content': desk.get('name', '')})
-        if article.get('task', {}).get('stage') is not None:
-            stage = superdesk.get_resource_service('stages').find_one(_id=article.get('task', {}).get('stage'),
-                                                                      req=None)
-            if stage is not None:
-                SubElement(head, 'meta', {'name': 'aap-stage', 'content': stage.get('name', '')})
-
-        SubElement(head, 'meta', {'name': 'aap-source', 'content': article.get('source', '')})
-        SubElement(head, 'meta', {'name': 'aap-original-source', 'content': article.get('original_source', '')})
-
-        if 'place' in article and article['place'] is not None and len(article.get('place', [])) > 0:
-            SubElement(head, 'meta', {'name': 'aap-place', 'content': article.get('place')[0]['qcode']})
-        if SIGN_OFF in article:
-            SubElement(head, 'meta', {'name': 'aap-signoff', 'content': article.get(SIGN_OFF, '')})
+        pass

--- a/superdesk/publish/formatters/nitf_formatter.py
+++ b/superdesk/publish/formatters/nitf_formatter.py
@@ -149,4 +149,9 @@ class NITFFormatter(Formatter):
         """
         Appends <meta> elements to <head>
         """
-        pass
+        if 'anpa_category' in article and article['anpa_category'] is not None and len(
+                article.get('anpa_category')) > 0:
+            SubElement(head, 'meta',
+                       {'name': 'anpa-category', 'content': article.get('anpa_category')[0].get('qcode', '')})
+
+        self._append_meta_priority(article, head)

--- a/superdesk/publish/formatters/nitf_formatter.py
+++ b/superdesk/publish/formatters/nitf_formatter.py
@@ -42,7 +42,7 @@ class NITFFormatter(Formatter):
             raise FormatterError.nitfFormatterError(ex, subscriber)
 
     def get_nitf(self, article, destination, pub_seq_num):
-        if app.config.get('DEBUG', False):
+        if app.config.get('NITF_INCLUDE_SCHEMA', False):
             self._message_attrib.update(self._debug_message_extra)
         nitf = etree.Element("nitf", attrib=self._message_attrib)
         head = SubElement(nitf, "head")

--- a/tests/publish/nitf_formatter_tests.py
+++ b/tests/publish/nitf_formatter_tests.py
@@ -111,3 +111,29 @@ class NitfFormatterTest(TestCase):
         self.assertEqual(company.text, 'YANCOAL AUSTRALIA LIMITED')
         self.assertEqual(company.attrib.get('idsrc', ''), 'ASX')
         self.assertEqual(company.attrib.get('value', ''), 'YAL')
+
+    def testNoneAsciNamesContent(self):
+        article = {
+            '_id': '3',
+            'source': 'AAP',
+            'anpa_category': [{'qcode': 'a'}],
+            'headline': 'This is a test headline',
+            'byline': 'joe',
+            'slugline': 'slugline',
+            'subject': [{'qcode': '02011001'}],
+            'anpa_take_key': 'take_key',
+            'unique_id': '1',
+            'type': 'text',
+            'body_html': '<p>Tommi Mäkinen crashes a Škoda in Äppelbo</p>',
+            'word_count': '1',
+            'priority': 1,
+            "linked_in_packages": [
+                {
+                    "package": "package",
+                    "package_type": "takes"
+                }
+            ],
+        }
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        nitf_xml = etree.fromstring(doc)
+        self.assertEqual(nitf_xml.find('body/body.content/p').text, 'Tommi Mäkinen crashes a Škoda in Äppelbo')


### PR DESCRIPTION
@jerome-poisson are you OK with removing the meta tags from the head! I doubt that they would be of much use to NTB.

Since we've been in production we've had a lot of trouble with the body html from the editor, I don't think the map_html_to_xml function is good enough.

Also in production we should not be injecting the schema definitions into the root.