### PR TITLE
fix(capi): allow where filtering, disable q search

### DIFF
--- a/content_api/errors.py
+++ b/content_api/errors.py
@@ -36,6 +36,7 @@ class UnexpectedParameterError(PublicApiError):
 
     def __init__(self, desc=None):
         super().__init__(10001, desc=desc)
+        self.status_code = 400
 
 
 class BadParameterValueError(PublicApiError):
@@ -45,6 +46,7 @@ class BadParameterValueError(PublicApiError):
 
     def __init__(self, desc=None):
         super().__init__(10002, desc=desc)
+        self.status_code = 400
 
 
 class FileNotFoundError(PublicApiError):

--- a/content_api/items/service.py
+++ b/content_api/items/service.py
@@ -76,16 +76,12 @@ class ItemsService(BaseService):
         orig_request_params = getattr(req, 'args', MultiDict())
 
         allowed_params = {
-            'q', 'start_date', 'end_date',
+            'start_date', 'end_date',
             'include_fields', 'exclude_fields',
-            'max_results', 'page'
+            'max_results', 'page',
+            'where'
         }
         self._check_for_unknown_params(req, whitelist=allowed_params)
-
-        # set the search query
-        if 'q' in orig_request_params:
-            internal_req.args['q'] = orig_request_params['q']
-            internal_req.args['default_operator'] = 'OR'
 
         # set the date range filter
         start_date, end_date = self._get_date_range(orig_request_params)
@@ -214,10 +210,6 @@ class ItemsService(BaseService):
         if not allow_filtering:
             err_msg = ("Filtering{} is not supported when retrieving a "
                        "single object (the \"{param}\" parameter)")
-
-            if 'q' in request_params.keys():
-                desc = err_msg.format('', param='q')
-                raise UnexpectedParameterError(desc=desc)
 
             if 'start_date' in request_params.keys():
                 desc = err_msg.format(' by date range', param='start_date')

--- a/content_api/packages/service.py
+++ b/content_api/packages/service.py
@@ -56,5 +56,6 @@ class PackagesService(ItemsService):
         :param dict document: MongoDB document representing a package object
         """
         for item in document.get('associations', {}).values():
-            item['uri'] = self._get_uri(item)
-            item.pop('_id', None)
+            if item.get('_id') or item.get('guid'):
+                item['uri'] = self._get_uri(item)
+                item.pop('_id', None)

--- a/content_api/tests/errors_test.py
+++ b/content_api/tests/errors_test.py
@@ -68,7 +68,7 @@ class UnknownParameterErrorTestCase(ApiTestCase):
 
     def test_error_code(self):
         error = self._make_one()
-        self.assertEqual(error.status_code, 10001)
+        self.assertEqual(error.status_code, 400)
 
     def test_error_message(self):
         error = self._make_one()
@@ -100,7 +100,7 @@ class BadParameterValueTestCase(ApiTestCase):
 
     def test_error_code(self):
         error = self._make_one()
-        self.assertEqual(error.status_code, 10002)
+        self.assertEqual(error.status_code, 400)
 
     def test_error_message(self):
         error = self._make_one()

--- a/content_api/tests/items_service_test.py
+++ b/content_api/tests/items_service_test.py
@@ -87,8 +87,7 @@ class CheckForUnknownParamsMethodTestCase(ItemsServiceTestCase):
         ex = context.exception
         self.assertEqual(
             ex.payload,
-            'Filtering is not supported when retrieving a single object '
-            '(the "q" parameter)'
+            'Unexpected parameter (q)'
         )
 
     def test_raises_descriptive_error_on_disabled_start_date_filtering(self):
@@ -170,8 +169,9 @@ class GetMethodTestCase(ItemsServiceTestCase):
 
         expected_whitelist = sorted([
             'start_date', 'end_date',
-            'exclude_fields', 'include_fields', 'q',
-            'max_results', 'page'
+            'exclude_fields', 'include_fields',
+            'max_results', 'page',
+            'where'
         ])
 
         whitelist_arg = kwargs.get('whitelist')
@@ -298,25 +298,6 @@ class GetMethodTestCase(ItemsServiceTestCase):
             'lte': '2012-08-26'
         }
         self.assertEqual(date_filter, expected_filter)
-
-    def test_includes_text_query_if_given(self):
-        request = MagicMock()
-        request.args = MultiDict([
-            ('q', 'text')
-        ])
-        lookup = {}
-
-        instance = self._make_one()
-        instance.get(request, lookup)
-
-        self.assertTrue(fake_super_get.called)
-        args, _ = fake_super_get.call_args
-        self.assertGreater(len(args), 0)
-
-        text_query = args[0].args['q']
-        self.assertEqual(text_query, 'text')
-        default_operator = args[0].args['default_operator']
-        self.assertEqual(default_operator, 'OR')
 
     @mock.patch('content_api.items.service.utcnow')
     def test_sets_end_date_to_today_if_not_given(self, fake_utcnow):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ LONG_DESCRIPTION = "Superdesk Server Core"
 
 install_requires = [
     'eve>=0.6,<0.7',
-    'eve-elastic>=0.4.1,<0.5',
+    'eve-elastic>=0.5.2,<0.6',
     'elasticsearch>=1.9.0,<2.0',
     'flask>=0.10,<0.11',
     'flask-mail>=0.9,<0.10',

--- a/superdesk/datalayer.py
+++ b/superdesk/datalayer.py
@@ -27,7 +27,7 @@ class SuperdeskDataLayer(DataLayer):
 
     serializers = {}
     serializers.update(Mongo.serializers)
-    serializers.update(Elastic.serializers)
+    serializers.update({'datetime': Elastic.serializers['datetime']})
 
     def init_app(self, app):
         app.data = self  # app.data must be set for locks to work


### PR DESCRIPTION
instead of allowing elastic query string search,
only allow `where` param which is using terms filter.