### PR TITLE
fix(validate): ignore list fields in schema

### DIFF
--- a/apps/validate/validate.py
+++ b/apps/validate/validate.py
@@ -75,8 +75,28 @@ class SchemaValidator(Validator):
         if isinstance(value, list) and not value:
             self._error(field, REQUIRED_FIELD)
 
-    def _validate_enabled(self, enabled, field, value):
+    def _validate_enabled(self, *args):
         """Ignore ``enabled`` in the schema."""
+        pass
+
+    def _validate_place(self, *args):
+        """Ignore place."""
+        pass
+
+    def _validate_genre(self, *args):
+        """Ignore genre."""
+        pass
+
+    def _validate_anpa_category(self, *args):
+        """Ignore anpa category."""
+        pass
+
+    def _validate_subject(self, *args):
+        """Ignore subject."""
+        pass
+
+    def _validate_company_codes(self, *args):
+        """Ignore company codes."""
         pass
 
 

--- a/features/validate.feature
+++ b/features/validate.feature
@@ -176,7 +176,8 @@ Feature: Validate
       [{"_id": "snap", "schema": {
         "headline": {"enabled": true},
         "foo": {"required": true},
-        "image": {"type": "picture"}
+        "image": {"type": "picture"},
+        "genre": {"genre": {"value": "foo"}, "type": "string"}
       }}]
       """
       When we post to "/validate"


### PR DESCRIPTION
due to client bug when there was default value set for a field
it ended up saving something like this:

```
{
    "schema": {
        "genre": {
            "genre": {"name": "sports"},
            "default": {"name": "sports"},
            "type": "list"
        }
    }
}
```

which raises an error on publish about missing rule for `genre`.
This will make it ignore all such fields in schema.

SDESK-579