### PR TITLE
fix(users): ensure username is unique

### DIFF
--- a/apps/prepopulate/app_initialization_test.py
+++ b/apps/prepopulate/app_initialization_test.py
@@ -62,9 +62,6 @@ class AppInitializeWithDataCommandTestCase(TestCase):
     def test_app_initialization_index_creation(self):
         result = self._run()
         self.assertEqual(result, 0)
-        result = app.data.mongo.pymongo(resource='users').db['users'].index_information()
-        self.assertTrue('username_1' in result)
-        self.assertTrue('first_name_1_last_name_-1' in result)
         result = app.data.mongo.pymongo(resource='archive').db['archive'].index_information()
         self.assertTrue('groups.refs.residRef_1' in result)
         self.assertTrue(result['groups.refs.residRef_1']['sparse'])

--- a/apps/prepopulate/app_initialize.py
+++ b/apps/prepopulate/app_initialize.py
@@ -36,11 +36,7 @@ dictionary:
 """
 __entities__ = OrderedDict([
     ('roles', ('roles.json', ['name'], False)),
-    ('users', ('users.json', [
-        [
-            ('first_name', pymongo.ASCENDING),
-            ('last_name', pymongo.DESCENDING)
-        ], 'username'], False)),
+    ('users', ('users.json', [], False)),
     ('stages', ('stages.json', ['desk'], False)),
     ('desks', ('desks.json', ['incoming_stage'], False)),
     ('groups', ('groups.json', '', False)),

--- a/superdesk/resource.py
+++ b/superdesk/resource.py
@@ -56,6 +56,7 @@ class Resource():
     resource_preferences = None
     etag_ignore_fields = []
     mongo_prefix = None
+    mongo_indexes = None
     auth_field = None
     authentication = None
     elastic_prefix = None
@@ -104,6 +105,8 @@ class Resource():
                 endpoint_schema.update({'elastic_prefix': self.elastic_prefix})
             if self.query_objectid_as_string:
                 endpoint_schema.update({'query_objectid_as_string': self.query_object_id_as_string})
+            if self.mongo_indexes:
+                endpoint_schema['mongo_indexes'] = self.mongo_indexes
 
         self.endpoint_schema = endpoint_schema
 

--- a/superdesk/users/users.py
+++ b/superdesk/users/users.py
@@ -133,5 +133,10 @@ class UsersResource(Resource):
             'default_sort': [('username', 1)],
         }
 
+        self.mongo_indexes = {
+            'username_1': ([('username', 1)], {'unique': True}),
+            'first_name_1_last_name_-1': [('first_name', 1), ('last_name', -1)],
+        }
+
         self.privileges = {'POST': 'users', 'DELETE': 'users', 'PATCH': 'users'}
         super().__init__(endpoint_name, app=app, service=service, endpoint_schema=endpoint_schema)


### PR DESCRIPTION
and use eve `mongo_indexes` for index creation.
this way indexes are created when app starts so
we can be sure it's in place, unlike when using
app:initialize_data.

so far only migrated users indexes to test this.

SDESK-514