### PR TITLE
fix(capi): use `CONTENTAPI_URL` instead of `PUBLICAPI_URL`

### DIFF
--- a/content_api/app/settings.py
+++ b/content_api/app/settings.py
@@ -38,9 +38,9 @@ CONTENTAPI_INSTALLED_APPS = [
 
 CONTENTAPI_DOMAIN = {}
 
-# NOTE: no trailing slash for the PUBLICAPI_URL setting!
-PUBLICAPI_URL = env('PUBLICAPI_URL', 'http://localhost:5400')
-server_url = urlparse(PUBLICAPI_URL)
+# NOTE: no trailing slash for the CONTENTAPI_URL setting!
+CONTENTAPI_URL = env('CONTENTAPI_URL', 'http://localhost:5400')
+server_url = urlparse(CONTENTAPI_URL)
 URL_PREFIX = server_url.path.strip('/')
 
 XML = False

--- a/content_api/auth/auth_data_manager.py
+++ b/content_api/auth/auth_data_manager.py
@@ -31,7 +31,7 @@ class AuthDataManager:
             return None
         client['client_id'] = client['_id']
         client['default_scopes'] = app.config['OAUTH2_SCOPES']
-        client['default_redirect_uri'] = app.config['PUBLICAPI_URL']
+        client['default_redirect_uri'] = app.config['CONTENTAPI_URL']
         return DictObject(**client)
 
     @staticmethod

--- a/content_api/items/service.py
+++ b/content_api/items/service.py
@@ -180,7 +180,7 @@ class ItemsService(BaseService):
             endpoint_name = 'items'
 
         resource_url = '{api_url}/{endpoint}/'.format(
-            api_url=app.config['PUBLICAPI_URL'],
+            api_url=app.config['CONTENTAPI_URL'],
             endpoint=app.config['URLS'][endpoint_name]
         )
 

--- a/content_api/tests/items_service_test.py
+++ b/content_api/tests/items_service_test.py
@@ -646,7 +646,7 @@ class OnFetchedItemMethodTestCase(ItemsServiceTestCase):
         super().setUp()
 
         self.app = Flask(__name__)
-        self.app.config['PUBLICAPI_URL'] = 'http://content_api.com'
+        self.app.config['CONTENTAPI_URL'] = 'http://content_api.com'
         self.app.config['URLS'] = {'items': 'items_endpoint'}
 
         self.app_context = self.app.app_context()
@@ -713,7 +713,7 @@ class OnFetchedMethodTestCase(ItemsServiceTestCase):
         super().setUp()
 
         self.app = Flask(__name__)
-        self.app.config['PUBLICAPI_URL'] = 'http://content_api.com'
+        self.app.config['CONTENTAPI_URL'] = 'http://content_api.com'
         self.app.config['URLS'] = {'items': 'items_endpoint'}
 
         self.app_context = self.app.app_context()
@@ -840,7 +840,7 @@ class GetUriMethodTestCase(ItemsServiceTestCase):
         super().setUp()
 
         self.app = Flask(__name__)
-        self.app.config['PUBLICAPI_URL'] = 'http://content_api.com'
+        self.app.config['CONTENTAPI_URL'] = 'http://content_api.com'
         self.app.config['URLS'] = {
             'items': 'items_endpoint',
             'packages': 'packages_endpoint'

--- a/content_api/tests/packages_service_test.py
+++ b/content_api/tests/packages_service_test.py
@@ -42,7 +42,7 @@ class OnFetchedItemMethodTestCase(PackagesServiceTestCase):
         super().setUp()
 
         self.app = Flask(__name__)
-        self.app.config['PUBLICAPI_URL'] = 'http://content_api.com'
+        self.app.config['CONTENTAPI_URL'] = 'http://content_api.com'
         self.app.config['URLS'] = {
             'items': 'items_endpoint',
             'packages': 'packages_endpoint'
@@ -108,7 +108,7 @@ class OnFetchedMethodTestCase(PackagesServiceTestCase):
         super().setUp()
 
         self.app = Flask(__name__)
-        self.app.config['PUBLICAPI_URL'] = 'http://content_api.com'
+        self.app.config['CONTENTAPI_URL'] = 'http://content_api.com'
         self.app.config['URLS'] = {
             'items': 'items_endpoint',
             'packages': 'packages_endpoint'

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -434,6 +434,12 @@ Content API Settings
 
 .. versionadded:: 1.5
 
+``CONTENTAPI_URL``
+
+Default: ``localhost:5400``
+
+Content API URL. Set this when running api behind a proxy.
+
 ``CONTENT_API_ENABLED``
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
so that we can deploy both on different urls.