### PR TITLE
fix(rss): ingest items with missing updated info

### DIFF
--- a/superdesk/io/feeding_services/rss.py
+++ b/superdesk/io/feeding_services/rss.py
@@ -147,10 +147,13 @@ class RSSFeedingService(FeedingService):
         field_aliases = config.get('field_aliases')
 
         for entry in data.entries:
-            t_entry_updated = utcfromtimestamp(timegm(entry.updated_parsed))
-
-            if t_entry_updated <= t_provider_updated:
-                continue
+            try:
+                t_entry_updated = utcfromtimestamp(timegm(entry.updated_parsed))
+                if t_entry_updated <= t_provider_updated:
+                    continue
+            except AttributeError:
+                # missing updated info, so better ingest it
+                pass
 
             item = self._create_item(entry, field_aliases, provider.get('source', None))
             self.add_timestamps(item)


### PR DESCRIPTION
it was using that field to determine if an item should be ingested
or not, but when this info was missing for an item it would raise
error and make this provider useless.