### PR TITLE
fix(upload): fix upload after changes to crop sizes

### DIFF
--- a/features/archive.feature
+++ b/features/archive.feature
@@ -665,3 +665,13 @@ Feature: News Items Archive
 
         When we get "/archive"
         Then we get list with 0 items
+
+    @auth
+    Scenario: Upload image with custom crops
+        Given "vocabularies"
+        """
+        [{"_id": "crop_sizes", "items": [{"is_active": true, "name": "3:2", "width": "3", "height": "2"}]}]
+        """
+
+        When we upload a file "bike.jpg" to "archive"
+        Then we get new resource

--- a/superdesk/media/renditions.py
+++ b/superdesk/media/renditions.py
@@ -149,6 +149,7 @@ def _resize_image(content, size, format='png', keepProportions=True):
             raise Exception('size parameter requires at least width or height value')
         # resize with width and height
         if new_width is not None and new_height is not None:
+            new_width, new_height = int(new_width), int(new_height)
             x_ratio = width / new_width
             y_ratio = height / new_height
             if x_ratio > y_ratio:


### PR DESCRIPTION
if you change width/height it is stored as string,
which raises an error later. so cast those to int before use.