### PR TITLE
fix(crop): let width/height to be strings

### DIFF
--- a/superdesk/media/crop.py
+++ b/superdesk/media/crop.py
@@ -65,8 +65,11 @@ class CropService():
     def _validate_values(self, crop):
         int_fields = ('CropLeft', 'CropTop', 'CropRight', 'CropBottom', 'width', 'height')
         for field in int_fields:
-            if field in crop and type(crop[field]) != int:
-                raise SuperdeskApiError.badRequestError('Invalid value for %s in renditions' % field)
+            if field in crop:
+                try:
+                    crop[field] = int(crop[field])
+                except (TypeError, ValueError):
+                    raise SuperdeskApiError.badRequestError('Invalid value for %s in renditions' % field)
 
     def _validate_poi(self, original, updates, crop_name):
         """Validate the crop point of interest in the renditions dictionary for the given crop

--- a/tests/media/crop_test.py
+++ b/tests/media/crop_test.py
@@ -119,6 +119,16 @@ class CropTestCase(TestCase):
         self.assertEqual(ex.message, 'Original file couldn\'t be found')
         self.assertEqual(ex.status_code, 400)
 
+    def test_validate_crop_converts_to_int(self):
+        crop = {'width': '300', 'height': 200}
+        self.service._validate_values(crop)
+        self.assertEqual(300, crop['width'])
+        self.assertEqual(200, crop['height'])
+
+        with self.assertRaises(SuperdeskApiError) as context:
+            self.service._validate_values({'width': 'foo'})
+            self.assertEqual(context.exception.message, 'Invalid value for width in renditions')
+
     @mock.patch('superdesk.media.crop.crop_image', return_value=(False, 'test'))
     def test_add_crop_raises_error(self, crop_name):
         original = {


### PR DESCRIPTION
after updating crop specs those could be stored as strings,
so only raise an error in case those values can't be converted
to integers.