### PR TITLE
[doc] authentication documentation

### DIFF
--- a/apps/auth/__init__.py
+++ b/apps/auth/__init__.py
@@ -63,7 +63,7 @@ def get_user(required=False):
 def get_user_id(required=False):
     """Get authenticated user id.
 
-    :param boolean requred: if True and there is no user it will raise an error
+    :param boolean required: if True and there is no user it will raise an error
     """
     user = get_user(required)
     return user.get(config.ID_FIELD)

--- a/apps/auth/service.py
+++ b/apps/auth/service.py
@@ -19,6 +19,12 @@ from superdesk.errors import SuperdeskApiError
 class AuthService(BaseService):
 
     def authenticate(self, document):
+        """Authenticate user according to credentials
+
+        :param documents: credentials for this authentication mechanism
+        :return: authenticated user
+        :raise: CredentialsAuthError if authentication is invalid
+        """
         raise NotImplementedError()
 
     def on_create(self, docs):

--- a/apps/search_providers/__init__.py
+++ b/apps/search_providers/__init__.py
@@ -11,13 +11,13 @@
 import superdesk
 
 from apps.search_providers.registry import registered_search_providers, allowed_search_providers, register_search_provider  # noqa
-from apps.search_providers.proxy import SearchProviderProxyResource, SearchProviderProxyService
 from apps.search_providers.resource import SearchProviderResource
 from apps.search_providers.service import SearchProviderService
 from apps.search_providers.registry import SearchProviderAllowedResource, SearchProviderAllowedService
 
 
 def init_app(app):
+    from apps.search_providers.proxy import SearchProviderProxyResource, SearchProviderProxyService
     superdesk.privilege(
         name='search_providers',
         label='Manage Search Providers',

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -1,0 +1,65 @@
+.. _authentication:
+
+Authentication
+==============
+This documentation explains the main mechanism of authentication.
+
+
+Overview
+--------
+Main host mechanisms are located in :mod:`apps.auth`.  
+Login is internally based on a token authentication: each user session is associated to a token.
+
+There is a common access point, ``auth`` which can be used to log out, but to log in, each authentication mechanism use its own endpoint (``auth_db`` and ``auth_xmpp`` so far). This way each endpoint can use its own schema validation while the common endpoint can be called for logout, allowing several auth mechanisms to be running at the same time.
+
+.. uml::
+
+    title Authentication in Superdesk
+
+    boundary client
+    control "auth_**XXX**" as backend
+    note right of backend
+        auth_**XXX** service uses __auth__ datasource
+    end note
+    database datalayer
+
+    backend <- client : **authenticate**\n(user credentials)
+
+    alt success
+        backend -> backend: //create token//
+        backend -> datalayer: //create session//
+        backend -> client: **user**\n(user name, token, user id)
+
+    else bad credentials or failure
+        backend -> client: HTTP error\n(401 or something else)
+
+    end
+
+
+Adding a new authentication mechanism
+-------------------------------------
+
+Adding a new authentication mechanism is done by creating a new endpoint extending the basic service. The new endpoint should be named **auth_XXX** where `XXX` is a short name for the new mechanism.
+
+.. module:: apps.auth.service
+
+The ``auth`` module provide the base features, with main service. 
+
+.. autoclass:: AuthService
+    :members:
+
+To implement its authentication mechanism, a module need to override the `authenticate` method.
+
+When creating a service based on `AuthService`, the authentication module must use the ``auth`` `datasource` instead of its own endpoint name. This allow several auth methods to use the same session system and to logout from ``auth`` common endpoint.
+
+Special case: ``auth_db``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+``auth_db`` is used for the basic database login/password authentication. In some cases it may be desirable to replace this mechanism (e.g. this is the case with LDAP). This is done by using the same endpoint name, and avoiding the import of :mod:`apps.auth.db` module. The login/pass default login interface in the client will then stay unchanged.
+
+
+Other uses of :mod:`apps.auth`
+------------------------------
+Following functions can be used:
+
+.. automodule:: apps.auth
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ sys.path.insert(0, os.path.abspath('../'))
 extensions = [
     'sphinx.ext.autodoc',
     #'sphinx.ext.viewcode',
+    'sphinxcontrib.plantuml',
 ]
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -45,3 +45,9 @@ If you want to document whole module with all its members, you can just use `aut
         :members:
 
 This will document all public members from the module which have a docstring.
+
+You can integrate UML diagrams using `PlantUML <http://plantuml.com/>`_ syntax, with::
+
+    .. uml::
+
+        [plantuml diagram]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,7 @@ works and can be developed further.
     content-types
     contentapi
     extending
+    authentication
 
 Additional topics
 -----------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ httmock
 wooper
 sphinx
 sphinx-autobuild
+sphinxcontrib-plantuml
 docutils==0.12
 requests-mock
 .


### PR DESCRIPTION
- authentication mechanism documentation
- added plantuml into Sphinx configuration and sphinxcontrib-plantuml in requirements, now ..uml syntax can be used (check http://plantuml.com/ and https://pypi.python.org/pypi/sphinxcontrib-plantuml)
- imports have been moved in search_providers/__init__.py to avoid error during Sphinx build

SDESK-551