### PR TITLE
fix(capi): fix content api bootstrap

### DIFF
--- a/content_api/tokens/__init__.py
+++ b/content_api/tokens/__init__.py
@@ -40,4 +40,4 @@ class SubscriberTokenAuth(TokenAuth):
 
 
 def init_app(app):
-    superdesk.register_resource(TOKEN_RESOURCE, AuthSubscriberTokenResource, SubscriberTokenService)
+    superdesk.register_resource(TOKEN_RESOURCE, AuthSubscriberTokenResource, SubscriberTokenService, _app=app)

--- a/superdesk/__init__.py
+++ b/superdesk/__init__.py
@@ -121,7 +121,7 @@ def register_default_session_preference(preference_name, preference):
     default_session_preferences[preference_name] = preference
 
 
-def register_resource(name, resource, service=None, backend=None, privilege=None):
+def register_resource(name, resource, service=None, backend=None, privilege=None, _app=None):
     """Shortcut for registering resource and service together.
 
     :param name: resource name
@@ -129,6 +129,7 @@ def register_resource(name, resource, service=None, backend=None, privilege=None
     :param service: service class
     :param backend: backend instance
     :param privilege: privilege to register with resource
+    :param _app: flask app
     """
     if not backend:
         backend = get_backend()
@@ -136,8 +137,10 @@ def register_resource(name, resource, service=None, backend=None, privilege=None
         service = Service
     if privilege:
         intrinsic_privilege(name, privilege)
+    if not _app:
+        _app = app
     service_instance = service(name, backend=backend)
-    resource(name, app=app, service=service_instance)
+    resource(name, app=_app, service=service_instance)
 
 
 def register_jinja_filter(name, jinja_filter):


### PR DESCRIPTION
it doesn't use `superdesk.app`, so it must pass the app
instance explicitly when registering resources.