### PR TITLE
fix(item): add more_coming field back to schema

### DIFF
--- a/features/archive.feature
+++ b/features/archive.feature
@@ -36,7 +36,7 @@ Feature: News Items Archive
 
         When we patch given
         """
-        {"headline": "TEST 2", "urgency": 2}
+        {"headline": "TEST 2", "urgency": 2, "more_coming": true}
         """
 
         And we patch latest

--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -371,6 +371,9 @@ metadata_schema = {
         'type': 'list',
         'schema': Resource.rel('highlights', True)
     },
+
+    'more_coming': {'type': 'boolean'},  # deprecated
+
     # Field which contains all the sign-offs done on this article, eg. twd/jwt/ets
     SIGN_OFF: {
         'type': 'string',


### PR DESCRIPTION
it won't be used anymore, but there will be items already having it
and any further action on them would fail due this unknown field.

so partially reverting https://github.com/superdesk/superdesk-core/pull/551

/cc @akintolga 