### PR TITLE
feat(celery): allow prefix for celery queue names

### DIFF
--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -23,11 +23,12 @@ from kombu.mixins import ConsumerMixin
 from kombu.pools import producers
 from superdesk.utc import utcnow
 from superdesk.utils import get_random_string
+from superdesk.default_settings import celery_queue
 from flask import json
 
 
 logger = logging.getLogger(__name__)
-exchange_name = 'socket_notification'
+exchange_name = celery_queue('socket_notification')
 
 
 class SocketBrokerClient:

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -1,0 +1,15 @@
+
+import unittest
+
+from unittest.mock import patch
+from superdesk.default_settings import celery_queue
+
+
+class SettingsTestCase(unittest.TestCase):
+
+    def test_celery_queue(self):
+        with patch('superdesk.default_settings.os.environ.get', return_value='') as env:
+            self.assertEqual('foo', celery_queue('foo'))
+            env.assert_called_with('SUPERDESK_CELERY_PREFIX', '')
+        with patch('superdesk.default_settings.os.environ.get', return_value='prefix'):
+            self.assertEqual('prefixfoo', celery_queue('foo'))


### PR DESCRIPTION
this way you can run multiple instances with single redis db.
it uses `SUPERDESK_CELERY_PREFIX` environment var as prefix.

SDESK-596