### PR TITLE
fix(xml file ingest) files with unicode BOM markers were causing exce…

### DIFF
--- a/superdesk/io/feeding_services/file_service.py
+++ b/superdesk/io/feeding_services/file_service.py
@@ -58,7 +58,7 @@ class FileFeedingService(FeedingService):
 
                     if self.is_latest_content(last_updated, provider.get('last_updated')):
                         if isinstance(registered_parser, XMLFeedParser):
-                            with open(file_path, 'rt') as f:
+                            with open(file_path, 'rb') as f:
                                 xml = ElementTree.parse(f)
                                 parser = self.get_feed_parser(provider, xml.getroot())
                                 item = parser.parse(xml.getroot(), provider)

--- a/tests/io/feed_parsers/pa_nitf_test.py
+++ b/tests/io/feed_parsers/pa_nitf_test.py
@@ -26,7 +26,7 @@ class PANITFFileTestCase(TestCase):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.normpath(os.path.join(dirname, '../fixtures', self.filename))
         provider = {'name': 'Test'}
-        with open(fixture, 'rt') as f:
+        with open(fixture, 'rb') as f:
             xml = ElementTree.parse(f)
             self.item = PAFeedParser().parse(xml.getroot(), provider)
 

--- a/tests/io/feed_parsers/scoop_parser_test.py
+++ b/tests/io/feed_parsers/scoop_parser_test.py
@@ -12,7 +12,7 @@
 import os
 import unittest
 
-from superdesk.etree import etree
+from xml.etree import ElementTree
 from superdesk.io.feed_parsers.scoop_newsml_2_0 import ScoopNewsMLTwoFeedParser
 
 
@@ -21,9 +21,10 @@ class ScoopTestCase(unittest.TestCase):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.normpath(os.path.join(dirname, '../fixtures', self.filename))
         provider = {'name': 'Test'}
-        with open(fixture) as f:
-            self.scoop = f.read()
-            self.item = ScoopNewsMLTwoFeedParser().parse(etree.fromstring(self.scoop), provider)
+        with open(fixture, 'rb') as f:
+            parser = ScoopNewsMLTwoFeedParser()
+            self.xml = ElementTree.parse(f)
+            self.item = parser.parse(self.xml.getroot(), provider)
 
 
 class AAPTestCase(ScoopTestCase):
@@ -40,4 +41,4 @@ class AAPTestCase(ScoopTestCase):
         self.assertEqual(self.item[0].get('firstcreated').isoformat(), '2016-01-11T23:35:40+00:00')
 
     def test_can_parse(self):
-        self.assertTrue(ScoopNewsMLTwoFeedParser().can_parse(etree.fromstring(self.scoop)))
+        self.assertTrue(ScoopNewsMLTwoFeedParser().can_parse(self.xml.getroot()))


### PR DESCRIPTION
…ptions

The ElementTree parse was throwing the following exception.
ParserError Error 1002 - Ingest file could not be parsed: 'ascii' codec can't decode byte 0xef in position 0: ordinal not in range(128)