### PR TITLE
fix comments with dot in username

### DIFF
--- a/apps/archive/__init__.py
+++ b/apps/archive/__init__.py
@@ -20,7 +20,6 @@ from .archive import ArchiveResource, ArchiveService, ArchiveVersionsResource, A
     ArchiveSaveService
 from .commands import RemoveExpiredContent
 from .ingest import IngestResource, AppIngestService
-from .item_comments import ItemCommentsResource, ItemCommentsSubResource, ItemCommentsService, ItemCommentsSubService
 from .user_content import UserContentResource, UserContentService
 from .archive_lock import ArchiveLockResource, ArchiveUnlockResource, ArchiveLockService, ArchiveUnlockService
 from .archive_spike import ArchiveUnspikeResource, ArchiveSpikeService, ArchiveSpikeResource, ArchiveUnspikeService
@@ -49,14 +48,6 @@ def init_app(app):
     endpoint_name = 'archive'
     service = ArchiveService(endpoint_name, backend=superdesk.get_backend())
     ArchiveResource(endpoint_name, app=app, service=service)
-
-    endpoint_name = 'item_comments'
-    service = ItemCommentsService(endpoint_name, backend=superdesk.get_backend())
-    ItemCommentsResource(endpoint_name, app=app, service=service)
-
-    endpoint_name = 'content_item_comments'
-    service = ItemCommentsSubService(endpoint_name, backend=superdesk.get_backend())
-    ItemCommentsSubResource(endpoint_name, app=app, service=service)
 
     endpoint_name = 'archive_lock'
     service = ArchiveLockService(endpoint_name, backend=superdesk.get_backend())

--- a/apps/archive/item_comments.py
+++ b/apps/archive/item_comments.py
@@ -48,3 +48,13 @@ class ItemCommentsSubService(BaseService):
     def get(self, req, lookup):
         self.check_item_valid(lookup.get('item'))
         return super().get(req, lookup)
+
+
+def init_app(app):
+    endpoint_name = 'item_comments'
+    service = ItemCommentsService(endpoint_name, backend=superdesk.get_backend())
+    ItemCommentsResource(endpoint_name, app=app, service=service)
+
+    endpoint_name = 'content_item_comments'
+    service = ItemCommentsSubService(endpoint_name, backend=superdesk.get_backend())
+    ItemCommentsSubResource(endpoint_name, app=app, service=service)

--- a/apps/comments/__init__.py
+++ b/apps/comments/__init__.py
@@ -9,9 +9,11 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 """Generic comments module."""
-from .comments import CommentsService, CommentsResource, comments_schema  # noqa
+
 import superdesk
-from .user_mentions import on_activity_updated
+
+from apps.comments.comments import CommentsService, CommentsResource, comments_schema  # noqa
+from apps.comments.user_mentions import on_activity_updated
 
 
 def init_app(app):

--- a/apps/comments/comments.py
+++ b/apps/comments/comments.py
@@ -42,6 +42,36 @@ class CommentsResource(Resource):
     privileges = {'POST': 'archive', 'DELETE': 'archive'}
 
 
+def encode_keys(doc, field):
+    """Encode field keys before storing.
+
+    Mongo doesn't allow `.` in dict key.
+
+    :param doc: doc
+    :param field: doc field
+    """
+    if not doc.get(field):
+        return
+    encoded = {}
+    for key, val in doc.get(field).items():
+        encoded[key.replace('.', ';')] = val
+    doc[field] = encoded
+
+
+def decode_keys(doc, field):
+    """Decode encoded field keys.
+
+    :param doc: doc
+    :param field: doc field
+    """
+    if not doc.get(field):
+        return
+    decoded = {}
+    for key, val in doc.get(field).items():
+        decoded[key.replace(';', '.')] = val
+    doc[field] = decoded
+
+
 class CommentsService(BaseService):
     notification_key = 'comments'
 
@@ -56,10 +86,19 @@ class CommentsService(BaseService):
             user_names, desk_names = get_mentions(doc.get('text'))
             doc['mentioned_users'] = get_users(user_names)
             doc['mentioned_desks'] = get_desks(desk_names)
+            encode_keys(doc, 'mentioned_users')
+            encode_keys(doc, 'mentioned_desks')
+
+    def on_fetched(self, doc):
+        for item in doc.get('_items', []):
+            decode_keys(item, 'mentioned_users')
+            decode_keys(item, 'mentioned_desks')
 
     def on_created(self, docs):
         for doc in docs:
             push_notification(self.notification_key, item=str(doc.get('item')))
+            decode_keys(doc, 'mentioned_users')
+            decode_keys(doc, 'mentioned_desks')
 
         notify_mentioned_users(docs, app.config.get('CLIENT_URL', ''))
         notify_mentioned_desks(docs)

--- a/apps/comments/user_mentions.py
+++ b/apps/comments/user_mentions.py
@@ -23,8 +23,8 @@ def get_mentions(text):
     Returns the names of desks and users from a given text
     User names starts with '@' and desk names starts with '#'
     """
-    user_pattern = re.compile("(^|\s)\@([a-zA-Z0-9-_.]\w+)")
-    desk_pattern = re.compile("(^|\s)\#([a-zA-Z0-9-_.]\w+)")
+    user_pattern = re.compile("(^|\s)\@([\w.-]+)")
+    desk_pattern = re.compile("(^|\s)\#([\w.-]+)")
     raw_user_names = set(username for match in re.finditer(user_pattern, text) for username in match.groups())
     raw_desk_names = set(deskname for match in re.finditer(desk_pattern, text) for deskname in match.groups())
     desk_names = [d.replace('_', ' ') for d in raw_desk_names if d.strip()]

--- a/features/comments.feature
+++ b/features/comments.feature
@@ -44,27 +44,26 @@ Feature: Default Comments
         {"_status": "ERR", "_message": "Commenting on behalf of someone else is prohibited."}
         """
 
-
     @auth
     @notification
     Scenario: Create comment with one user mention
         Given empty "comments"
         When we post to "/users"
         """
-        {"username": "joe", "display_name": "Joe Black", "email": "joe@black.com", "is_active": true, "sign_off": "abc"}
+        {"username": "joe.black", "display_name": "Joe Black", "email": "joe@black.com", "is_active": true, "sign_off": "abc"}
         """
         Then we get new resource
         """
-        {"username": "joe", "display_name": "Joe Black", "email": "joe@black.com"}
+        {"username": "joe.black", "display_name": "Joe Black", "email": "joe@black.com"}
         """
         When we mention user in comment for "/comments"
         """
-        [{"text": "test comment @no_user with one user mention @joe", "item": "xyz"}]
+        [{"text": "test comment @no_user with one user mention @joe.black", "item": "xyz"}]
         """
         And we get "/comments"
         Then we get list with 1 items
         """
-        {"_items": [{"text": "test comment @no_user with one user mention @joe", "item": "xyz", "mentioned_users": {"joe": "#users._id#"}}]}
+        {"_items": [{"text": "test comment @no_user with one user mention @joe.black", "item": "xyz", "mentioned_users": {"joe.black": "#users._id#"}}]}
         """
         When we get "/users/test_user"
         Then we get "_id"

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -322,6 +322,7 @@ CORE_APPS.extend([
 
     'apps.auth',
     'apps.archive',
+    'apps.archive.item_comments',
     'apps.stages',
     'apps.desks',
     'apps.tasks',

--- a/tests/comments_test.py
+++ b/tests/comments_test.py
@@ -1,0 +1,13 @@
+
+import unittest
+
+from apps.comments.user_mentions import get_mentions
+
+
+class CommentsTestCase(unittest.TestCase):
+
+
+    def test_user_mentions(self):
+        users, desks = get_mentions('hello @petr.jasek and #sports.desk')
+        self.assertIn('petr.jasek', users)
+        self.assertIn('sports.desk', desks)

--- a/tests/comments_test.py
+++ b/tests/comments_test.py
@@ -1,13 +1,23 @@
 
 import unittest
 
+from apps.comments.comments import encode_keys, decode_keys
 from apps.comments.user_mentions import get_mentions
 
 
 class CommentsTestCase(unittest.TestCase):
 
-
     def test_user_mentions(self):
-        users, desks = get_mentions('hello @petr.jasek and #sports.desk')
+        users, desks = get_mentions('hello @petr.jasek and #sports.desk and @a-_.')
+        self.assertIn('a-_.', users)
         self.assertIn('petr.jasek', users)
         self.assertIn('sports.desk', desks)
+
+    def test_encode_decode_keys(self):
+        doc = {'foo': {'x.y': 1}}
+        encode_keys(doc, 'foo')
+        for key in doc['foo']:
+            self.assertNotIn('.', key)
+        decode_keys(doc, 'foo')
+        self.assertIn('x.y', doc['foo'])
+        self.assertEqual(1, doc['foo']['x.y'])


### PR DESCRIPTION
- fix username and desk name parser to pick up these
- add a workaround for storage - it doesn't allow `.` in dict keys

SDESK-472