### PR TITLE
[SDESK-273] Byline to be empty when editing a published item to kill it.

### DIFF
--- a/apps/templates/content_templates.py
+++ b/apps/templates/content_templates.py
@@ -37,6 +37,7 @@ TEMPLATE_FIELDS = {'template_name', 'template_type', 'schedule', 'type', 'state'
                    config.ETAG, 'task'}
 KILL_TEMPLATE_NOT_REQUIRED_FIELDS = ['schedule', 'dateline', 'template_desks', 'schedule_desk',
                                      'schedule_stage']
+KILL_TEMPLATE_NULL_FIELDS = ['byline', 'place']
 PLAINTEXT_FIELDS = {'headline'}
 
 
@@ -288,6 +289,10 @@ class ContentTemplatesApplyService(Service):
 
         updates = render_content_template(item, template)
         item.update(updates)
+
+        if template_name == 'kill':
+            apply_null_override_for_kill(item)
+
         docs[0] = item
         build_custom_hateoas(CUSTOM_HATEOAS, docs[0])
         return [docs[0].get(config.ID_FIELD)]
@@ -401,6 +406,12 @@ def filter_plaintext_fields(item):
     for field in PLAINTEXT_FIELDS:
         if field in item:
             item[field] = plaintext_filter(item[field])
+
+
+def apply_null_override_for_kill(item):
+    for key in KILL_TEMPLATE_NULL_FIELDS:
+        if key in item:
+            item[key] = None
 
 
 @celery.task(soft_time_limit=120)

--- a/features/templates.feature
+++ b/features/templates.feature
@@ -450,3 +450,49 @@ Feature: Templates
          "_status": "ERR"
         }
         """
+
+    @auth
+    Scenario: Byline and Place is null after Kill template is applied to an item
+        When we post to "content_templates"
+        """
+        {
+            "template_name": "kill",
+            "template_type": "kill",
+            "is_public": true,
+            "data": {
+                "body_html": "<p>Please kill story slugged {{ item.slugline }} ex {{ item.dateline['text'] }} at {{item.versioncreated | format_datetime(date_format='%d %b %Y %H:%S %Z')}}.<\/p>",
+                "type": "text",
+                "abstract": "This article has been removed",
+                "headline": "Kill\/Takedown notice ~~~ Kill\/Takedown notice",
+                "urgency": 1, "priority": 1,
+                "anpa_take_key": "KILL\/TAKEDOWN"
+            }
+        }
+        """
+        Then we get new resource
+        When we post to "content_templates_apply"
+        """
+            {
+                "template_name": "kill",
+                "item": {
+                    "headline": "Test", "_id": "123",
+                    "body_html": "test", "slugline": "testing",
+                    "abstract": "abstract",
+                    "byline": "Test-byline",
+                    "place": [{"qcode" : "ACT", "world_region" : "Oceania", "country" : "Australia",
+                    "name" : "ACT", "state" : "Australian Capital Territory"}],
+                    "urgency": 5, "priority": 6,
+                    "dateline": {
+                        "text": "Prague, 9 May (SAP)"
+                    },
+                    "versioncreated": "2015-01-01T22:54:53+0000"
+                }
+            }
+        """
+        Then we get updated response
+        """
+        {
+          "byline": null,
+          "place": null
+        }
+        """


### PR DESCRIPTION
When a published item is being killed and opened for editing, it should have an empty byline.