### PR TITLE
fix(filemeta): store filemeta json encoded

### DIFF
--- a/apps/archive/archive_media.py
+++ b/apps/archive/archive_media.py
@@ -20,6 +20,7 @@ from superdesk.upload import url_for_media
 from .common import update_dates_for, generate_guid, GUID_TAG, set_original_creator, \
     generate_unique_id_and_name, set_item_expiry
 from superdesk.activity import add_activity
+from superdesk.filemeta import set_filemeta
 
 
 logger = logging.getLogger(__name__)
@@ -49,7 +50,7 @@ class ArchiveMediaService():
                                                  content_type, rendition_spec, url_for_media)
                 doc['renditions'] = renditions
                 doc['mimetype'] = content_type
-                doc['filemeta'] = metadata
+                set_filemeta(doc, metadata)
 
                 add_activity('upload', 'uploaded media {{ name }}',
                              'archive', item=doc,

--- a/apps/publish/formatters/newsml_g2_formatter.py
+++ b/apps/publish/formatters/newsml_g2_formatter.py
@@ -21,6 +21,7 @@ from superdesk.publish.formatters.nitf_formatter import NITFFormatter
 from apps.archive.common import ARCHIVE, get_utc_schedule
 from superdesk.metadata.packages import PACKAGE_TYPE, REFS, RESIDREF, ROLE, GROUPS, GROUP_ID, ID_REF
 from bs4 import BeautifulSoup
+from superdesk.filemeta import get_filemeta
 
 
 def get_newsml_provider_id():
@@ -443,16 +444,16 @@ class NewsMLG2Formatter(Formatter):
                 if 'width' in value:
                     attrib['width'] = str(value.get('width'))
             elif article.get(ITEM_TYPE) in {CONTENT_TYPE.VIDEO, CONTENT_TYPE.AUDIO}:
-                if article.get('filemeta', {}).get('width'):
-                    attrib['width'] = str(article.get('filemeta', {}).get('width'))
-                if article.get('filemeta', {}).get('height'):
-                    attrib['height'] = str(article.get('filemeta', {}).get('height'))
-                if article.get('filemeta', {}).get('duration'):
-                    attrib['duration'] = article.get('filemeta', {}).get('duration')
+                if get_filemeta(article, 'width'):
+                    attrib['width'] = str(get_filemeta(article, 'width'))
+                if get_filemeta(article, 'height'):
+                    attrib['height'] = str(get_filemeta(article, 'height'))
+                if get_filemeta(article, 'duration'):
+                    attrib['duration'] = get_filemeta(article, 'duration')
                     attrib['durationunit'] = 'timeunit:normalPlayTime'
 
-            if rendition == 'original' and 'filemeta' in article and 'length' in article['filemeta']:
-                attrib['size'] = str(article.get('filemeta').get('length'))
+            if rendition == 'original' and get_filemeta(article, 'length'):
+                attrib['size'] = str(get_filemeta(article, 'length'))
             SubElement(content_set, 'remoteContent', attrib=attrib)
 
     def _format_company_codes(self, article, content_meta, item):

--- a/superdesk/filemeta.py
+++ b/superdesk/filemeta.py
@@ -1,0 +1,28 @@
+
+from flask import json
+
+
+def set_filemeta(item, metadata):
+    """Set filemeta info into item for storage.
+
+    it's json encoded so it can be stored into elastic without mapping
+
+    :param item: news item dict
+    :param metadata: metadata dict
+    """
+    item['filemeta_json'] = json.dumps(metadata)
+
+
+def get_filemeta(item, key=None, default_value=None):
+    """Get file metadata.
+
+    :param item: news item dict
+    :param key: key string
+    :param default_value
+    """
+    if item.get('filemeta_json'):
+        meta = json.loads(item['filemeta_json'])
+    else:
+        meta = item.get('filemeta', {})
+
+    return meta.get(key, default_value) if key else meta

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -34,6 +34,7 @@ from superdesk.upload import url_for_media
 from superdesk.utc import utcnow, get_expiry_date
 from superdesk.workflow import set_default_state
 from copy import deepcopy
+from superdesk.filemeta import set_filemeta
 
 UPDATE_SCHEDULE_DEFAULT = {'minutes': 5}
 LAST_UPDATED = 'last_updated'
@@ -515,6 +516,7 @@ def update_renditions(item, href, old_item):
                 item['renditions'] = old_item['renditions']
                 item['mimetype'] = old_item.get('mimetype')
                 item['filemeta'] = old_item.get('filemeta')
+                item['filemeta_json'] = old_item.get('filemeta_json')
                 return
 
         content, filename, content_type = download_file_from_url(href)
@@ -527,7 +529,7 @@ def update_renditions(item, href, old_item):
                                          content_type, rendition_spec, url_for_media)
         item['renditions'] = renditions
         item['mimetype'] = content_type
-        item['filemeta'] = metadata
+        set_filemeta(item, metadata)
     except Exception:
         for file_id in inserted:
             app.media.delete(file_id)

--- a/superdesk/io/feed_parsers/rfc822.py
+++ b/superdesk/io/feed_parsers/rfc822.py
@@ -33,6 +33,7 @@ from superdesk.metadata.utils import generate_guid
 from superdesk.users.errors import UserNotRegisteredException
 from superdesk.utc import utcnow, get_date
 from apps.archive.common import format_dateline_to_locmmmddsrc
+from superdesk.filemeta import set_filemeta
 
 
 logger = logging.getLogger(__name__)
@@ -181,7 +182,7 @@ class EMailRFC822FeedParser(EmailFeedParser):
                             media_item[ITEM_TYPE] = CONTENT_TYPE.PICTURE
                             media_item['renditions'] = renditions
                             media_item['mimetype'] = content_type
-                            media_item['filemeta'] = metadata
+                            set_filemeta(media_item, metadata)
                             media_item['slugline'] = fileName
                             if text_body is not None:
                                 media_item['body_html'] = text_body

--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -303,6 +303,9 @@ metadata_schema = {
     'filemeta': {
         'type': 'dict'
     },
+    'filemeta_json': {
+        'type': 'string'
+    },
     'media_file': {
         'type': 'string'
     },

--- a/superdesk/publish/formatters/newsml_1_2_formatter.py
+++ b/superdesk/publish/formatters/newsml_1_2_formatter.py
@@ -24,6 +24,7 @@ from superdesk.utc import utcnow
 from flask import current_app as app
 from apps  .archive.common import get_utc_schedule
 from bs4 import BeautifulSoup
+from superdesk.filemeta import get_filemeta
 
 logger = logging.getLogger(__name__)
 
@@ -350,8 +351,8 @@ class NewsML12Formatter(Formatter):
             SubElement(content_item, 'MediaType', {'FormalName': media_type})
             SubElement(content_item, 'Format', {'FormalName': value.get('mimetype', '')})
             characteristics = SubElement(content_item, 'Characteristics')
-            if rendition == 'original' and 'filemeta' in article and 'length' in article['filemeta']:
-                SubElement(characteristics, 'SizeInBytes').text = str(article.get('filemeta').get('length'))
+            if rendition == 'original' and get_filemeta(article, 'length'):
+                SubElement(characteristics, 'SizeInBytes').text = str(get_filemeta(article, 'length'))
             if article.get(ITEM_TYPE) == CONTENT_TYPE.PICTURE:
                 if value.get('width'):
                     SubElement(characteristics, 'Property',
@@ -360,16 +361,16 @@ class NewsML12Formatter(Formatter):
                     SubElement(characteristics, 'Property',
                                attrib={'FormalName': 'Height', 'Value': str(value.get('height'))})
             elif article.get(ITEM_TYPE) in {CONTENT_TYPE.VIDEO, CONTENT_TYPE.AUDIO}:
-                if article.get('filemeta', {}).get('width'):
+                if get_filemeta(article, 'width'):
                     SubElement(characteristics, 'Property',
                                attrib={'FormalName': 'Width',
-                                       'Value': str(article.get('filemeta', {}).get('width'))})
-                if article.get('filemeta', {}).get('height'):
+                                       'Value': str(get_filemeta(article, 'width'))})
+                if get_filemeta(article, 'height'):
                     SubElement(characteristics, 'Property',
                                attrib={'FormalName': 'Height',
-                                       'Value': str(article.get('filemeta', {}).get('height'))})
+                                       'Value': str(get_filemeta(article, 'height'))})
 
-                duration = self._get_total_duration(article.get('filemeta', {}).get('duration'))
+                duration = self._get_total_duration(get_filemeta(article, 'duration'))
                 if duration:
                     SubElement(characteristics, 'Property',
                                attrib={'FormalName': 'TotalDuration', 'Value': str(duration)})

--- a/superdesk/upload.py
+++ b/superdesk/upload.py
@@ -20,6 +20,7 @@ from flask import url_for, request, current_app as app
 from superdesk.media.renditions import generate_renditions, delete_file_on_error
 from superdesk.media.media_operations import download_file_from_url, process_file_from_stream, \
     crop_image, decode_metadata, download_file_from_encoded_str
+from superdesk.filemeta import set_filemeta
 
 
 bp = superdesk.Blueprint('upload_raw', __name__)
@@ -130,7 +131,7 @@ class UploadService(BaseService):
                                     resource=self.datasource, metadata=metadata)
             doc['media'] = file_id
             doc['mimetype'] = content_type
-            doc['filemeta'] = decode_metadata(metadata)
+            set_filemeta(doc, decode_metadata(metadata))
             inserted = [doc['media']]
             file_type = content_type.split('/')[0]
             rendition_spec = config.RENDITIONS['avatar']

--- a/tests/filemeta_test.py
+++ b/tests/filemeta_test.py
@@ -1,0 +1,16 @@
+
+import unittest
+from superdesk.filemeta import get_filemeta, set_filemeta
+
+
+class FilemetaTestCase(unittest.TestCase):
+
+    def test_get_set_filemeta(self):
+        item = {}
+        set_filemeta(item, {'foo': 'bar'})
+        self.assertEqual('bar', get_filemeta(item, 'foo'))
+        self.assertEqual({'foo': 'bar'}, get_filemeta(item))
+
+    def test_get_filemeta_obsolete(self):
+        item = {'filemeta': {'x': 1}}
+        self.assertEqual(1, get_filemeta(item, 'x'))


### PR DESCRIPTION
filemeta could have inconsistent types for certain exif keys from
different cameras etc, which can confuse elastic auto mapping and
lead to conflicts there. so storing it json encoded instead will
avoid such conflicts in filemeta, no matter what is there.

SD-4964