### PR TITLE
fix(enqueue): Using system_update to modify the schedule item instead of patch.

### DIFF
--- a/apps/publish/enqueue/__init__.py
+++ b/apps/publish/enqueue/__init__.py
@@ -98,8 +98,10 @@ def enqueue_item(published_item):
             resolve_document_version(document=item_updates, resource=ARCHIVE,
                                      method='PATCH',
                                      latest_doc={config.VERSION: published_item[config.VERSION]})
+
             # update the archive collection
-            archive_service.patch(published_item['item_id'], item_updates)
+            archive_item = archive_service.find_one(req=None, _id=published_item['item_id'])
+            archive_service.system_update(published_item['item_id'], item_updates, archive_item)
             # insert into version.
             insert_into_versions(published_item['item_id'], doc=None)
             # import to legal archive

--- a/features/content_publish.feature
+++ b/features/content_publish.feature
@@ -554,7 +554,7 @@ Feature: Content Publishing
       {"_issues": {"validator exception": "500: Failed to publish the item: PublishQueueError Error 9009 - Item could not be queued"}}
       """
 
-    @auth @test
+    @auth
     Scenario: Schedule a user content publish
       Given empty "subscribers"
       And "desks"
@@ -595,6 +595,23 @@ Feature: Content Publishing
       {"_current_version": 2, "state": "scheduled", "operation": "publish"}
       """
       And we get expiry for schedule and embargo content 60 minutes after "#archive_publish.publish_schedule#"
+      When we get "/published"
+      Then we get list with 2 items
+      """
+      {
+        "_items": [
+          {
+            "_id": "123", "type": "text", "state": "scheduled",
+            "_current_version": 2, "operation": "publish", "queue_state": "pending"
+          },
+          {
+            "_id": "#archive.123.take_package#", "type": "composite",
+            "state": "scheduled", "_current_version": 2, "operation": "publish",
+            "queue_state": "pending"
+          }
+        ]
+      }
+      """
       When we enqueue published
       When we get "/publish_queue"
       Then we get list with 0 items
@@ -611,10 +628,13 @@ Feature: Content Publishing
       {
         "_items": [
           {
-            "_id": "123", "type": "text", "state": "published", "_current_version": 3
+            "_id": "123", "type": "text", "state": "published",
+            "_current_version": 3, "operation": "publish", "queue_state": "queued_not_transmitted"
           },
           {
-            "_id": "#archive.123.take_package#", "type": "composite", "state": "published", "_current_version": 3
+            "_id": "#archive.123.take_package#", "type": "composite",
+            "state": "published", "_current_version": 3, "operation": "publish",
+            "queue_state": "queued"
           }
         ]
       }


### PR DESCRIPTION
The `archiveservice.patch` call updates the `operation` field from `publish` to `update` for scheduled items. If the scheduled item fails to queue in the first attempt then in the subsequent attempts it throws `keyerror` exception as there is not `enqueue service` for `update` operation. 