### PR TITLE
fix(dictionary): remove BOM from file input if present

### DIFF
--- a/apps/dictionaries/service.py
+++ b/apps/dictionaries/service.py
@@ -70,7 +70,7 @@ def add_words(nwords, text, val=1):
 
 
 def read(stream):
-    return stream.read().decode('utf-8')
+    return stream.read().decode('utf-8').replace('\ufeff', '')
 
 
 def merge(doc, words):


### PR DESCRIPTION
this would make first word from a file not usable,
because it would be read with bom prefix, so better filter it out.

SD-5227