### PR TITLE
(fix) [SD-5077] Moving invisible stages to user collection to reduce queries.

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -74,7 +74,11 @@ def private_content_filter():
             {'term': {'original_creator': str(user['_id'])}},
         ]}
 
-        stages = get_resource_service('users').get_invisible_stages_ids(user.get('_id'))
+        if 'invisible_stages' in user:
+            stages = user.get('invisible_stages')
+        else:
+            stages = get_resource_service('users').get_invisible_stages_ids(user.get('_id'))
+
         if stages:
             private_filter['must_not'] = [{'terms': {'task.stage': stages}}]
 

--- a/apps/desks.py
+++ b/apps/desks.py
@@ -12,6 +12,8 @@ import itertools
 
 import superdesk
 from flask import current_app as app
+
+from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError
 from superdesk.resource import Resource
 from superdesk import config
@@ -154,6 +156,7 @@ class DesksService(BaseService):
     def on_created(self, docs):
         for doc in docs:
             push_notification(self.notification_key, created=1, desk_id=str(doc.get(config.ID_FIELD)))
+            get_resource_service('users').update_stage_visibility_for_users()
 
     def on_update(self, updates, original):
         if updates.get('content_expiry') == 0:
@@ -252,6 +255,8 @@ class DesksService(BaseService):
                                         self.datasource, notify=added, can_push_notification=False,
                                         user=user.get('username'), desk=desk.get('name'))
                 push_notification('activity', _dest=activity['recipients'])
+
+            get_resource_service('users').update_stage_visibility_for_users()
         else:
             push_notification(self.notification_key, updated=1, desk_id=str(desk.get(config.ID_FIELD)))
 

--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -12,6 +12,8 @@ from flask import current_app as app, json, g
 from eve_elastic.elastic import set_filters
 
 import superdesk
+
+from superdesk import get_resource_service
 from superdesk.metadata.item import CONTENT_STATE, ITEM_STATE
 from superdesk.metadata.utils import aggregations, item_url
 from apps.archive.archive import SOURCE as ARCHIVE
@@ -94,8 +96,12 @@ class SearchService(superdesk.Service):
         query = self._get_query(req)
         types = self._get_types(req)
         filters = self._get_filters(types)
+        user = g.get('user', {})
+        if 'invisible_stages' in user:
+            stages = user.get('invisible_stages')
+        else:
+            stages = get_resource_service('users').get_invisible_stages_ids(user.get('_id'))
 
-        stages = superdesk.get_resource_service('users').get_invisible_stages_ids(g.get('user', {}).get('_id'))
         if stages:
             filters.append({'and': [{'not': {'terms': {'task.stage': stages}}}]})
 

--- a/apps/stages.py
+++ b/apps/stages.py
@@ -63,10 +63,14 @@ class StagesResource(Resource):
         'content_expiry': {
             'type': 'integer'
         },
+        # if true then desk members can see the item on that stage
+        # if false then non-members cannot see the item on that stage
         'is_visible': {
             'type': 'boolean',
             'default': True
         },
+        # if true then desk members cannot edit items on the stage
+        # if false then desk member can edit items on the stage
         'local_readonly': {
             'type': 'boolean',
             'default': False
@@ -138,6 +142,9 @@ class StagesService(BaseService):
             if doc.get('default_incoming', False):
                 self.set_desk_ref(doc, 'incoming_stage')
 
+            if not doc.get('is_visible', True):
+                get_resource_service('users').update_stage_visibility_for_users()
+
     def on_delete(self, doc):
         """
         Checks if deleting the stage would not violate data integrity, raises an exception if it does.
@@ -207,6 +214,7 @@ class StagesService(BaseService):
                               stage_id=str(original[config.ID_FIELD]),
                               desk_id=str(original['desk']),
                               is_visible=updates.get('is_visible', original.get('is_visible', True)))
+            get_resource_service('users').update_stage_visibility_for_users()
         else:
             push_notification(self.notification_key,
                               updated=1,

--- a/features/desks.feature
+++ b/features/desks.feature
@@ -15,7 +15,11 @@ Feature: Desks
         """
         {"username": "foo", "email": "foo@bar.com", "is_active": true, "sign_off": "abc"}
         """
-        And we post to "/desks"
+        Then we get existing resource
+        """
+        {"_id": "#users._id#", "invisible_stages": []}
+        """
+        When we post to "/desks"
         """
         {"name": "Sports Desk", "members": [{"user": "#users._id#"}]}
         """
@@ -35,6 +39,21 @@ Feature: Desks
         Then we get error 412
         """
         {"_status": "ERR", "_message": "Cannot delete a Incoming Stage."}
+        """
+        When we post to "/stages"
+        """
+        {"name": "invisible1", "desk": "#desks._id#", "is_visible" : false}
+        """
+        Then we get OK response
+        When we get "/users/#users._id#"
+        Then we get existing resource
+        """
+        {"_id": "#users._id#", "invisible_stages": []}
+        """
+        When we get "/users/#CONTEXT_USER_ID#"
+        Then we get existing resource
+        """
+        {"_id": "#CONTEXT_USER_ID#", "invisible_stages": ["#stages._id#"]}
         """
 
 	@auth

--- a/features/stages.feature
+++ b/features/stages.feature
@@ -119,15 +119,50 @@ Feature: Stages
         {"name": "stage visibility", "desk": "#desks._id#", "is_visible" : true}
         """
         And we reset notifications
-        And we patch "/stages/#stages._id#"
+        And we get "/users/#CONTEXT_USER_ID#"
+        Then we get existing resource
+        """
+        {"_id": "#CONTEXT_USER_ID#", "invisible_stages": []}
+        """
+        When we patch "/stages/#stages._id#"
         """
         {"is_visible" : false}
         """
         Then we get response code 200
+        When we get "/users/#CONTEXT_USER_ID#"
+        Then we get existing resource
+        """
+        {"_id": "#CONTEXT_USER_ID#", "invisible_stages": ["#stages._id#"]}
+        """
         And we get notifications
         """
         [{"event": "stage_visibility_updated", "extra": {"updated": 1, "desk_id": "#desks._id#", "stage_id": "#stages._id#", "is_visible": false}}]
         """
+        When we post to "/users"
+        """
+        {"username": "foo", "email": "foo@bar.com", "is_active": true, "sign_off": "abc"}
+        """
+        Then we get OK response
+        And we get existing resource
+        """
+        {"_id": "#users._id#", "invisible_stages": ["#stages._id#"]}
+        """
+        When we patch "/stages/#stages._id#"
+        """
+        {"is_visible" : true}
+        """
+        Then we get response code 200
+        When we get "/users/#CONTEXT_USER_ID#"
+        Then we get existing resource
+        """
+        {"_id": "#CONTEXT_USER_ID#", "invisible_stages": []}
+        """
+        When we get "/users/#users._id#"
+        Then we get existing resource
+        """
+        {"_id": "#users._id#", "invisible_stages": []}
+        """
+
 
     @auth @notification
     Scenario: Get visible and invisible stages

--- a/superdesk/data_updates/00001_20160722-111630_users.py
+++ b/superdesk/data_updates/00001_20160722-111630_users.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : sdesk
+# Creation: 2016-07-22 11:16
+
+from superdesk.commands.data_updates import DataUpdate
+from superdesk import get_resource_service
+from eve.utils import config
+
+
+class DataUpdate(DataUpdate):
+    """
+    Updates the user collection with invisible stages.
+    Refer to https://dev.sourcefabric.org/browse/SD-5077 for more information
+    """
+    resource = 'users'
+
+    def forwards(self, mongodb_collection, mongodb_database):
+        for user in mongodb_collection.find({}):
+            stages = get_resource_service(self.resource).get_invisible_stages_ids(user.get(config.ID_FIELD))
+            print(mongodb_collection.update({'_id': user.get(config.ID_FIELD)},
+                                            {'$set': {
+                                                'invisible_stages': stages
+                                            }}))
+
+    def backwards(self, mongodb_collection, mongodb_database):
+        print(mongodb_collection.update({},
+                                        {'$unset': {'invisible_stages': []}},
+                                        upsert=False, multi=True))

--- a/superdesk/users/users.py
+++ b/superdesk/users/users.py
@@ -100,6 +100,16 @@ class UsersResource(Resource):
                 'type': 'string',
                 'required': False,
                 'nullable': True
+            },
+            # list to hold invisible stages.
+            # This field is updated under following scenario:
+            # 1. stage visible flag is updated
+            # 2. desk membership is modified
+            # 3. new user is created
+            'invisible_stages': {
+                'type': 'list',
+                'required': False,
+                'nullable': True
             }
         }
 
@@ -116,7 +126,7 @@ class UsersResource(Resource):
             'desk'
         ]
 
-        self.etag_ignore_fields = ['session_preferences', '_etag']
+        self.etag_ignore_fields = ['session_preferences', '_etag', 'invisible_stages']
 
         self.datasource = {
             'projection': {'password': 0},


### PR DESCRIPTION
- This reduces the no. of calls to get the invisible stages for each search operation.
- Downside is Desk/Stage CRUD takes bit longer.
- It also includes schema migration for users collection.