### PR TITLE
[SDESK-419] Duplication of text archived items to be supported

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -385,7 +385,7 @@ class ArchiveService(BaseService):
 
         new_doc = original_doc.copy()
         self._remove_after_copy(new_doc)
-        on_duplicate_item(new_doc)
+        on_duplicate_item(new_doc, original_doc)
         resolve_document_version(new_doc, SOURCE, 'PATCH', new_doc)
 
         if original_doc.get('task', {}).get('desk') is not None and new_doc.get(ITEM_STATE) != CONTENT_STATE.SUBMITTED:

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -265,7 +265,7 @@ def set_default_source(doc):
                                                              doc['dateline'].get('date'), source)
 
 
-def on_duplicate_item(doc):
+def on_duplicate_item(doc, original_doc):
     """Make sure duplicated item has basic fields populated."""
 
     doc[GUID_FIELD] = generate_guid(type=GUID_NEWSML)
@@ -274,6 +274,7 @@ def on_duplicate_item(doc):
     set_sign_off(doc)
     doc['force_unlock'] = True
     doc[ITEM_OPERATION] = ITEM_DUPLICATE
+    doc['original_id'] = original_doc.get('item_id', original_doc.get('_id'))
     set_default_source(doc)
 
 

--- a/features/embargo.feature
+++ b/features/embargo.feature
@@ -561,7 +561,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     Then we get response code 200
     When we post to "/archive/123/duplicate" with success
     """
-    {"desk": "#desks._id#"}
+    {"desk": "#desks._id#","type": "archive"}
     """
     And we get "/archive/#duplicate._id#"
     Then there is no "embargo" in response


### PR DESCRIPTION
Note: When a text archived item is duplicated, latest item is obtained from the archived collection which has the same original item ( item_id ) for duplication.