### PR TITLE
refactor(search): refactor search providers

### DIFF
--- a/apps/io/search_ingest.py
+++ b/apps/io/search_ingest.py
@@ -52,6 +52,9 @@ class SearchIngestService(superdesk.Service):
             self.backend.set_credentials(provider['config']['username'], provider['config'].get('password', ''))
         return provider
 
+    def fetch(self, guid):
+        return self.backend.find_one_raw(guid, guid)
+
     def create(self, docs, **kwargs):
         new_guids = []
         provider = self.get_provider()
@@ -60,7 +63,7 @@ class SearchIngestService(superdesk.Service):
                 # if no desk is selected then it is bad request
                 raise SuperdeskApiError.badRequestError("Destination desk cannot be empty.")
             try:
-                archived_doc = self.backend.find_one_raw(doc['guid'], doc['guid'])
+                archived_doc = self.fetch(doc['guid'])
             except FileNotFoundError as ex:
                 raise ProviderError.externalProviderError(ex, provider)
 

--- a/apps/picture_crop/__init__.py
+++ b/apps/picture_crop/__init__.py
@@ -4,10 +4,13 @@ import superdesk
 from flask import current_app as app
 from superdesk.utils import get_random_string
 from superdesk.media.media_operations import crop_image
+from apps.search_providers.proxy import PROXY_ENDPOINT
 
 
 def get_file(rendition, item):
     if item.get('fetch_endpoint'):
+        if item['fetch_endpoint'] == PROXY_ENDPOINT:  # it requires provider info
+            return superdesk.get_resource_service(item['fetch_endpoint']).fetch_rendition(rendition, item=item)
         return superdesk.get_resource_service(item['fetch_endpoint']).fetch_rendition(rendition)
     else:
         return app.media.fetch_rendition(rendition)

--- a/apps/search_providers/proxy.py
+++ b/apps/search_providers/proxy.py
@@ -1,0 +1,102 @@
+
+import bson
+import superdesk
+
+from flask import abort, request
+from superdesk.utc import utcnow
+from superdesk.utils import ListCursor
+from apps.search_providers.registry import registered_search_providers
+from apps.io.search_ingest import SearchIngestService
+
+
+PROXY_ENDPOINT = 'search_providers_proxy'
+
+
+class SearchProviderProxyResource(superdesk.Resource):
+    schema = {
+        'guid': {'type': 'string', 'required': True},
+        'desk': superdesk.Resource.rel('desks', False, nullable=True),
+        'repo': superdesk.Resource.rel('search_providers', False, nullable=True),
+    }
+
+    resource_methods = ['GET', 'POST']
+    privileges = {'POST': 'search_providers'}
+
+
+class SearchProviderProxyService(SearchIngestService):
+    """Search Provider Proxy.
+
+    It will forward requests to specific SearchProvider instance.
+
+    Old implementations will get forwarded to its service.
+    """
+
+    def get_provider(self, provider_id=None):
+        if not provider_id:
+            provider_id = request.args.get('repo')
+        if not provider_id:
+            abort(400)
+        provider = superdesk.get_resource_service('search_providers').find_one(req=None, _id=provider_id)
+        if not provider:
+            abort(400)
+        if provider.get('is_closed'):
+            abort(400)
+        return provider
+
+    def _get_service(self, provider):
+        service = registered_search_providers[provider['search_provider']]
+        if not isinstance(service, str):
+            return service(provider)
+        return service
+
+    def get(self, req, lookup):
+        """Search using provider."""
+        provider = self.get_provider()
+        service = self._get_service(provider)
+        if isinstance(service, str):
+            return superdesk.get_resource_service(service).get(req, lookup)
+        query = self._get_query(req)
+        items = service.find(query)
+        if isinstance(items, list):
+            items = ListCursor(items)
+        for item in items:
+            self._set_item_defaults(item, provider)
+        return items
+
+    def create(self, docs, **kwargs):
+        """Archive items from provider."""
+        provider = self.get_provider()
+        service = self._get_service(provider)
+        if isinstance(service, str):
+            return superdesk.get_resource_service(service).create(docs, **kwargs)
+        return super().create(docs, **kwargs)
+
+    def fetch(self, guid):
+        """Fetch single item from provider to archive it."""
+        provider = self.get_provider()
+        service = self._get_service(provider)
+        if isinstance(service, str):
+            return superdesk.get_resource_service(service).fetch(guid)
+        item = service.fetch(guid)
+        self._set_item_defaults(item, provider)
+        return item
+
+    def fetch_rendition(self, rendition, item):
+        """Fetch binary from provider."""
+        provider = self.get_provider(item.get('ingest_provider'))
+        service = self._get_service(provider)
+        if isinstance(service, str):
+            return superdesk.get_resource_service(service).fetch_rendition(self, rendition)
+        return service.fetch_file(rendition.get('href'))
+
+    def _set_item_defaults(self, item, provider):
+        """Add default values to external items."""
+        now = utcnow()
+        item.setdefault('_id', item.get('guid') or bson.ObjectId())
+        item.setdefault('_type', 'externalsource')
+        item.setdefault('type', 'picture')
+        item.setdefault('pubstatus', 'usable')
+        item.setdefault('firstcreated', now)
+        item.setdefault('versioncreated', now)
+        item.setdefault('fetch_endpoint', PROXY_ENDPOINT)
+        item.setdefault('ingest_provider', str(provider['_id']))

--- a/apps/search_providers/registry.py
+++ b/apps/search_providers/registry.py
@@ -1,0 +1,57 @@
+
+from superdesk import Resource, Service
+from superdesk.utils import ListCursor
+from superdesk.errors import AlreadyExistsError
+
+
+registered_search_providers = {}
+allowed_search_providers = []
+
+
+def register_search_provider(name, fetch_endpoint=None, provider_class=None):
+    """Register a Search Provider with the given name and fetch_endpoint.
+
+    Both have to be unique and if not raises AlreadyExistsError.
+    The fetch_endpoint is used by clients to fetch the article from the Search Provider.
+
+    :param name: Search Provider Name
+    :type name: str
+    :param fetch_endpoint: relative url to /api
+    :type fetch_endpoint: str
+    :param provider_class: provider implementation
+    :type provider: superdesk.SearchProvider
+    :raises: AlreadyExistsError - if a search has been registered with either name or fetch_endpoint.
+    """
+    if name in registered_search_providers:
+        raise AlreadyExistsError("A Search Provider with name: {} already exists".format(name))
+
+    if fetch_endpoint and fetch_endpoint in registered_search_providers.values():
+        raise AlreadyExistsError("A Search Provider for the fetch endpoint: {} exists with name: {}"
+                                 .format(fetch_endpoint, registered_search_providers[name]))
+
+    registered_search_providers[name] = provider_class if provider_class else fetch_endpoint
+
+    if not registered_search_providers[name]:
+        raise ValueError('You have to specify fetch_endpoint or provider_class.')
+
+    allowed_search_providers.append(name)
+
+
+class SearchProviderAllowedResource(Resource):
+    resource_methods = ['GET']
+    item_methods = []
+
+
+class SearchProviderAllowedService(Service):
+
+    def get(self, req, lookup):
+        def provider(provider_id):
+            registered = registered_search_providers[provider_id]
+            return {
+                'search_provider': provider_id,
+                'label': getattr(registered, 'label', provider_id)
+            }
+
+        return ListCursor(
+            [provider(_id) for _id in registered_search_providers]
+        )

--- a/apps/search_providers/resource.py
+++ b/apps/search_providers/resource.py
@@ -8,13 +8,9 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-import logging
-
 from apps.search_providers import allowed_search_providers
 from superdesk.resource import Resource
 from superdesk.utils import required_string
-
-logger = logging.getLogger(__name__)
 
 
 class SearchProviderResource(Resource):
@@ -22,7 +18,6 @@ class SearchProviderResource(Resource):
         'search_provider': {
             'type': 'string',
             'required': True,
-            'unique': True,
             'allowed': allowed_search_providers
         },
         'source': required_string,

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -1,0 +1,36 @@
+Extending Superdesk
+===================
+
+.. versionchanged:: 1.6
+
+Adding new Search Provider
+--------------------------
+
+.. module:: superdesk
+
+You have to implement a new :class:`SearchProvider` and register it within superdesk::
+
+    import superdesk
+
+
+    class FooSearchProvider(superdesk.SearchProvider):
+
+        label = 'Foo'
+
+        def find(self, query):
+            return [{'headline': 'Static list'}]
+
+
+    def init_app(app):
+        superdesk.register_search_provider('foo', provider_class=FooSearchProvider)
+
+This way it will add a new option to subscribers settings.
+
+.. important::
+    Don't forget to add such module into :ref:`settings.installed_apps`.
+
+Search Provider API
+^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: SearchProvider
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,6 +57,7 @@ works and can be developed further.
     schema
     content-types
     contentapi
+    extending
 
 Additional topics
 -----------------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -47,6 +47,8 @@ Default: ``300``
 
 This is used for all ftp operations. Increase if you get ftp timeout errors.
 
+.. _settings.installed_apps:
+
 ``INSTALLED_APPS``
 ^^^^^^^^^^^^^^^^^^
 

--- a/features/search_providers.feature
+++ b/features/search_providers.feature
@@ -33,23 +33,6 @@ Feature: Search Provider Feature
         """
 
     @auth
-    Scenario: Creating a Search Provider with same type more than once fails
-        Given empty "search_providers"
-        When we post to "search_providers"
-	    """
-        [{"search_provider": "testsearch", "source": "testsearch", "config": {"password":"", "username":""}}]
-	    """
-        Then we get new resource
-        When we post to "search_providers"
-	    """
-        [{"search_provider": "testsearch", "source": "testsearch", "config": {"password":"", "username":""}}]
-	    """
-        Then we get error 400
-        """
-        {"_status": "ERR", "_issues": {"search_provider": {"unique": 1}}}
-        """
-
-    @auth
     Scenario: Updating an existing search provider fails if the search provider type hasn't been registered with the application
         Given empty "search_providers"
         When we post to "search_providers"
@@ -81,4 +64,43 @@ Feature: Search Provider Feature
         Then we get existing resource
         """
         {"_items": [{"_id": "search_providers.search_provider", "items": ["testsearch"]}]}
+        """
+
+    @wip
+    @auth
+    Scenario: Search using custom search provider
+        Given "search_providers"
+        """
+        [{"search_provider": "testsearch", "source": "testsearch", "config": {"password":"", "username":""}}]
+        """
+        Given "desks"
+        """
+        [{"name": "sports"}]
+        """
+        When we get "search_providers_proxy?repo=#search_providers._id#"
+        Then we get list with 1 items
+        """
+        {"_items": [{
+            "_id": "foo",
+            "guid": "foo",
+            "_type": "externalsource",
+            "pubstatus": "usable",
+            "fetch_endpoint": "search_providers_proxy"
+        }]}
+        """
+
+        When we post to "search_providers_proxy?repo=#search_providers._id#"
+        """
+        {"guid": "foo", "desk": "#desks._id#"}
+        """
+        Then we get new resource
+
+
+    @wip
+    @auth
+    Scenario: Get available search providers
+        When we get "search_providers_allowed"
+        Then we get list with 1+ items
+        """
+        {"_items": [{"search_provider": "testsearch", "label": "Foo"}]}
         """

--- a/superdesk/__init__.py
+++ b/superdesk/__init__.py
@@ -147,3 +147,7 @@ def register_jinja_filter(name, jinja_filter):
     :param jinja_filter: jinja filter function
     """
     JINJA_FILTERS[name] = jinja_filter
+
+
+from superdesk.search_provider import SearchProvider  # noqa
+from apps.search_providers import register_search_provider  # noqa

--- a/superdesk/search_provider.py
+++ b/superdesk/search_provider.py
@@ -1,0 +1,43 @@
+
+class SearchProvider():
+    """Base class for Search Providers.
+
+    You can use ``self.provider`` to get config data.
+    """
+
+    #: Provider Type Label
+    label = 'unknown'
+
+    def __init__(self, provider):
+        """Create search provider instance.
+
+        :param provider: provider data dict
+        """
+        self.provider = provider
+
+    def find(self, query):
+        """Find items using query.
+
+        This must return cursor like object.
+
+        :param query: query dict
+        """
+        raise NotImplementedError
+
+    def fetch(self, guid):
+        """Get single item.
+
+        Get an item before archiving it. Should contain all metadata.
+
+        :param guid: item guid
+        """
+        raise NotImplementedError
+
+    def fetch_file(self, href):
+        """Fetch binary using given href.
+
+        Href is from renditions dict.
+
+        :param href: binary href
+        """
+        raise NotImplementedError

--- a/superdesk/tests/environment.py
+++ b/superdesk/tests/environment.py
@@ -17,6 +17,7 @@ from superdesk import tests
 from superdesk.factory.app import get_app
 from superdesk.tests import setup_auth_user
 from superdesk.vocabularies.command import VocabulariesPopulateCommand
+from superdesk.tests.mocks import TestSearchProvider
 
 
 readonly_fields = ['display_name', 'password', 'phone', 'first_name', 'last_name']
@@ -152,4 +153,4 @@ def before_step(context, step):
 def setup_search_provider(app):
     from apps.search_providers import register_search_provider, allowed_search_providers
     if 'testsearch' not in allowed_search_providers:
-        register_search_provider('testsearch', 'testsearch')
+        register_search_provider('testsearch', TestSearchProvider)

--- a/superdesk/tests/mocks.py
+++ b/superdesk/tests/mocks.py
@@ -1,0 +1,16 @@
+
+from superdesk import SearchProvider
+
+
+class TestSearchProvider(SearchProvider):
+
+    label = 'Foo'
+
+    def find(self, query):
+        return [{'guid': 'foo'}]
+
+    def fetch(self, guid):
+        return {'_id': guid, 'headline': guid}
+
+    def fetch_file(self, href):
+        return {'href': href}


### PR DESCRIPTION
Change the way how these are registered, instead of creating an
endpoint and datalayer for each it only requires a single class.

There is a proxy resource that will forward the call to appropriate
instance.