### PR TITLE
[SDESK-347] - Remove the link to other stories

### DIFF
--- a/apps/archive/__init__.py
+++ b/apps/archive/__init__.py
@@ -100,7 +100,7 @@ def init_app(app):
     superdesk.privilege(name='rewrite', label='Update', description='Update a published content')
 
     superdesk.intrinsic_privilege(ArchiveUnlockResource.endpoint_name, method=['POST'])
-    superdesk.intrinsic_privilege(ArchiveLinkResource.endpoint_name, method=['POST'])
+    superdesk.intrinsic_privilege(ArchiveLinkResource.endpoint_name, method=['POST', 'DELETE'])
 
 
 @celery.task(soft_time_limit=600)

--- a/apps/archive/archive_rewrite.py
+++ b/apps/archive/archive_rewrite.py
@@ -222,7 +222,8 @@ class ArchiveRewriteService(Service):
         archive_service = get_resource_service(ARCHIVE)
 
         published_rewritten_stories = publish_service.get_rewritten_items_by_event_story(event_id,
-                                                                                         rewrite_id, rewrite_field)
+                                                                                         rewrite_id,
+                                                                                         rewrite_field)
         processed_items = set()
         for doc in published_rewritten_stories:
             doc_id = doc.get(config.ID_FIELD)

--- a/apps/archive/archive_spike.py
+++ b/apps/archive/archive_spike.py
@@ -72,7 +72,7 @@ class ArchiveSpikeService(BaseService):
         updates[ITEM_OPERATION] = ITEM_SPIKE
         self._validate_item(original)
         self._validate_take(original)
-        self._update_rewrite(original)
+        self.update_rewrite(original)
         set_sign_off(updates, original=original)
 
     def _validate_item(self, original):
@@ -98,7 +98,7 @@ class ArchiveSpikeService(BaseService):
         if not takes_service.is_last_takes_package_item(original):
             raise SuperdeskApiError.badRequestError(message="Only last take of the package can be spiked.")
 
-    def _update_rewrite(self, original):
+    def update_rewrite(self, original):
         """Removes the reference from the rewritten story in published collection."""
         rewrite_service = ArchiveRewriteService()
         if original.get('rewrite_of') and original.get('event_id'):

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -635,6 +635,15 @@ def step_impl_when_delete_url(context, url):
         context.outbox = outbox
 
 
+@when('we delete link "{url}"')
+def step_impl_when_delete_link_url(context, url):
+    with context.app.mail.record_messages() as outbox:
+        url = apply_placeholders(context, url)
+        headers = context.headers
+        context.response = context.client.delete(get_prefixed_url(context.app, url), headers=headers)
+        context.outbox = outbox
+
+
 @when('we delete all sessions "{url}"')
 def step_impl_when_delete_all_url(context, url):
     with context.app.mail.record_messages() as outbox:


### PR DESCRIPTION
- For the takes and updates the only way to remove the link was to spike the linked story.
- It is now possible to remove the link from the latest take or update without spiking the story
