### PR TITLE
fix(updates): avoid creating of directories in get_data_update_files

### DIFF
--- a/superdesk/commands/data_updates.py
+++ b/superdesk/commands/data_updates.py
@@ -76,7 +76,7 @@ def get_data_updates_files(strip_file_extension=False):
     # create folder if doens't exist
     for folder in get_dirs():
         if not os.path.exists(folder):
-            os.makedirs(folder)
+            continue
         # list all files from data updates directory
         if os.path.exists(folder):
             files += [f for f in os.listdir(folder) if os.path.isfile(os.path.join(folder, f))]
@@ -242,6 +242,8 @@ class GenerateUpdate(superdesk.Command):
             update_dir = MAIN_DATA_UPDATES_DIR
         else:
             update_dir = get_dirs(only_relative_folder=True)[0]
+        if not os.path.exists(update_dir):
+            os.makedirs(update_dir)
         data_update_filename = os.path.join(update_dir, '{:05d}_{}_{}.py'.format(name_id, timestamp, resource_name))
         if os.path.exists(data_update_filename):
             raise Exception('The file "%s" already exists' % (data_update_filename))

--- a/tests/data_updates_test.py
+++ b/tests/data_updates_test.py
@@ -1,9 +1,11 @@
+import os
+import shutil
+import tempfile
+
 from superdesk.tests import TestCase
 import superdesk.commands.data_updates
 import superdesk
 from superdesk.commands.data_updates import get_data_updates_files, GenerateUpdate, Upgrade, Downgrade
-import shutil
-import os
 
 # change the folder where to store updates for test purpose
 DEFAULT_DATA_UPDATE_DIR_NAME = '/tmp/data_updates'
@@ -33,6 +35,16 @@ class DataUpdatesTestCase(TestCase):
         assert len(get_data_updates_files()) is 1, get_data_updates_files()
         GenerateUpdate().run(resource_name='RESOURNCE_NAME')
         assert len(get_data_updates_files()) is 2, get_data_updates_files()
+
+    def test_data_update_generation_create_updates_dir(self):
+        updates_dir = tempfile.mkdtemp()
+        shutil.rmtree(updates_dir)
+        self.assertFalse(os.path.exists(updates_dir))
+        self.app.config['DATA_UPDATES_PATH'] = updates_dir
+        GenerateUpdate().run('tmp')
+        print(updates_dir)
+        self.assertTrue(os.path.exists(updates_dir))
+        shutil.rmtree(updates_dir)
 
     def number_of_data_updates_applied(self):
         return superdesk.get_resource_service('data_updates').find({}).count()


### PR DESCRIPTION
there is race condition when multiple workers are starting they can
try to create those folders, but only one will succed and others will
get OSError.

/cc @vied12 