### PR TITLE
[SETTINGS] use local timezone in DEFAULT_TIMEZONE when it is not expl…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ install_requires = [
     'python-magic>=0.4',
     'python3-ldap>=0.9.8',
     'pytz>=2015.4',
+    'tzlocal>=1.2.2',
     'raven[flask]>=5.10.0,<5.11',
     'requests>=2.7.0',
     'statsd>=3.1',

--- a/superdesk/factory/default_settings.py
+++ b/superdesk/factory/default_settings.py
@@ -15,6 +15,7 @@ import json
 from datetime import timedelta
 from celery.schedules import crontab
 from kombu import Queue, Exchange
+import tzlocal
 
 try:
     from urllib.parse import urlparse
@@ -359,7 +360,13 @@ ADMINS = [MAIL_FROM]
 SUPERDESK_TESTING = (env('SUPERDESK_TESTING', 'false').lower() == 'true')
 
 # Default TimeZone
-DEFAULT_TIMEZONE = env('DEFAULT_TIMEZONE', 'Europe/Prague')
+DEFAULT_TIMEZONE = env('DEFAULT_TIMEZONE')
+
+if DEFAULT_TIMEZONE is None:
+    DEFAULT_TIMEZONE = tzlocal.get_localzone().zone
+
+if not DEFAULT_TIMEZONE:
+    raise ValueError("DEFAULT_TIMEZONE is empty")
 
 # The number of minutes since the last update of the Mongo auth object after which it will be deleted
 SESSION_EXPIRY_MINUTES = int(env('SESSION_EXPIRY_MINUTES', 240))


### PR DESCRIPTION
…icitly set

This commit add a new dependency: tzlocal

DEFAULT_TIMEZONE was defaulting on Europe/Prague. This commit fix it by using the timezone actually set
on the running machine.

SDNTB-285