### PR TITLE
[INGEST] added an option to skip iptc_codes processing

### DIFF
--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -444,7 +444,9 @@ def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=N
             process_anpa_category(item, provider)
 
         if 'subject' in item:
-            process_iptc_codes(item, provider)
+            if not app.config.get('INGEST_SKIP_IPTC_CODES', False):
+                # FIXME: temporary fix for SDNTB-344, need to be removed once SDESK-439 is implemented
+                process_iptc_codes(item, provider)
             if 'anpa_category' not in item:
                 derive_category(item, provider)
         elif 'anpa_category' in item:


### PR DESCRIPTION
process_iptc_codes was causing trouble with NTB (see SDNTB-344
comments), this commit add an "INGEST_SKIP_IPTC_CODES" option to skip
this processing.

This is a temporary solution, a better option should be applied using
some extensions mechanism like hooks (SDESK-439).

needed for SDNTB-344