### PR TITLE
Use separate flag to skip "os.environ" usage in settings

### DIFF
--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -29,7 +29,7 @@ except ImportError:
 
 
 def env(variable, fallback_value=None):
-    if os.environ.get('SUPERDESK_TESTING'):
+    if os.environ.get('SUPERDESK_USE_DEFAULTS'):
         return fallback_value
 
     env_value = os.environ.get(variable)


### PR DESCRIPTION
@akintolga reported they have problems with running e2e tests locally, so let's use separate flag for such purpose.