### PR TITLE
[publishing] encoding handling in formatter and transmitter

### DIFF
--- a/apps/publish/publish_service_tests.py
+++ b/apps/publish/publish_service_tests.py
@@ -23,7 +23,8 @@ class PublishServiceTests(SuperdeskTestCase):
                     "destination": {"name": "NITF", "delivery_type": "ftp", "format": "nitf", "config": {}},
                     "subscriber_id": "1",
                     "state": "in-progress",
-                    "item_id": 1
+                    "item_id": 1,
+                    "formatted_item": ''
                     }]
 
     subscribers = [{"_id": "1", "name": "Test", "subscriber_type": SUBSCRIBER_TYPES.WIRE, "media_type": "media",

--- a/superdesk/publish/transmitters/file_output.py
+++ b/superdesk/publish/transmitters/file_output.py
@@ -18,28 +18,17 @@ errors = [PublishFileError.fileSaveError().get_error_description()]
 class FilePublishService(PublishService):
     def _transmit(self, queue_item, subscriber):
         config = queue_item.get('destination', {}).get('config', {})
-
         try:
-            if isinstance(queue_item['formatted_item'], bytes):
-                self.copy_file(config, queue_item)
-            elif isinstance(queue_item['formatted_item'], str):
-                queue_item['formatted_item'] = queue_item['formatted_item'].encode('utf-8')
-                self.copy_file(config, queue_item)
-            else:
-                raise Exception
+            # use the file extension from config if it is set otherwise use extension for the format
+            extension = config.get('file_extension') or get_file_extension(queue_item)
+            with open('{}/{}-{}-{}.{}'.format(config['file_path'],
+                                              queue_item['item_id'].replace(':', '-'),
+                                              str(queue_item.get('item_version', '')),
+                                              str(queue_item.get('published_seq_num', '')),
+                                              extension), 'wb') as f:
+                f.write(queue_item['encoded_item'])
         except Exception as ex:
             raise PublishFileError.fileSaveError(ex, config)
-
-    def copy_file(self, config, queue_item):
-        # use the file extension from config if it is set otherwise use extension for the format
-        extension = config.get('file_extension') if config.get('file_extension', '') != '' else get_file_extension(
-            queue_item)
-        with open('{}/{}-{}-{}.{}'.format(config['file_path'],
-                                          queue_item['item_id'].replace(':', '-'),
-                                          str(queue_item.get('item_version', '')),
-                                          str(queue_item.get('published_seq_num', '')),
-                                          extension), 'wb') as f:
-            f.write(queue_item['formatted_item'])
 
 
 register_transmitter('File', FilePublishService(), errors)

--- a/superdesk/publish/transmitters/ftp.py
+++ b/superdesk/publish/transmitters/ftp.py
@@ -43,7 +43,7 @@ class FTPPublishService(PublishService):
         try:
             with ftp_connect(config) as ftp:
                 filename = '{}.{}'.format(queue_item['item_id'].replace(':', '-'), get_file_extension(queue_item))
-                b = BytesIO(queue_item['formatted_item'].encode('UTF-8'))
+                b = BytesIO(queue_item['encoded_item'])
                 ftp.storbinary("STOR " + filename, b)
         except PublishFtpError:
             raise

--- a/tests/publish/file_output_tests.py
+++ b/tests/publish/file_output_tests.py
@@ -28,28 +28,13 @@ class FileOutputTest(TestCase):
                                                "config": {"file_path": self.fixtures}
                                                }]}]
 
-    def test_file_write_binary(self):
-        item = {'item_id': 'test_file_name',
-                'item_version': 1,
-                'published_seq_num': 1,
-                'formatted_item': b'I was here',
-                'destination': {"name": "test", "delivery_type": "File", "format": "nitf",
-                                "config": {"file_path": self.fixtures, "file_extension": "txt"}}
-                }
-        service = FilePublishService()
-        try:
-            service._transmit(item, self.subscribers)
-            self.assertTrue(True)
-        finally:
-            path = os.path.join(self.fixtures, 'test_file_name-1-1.txt')
-            if os.path.isfile(path):
-                os.remove(path)
-
-    def test_file_write_string(self):
+    def test_file_write(self):
         item = {'item_id': 'test_file_name',
                 'item_version': 1,
                 'published_seq_num': 1,
                 'formatted_item': 'I was here',
+                'encoded_item': b'I was here',
+                'item_encoding': 'utf-8',
                 'destination': {"name": "test", "delivery_type": "File", "format": "nitf",
                                 "config": {"file_path": self.fixtures, "file_extension": "txt"}}
                 }
@@ -67,6 +52,8 @@ class FileOutputTest(TestCase):
                 'item_version': 1,
                 'published_seq_num': 1,
                 'formatted_item': 'I was here',
+                'encoded_item': b'I was here',
+                'item_encoding': 'utf-8',
                 'destination': {"name": "test", "delivery_type": "File", "format": "nitf",
                                 "config": {"file_path": self.fixtures}}
                 }
@@ -93,6 +80,8 @@ class FileOutputTest(TestCase):
         item = {'item_id': 'test_file_name',
                 'item_version': 1,
                 'formatted_item': 'I was here',
+                'encoded_item': b'I was here',
+                'item_encoding': 'utf-8',
                 'destination': {"name": "test", "delivery_type": "File", "format": "nitf",
                                 "config": {"file_path": self.fixtures}}
                 }


### PR DESCRIPTION
formatter can now specify the final encoding using "transmitter_encoding" encoding, to do this they can return a list of dictionnaries instead of a list of tuples.
Only file_output transmitter was testing if "formatted_item" is a bytes
or str, so this part was removed, and it is now assumed that
"formatted_item" is always str, while encoded_item will be bytes.

needed for SDNTB-253