### PR TITLE
fix(content-filters) - Keywords field can't operate with string operators

### DIFF
--- a/apps/content_filters/filter_condition/filter_condition_parameters.py
+++ b/apps/content_filters/filter_condition/filter_condition_parameters.py
@@ -50,7 +50,7 @@ class FilterConditionParametersService(BaseService):
                             'value_field': 'qcode'
                             },
                            {'field': 'keywords',
-                            'operators': ['in', 'nin', 'like', 'notlike', 'startswith', 'endswith']
+                            'operators': ['in', 'nin']
                             },
                            {'field': 'slugline',
                             'operators': ['in', 'nin', 'like', 'notlike', 'startswith', 'endswith']


### PR DESCRIPTION
- Keywords field is a list so only `in` and `not-in` operators can be used