### PR TITLE
Superdesk io refactor

### DIFF
--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -365,7 +365,7 @@ def apply_rule_set(item, provider, rule_set=None):
         raise ProviderError.ruleError(ex, provider)
 
 
-def ingest_cancel(item):
+def ingest_cancel(item, feeding_service):
     """Given an item that has a pubstatus of canceled finds all versions of this item and mark them as canceled as well.
 
     Uses the URI to identify those items in ingest that are related to this cancellation.
@@ -374,7 +374,7 @@ def ingest_cancel(item):
     :return:
     """
     ingest_service = superdesk.get_resource_service(
-        feeding_service.service if hasattr(feeding_service, 'service')  else 'ingest')
+        feeding_service.service if hasattr(feeding_service, 'service') else 'ingest')
     lookup = {'uri': item.get('uri')}
     family_members = ingest_service.get_from_mongo(req=None, lookup=lookup)
     for relative in family_members:
@@ -420,7 +420,7 @@ def ingest_items(items, provider, feeding_service, rule_set=None, routing_scheme
             failed_items.add(item[GUID_FIELD])
 
     # sync mongo with ingest after all changes
-    ingest_collection = feeding_service.service if hasattr(feeding_service, 'service')  else 'ingest'
+    ingest_collection = feeding_service.service if hasattr(feeding_service, 'service') else 'ingest'
     ingest_service = superdesk.get_resource_service(ingest_collection)
     updated_items_ids = [item['_id'] for item in all_items if item[GUID_FIELD] not in failed_items]
     updated_items = ingest_service.find({'_id': {'$in': updated_items_ids}}, max_results=len(updated_items_ids))
@@ -434,7 +434,7 @@ def ingest_items(items, provider, feeding_service, rule_set=None, routing_scheme
 def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=None):
     try:
         ingest_service = superdesk.get_resource_service(
-            feeding_service.service if hasattr(feeding_service, 'service')  else 'ingest')
+            feeding_service.service if hasattr(feeding_service, 'service') else 'ingest')
 
         # determine if we already have this item
         old_item = ingest_service.find_one(guid=item[GUID_FIELD], req=None)
@@ -465,7 +465,7 @@ def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=N
 
         if item.get('pubstatus', '') == 'canceled':
             item[ITEM_STATE] = CONTENT_STATE.KILLED
-            ingest_cancel(item)
+            ingest_cancel(item, feeding_service)
 
         rend = item.get('renditions', {})
         if rend:

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -373,7 +373,8 @@ def ingest_cancel(item):
     :param item:
     :return:
     """
-    ingest_service = superdesk.get_resource_service(feeding_service.get('service', 'ingest'))
+    ingest_service = superdesk.get_resource_service(
+        feeding_service.service if hasattr(feeding_service, 'service')  else 'ingest')
     lookup = {'uri': item.get('uri')}
     family_members = ingest_service.get_from_mongo(req=None, lookup=lookup)
     for relative in family_members:
@@ -419,10 +420,11 @@ def ingest_items(items, provider, feeding_service, rule_set=None, routing_scheme
             failed_items.add(item[GUID_FIELD])
 
     # sync mongo with ingest after all changes
-    ingest_service = superdesk.get_resource_service(feeding_service.get('service', 'ingest'))
+    ingest_collection = feeding_service.service if hasattr(feeding_service, 'service')  else 'ingest'
+    ingest_service = superdesk.get_resource_service(ingest_collection)
     updated_items_ids = [item['_id'] for item in all_items if item[GUID_FIELD] not in failed_items]
     updated_items = ingest_service.find({'_id': {'$in': updated_items_ids}}, max_results=len(updated_items_ids))
-    app.data._search_backend('ingest').bulk_insert('ingest', [item for item in updated_items])
+    app.data._search_backend(ingest_collection).bulk_insert(ingest_collection, [item for item in updated_items])
 
     if failed_items:
         logger.error('Failed to ingest the following items: %s', failed_items)
@@ -431,7 +433,8 @@ def ingest_items(items, provider, feeding_service, rule_set=None, routing_scheme
 
 def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=None):
     try:
-        ingest_service = superdesk.get_resource_service(feeding_service.get('service', 'ingest'))
+        ingest_service = superdesk.get_resource_service(
+            feeding_service.service if hasattr(feeding_service, 'service')  else 'ingest')
 
         # determine if we already have this item
         old_item = ingest_service.find_one(guid=item[GUID_FIELD], req=None)

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -373,7 +373,7 @@ def ingest_cancel(item):
     :param item:
     :return:
     """
-    ingest_service = superdesk.get_resource_service('ingest')
+    ingest_service = superdesk.get_resource_service(feeding_service.get('service', 'ingest'))
     lookup = {'uri': item.get('uri')}
     family_members = ingest_service.get_from_mongo(req=None, lookup=lookup)
     for relative in family_members:
@@ -419,7 +419,7 @@ def ingest_items(items, provider, feeding_service, rule_set=None, routing_scheme
             failed_items.add(item[GUID_FIELD])
 
     # sync mongo with ingest after all changes
-    ingest_service = superdesk.get_resource_service('ingest')
+    ingest_service = superdesk.get_resource_service(feeding_service.get('service', 'ingest'))
     updated_items_ids = [item['_id'] for item in all_items if item[GUID_FIELD] not in failed_items]
     updated_items = ingest_service.find({'_id': {'$in': updated_items_ids}}, max_results=len(updated_items_ids))
     app.data._search_backend('ingest').bulk_insert('ingest', [item for item in updated_items])
@@ -431,7 +431,7 @@ def ingest_items(items, provider, feeding_service, rule_set=None, routing_scheme
 
 def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=None):
     try:
-        ingest_service = superdesk.get_resource_service('ingest')
+        ingest_service = superdesk.get_resource_service(feeding_service.get('service', 'ingest'))
 
         # determine if we already have this item
         old_item = ingest_service.find_one(guid=item[GUID_FIELD], req=None)

--- a/superdesk/io/ingest.py
+++ b/superdesk/io/ingest.py
@@ -28,13 +28,6 @@ class IngestResource(Resource):
     schema = {
         'archived': {
             'type': 'datetime'
-        },
-        'payload': {
-            'type': 'dict'
-        },
-        'searchable': {
-            'type': 'boolean',
-            'default': True
         }
     }
     schema.update(metadata_schema)

--- a/superdesk/io/ingest.py
+++ b/superdesk/io/ingest.py
@@ -32,7 +32,7 @@ class IngestResource(Resource):
         'payload': {
             'type': 'dict'
         },
-        'searchable': 
+        'searchable': {
             'type': 'boolean',
             'default': True
         }

--- a/superdesk/io/ingest.py
+++ b/superdesk/io/ingest.py
@@ -28,6 +28,13 @@ class IngestResource(Resource):
     schema = {
         'archived': {
             'type': 'datetime'
+        },
+        'payload': {
+            'type': 'dict'
+        },
+        'searchable': 
+            'type': 'boolean',
+            'default': True
         }
     }
     schema.update(metadata_schema)

--- a/superdesk/io/registry.py
+++ b/superdesk/io/registry.py
@@ -108,7 +108,7 @@ class FeedingServiceAllowedService(Service):
         def service(service_id):
             registered = registered_feeding_services[service_id]
             return {
-                'search_provider': service_id,
+                'feeding_service': service_id,
                 'label': getattr(registered, 'label', service_id)
             }
 


### PR DESCRIPTION
this change allows ingest services to write to an alternate collection rather than the default 'ingest' collection.  which was needed for superdesk-planning component.