### PR TITLE
[SD-5472] - Marking stories for desks

### DIFF
--- a/apps/highlights/service.py
+++ b/apps/highlights/service.py
@@ -115,10 +115,10 @@ class MarkedForHighlightsService(BaseService):
                     publishedService.update(publishedItem['_id'], updates, publishedItem)
 
             push_notification(
-                'item:highlight',
+                'item:highlights',
                 marked=int(highlight_on),
                 item_id=item['_id'],
-                highlight_id=str(doc['highlights']))
+                mark_id=str(doc['highlights']))
 
         return ids
 

--- a/apps/highlights/service_tests.py
+++ b/apps/highlights/service_tests.py
@@ -87,16 +87,16 @@ class CreateMethodTestCase(MarkedForHighlightsServiceTest):
         # notifications should have been pushed, one for each highlighted item
         self.assertEqual(fake_push_notify.call_count, 2)
         fake_push_notify.assert_any_call(
-            'item:highlight',
+            'item:highlights',
             marked=1,
             item_id='tag:item_1',
-            highlight_id='highlight_X'
+            mark_id='highlight_X'
         )
         fake_push_notify.assert_any_call(
-            'item:highlight',
+            'item:highlights',
             marked=1,
             item_id='tag:item_2',
-            highlight_id='highlight_Y'
+            mark_id='highlight_Y'
         )
 
     def test_pushes_notifications_for_newly_unhighlighted_items(
@@ -130,14 +130,14 @@ class CreateMethodTestCase(MarkedForHighlightsServiceTest):
         # notifications should have been pushed, one for each highlighted item
         self.assertEqual(fake_push_notify.call_count, 2)
         fake_push_notify.assert_any_call(
-            'item:highlight',
+            'item:highlights',
             marked=0,
             item_id='tag:item_1',
-            highlight_id='highlight_X'
+            mark_id='highlight_X'
         )
         fake_push_notify.assert_any_call(
-            'item:highlight',
+            'item:highlights',
             marked=0,
             item_id='tag:item_2',
-            highlight_id='highlight_Y'
+            mark_id='highlight_Y'
         )

--- a/apps/marked_desks/__init__.py
+++ b/apps/marked_desks/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import superdesk
+
+from superdesk import get_backend
+from apps.marked_desks.resource import MarkedForDesksResource
+from apps.marked_desks.service import MarkedForDesksService
+
+
+def init_app(app):
+    endpoint_name = 'marked_for_desks'
+    service = MarkedForDesksService(endpoint_name, backend=get_backend())
+    MarkedForDesksResource(endpoint_name, app=app, service=service)
+
+    superdesk.privilege(name='mark_for_desks', label='Mark items for desks',
+                        description='User can mark items for other desks.')

--- a/apps/marked_desks/resource.py
+++ b/apps/marked_desks/resource.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.resource import Resource
+
+
+class MarkedForDesksResource(Resource):
+    """Marked for desks Schema"""
+
+    schema = {
+        'marked_desk': {
+            'type': 'string',
+            'required': True
+        },
+        'marked_item': {
+            'type': 'string',
+            'required': True
+        }
+    }
+    privileges = {'POST': 'mark_for_desks'}

--- a/apps/marked_desks/service.py
+++ b/apps/marked_desks/service.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import json
+from superdesk import get_resource_service
+from superdesk.services import BaseService
+from eve.utils import ParsedRequest
+from superdesk.notification import push_notification
+from apps.archive.common import get_user
+from eve.utils import config
+from superdesk.utc import utcnow
+
+
+def get_marked_items(desk_id):
+    """Get items marked for given desk"""
+    query = {
+        'query': {'filtered': {'filter': {'term': {'marked_desks.desk_id': str(desk_id)}}}},
+        'sort': [{'versioncreated': 'desc'}],
+        'size': 200
+    }
+    request = ParsedRequest()
+    request.args = {'source': json.dumps(query), 'repo': 'archive,published'}
+    return list(get_resource_service('search').get(req=request, lookup=None))
+
+
+class MarkedForDesksService(BaseService):
+    def create(self, docs, **kwargs):
+        """Toggle marked desk status for given desk and item."""
+
+        service = get_resource_service('archive')
+        published_service = get_resource_service('published')
+        ids = []
+        for doc in docs:
+            item = service.find_one(req=None, guid=doc['marked_item'])
+            if not item:
+                ids.append(None)
+                continue
+            ids.append(item['_id'])
+            marked_desks = item.get('marked_desks', [])
+            if not marked_desks:
+                marked_desks = []
+
+            existing_mark = next((m for m in marked_desks if m['desk_id'] == doc['marked_desk']), None)
+
+            if existing_mark:
+                # there is an existing mark so this is un-mark action
+                marked_desks = [m for m in marked_desks if m['desk_id'] != doc['marked_desk']]
+                marked_desks_on = False  # highlight toggled off
+            else:
+                # there is no existing mark so this is mark action
+                new_mark = {}
+                new_mark['desk_id'] = doc['marked_desk']
+                new_mark['user_marked'] = str(get_user(True).get(config.ID_FIELD, ''))
+                new_mark['date_marked'] = utcnow()
+                marked_desks.append(new_mark)
+                marked_desks_on = True
+
+            updates = {'marked_desks': marked_desks}
+            service.system_update(item['_id'], updates, item)
+
+            publishedItems = published_service.find({'item_id': item['_id']})
+            for publishedItem in publishedItems:
+                if publishedItem['_current_version'] == item['_current_version'] or not marked_desks_on:
+                    updates = {'marked_desks': marked_desks}
+                    published_service.system_update(publishedItem['_id'], updates, publishedItem)
+
+            push_notification(
+                'item:marked_desks',
+                marked=int(marked_desks_on),
+                item_id=item['_id'],
+                mark_id=str(doc['marked_desk']))
+
+        return ids

--- a/features/marked_desks.feature
+++ b/features/marked_desks.feature
@@ -1,0 +1,34 @@
+Feature: Marked For Desks
+
+  @auth
+  Scenario: Mark a story for a desk
+        Given "desks"
+        """
+        [{"name": "desk1"}]
+        """
+        When we post to "archive"
+        """
+        [{"headline": "test"}]
+        """
+        When we post to "/marked_for_desks" with success
+        """
+        [{"marked_desk": "#desks._id#", "marked_item": "#archive._id#"}]
+        """
+        Then we get new resource
+        """
+        {"marked_desk": "#desks._id#", "marked_item": "#archive._id#"}
+        """
+        When we get "archive"
+        Then we get list with 1 items
+        """
+        {"_items": [{"headline": "test", "marked_desks": [{"desk_id": "#desks._id#", "user_marked": "#user._id#"}]}]}
+        """
+        When we post to "marked_for_desks"
+        """
+        [{"marked_desk": "#desks._id#", "marked_item": "#archive._id#"}]
+        """
+        And we get "archive"
+        Then we get list with 1 items
+        """
+        {"_items": [{"marked_desks": []}]}
+        """

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -336,6 +336,7 @@ CORE_APPS.extend([
     'apps.privilege',
     'apps.rules',
     'apps.highlights',
+    'apps.marked_desks',
     'apps.products',
     'apps.publish',
     'apps.publish.formatters',

--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -374,6 +374,20 @@ metadata_schema = {
         'type': 'list',
         'schema': Resource.rel('highlights', True)
     },
+    'marked_desks': {
+        'type': 'list',
+        'nullable': True,
+        'schema': {
+            'type': 'dict',
+            'schema': {
+                'desk_id': Resource.rel('desks', True),
+                'date_marked': {'type': 'datetime', 'nullable': True},
+                'user_marked': Resource.rel('users', required=False, nullable=True),
+                'date_acknowledged': {'type': 'datetime', 'nullable': True},
+                'user_acknowledged': Resource.rel('users', required=False, nullable=True)
+            }
+        },
+    },
 
     'more_coming': {'type': 'boolean'},  # deprecated
 


### PR DESCRIPTION
- A new end point created to mark a story for the desks. Similar to the highlights, a story can be marked for 0..n desks. This won't change existing functionality about the actual desk the story is in. 