### PR TITLE
fix(renditions): fix image cropping when size is not int

### DIFF
--- a/superdesk/media/media_operations.py
+++ b/superdesk/media/media_operations.py
@@ -140,7 +140,7 @@ def _get_cropping_data(doc):
     """
     if all([doc.get('CropTop', None) is not None, doc.get('CropLeft', None) is not None,
             doc.get('CropRight', None) is not None, doc.get('CropBottom', None) is not None]):
-        return (doc['CropLeft'], doc['CropTop'], doc['CropRight'], doc['CropBottom'])
+        return (int(doc['CropLeft']), int(doc['CropTop']), int(doc['CropRight']), int(doc['CropBottom']))
 
 
 def crop_image(content, file_name, cropping_data, exact_size=None, image_format=None):
@@ -159,7 +159,7 @@ def crop_image(content, file_name, cropping_data, exact_size=None, image_format=
         img = Image.open(content)
         cropped = img.crop(cropping_data)
         if exact_size and 'width' in exact_size and 'height' in exact_size:
-            cropped = cropped.resize((exact_size['width'], exact_size['height']), Image.ANTIALIAS)
+            cropped = cropped.resize((int(exact_size['width']), int(exact_size['height'])), Image.ANTIALIAS)
         logger.debug('Cropped image {} from stream, going to save it'.format(file_name))
         try:
             out = BytesIO()

--- a/superdesk/media/renditions.py
+++ b/superdesk/media/renditions.py
@@ -124,6 +124,14 @@ def _crop_image(content, format, ratio):
     return out, new_width, new_height, cropping_data
 
 
+def to_int(x):
+    """Try to convert x to int."""
+    try:
+        return int(x)
+    except TypeError:
+        return x
+
+
 def _resize_image(content, size, format='png', keepProportions=True):
     """Resize the image given as a binary stream
 
@@ -142,13 +150,13 @@ def _resize_image(content, size, format='png', keepProportions=True):
     assert isinstance(size, tuple)
     img = Image.open(content)
     width, height = img.size
-    new_width, new_height = size
+    new_width, new_height = [to_int(x) for x in size]
     if keepProportions:
         if new_width is None and new_height is None:
             raise Exception('size parameter requires at least width or height value')
         # resize with width and height
         if new_width is not None and new_height is not None:
-            new_width, new_height = int(new_width), int(new_height)
+            new_width, new_height = new_width, new_height
             x_ratio = width / new_width
             y_ratio = height / new_height
             if x_ratio > y_ratio:
@@ -159,7 +167,7 @@ def _resize_image(content, size, format='png', keepProportions=True):
         else:
             original_ratio = width / height
             if new_width is not None:
-                new_height = int(new_width / original_ratio)
+                new_height = int(int(new_width) / original_ratio)
             else:
                 new_width = int(new_height * original_ratio)
     resized = img.resize((new_width, new_height), Image.ANTIALIAS)

--- a/tests/media/__init__.py
+++ b/tests/media/__init__.py
@@ -1,0 +1,7 @@
+
+import os
+
+
+def get_picture_fixture():
+    """Get picture file path."""
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'iphone_gpsinfo_exif.JPG')

--- a/tests/media/crop_test.py
+++ b/tests/media/crop_test.py
@@ -10,10 +10,13 @@
 
 from unittest import mock
 from nose.tools import assert_raises
+from ..media import get_picture_fixture
 from superdesk.tests import TestCase
 from superdesk.media.crop import CropService
 from superdesk.errors import SuperdeskApiError
 from superdesk.vocabularies.command import populate_table_json
+from superdesk.media.media_operations import crop_image
+from superdesk.media.renditions import _resize_image
 
 
 class CropTestCase(TestCase):
@@ -149,3 +152,19 @@ class CropTestCase(TestCase):
             ex = context.exception
             self.assertEqual(ex.message, 'Saving crop failed.')
             self.assertEqual(ex.status_code, 400)
+
+    def test_crop_image_exact_size(self):
+        img = get_picture_fixture()
+        size = {'width': '300', 'height': '200'}
+        crop = {'CropTop': '0', 'CropRight': '300', 'CropBottom': '200', 'CropLeft': '0'}
+        with open(img, 'rb') as imgfile:
+            res = crop_image(imgfile, img, crop, size)
+            self.assertTrue(res[0])
+            self.assertEqual(300, res[1].width)
+            self.assertEqual(200, res[1].height)
+
+    def test_resize_image(self):
+        img = get_picture_fixture()
+        with open(img, 'rb') as imgfile:
+            resized, width, height = _resize_image(imgfile, ('200', None), 'jpeg')
+            self.assertEqual(150, height)


### PR DESCRIPTION
when you add new renditions via vocabularies it gets saved
as strings, so convert it before usage.

SDESK-656