### PR TITLE
[publish] PublishService and filename generation refactoring

### DIFF
--- a/superdesk/publish/__init__.py
+++ b/superdesk/publish/__init__.py
@@ -38,13 +38,17 @@ def transmit():
 
 
 # must be imported for registration
-import superdesk.publish.transmitters  # NOQA
-import superdesk.publish.formatters  # NOQA
 from superdesk.publish.subscribers import SubscribersResource, SubscribersService  # NOQA
 from superdesk.publish.publish_queue import PublishQueueResource, PublishQueueService  # NOQA
 
 
 def init_app(app):
+    # XXX: we need to do imports for transmitters and formatters here
+    #      so classes creation is done after PublishService is set
+    #      this is a temporary workaround until a proper plugin system
+    #      is implemented in Superdesk
+    import superdesk.publish.transmitters  # NOQA
+    import superdesk.publish.formatters  # NOQA
     endpoint_name = 'subscribers'
     service = SubscribersService(endpoint_name, backend=get_backend())
     SubscribersResource(endpoint_name, app=app, service=service)

--- a/superdesk/publish/publish_service_test.py
+++ b/superdesk/publish/publish_service_test.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.tests import TestCase
+from superdesk.publish import publish_service
+from importlib import reload
+
+
+class Base(TestCase):
+    def setUp(self):
+        super().setUp()
+        reload(publish_service)
+        self.service = publish_service.PublishService()
+        self.fake_item = {
+            "destination": {'format': 'nitf'},
+            "item_id": "123:test_id-123",
+            "item_version": "3",
+            "published_seq_num": "5", }
+
+    def fake_item_ext(self, format_):
+        """return a copy of self.fake_item with given destination/format"""
+        item = self.fake_item.copy()
+        item['destination'] = {'format': format_}
+        return item
+
+
+class FilenameTest(Base):
+    def test_get_extension(self):
+        nitf_ext = self.service.get_file_extension(self.fake_item_ext('nitf'))
+        self.assertEqual(nitf_ext, 'ntf')
+        xml_ext = self.service.get_file_extension(self.fake_item_ext('xml'))
+        self.assertEqual(xml_ext, 'xml')
+        ninjs_ext = self.service.get_file_extension(self.fake_item_ext('ninjs'))
+        self.assertEqual(ninjs_ext, 'json')
+        default_ext = self.service.get_file_extension(self.fake_item_ext('this_is_an_unknown_format'))
+        self.assertEqual(default_ext, 'txt')
+        # variant containing nitf must return nitf extension by default
+        nitf_variant_ext = self.service.get_file_extension(self.fake_item_ext('nitf_variant'))
+        self.assertEqual(nitf_variant_ext, 'ntf')
+
+    def test_get_filename(self):
+        filename = self.service.get_filename(self.fake_item)
+        self.assertEqual(filename, "123-test_id-123-3-5.ntf")
+
+    def test_get_filename_with_config(self):
+        item = self.fake_item.copy()
+        item['destination']['config'] = {'file_extension': 'test_ext'}
+        filename = self.service.get_filename(item)
+        self.assertEqual(filename, "123-test_id-123-3-5.test_ext")
+
+
+class FilenameCustomizedExtTest(Base):
+    def setUp(self):
+        super().setUp()
+        self.service.register_file_extension("custom_format", "custom_ext")
+
+    def test_get_extension(self):
+        # is other file ext still working?
+        nitf_ext = self.service.get_file_extension(self.fake_item_ext('nitf'))
+        self.assertEqual(nitf_ext, 'ntf')
+        # is the new one here ?
+        custom_ext = self.service.get_file_extension(self.fake_item_ext('custom_format'))
+        self.assertEqual(custom_ext, 'custom_ext')
+        other_custom = self.service.get_file_extension(self.fake_item_ext('other_custom_format'))
+        self.assertEqual(other_custom, 'custom_ext')
+
+    def test_get_filename(self):
+        filename = self.service.get_filename(self.fake_item_ext('custom_format'))
+        self.assertEqual(filename, "123-test_id-123-3-5.custom_ext")
+        filename = self.service.get_filename(self.fake_item)
+        self.assertEqual(filename, "123-test_id-123-3-5.ntf")
+
+
+class CustomizedService(publish_service.PublishServiceBase):
+
+    @classmethod
+    def get_filename(cls, queue_item):
+        return "customized_filename.ext"
+
+
+class FilenameCustomizedServiceTest(Base):
+    def setUp(self):
+        super().setUp()
+        publish_service.set_publish_service(CustomizedService)
+        self.service = publish_service.PublishService()
+
+    def test_get_filename(self):
+        filename = self.service.get_filename(self.fake_item)
+        self.assertEqual(filename, "customized_filename.ext")

--- a/superdesk/publish/transmitters/file_output.py
+++ b/superdesk/publish/transmitters/file_output.py
@@ -8,24 +8,22 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from superdesk.publish.publish_service import PublishService, get_file_extension
+from superdesk.publish.publish_service import PublishService
 from superdesk.publish import register_transmitter
 from superdesk.errors import PublishFileError
+from os import path
 
 errors = [PublishFileError.fileSaveError().get_error_description()]
 
 
 class FilePublishService(PublishService):
     def _transmit(self, queue_item, subscriber):
-        config = queue_item.get('destination', {}).get('config', {})
         try:
-            # use the file extension from config if it is set otherwise use extension for the format
-            extension = config.get('file_extension') or get_file_extension(queue_item)
-            with open('{}/{}-{}-{}.{}'.format(config['file_path'],
-                                              queue_item['item_id'].replace(':', '-'),
-                                              str(queue_item.get('item_version', '')),
-                                              str(queue_item.get('published_seq_num', '')),
-                                              extension), 'wb') as f:
+            config = queue_item['destination']['config']
+            file_path = config['file_path']
+            if not path.isabs(file_path):
+                file_path = "/" + file_path
+            with open(path.join(file_path, PublishService.get_filename(queue_item)), 'wb') as f:
                 f.write(queue_item['encoded_item'])
         except Exception as ex:
             raise PublishFileError.fileSaveError(ex, config)

--- a/superdesk/publish/transmitters/ftp.py
+++ b/superdesk/publish/transmitters/ftp.py
@@ -11,7 +11,7 @@
 from superdesk.ftp import ftp_connect
 from superdesk.publish import register_transmitter
 from io import BytesIO
-from superdesk.publish.publish_service import PublishService, get_file_extension
+from superdesk.publish.publish_service import PublishService
 from superdesk.errors import PublishFtpError
 errors = [PublishFtpError.ftpError().get_error_description()]
 
@@ -42,7 +42,7 @@ class FTPPublishService(PublishService):
 
         try:
             with ftp_connect(config) as ftp:
-                filename = '{}.{}'.format(queue_item['item_id'].replace(':', '-'), get_file_extension(queue_item))
+                filename = PublishService.get_filename(queue_item)
                 b = BytesIO(queue_item['encoded_item'])
                 ftp.storbinary("STOR " + filename, b)
         except PublishFtpError:


### PR DESCRIPTION
PublishService base class can now be changed using set_publish_service,
this allow overriding in specific superdesk flavours without modifying current code.

filename in file_output and ftp now use a common get_filename method,
which is part of PublishService so it can be overridden

ftp filename pattern has changed, it is now common with file_output and
use by default version and sequence number.

needed for SDNTB-264