### PR TITLE
feat(projections) - Projecting the search results

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -138,12 +138,12 @@ class ArchiveService(BaseService):
         """
         Overriding this to handle existing data in Mongo & Elastic
         """
-        self.__enhance_items(docs[config.ITEMS])
+        self.enhance_items(docs[config.ITEMS])
 
     def on_fetched_item(self, doc):
-        self.__enhance_items([doc])
+        self.enhance_items([doc])
 
-    def __enhance_items(self, items):
+    def enhance_items(self, items):
         for item in items:
             handle_existing_data(item)
 

--- a/apps/archive/archive_test.py
+++ b/apps/archive/archive_test.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock
 from bson import ObjectId
 from pytz import timezone
 
-from apps.archive.archive import SOURCE as ARCHIVE
+from apps.archive.archive import ArchiveService, SOURCE as ARCHIVE
 from apps.archive.common import (
     validate_schedule, remove_media_files,
     format_dateline_to_locmmmddsrc, convert_task_attributes_to_objectId,
@@ -477,3 +477,41 @@ class ExpiredArchiveContentTestCase(TestCase):
         test_items['item3'] = self.published_items[3]
         result = self.class_under_test().check_if_items_imported_to_legal_archive(test_items)
         self.assertIn('item3', result)
+
+
+class ArchiveEnhanceTestCase(TestCase):
+    def test_enhancing_archive_items(self):
+        for i in range(0, 10):
+            self.app.data.insert(ARCHIVE, [{
+                '_id': str(i),
+                'type': 'text',
+                'linked_in_packages': [{
+                    'package': str(i + 10),
+                    'package_type': 'takes'}]}])
+
+            self.app.data.insert(ARCHIVE, [{
+                '_id': str(i + 10),
+                'type': 'composite',
+                'package_type': 'takes',
+                'groups': [
+                    {'id': 'root', 'refs': [{'idRef': 'main'}], 'role': 'grpRole:NEP'},
+                    {
+                        'id': 'main',
+                        'refs': [
+                            {
+                                'location': ARCHIVE,
+                                'residRef': str(i),
+                                'sequence': 1,
+                                'type': 'text'
+                            }
+                        ],
+                        'role': 'grpRole:main'}]}])
+
+        items = list(self.app.data.find_all('archive', None))
+        ArchiveService().enhance_items(items)
+        self.assertEqual(len(items), 20)
+
+        for item in items:
+            if item['type'] == 'text':
+                self.assertTrue('takes' in item)
+                self.assertEqual(item['takes']['_id'], str(int(item['_id']) + 10))

--- a/apps/packages/takes_package_service.py
+++ b/apps/packages/takes_package_service.py
@@ -339,11 +339,16 @@ class TakesPackageService():
 
     def enhance_items_with_takes_packages(self, items):
         """Get the takes packages for items
-
         :param items:
         """
+        item_lookup = {}
         packages = []
+
         for item in items:
+            if item.get(TAKES_PACKAGE):
+                continue
+
+            item_lookup[item[config.ID_FIELD]] = item
             takes_package_id = self.get_take_package_id(item)
             if takes_package_id:
                 packages.append(takes_package_id)
@@ -355,8 +360,7 @@ class TakesPackageService():
 
             for package in takes_packages:
                 refs = self.get_package_refs(package) or []
-                takes = {ref.get(RESIDREF) for ref in refs}
-
-                for item in items:
-                    if not item.get(TAKES_PACKAGE) and item.get(config.ID_FIELD) in takes:
-                        item[TAKES_PACKAGE] = package
+                take_ids = {ref.get(RESIDREF) for ref in refs}
+                for take_id in take_ids:
+                    if take_id in item_lookup:
+                        item_lookup[take_id][TAKES_PACKAGE] = package

--- a/apps/publish/published_item.py
+++ b/apps/publish/published_item.py
@@ -184,6 +184,7 @@ class PublishedItemService(BaseService):
         if items:
             ids = list(set([item.get('item_id') for item in items if item.get('item_id')]))
             archive_items = []
+            archive_lookup = {}
             if ids:
                 query = {'$and': [{config.ID_FIELD: {'$in': ids}}]}
                 archive_req = ParsedRequest()
@@ -196,11 +197,10 @@ class PublishedItemService(BaseService):
                 takes_service.enhance_items_with_takes_packages(archive_items)
                 for item in archive_items:
                     handle_existing_data(item)
+                    archive_lookup[item[config.ID_FIELD]] = item
 
             for item in items:
-                archive_item = [i for i in archive_items if i.get(config.ID_FIELD) == item.get('item_id')]
-                archive_item = archive_item[0] if len(archive_item) > 0 else \
-                    {config.VERSION: item.get(config.VERSION, 1)}
+                archive_item = archive_lookup.get(item.get('item_id'), {config.VERSION: item.get(config.VERSION, 1)})
 
                 updates = {
                     config.ID_FIELD: item.get('item_id'),

--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -74,6 +74,11 @@ class SearchService(superdesk.Service):
 
         return query
 
+    def _get_projected_fields(self, req):
+            """Get elastic projected fields."""
+            if app.data.elastic.should_project(req):
+                return app.data.elastic.get_projected_fields(req)
+
     def _get_types(self, req):
         """Get document types for the given query."""
         args = getattr(req, 'args', {})
@@ -102,6 +107,7 @@ class SearchService(superdesk.Service):
         """
 
         query = self._get_query(req)
+        fields = self._get_projected_fields(req)
         types = self._get_types(req)
         filters = self._get_filters(types)
         user = g.get('user', {})
@@ -119,7 +125,11 @@ class SearchService(superdesk.Service):
 
         set_filters(query, filters)
 
-        hits = self.elastic.es.search(body=query, index=self._get_index(), doc_type=types)
+        params = {}
+        if fields:
+            params['_source'] = fields
+
+        hits = self.elastic.es.search(body=query, index=self._get_index(), doc_type=types, params=params)
         docs = self._get_docs(hits)
 
         for resource in types:

--- a/features/search.feature
+++ b/features/search.feature
@@ -273,3 +273,30 @@ Feature: Search Feature
                         }}]
         }
         """
+
+    @auth
+    Scenario: Search items with projections
+        Given "desks"
+        """
+        [{"name": "Sports Desk", "content_expiry": 60}]
+        """
+        Given "archive"
+        """
+        [{"guid": "1", "state": "in_progress", "task": {"desk": "#desks._id#"},
+         "headline": "Foo", "body_html": "foo"},
+        {"guid": "2", "state": "in_progress", "task": {"desk": "#desks._id#"},
+         "headline": "bar", "body_html": "bar"}]
+        """
+        When we get "/search?source={"query": {"filtered": {"query": {"query_string": {"query": "(foo)", "lenient": false, "default_operator": "AND"}}}}}"
+        Then we get list with 1 items
+        """
+        {
+            "_items": [{"guid": "1", "state": "in_progress", "task": {"desk": "#desks._id#"},
+                        "headline": "Foo", "body_html": "foo", "es_highlight": "__no_value__"}]
+        }
+        """
+        When we get "/search?projections=["headline"]&source={"query": {"filtered": {"query": {"query_string": {"query": "(foo)", "lenient": false, "default_operator": "AND"}}}}}"
+        Then we get list with 1 items
+        And we get "body_html" does not exist
+        And we get "state" does not exist
+        And we get "headline" does exist

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ LONG_DESCRIPTION = "Superdesk Server Core"
 
 install_requires = [
     'eve>=0.6,<0.7',
-    'eve-elastic>=0.5.2,<0.6',
+    'eve-elastic>=0.5.2,<0.7',
     'elasticsearch>=1.9.0,<2.0',
     'flask>=0.10,<0.11',
     'flask-mail>=0.9,<0.10',

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -1755,6 +1755,20 @@ def step_impl_when_rewrite(context, item_id):
     set_placeholder(context, 'REWRITE_ID', resp['_id']['_id'])
 
 
+@then('we get "{field_name}" does not exist')
+def then_field_is_not_populated_in_results(context, field_name):
+    resps = parse_json_response(context.response)
+    for resp in resps['_items']:
+        assert field_name not in resp, 'field exists'
+
+
+@then('we get "{field_name}" does exist')
+def then_field_is_not_populated_in_results(context, field_name):
+    resps = parse_json_response(context.response)
+    for resp in resps['_items']:
+        assert field_name in resp, 'field does not exist'
+
+
 @when('we publish "{item_id}" with "{pub_type}" type and "{state}" state')
 def step_impl_when_publish_url(context, item_id, pub_type, state):
     item_id = apply_placeholders(context, item_id)


### PR DESCRIPTION
- Search endpoint now parses the request for an optional `projections` field having the list of field names to be returned
- Resource endpoints (such as Archive, Published, Ingest) can also have the optional `projections` field
- Also there has been some performance improvements in `enhance_items` functions 