### PR TITLE
[FORMATER] [NITF] accept table elements in html2nitf

### DIFF
--- a/superdesk/publish/formatters/nitf_formatter.py
+++ b/superdesk/publish/formatters/nitf_formatter.py
@@ -34,6 +34,8 @@ class NITFFormatter(Formatter):
     _debug_message_extra = {
         'schemaLocation': '{} {}'.format(_schema_uri, _schema_ref)}
     NITF_COMMON_ATTR = ('id', 'class', 'style')
+    NITF_CELL_ALIGN = ('align', 'char', 'charoff')
+    NITF_CELL_VALIGN = ('valign',)
     NITF_ALLOWED_ATTR = {
         'p': NITF_COMMON_ATTR + ('lede', 'summary', 'optional-tex'),
         'a': NITF_COMMON_ATTR + ('href', 'name', 'rel', 'rev', 'title'),
@@ -52,6 +54,20 @@ class NITFFormatter(Formatter):
             'rules',
             'cellspacing',
             'cellpadding'),
+        'tbody': NITF_COMMON_ATTR + NITF_CELL_ALIGN + NITF_CELL_VALIGN,
+        'tr': NITF_COMMON_ATTR + NITF_CELL_ALIGN + NITF_CELL_VALIGN,
+        'th': NITF_COMMON_ATTR + NITF_CELL_ALIGN + NITF_CELL_VALIGN + (
+            'axis',
+            'axes',
+            'nowrap',
+            'rowspan',
+            'colspan'),
+        'td': NITF_COMMON_ATTR + NITF_CELL_ALIGN + NITF_CELL_VALIGN + (
+            'axis',
+            'axes',
+            'nowrap',
+            'rowspan',
+            'colspan'),
         'nitf-table': ('id',),
         'ol': NITF_COMMON_ATTR + ('seqnum',),
         'ul': NITF_COMMON_ATTR,
@@ -106,6 +122,12 @@ class NITFFormatter(Formatter):
         'h4': {'nitf': 'hl2'},
         'h5': {'nitf': 'hl2'},
         'h6': {'nitf': 'hl2'},
+        # tables
+        'table': {},
+        'tbody': {},
+        'tr': {},
+        'td': {},
+        'th': {},
     }
 
     def format(self, article, subscriber, codes=None):

--- a/tests/publish/nitf_formatter_tests.py
+++ b/tests/publish/nitf_formatter_tests.py
@@ -105,6 +105,34 @@ class NitfFormatterTest(TestCase):
             </div>""").replace('\n', '').replace(' ', '')
         self.assertEqual(etree.tostring(nitf, 'unicode').replace('\n', '').replace(' ', ''), expected)
 
+    def test_table(self):
+        html_raw = """
+        <div>
+        <table>
+            <tbody>
+                <tr>
+                    <td>Table cell 1</td>
+                    <td>Table cell 2</td>
+                    <td>Table cell 3</td>
+                </tr>
+                <tr>
+                    <td>Table cell 2.1</td>
+                    <td>Table cell 2.2</td>
+                    <td>Table cell 2.3</td>
+                </tr>
+                <tr>
+                    <td>Table cell 3.1</td>
+                    <td>Table cell 3.2</td>
+                    <td>Table cell 3.3</td>
+                </tr>
+            </tbody>
+        </table>
+        </div>
+        """.replace('\n', '').replace(' ', '')
+        html = etree.fromstring(html_raw)
+        nitf = self.formatter.html2nitf(html)
+        self.assertEqual(etree.tostring(nitf, 'unicode'), html_raw)
+
     def test_company_codes(self):
         article = {
             'guid': 'tag:aap.com.au:20150613:12345',


### PR DESCRIPTION
table elements (table, tbody, th, td, tr) are not removed anymore when
converting to NITF format.

SDNTB-343