### PR TITLE
feat(translate): Automatically call translate macros on translate oper…

### DIFF
--- a/apps/duplication/archive_translate.py
+++ b/apps/duplication/archive_translate.py
@@ -59,6 +59,8 @@ class TranslateService(BaseService):
             if not is_workflow_state_transition_valid('translate', archived_doc[ITEM_STATE]):
                 raise InvalidStateTransitionError()
 
+            get_resource_service('macros').execute_translation_macro(
+                archived_doc, archived_doc.get('language', None), doc.get('language'))
             archived_doc['language'] = doc.get('language')
             new_guid = archive_service.duplicate_content(archived_doc)
             guid_of_translated_items.append(new_guid)

--- a/apps/macros/macro_register.py
+++ b/apps/macros/macro_register.py
@@ -57,14 +57,10 @@ def register_macros():
                   'access_type': macro_module.access_type,
                   'action_type': macro_module.action_type}
 
-        if hasattr(macro_module, 'label'):
-            kwargs['label'] = macro_module.label
-
-        if hasattr(macro_module, 'order'):
-            kwargs['order'] = macro_module.order
-
-        if hasattr(macro_module, 'shortcut'):
-            kwargs['shortcut'] = macro_module.shortcut
+        options = ['label', 'order', 'shortcut', 'from_languages', 'to_languages']
+        for field in options:
+            if hasattr(macro_module, field):
+                kwargs[field] = getattr(macro_module, field)
 
         register(**kwargs)
 

--- a/apps/macros/macros.py
+++ b/apps/macros/macros.py
@@ -66,6 +66,16 @@ class MacrosService(superdesk.Service):
         else:
             return [m for m in macros if m.get('access_type') == 'frontend']
 
+    def execute_translation_macro(self, doc, from_language, to_language):
+        """
+        Apply to doc all macros that are related to current translation defined by from_language and to_language
+        Macros can have optionally defined translation related settings: from_languages, to_languages.
+        """
+        for m in macros:
+            if (not m.get('from_languages', None) or from_language in m['from_languages']) \
+                    and to_language in m.get('to_languages', []):
+                m['callback'](doc)
+
 
 class MacrosResource(superdesk.Resource):
     resource_methods = ['GET', 'POST']

--- a/features/content_translate.feature
+++ b/features/content_translate.feature
@@ -4,16 +4,16 @@ Feature: Translate Content
     Scenario: Translate content item
       Given "archive"
       """
-      [{"type":"text", "headline": "test1", "guid": "123", "original_creator": "abc", "state": "draft"}]
+      [{"type":"text", "headline": "test1", "guid": "123", "original_creator": "abc", "state": "draft",  "language": "en-CA", "body_html": "$10"}]
       """
       When we post to "/archive/translate"
       """
-      {"guid": "123", "language": "de"}
+      {"guid": "123", "language": "en-AU"}
       """
       When we get "/archive/#translate._id#"
       Then we get existing resource
       """
-      {"type":"text", "headline": "test1", "state": "draft", "sign_off": "abc", "language": "de"}
+      {"type":"text", "headline": "test1", "state": "draft", "sign_off": "abc", "language": "en-AU", "body_html": "$10 (CAD 20)"}
       """
 
     @auth

--- a/superdesk/macros/currency_usd_to_cad.py
+++ b/superdesk/macros/currency_usd_to_cad.py
@@ -39,3 +39,5 @@ shortcut = 'd'
 callback = usd_to_cad
 access_type = 'frontend'
 action_type = 'interactive'
+from_languages = ['en-CA']
+to_languages = ['en-AU']


### PR DESCRIPTION
…ation

The translate macros had defined the translate related settings
from_language(optional) and to_language(mandatory).
Example:
from_languages = ['en']
to_languages = ['nn-NO', 'nb-NO']
If from_language is not defined, the from language is not checked.