### PR TITLE
[TRANSMITER] [FILE] fixed filename

### DIFF
--- a/superdesk/publish/transmitters/file_output.py
+++ b/superdesk/publish/transmitters/file_output.py
@@ -8,7 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from superdesk.publish.publish_service import PublishService
+from superdesk.publish import publish_service
 from superdesk.publish import register_transmitter
 from superdesk.errors import PublishFileError
 from os import path
@@ -16,7 +16,7 @@ from os import path
 errors = [PublishFileError.fileSaveError().get_error_description()]
 
 
-class FilePublishService(PublishService):
+class FilePublishService(publish_service.PublishService):
     """Superdesk file transmitter.
 
     It creates files on superdesk server in configured folder.
@@ -28,7 +28,7 @@ class FilePublishService(PublishService):
             file_path = config['file_path']
             if not path.isabs(file_path):
                 file_path = "/" + file_path
-            with open(path.join(file_path, PublishService.get_filename(queue_item)), 'wb') as f:
+            with open(path.join(file_path, publish_service.get_publish_service().get_filename(queue_item)), 'wb') as f:
                 f.write(queue_item['encoded_item'])
         except Exception as ex:
             raise PublishFileError.fileSaveError(ex, config)


### PR DESCRIPTION
filename is using PublishService which can be overridden, but it depends
of module loading order which may result in the wrong method being
called.

This commit use the get_public_service when
getting the filename to fix this.