### PR TITLE
replace ElementTree and BeautifulSoup by lxml (SDESK-505)

### DIFF
--- a/apps/content_filters/filter_condition/filter_condition_field.py
+++ b/apps/content_filters/filter_condition/filter_condition_field.py
@@ -8,7 +8,8 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 from enum import Enum
-from bs4 import BeautifulSoup
+from lxml import etree
+from superdesk.etree import get_text
 
 
 class FilterConditionFieldsEnum(Enum):
@@ -74,9 +75,8 @@ class FilterConditionField:
 
     def get_value(self, article):
         try:
-            soup = BeautifulSoup(article[self.field.name], "html.parser")
-            return soup.get_text().replace('\n', ' ')
-        except:
+            return get_text(article[self.field.name]).replace('\n', ' ')
+        except (etree.XMLSyntaxError, ValueError):
             return article[self.field.name]
 
 

--- a/apps/io/afp_tests.py
+++ b/apps/io/afp_tests.py
@@ -22,7 +22,7 @@ class TestCase(unittest.TestCase):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.join(dirname, 'fixtures', 'afp.xml')
         provider = {'name': 'Test'}
-        with open(fixture) as f:
+        with open(fixture, 'rb') as f:
             self.item = AFPNewsMLOneFeedParser().parse(etree.fromstring(f.read()), provider)
 
     def test_headline(self):

--- a/apps/validate/validate.py
+++ b/apps/validate/validate.py
@@ -10,10 +10,10 @@
 
 import superdesk
 
-from bs4 import BeautifulSoup
 from eve.io.mongo import Validator
 from superdesk.metadata.item import ITEM_TYPE
 from superdesk.logging import logger
+from superdesk.etree import get_text
 
 REQUIRED_FIELD = 'is a required field'
 
@@ -154,7 +154,7 @@ class ValidateService(superdesk.Service):
         for field in schema:
             if doc.get(field) and schema.get(field) and any(k in schema[field] for k in fields_to_check):
                 try:
-                    doc[field] = BeautifulSoup(doc[field], 'html.parser').get_text()
+                    doc[field] = get_text(doc[field])
                 except TypeError:
                     # fails for json fields like subject, genre
                     pass

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ install_requires = [
     'arrow>=0.4,<0.9',
     'asyncio>=3.4,<3.5',
     'bcrypt>=3.1.1,<3.2',
-    'beautifulsoup4>=4.4,<4.6',
     'blinker>=1.3,<1.5',
     'celery[redis]>=4.0.2,<4.1',
     'feedparser>=5.2,<5.3',

--- a/superdesk/etree.py
+++ b/superdesk/etree.py
@@ -10,8 +10,8 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import bs4
-import xml.etree.ElementTree as etree  # noqa
-from xml.etree.ElementTree import ParseError  # noqa
+from lxml import etree  # noqa
+from lxml.etree import ParseError  # noqa
 
 inline_elements = set([
     'a',
@@ -49,7 +49,7 @@ def get_text(html):
     :param html: html string to convert to plain text
     """
     try:
-        root = etree.fromstringlist('<doc>{0}</doc>'.format(html))
+        root = etree.fromstring('<doc>{0}</doc>'.format(html))
         text = etree.tostring(root, encoding='unicode', method='text')
         return text
     except ParseError:

--- a/superdesk/etree.py
+++ b/superdesk/etree.py
@@ -9,74 +9,186 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-import bs4
+import re
 from lxml import etree  # noqa
 from lxml.etree import ParseError  # noqa
+from lxml import html as lxml_html
+from lxml.html import clean
 
-inline_elements = set([
-    'a',
-    'b',
-    'i',
-    'em',
-    'img',
-    'sub',
-    'sup',
-    'abbr',
-    'bold',
-    'span',
-    'cite',
-    'code',
-    'small',
-    'label',
-    'script',
-    'strong',
-    'object',
-])
+
+# This pattern matches http(s) links, numbers (1.000.000 or 1,000,000 or 1 000 000), regulars words,
+# compound words (e.g. "two-done") or abbreviation (e.g. D.C.)
+WORD_PATTERN = re.compile(r'https?:[^ ]*|([0-9]+[,. ]?)+|([\w]\.)+|[\w][\w-]*')
+
+# from https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements
+BLOCK_ELEMENTS = (
+    "address",
+    "article",
+    "aside",
+    "blockquote",
+    "br",
+    "canvas",
+    "dd",
+    "div",
+    "dl",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "hgroup",
+    "hr",
+    "li",
+    "main",
+    "nav",
+    "noscript",
+    "ol",
+    "output",
+    "p",
+    "pre",
+    "section",
+    "table",
+    "tfoot",
+    "ul",
+    "video")
+
+
+def parse_html(html, content='xml', lf_on_block=False, space_on_elements=False):
+    """Parse element and return etreeElement
+
+    <div> element is added around the HTML
+    recovery is used in case of bad markup
+    :param str html: HTML markup
+    :param str content: use 'xml' for XHTML or non html XML, and 'html' for HTML or if you are unsure
+    :param bool lf_on_block: if True, add a line feed on block elements' tail
+    :param bool space_on_elements: if True, add a space on each element's tail
+        mainly used to count words with non HTML markup
+    :return etree.Element: parsed element
+    """
+    if not isinstance(html, str):
+        raise ValueError("a string is expected")
+    if content == 'xml':
+        parser = etree.XMLParser(recover=True, remove_blank_text=True)
+        root = etree.fromstring("<div>" + html + "</div>", parser)
+    elif content == 'html':
+        parser = etree.HTMLParser(recover=True, remove_blank_text=True)
+        root = etree.fromstring(html, parser)
+    else:
+        raise ValueError('invalid content: {}'.format(content))
+    if lf_on_block:
+        for elem in root.iterfind('.//'):
+            if elem.tag in BLOCK_ELEMENTS:
+                elem.tail = (elem.tail or '') + '\n'
+    if space_on_elements:
+        for elem in root.iterfind('.//'):
+            elem.tail = (elem.tail or '') + ' '
+    return root
 
 
 def get_text_word_count(text):
     """Get word count for given plain text.
 
-    :param text: text string
+    :param str text: text string
+    :return int: word count
     """
-    return len(text.split())
+    return sum(1 for word in WORD_PATTERN.finditer(text))
 
 
-def get_text(html):
-    """Get plain text version of HTML element
+def get_text(markup, content='xml', lf_on_block=False, space_on_elements=False):
+    """Get plain text version of (X)HTML or other XML element
 
-    if the HTML string can't be parsed, it will be returned unchanged
-    :param html: html string to convert to plain text
+    if the markup can't be parsed, it will be returned unchanged
+    :param str markup: string to convert to plain text
+    :param str content: 'xml' or 'html', as in parse_html
+    :param bool lf_on_block: if True, add a line feed on block elements' tail
+    :param bool space_on_elements: if True, add a space on each element's tail
+        mainly used to count words with non HTML markup
+    :return str: plain text version of markup
     """
     try:
-        root = etree.fromstring('<doc>{0}</doc>'.format(html))
+        root = parse_html(markup, content=content, lf_on_block=lf_on_block, space_on_elements=space_on_elements)
         text = etree.tostring(root, encoding='unicode', method='text')
         return text
     except ParseError:
-        return html
+        return markup
 
 
-def get_word_count(html):
+def to_string(elem, encoding="unicode", method="xml", remove_root_div=True):
+    """Convert Element to string
+
+    :param etree.Element elem: element to convert
+    :param str encoding: encoding to use (same as for etree.tostring)
+    :param str method: method to use (same as for etree.tostring)
+    :param bool remove_root_dir: if True remove surrounding <div> which is added by parse_html
+    :return str: converted element
+    """
+    string = etree.tostring(elem, encoding=encoding, method=method)
+    if remove_root_div:
+        if encoding == "unicode":
+            div_start = "<div>"
+            div_end = "</div>"
+        else:
+            div_start = b"<div>"
+            div_end = b"</div>"
+        if string.startswith(div_start) and string.endswith(div_end):
+            return string[len(div_start):-len(div_end)]
+    return string
+
+
+def get_word_count(markup, no_html=False):
     """Get word count for given html.
 
-    :param html: html string to count
+    :param str markup: xhtml (or other xml) markup
+    :param bool no_html: set to True if xml param is not (X)HTML
+        if True, a space will be added after each element to separate words.
+        This avoid to have construct like <hl2>word</hl2><p>another</p> (like in NITF)
+        being counted as one word.
+    :return int: count of words inside the text
     """
-    soup = bs4.BeautifulSoup(html.replace('<br>', ' ').replace('<hr>', ' '), 'html.parser')
-
-    # first run to filter out inlines
-    for elem in soup.find_all():
-        if elem.name in inline_elements:  # ignore inline elements
-            elem.unwrap()
-
-    # re-parse without inline, it will merge sibling text nodes
-    soup = bs4.BeautifulSoup(str(soup), 'html.parser')
-    text = ' '.join(soup.find_all(text=True))
-    return get_text_word_count(text)
+    if no_html:
+        return get_text_word_count(get_text(markup, content='xml', space_on_elements=True))
+    else:
+        return get_text_word_count(get_text(markup, content='html', lf_on_block=True))
 
 
 def get_char_count(html):
     """Get character count for given html.
 
     :param html: html string to count
+    :return int: count of chars inside the text
     """
     return len(get_text(html))
+
+
+def sanitize_html(html):
+    """Sanitize HTML
+
+    :param str html: unsafe HTML markup
+    :return str: sanitized HTML
+    """
+    if not html:
+        return ""
+
+    blacklist = ["script", "style", "head"]
+
+    root_elem = lxml_html.fromstring(html)
+    cleaner = clean.Cleaner(
+        add_nofollow=False,
+        kill_tags=blacklist
+    )
+    cleaned_xhtml = cleaner.clean_html(root_elem)
+
+    safe_html = etree.tostring(cleaned_xhtml, encoding="unicode")
+
+    # the following code is legacy (pre-lxml)
+    if safe_html == ", -":
+        return ""
+
+    return safe_html

--- a/superdesk/io/feed_parsers/ap_anpa.py
+++ b/superdesk/io/feed_parsers/ap_anpa.py
@@ -14,7 +14,7 @@ from superdesk.io.iptc import subject_codes
 from flask import current_app as app
 from apps.archive.common import format_dateline_to_locmmmddsrc
 from superdesk.utc import get_date
-from bs4 import BeautifulSoup
+from lxml import etree
 from superdesk import get_resource_service
 import logging
 
@@ -115,10 +115,10 @@ class AP_ANPAFeedParser(ANPAFeedParser):
         try:
             html = item.get('body_html')
             if html:
-                soup = BeautifulSoup(html, "html.parser")
-                pars = soup.findAll('p')
+                elem = etree.fromstring("<div>" + html + "</div>")
+                pars = elem.iterfind('.//p')
                 for par in pars:
-                    city, source, the_rest = par.get_text().partition(' (AP) _ ')
+                    city, source, the_rest = par.text.partition(' (AP) _ ')
                     if source:
                         # sometimes the city is followed by a comma and either a date or a state
                         city = city.split(',')[0]

--- a/superdesk/io/feed_parsers/newsml_1_2.py
+++ b/superdesk/io/feed_parsers/newsml_1_2.py
@@ -45,7 +45,7 @@ class NewsMLOneFeedParser(XMLFeedParser):
                 item['ingest_provider_sequence'] = parsed_el.text
 
             parsed_el = xml.find('NewsEnvelope/Priority')
-            item['priority'] = self.map_priority(parsed_el.text if parsed_el else None)
+            item['priority'] = self.map_priority(parsed_el.text if parsed_el is not None else None)
 
             self.parse_news_identifier(item, xml)
             self.parse_newslines(item, xml)

--- a/superdesk/io/feed_parsers/newsml_2_0.py
+++ b/superdesk/io/feed_parsers/newsml_2_0.py
@@ -76,7 +76,7 @@ class NewsMLTwoFeedParser(XMLFeedParser):
         """
         header = tree.find(self.qname('header'))
         priority = 5
-        if header:
+        if header is not None:
             priority = self.map_priority(header.find(self.qname('priority')).text)
 
         return {'priority': priority}

--- a/superdesk/io/feed_parsers/nitf.py
+++ b/superdesk/io/feed_parsers/nitf.py
@@ -13,7 +13,7 @@ from datetime import datetime
 import dateutil.parser
 from superdesk.io.registry import register_feed_parser
 from superdesk.io.feed_parsers import XMLFeedParser
-import xml.etree.ElementTree as etree
+from lxml import etree
 from superdesk.errors import ParserError
 from superdesk.utc import utc
 from superdesk.metadata.item import CONTENT_TYPE, ITEM_TYPE, FORMAT, FORMATS

--- a/superdesk/io/feed_parsers/nitf.py
+++ b/superdesk/io/feed_parsers/nitf.py
@@ -19,7 +19,6 @@ from superdesk.utc import utc
 from superdesk.metadata.item import CONTENT_TYPE, ITEM_TYPE, FORMAT, FORMATS
 from superdesk.etree import get_word_count
 from superdesk.io.iptc import subject_codes
-from bs4 import BeautifulSoup
 import re
 import superdesk
 
@@ -160,7 +159,7 @@ class NITFFeedParser(XMLFeedParser):
 
         The following mappings are used in this order (last is more important):
             - self.default_mapping
-            - self.MAPPING, intended for sublasses
+            - self.MAPPING, intended for subclasses
             - NITF_MAPPING dictionary which can be put in settings
         If a value is a non-empty string, it is a xpath, @attribute can be used as last path component.
         If value is empty string/dict, the key will be ignored
@@ -264,7 +263,7 @@ class NITFFeedParser(XMLFeedParser):
             if elem is not None:
                 self.set_dateline(item, city=elem.text)
 
-            item.setdefault('word_count', get_word_count(item['body_html']))
+            item.setdefault('word_count', get_word_count(item['body_html'], no_html=True))
             return item
         except Exception as ex:
             raise ParserError.nitfParserError(ex, provider)
@@ -334,9 +333,10 @@ class NITFFeedParser(XMLFeedParser):
         :return:
         """
         elements = []
-        soup = BeautifulSoup(element, 'html.parser')
-        for elem in soup.findAll(True):
-            elements.append(elem.get_text() + '\r\n')
+        parsed = etree.fromstring("<div>" + element + "</div>")
+        for elem in parsed.iterfind(".//"):
+            text = etree.tostring(elem, encoding="unicode", method="text")
+            elements.append(text + '\r\n')
         return ''.join(elements)
 
     def get_content(self, xml):

--- a/superdesk/io/feed_parsers/pa_nitf.py
+++ b/superdesk/io/feed_parsers/pa_nitf.py
@@ -12,7 +12,6 @@
 from superdesk.io.feed_parsers.nitf import NITFFeedParser, SkipValue
 from superdesk.io.registry import register_feed_parser
 import re
-from bs4 import BeautifulSoup
 from lxml import etree
 import html
 
@@ -57,10 +56,9 @@ class PAFeedParser(NITFFeedParser):
         """
         elements = []
         for elem in xml.find('body/body.content'):
-            soup = BeautifulSoup(etree.tostring(elem), 'html.parser')
-            for top_level_tag in soup.find_all(recursive=False):
-                elements.append(
-                    '<p>{}</p>\n'.format(html.escape(top_level_tag.get_text().encode('iso-8859-1').decode('utf-8'))))
+            text = etree.tostring(elem, encoding="unicode", method="text")
+            elements.append(
+                '<p>{}</p>\n'.format(html.escape(text)))
         content = ''.join(elements)
         if self.get_anpa_format(xml) == 't':
             if not content.startswith('<pre>'):
@@ -90,7 +88,7 @@ class PAFeedParser(NITFFeedParser):
         :return:
         """
         # Remove any leading numbers and split to list of words
-        sluglineList = re.sub('^[\d.]+\W+', '', elem.text).split(' ')
+        sluglineList = re.sub(r'^[\d.]+\W+', '', elem.text).split(' ')
         slugline = sluglineList[0].capitalize()
         if len(sluglineList) > 1:
             slugline = '{} {}'.format(slugline, ' '.join(sluglineList[1:]))

--- a/superdesk/io/feed_parsers/pa_nitf.py
+++ b/superdesk/io/feed_parsers/pa_nitf.py
@@ -13,7 +13,7 @@ from superdesk.io.feed_parsers.nitf import NITFFeedParser, SkipValue
 from superdesk.io.registry import register_feed_parser
 import re
 from bs4 import BeautifulSoup
-import xml.etree.ElementTree as etree
+from lxml import etree
 import html
 
 

--- a/superdesk/io/feed_parsers/scoop_newsml_2_0.py
+++ b/superdesk/io/feed_parsers/scoop_newsml_2_0.py
@@ -64,7 +64,7 @@ class ScoopNewsMLTwoFeedParser(NewsMLTwoFeedParser):
         """
         header = tree.find(self.qname('Header'))
         priority = 5
-        if header:
+        if header is not None:
             priority = self.map_priority(header.find(self.qname('priority')).text)
 
         return {'priority': priority}

--- a/superdesk/io/feed_parsers/wenn_parser.py
+++ b/superdesk/io/feed_parsers/wenn_parser.py
@@ -63,7 +63,7 @@ class WENNFeedParser(XMLFeedParser):
 
     def parse_news_management(self, item, entry):
         news_mgmt_el = entry.find(self.qname('NewsManagement', self.WENN_NM_NS))
-        if news_mgmt_el:
+        if news_mgmt_el is not None:
             item['firstcreated'] = self.datetime(self.get_elem_content(
                 news_mgmt_el.find(self.qname('published', self.WENN_NM_NS))))
             item['versioncreated'] = self.datetime(self.get_elem_content(
@@ -73,7 +73,7 @@ class WENNFeedParser(XMLFeedParser):
 
     def parse_content_management(self, item, entry):
         content_mgmt_el = entry.find(self.qname('ContentMetadata', self.WENN_CM_NS))
-        if content_mgmt_el:
+        if content_mgmt_el is not None:
             item['headline'] = self.get_elem_content(content_mgmt_el.find(self.qname('title', self.WENN_CM_NS)))
             item['abstract'] = self.get_elem_content(
                 content_mgmt_el.find(self.qname('first_line', self.WENN_CM_NS)))

--- a/superdesk/io/feeding_services/__init__.py
+++ b/superdesk/io/feeding_services/__init__.py
@@ -146,10 +146,10 @@ class FeedingService(metaclass=ABCMeta):
         if not parser:
             raise SuperdeskIngestError.parserNotFoundError(provider=provider)
 
-        if article and not parser.can_parse(article):
+        if article is not None and not parser.can_parse(article):
             raise SuperdeskIngestError.parserNotFoundError(provider=provider)
 
-        if article:
+        if article is not None:
             parser = parser.__class__()
 
         return parser

--- a/superdesk/io/feeding_services/file_service.py
+++ b/superdesk/io/feeding_services/file_service.py
@@ -13,7 +13,7 @@ import os
 import shutil
 from datetime import timedelta, datetime
 
-from xml.etree import ElementTree
+from lxml import etree
 from superdesk.errors import IngestFileError, ParserError, ProviderError
 from superdesk.io.registry import register_feeding_service
 from superdesk.io.feed_parsers import XMLFeedParser
@@ -62,7 +62,7 @@ class FileFeedingService(FeedingService):
                     if self.is_latest_content(last_updated, provider.get('last_updated')):
                         if isinstance(registered_parser, XMLFeedParser):
                             with open(file_path, 'rb') as f:
-                                xml = ElementTree.parse(f)
+                                xml = etree.parse(f)
                                 parser = self.get_feed_parser(provider, xml.getroot())
                                 item = parser.parse(xml.getroot(), provider)
                         else:

--- a/superdesk/macros/abstract_populator.py
+++ b/superdesk/macros/abstract_populator.py
@@ -9,15 +9,13 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import re
-from bs4 import BeautifulSoup
+from superdesk.etree import get_text
+
+p = re.compile('(?i)(?<=[.?!])\\S+(?=[a-z])')
 
 
 def populate(item, **kwargs):
     """Populate the abstract field with the first sentence of the body"""
-
-    # compile the regex
-    # p = re.compile('[.!?]')
-    p = re.compile('(?i)(?<=[.?!])\\S+(?=[a-z])')
 
     # get the list of sentences of the body
     if not item.get('body_html', None):
@@ -27,7 +25,7 @@ def populate(item, **kwargs):
 
         # chop the first sentence to size for abstract (64)
         if sentences and len(sentences) > 0:
-            item['abstract'] = BeautifulSoup(sentences[0][:64], "html.parser").text
+            item['abstract'] = get_text(sentences[0][:64]).strip()
 
     return item
 

--- a/superdesk/publish/formatters/newsml_1_2_formatter.py
+++ b/superdesk/publish/formatters/newsml_1_2_formatter.py
@@ -16,13 +16,13 @@ from eve.utils import config
 from superdesk.publish.formatters import Formatter
 import superdesk
 from superdesk.errors import FormatterError
+from superdesk.etree import parse_html
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE, EMBARGO, ITEM_STATE, CONTENT_STATE,\
     GUID_FIELD
 from superdesk.metadata.packages import PACKAGE_TYPE, GROUP_ID, REFS, RESIDREF, ROLE, ROOT_GROUP
 from superdesk.utc import utcnow
 from flask import current_app as app
 from apps  .archive.common import get_utc_schedule
-from bs4 import BeautifulSoup
 from superdesk.filemeta import get_filemeta
 
 logger = logging.getLogger(__name__)
@@ -315,8 +315,8 @@ class NewsML12Formatter(Formatter):
         content_item = SubElement(abstract_news_component, "ContentItem")
         SubElement(content_item, 'MediaType', {'FormalName': 'Text'})
         SubElement(content_item, 'Format', {'FormalName': 'Text'})
-        soup = BeautifulSoup(article.get('abstract', ''), 'html.parser')
-        SubElement(content_item, 'DataContent').text = soup.get_text()
+        abstract = parse_html(article.get('abstract', ''))
+        SubElement(content_item, 'DataContent').text = etree.tostring(abstract, encoding="unicode", method="text")
 
     def _format_body(self, article, main_news_component):
         """

--- a/superdesk/publish/formatters/newsml_g2_formatter.py
+++ b/superdesk/publish/formatters/newsml_g2_formatter.py
@@ -471,9 +471,9 @@ class NewsMLG2Formatter(Formatter):
         :param article: object having published article details
         :type article: dict
         :param content_meta: object representing <contentMeta> in the XML tree
-        :type content_meta: xml.etree.ElementTree.Element
+        :type content_meta: lxml.etree.Element
         :param item: object representing <newsItem> in the XML tree
-        :type item: xml.etree.ElementTree.Element
+        :type item: lxml.etree.Element
         """
 
         for company in article.get('company_codes', []):

--- a/superdesk/publish/formatters/newsml_g2_formatter.py
+++ b/superdesk/publish/formatters/newsml_g2_formatter.py
@@ -14,7 +14,7 @@ import superdesk
 from lxml import etree
 from lxml.etree import SubElement
 
-from bs4 import BeautifulSoup
+from superdesk.etree import get_text
 from flask import current_app as app
 
 from superdesk.publish.formatters import Formatter
@@ -160,9 +160,9 @@ class NewsMLG2Formatter(Formatter):
         """
         content_set = SubElement(news_item, 'contentSet')
         if article.get(FORMAT) == FORMATS.PRESERVED:
+            inline_data = get_text(self.append_body_footer(article))
             SubElement(content_set, 'inlineData',
-                       attrib={'contenttype': 'text/plain'}).text = BeautifulSoup(self.append_body_footer(article),
-                                                                                  "html.parser").get_text()
+                       attrib={'contenttype': 'text/plain'}).text = inline_data
         elif article[ITEM_TYPE] in [CONTENT_TYPE.TEXT, CONTENT_TYPE.COMPOSITE]:
             inline = SubElement(content_set, 'inlineXML',
                                 attrib={'contenttype': 'application/nitf+xml'})

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -26,7 +26,7 @@ from superdesk.metadata.packages import RESIDREF, GROUP_ID, GROUPS, ROOT_GROUP, 
 from superdesk.utils import json_serialize_datetime_objectId
 from superdesk.media.renditions import get_renditions_spec
 from apps.archive.common import get_utc_schedule
-from bs4 import BeautifulSoup
+from superdesk.etree import get_text
 
 
 def filter_empty_vals(data):
@@ -147,10 +147,9 @@ class NINJSFormatter(Formatter):
 
         # SDPA-317
         if article.get('abstract'):
-            abstract = article.get('abstract')
+            abstract = article.get('abstract', '')
             ninjs['description_html'] = abstract
-            soup = BeautifulSoup(abstract, 'html.parser')
-            ninjs['description_text'] = soup.get_text()
+            ninjs['description_text'] = get_text(abstract)
         elif article.get('description_text'):
             ninjs['description_text'] = article.get('description_text')
 

--- a/superdesk/publish/formatters/nitf_formatter.py
+++ b/superdesk/publish/formatters/nitf_formatter.py
@@ -16,7 +16,7 @@ from superdesk.publish.formatters import Formatter
 from superdesk.errors import FormatterError
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE, EMBARGO, FORMAT, FORMATS
 from apps.archive.common import get_utc_schedule
-from bs4 import BeautifulSoup
+from superdesk.etree import get_text
 
 
 class NITFFormatter(Formatter):
@@ -344,8 +344,8 @@ class NITFFormatter(Formatter):
 
     def _format_body_content(self, article, body_content):
         if article.get(FORMAT) == FORMATS.PRESERVED:
-            soup = BeautifulSoup(self.append_body_footer(article), 'html.parser')
-            SubElement(body_content, 'pre').text = soup.get_text()
+            pre = get_text(self.append_body_footer(article))
+            SubElement(body_content, 'pre').text = pre
         else:
             self.map_html_to_xml(body_content, self.append_body_footer(article))
 

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -475,7 +475,7 @@ def fetch_from_provider(context, provider_name, guid, routing_scheme=None, desk_
         file_path = os.path.join(provider.get('config', {}).get('path', ''), guid)
         feeding_parser = provider_service.get_feed_parser(provider)
         if isinstance(feeding_parser, XMLFeedParser):
-            with open(file_path, 'r') as f:
+            with open(file_path, 'rb') as f:
                 xml_string = etree.etree.fromstring(f.read())
                 items = [feeding_parser.parse(xml_string, provider)]
         else:

--- a/superdesk/utils.py
+++ b/superdesk/utils.py
@@ -20,8 +20,8 @@ from bson import ObjectId
 from enum import Enum
 from importlib import import_module
 from eve.utils import config
-from bs4 import BeautifulSoup
 from superdesk.default_settings import ELASTIC_DATE_FORMAT
+from superdesk.etree import get_text
 
 
 required_string = {'type': 'string', 'required': True, 'nullable': False, 'empty': False}
@@ -191,9 +191,7 @@ def sha(text):
 
 def plaintext_filter(value):
     """Filter out html from value."""
-    soup = BeautifulSoup(value, 'html.parser')
-    text = soup.get_text()
-    return text.replace('\n', ' ').strip()
+    return get_text(value).replace('\n', ' ').strip()
 
 
 def format_date(date_string):

--- a/tests/etree_test.py
+++ b/tests/etree_test.py
@@ -27,13 +27,13 @@ class WordCountTestCase(unittest.TestCase):
         """))
 
     def test_word_count_nitf(self):
-        self.assertEqual(39, get_word_count("""
+        self.assertEqual(40, get_word_count("""
         <p>2014: Northern Ireland beat <location>Greece</location> 2-0 in <location>Athens</location>
         with goals from <person>Jamie Ward</person> and <person>Kyle Lafferty</person> to boost their
         hopes of qualifying for <money>Euro 2016</money>. <person>Michael O'Neill's</person> side
         sealed their place at the finals in <chron>October 2015</chron>.</p>"""))
 
-    def test_word_count_nitf(self):
+    def test_word_count_nitf_2(self):
         self.assertEqual(316, get_word_count("""
         <p>Rio Tinto has kept intact its target for iron ore shipments in 2017 after hitting the mid-point
         of its revised guidance range for 2016. </p><p>The world's second largest iron ore exporter shipped

--- a/tests/io/feed_parsers/nitf_tests.py
+++ b/tests/io/feed_parsers/nitf_tests.py
@@ -27,7 +27,7 @@ class NITFTestCase(TestCase):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.normpath(os.path.join(dirname, '../fixtures', self.filename))
         provider = {'name': 'Test'}
-        with open(fixture) as f:
+        with open(fixture, 'rb') as f:
             self.nitf = f.read()
             self.item = NITFFeedParser().parse(etree.fromstring(self.nitf), provider)
 
@@ -73,7 +73,7 @@ class AAPTestCase(NITFTestCase):
         self.assertEqual(self.item.get('versioncreated').isoformat(), '2013-10-20T08:27:51+00:00')
 
     def test_content(self):
-        text = "<p>   1A) More extreme weather forecast over the next few days the <br />fire situation is likely"
+        text = "<p>   1A) More extreme weather forecast over the next few days the <br/>fire situation is likely"
         self.assertIn(text, self.item.get('body_html'))
         self.assertIsInstance(self.item.get('body_html'), type(''))
         self.assertNotIn('<body.content>', self.item.get('body_html'))
@@ -199,26 +199,26 @@ class PATestCase2(NITFTestCase):
 
 class ParseSubjects(TestCase):
     def test_get_subjects(self):
-        xml = ('<?xml version="1.0" encoding="UTF-8"?>'
-               '<nitf><head>'
-               '<tobject tobject.type="News">'
-               '<tobject.property tobject.property.type="Current" />'
-               '<tobject.subject tobject.subject.refnum="02003000" '
-               'tobject.subject.type="Justice" tobject.subject.matter="Police" />'
-               '</tobject></head></nitf>')
+        xml = (b'<?xml version="1.0" encoding="UTF-8"?>'
+               b'<nitf><head>'
+               b'<tobject tobject.type="News">'
+               b'<tobject.property tobject.property.type="Current" />'
+               b'<tobject.subject tobject.subject.refnum="02003000" '
+               b'tobject.subject.type="Justice" tobject.subject.matter="Police" />'
+               b'</tobject></head></nitf>')
         subjects = NITFFeedParser().get_subjects(etree.fromstring(xml))
         self.assertEqual(len(subjects), 2)
         self.assertIn({'qcode': '02000000', 'name': 'Justice'}, subjects)
         self.assertIn({'qcode': '02003000', 'name': 'Police'}, subjects)
 
     def test_get_subjects_with_invalid_qcode(self):
-        xml = ('<?xml version="1.0" encoding="UTF-8"?>'
-               '<nitf><head>'
-               '<tobject tobject.type="News">'
-               '<tobject.property tobject.property.type="Current" />'
-               '<tobject.subject tobject.subject.refnum="00000000" '
-               'tobject.subject.type="Justice" tobject.subject.matter="Police" />'
-               '</tobject></head></nitf>')
+        xml = (b'<?xml version="1.0" encoding="UTF-8"?>'
+               b'<nitf><head>'
+               b'<tobject tobject.type="News">'
+               b'<tobject.property tobject.property.type="Current" />'
+               b'<tobject.subject tobject.subject.refnum="00000000" '
+               b'tobject.subject.type="Justice" tobject.subject.matter="Police" />'
+               b'</tobject></head></nitf>')
         subjects = NITFFeedParser().get_subjects(etree.fromstring(xml))
         self.assertEqual(len(subjects), 0)
 
@@ -242,7 +242,7 @@ class MappingTestCase(TestCase):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.normpath(os.path.join(dirname, '../fixtures', self.filename))
         provider = {'name': 'Test'}
-        with open(fixture) as f:
+        with open(fixture, 'rb') as f:
             self.nitf = f.read()
             self.item = NITFFeedParser().parse(etree.fromstring(self.nitf), provider)
 

--- a/tests/io/feed_parsers/nitf_tests.py
+++ b/tests/io/feed_parsers/nitf_tests.py
@@ -105,7 +105,7 @@ class APExampleTestCase(NITFTestCase):
         self.assertEqual(self.item.get('ednote'), 'For global distribution')
 
     def test_word_count(self):
-        self.assertEqual(1047, self.item.get('word_count'))
+        self.assertEqual(1063, self.item.get('word_count'))
 
 
 class IPTCExampleTestCase(NITFTestCase):
@@ -143,7 +143,7 @@ class IPTCExampleTestCase(NITFTestCase):
         self.assertEqual('By Alan Karben', self.item.get('byline'))
 
     def test_word_count(self):
-        self.assertEqual(221, self.item.get('word_count'))
+        self.assertEqual(223, self.item.get('word_count'))
 
 
 class PATestCase(NITFTestCase):
@@ -167,7 +167,7 @@ class PATestCase(NITFTestCase):
         self.assertIn('Trivia (Oct 14)', self.item.get('keywords'))
 
     def test_word_count(self):
-        self.assertEqual(678, self.item.get('word_count'))
+        self.assertEqual(637, self.item.get('word_count'))
 
 
 class PATestCase2(NITFTestCase):
@@ -184,7 +184,7 @@ class PATestCase2(NITFTestCase):
         self.assertEqual('T201510140143580001T', self.item.get('guid'))
         self.assertEqual(self.item.get('format'), 'preserved')
 
-    def test_guid(self):
+    def test_guid_2(self):
         self.assertEqual(self.item.get('type'), 'text')
 
     def test_subjects(self):

--- a/tests/io/feed_parsers/pa_nitf_test.py
+++ b/tests/io/feed_parsers/pa_nitf_test.py
@@ -12,7 +12,7 @@
 import os
 from superdesk.tests import TestCase
 from superdesk.io.feed_parsers.pa_nitf import PAFeedParser
-from xml.etree import ElementTree
+from lxml import etree
 
 
 class PANITFFileTestCase(TestCase):
@@ -27,7 +27,7 @@ class PANITFFileTestCase(TestCase):
         fixture = os.path.normpath(os.path.join(dirname, '../fixtures', self.filename))
         provider = {'name': 'Test'}
         with open(fixture, 'rb') as f:
-            xml = ElementTree.parse(f)
+            xml = etree.parse(f)
             self.item = PAFeedParser().parse(xml.getroot(), provider)
 
 

--- a/tests/io/feed_parsers/pa_nitf_test.py
+++ b/tests/io/feed_parsers/pa_nitf_test.py
@@ -54,7 +54,7 @@ class PATestCase(PANITFFileTestCase):
         self.assertEqual(self.item.get('format'), 'HTML')
         self.assertEqual(4, len(self.item.get('subject')))
         self.assertIn('Trivia (Oct 14)', self.item.get('keywords'))
-        self.assertEqual(665, self.item.get('word_count'))
+        self.assertEqual(637, self.item.get('word_count'))
 
 
 class PAEmbargoTestCase(PANITFFileTestCase):

--- a/tests/io/feed_parsers/rfc822_parser_test.py
+++ b/tests/io/feed_parsers/rfc822_parser_test.py
@@ -45,7 +45,8 @@ class RFC822TestCase(TestCase):
         self.assertEqual(self.items[0]['headline'], 'Test message 1234')
 
     def test_body(self):
-        self.assertEqual(self.items[0]['body_html'].strip(), '<div>body text<br/><div>\n</div></div>')
+        self.assertEqual(self.items[0]['body_html'].strip(),
+                         '<div dir="ltr">body text<br clear="all"/><div>&#13;\n</div></div>')
 
     def test_from(self):
         self.assertEqual(self.items[0]['original_source'],
@@ -97,7 +98,7 @@ class RFC822OddCharSet(TestCase):
         self.assertEqual(self.items[0]['headline'], '=?windows-1252?Q?TravTalk���s_Special_for_TAAI_convention?=')
 
     def test_body(self):
-        self.assertRegex(self.items[0]['body_html'], '<span>')
+        self.assertRegex(self.items[0]['body_html'], '<span lang="EN-AU">')
 
 
 class RFC822CharSetInSubject(TestCase):

--- a/tests/io/feed_parsers/scoop_parser_test.py
+++ b/tests/io/feed_parsers/scoop_parser_test.py
@@ -12,7 +12,7 @@
 import os
 import unittest
 
-from xml.etree import ElementTree
+from lxml import etree
 from superdesk.io.feed_parsers.scoop_newsml_2_0 import ScoopNewsMLTwoFeedParser
 
 
@@ -23,7 +23,7 @@ class ScoopTestCase(unittest.TestCase):
         provider = {'name': 'Test'}
         with open(fixture, 'rb') as f:
             parser = ScoopNewsMLTwoFeedParser()
-            self.xml = ElementTree.parse(f)
+            self.xml = etree.parse(f)
             self.item = parser.parse(self.xml.getroot(), provider)
 
 

--- a/tests/io/feed_parsers/wenn_parser_test.py
+++ b/tests/io/feed_parsers/wenn_parser_test.py
@@ -25,7 +25,7 @@ class WENNTestCase(unittest.TestCase):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.normpath(os.path.join(dirname, '../fixtures', self.filename))
         provider = {'name': 'Wenn'}
-        with open(fixture) as f:
+        with open(fixture, 'rb') as f:
             self.file = f.read()
             etree.fromstring(self.file)
             self.items = WENNFeedParser().parse(etree.fromstring(self.file), provider)

--- a/tests/io/fixtures/pa5.xml
+++ b/tests/io/fixtures/pa5.xml
@@ -32,12 +32,12 @@
 			</abstract>
 		</body.head>
 		<body.content>
-<p>Treasury coffers will take a Â£66 billion annual hit if <location>Britain</location> goes for a so-called hard Brexit, Cabinet ministers have been warned.</p>
+<p>Treasury coffers will take a £66 billion annual hit if <location>Britain</location> goes for a so-called hard Brexit, Cabinet ministers have been warned.</p>
           <p>Leaked Government papers suggest leaving the single market and switching to <org>World Trade Organisation</org> (WTO) rules would cause GDP to fall by up to 9.5% compared with if the country remained in the <org>European Union</org>.</p>
           <p>The draft Cabinet committee paper seen by The Times is based on forecasts from the controversial study into the predicted impact of quitting the EU published by <person>George Osborne</person> in April during the referendum campaign.</p>
           <p>Although the then chancellor faced widespread criticism over the report, the Treasury stands by its calculations, according to The Times.</p>
           <p>The documents says: &quot;The Treasury estimates that UK GDP would be between 5.4% and 9.5% of GDP lower after 15 years if we left the EU with no successor arrangement, with a central estimate of 7.5%.&quot;</p>
-          <p>It adds: &quot;The net impact on public sector receipts - assuming no contributions to the EU and current receipts from the EU are replicated in full - would be a loss of between Â£38 billion and Â£66 billion per year after 15 years, driven by the smaller size of the economy.&quot;</p>
+          <p>It adds: &quot;The net impact on public sector receipts - assuming no contributions to the EU and current receipts from the EU are replicated in full - would be a loss of between £38 billion and £66 billion per year after 15 years, driven by the smaller size of the economy.&quot;</p>
           <p>Brexit backers who have seen the documents told the newspaper the figures were unrealistic and claimed there was a push to &quot;make leaving the single market look bad&quot;.</p>
           <p>But prominent Remain campaigners pushing for a &quot;soft&quot; Brexit that would keep <location>Britain</location> in the single market said the documents showed the &quot;horrific damage&quot; of leaving the trading bloc.</p>
           <p>Conservative former minister <person>Anna Soubry</person>, a supporter of the Open Britain campaign, said: &quot;The horrific damage of a hard Brexit is clear. Less tax revenue means less to invest in schools and hospitals, lower trade and investment means businesses and jobs at risk.</p>

--- a/tests/io/io_tests.py
+++ b/tests/io/io_tests.py
@@ -33,7 +33,7 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(2, get_word_count('plain text'), 'plain text')
         self.assertEqual(2, get_word_count('<p> html text </p>'), 'paragraph')
 
-        self.assertEqual(23, get_word_count(
+        self.assertEqual(22, get_word_count(
             '<doc><p xml:lang="en-US">The weather was superb today in Norfolk, Virginia. Made me want to take\n'
             'out my boat, manufactured by the <org value="acm" idsrc="iptc.org">Acme Boat Company</org>.</p></doc>'))
 


### PR DESCRIPTION
this P.R. replaces ElementTree and BeautifulSoup by lxml.

There are several reasons for that:

- ElementTree is a light version of lxml's etree, missing a lot of features

- using different parsers result in a useless reparsing in several places, impacting performances

- ElementTree and BeautifulSoup use different ways of accessing elements and attributes, this is confusing for developer, and force her/him to know 2 APIs

- some features need to be done by hand while it's native for lxml, for instance unsafe HTML cleaning (and it is better to use a widely spread and checked cleaning method)

- lxml is really fast, powerful, XML compliant, has a full support for xpath and a clean API

- furthermore, lxml can use BeautifulSoup parser if needed

SDESK-505