### PR TITLE
support elastic2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,61 @@
 language: python
 
 sudo: required
-
-python:
-    - "3.4"
-    - "3.5"
+dist: trusty
 
 services:
-    - elasticsearch
-    - mongodb
     - redis-server
-
-addons:
-  apt:
-    sources:
-    - mongodb-3.0-precise
-    - elasticsearch-1.7
-    packages:
-    - mongodb-org-server
     - elasticsearch
+
+matrix:
+    include:
+        - env: ELASTIC2X
+          python: "3.5"
+          addons:
+              apt:
+                  sources:
+                      - elasticsearch-2.x
+                      - mongodb-3.0-precise
+                  packages:
+                      - elasticsearch
+                      - mongodb-org-server
+
+        - env: ELASTIC17
+          python: "3.4"
+          addons:
+              apt:
+                  sources:
+                      - elasticsearch-1.7
+                      - mongodb-3.0-precise
+                  packages:
+                      - elasticsearch
+                      - mongodb-org-server
+
+
+        - env: ELASTIC17
+          python: "3.5"
+          addons:
+              apt:
+                  sources:
+                      - elasticsearch-1.7
+                      - mongodb-3.0-precise
+                  packages:
+                      - elasticsearch
+                      - mongodb-org-server
 
 cache:
   - pip
 
 install:
     - pip install .
-    - pip install -r requirements.txt
-    - pip install nose-timer
+    - pip install -r dev-requirements.txt
 
 before_script: >
     df -h
     && sudo sed -i 's\enabled: true\enabled: false\' /etc/mongod.conf
     && sudo service mongod restart
-    && mkdir /tmp/es-backups
-    && sudo chown elasticsearch:elasticsearch /tmp/es-backups
-    && echo "path.repo: ['/tmp/es-backups']" | sudo tee -a /etc/elasticsearch/elasticsearch.yml
-    && echo "index.store.type: memory" | sudo tee -a /etc/elasticsearch/elasticsearch.yml
-    && sudo service elasticsearch restart
-    && tail -n1 /etc/elasticsearch/elasticsearch.yml
-    && sleep 10
-    && curl -XPUT 'http://localhost:9200/_snapshot/backups' -d '{"type": "fs", "settings": {"location": "/tmp/es-backups"}}'
 
 script:
     - flake8
-    - time nosetests
-    - time behave --format progress2 --logging-clear-handlers --logcapture
+    - nosetests --logging-level=ERROR
+    - behave --format progress2 --logging-level=ERROR

--- a/apps/prepopulate/app_initialize.py
+++ b/apps/prepopulate/app_initialize.py
@@ -317,7 +317,7 @@ class AppInitializeWithDataCommand(superdesk.Command):
                 crt_index = list(index) if isinstance(index, list) else index
                 options = crt_index.pop() if isinstance(crt_index[-1], dict) and isinstance(index, list) else {}
                 collection = app.data.mongo.pymongo(resource=entity_name).db[entity_name]
-                index_name = collection.create_index(crt_index, cache_for=300, **options)
+                index_name = collection.create_index(crt_index, **options)
                 logger.info(' - index: %s for collection %s created successfully.', index_name, entity_name)
 
 

--- a/apps/prepopulate/app_prepopulate_data.json
+++ b/apps/prepopulate/app_prepopulate_data.json
@@ -863,7 +863,7 @@
     		"headline": "package1",
     		"type": "composite",
     		"guid": "package1",
-            "versioncreated": "2015-01-01T10:10:10+0000",
+            "versioncreated": "2015-01-01T10:05:10+0000",
             "_current_version" : 1,
             "original_creator": "-id user admin-",
             "state": "in_progress",

--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -121,7 +121,7 @@ class SearchService(superdesk.Service):
 
         # if the system has a setting value for the maximum search depth then apply the filter
         if not app.settings['MAX_SEARCH_DEPTH'] == -1:
-            filters.append(dict(limit={'value': app.settings['MAX_SEARCH_DEPTH']}))
+            query['terminate_after'] = app.settings['MAX_SEARCH_DEPTH']
 
         set_filters(query, filters)
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,13 @@
+flake8
+flake8-docstrings
+nose
+pep8
+pyflakes
+pydocstyle==1.0.0
+httmock
+wooper
+sphinx
+sphinx-autobuild
+sphinxcontrib-plantuml
+docutils==0.12
+requests-mock

--- a/features/search.feature
+++ b/features/search.feature
@@ -51,7 +51,7 @@ Feature: Search Feature
         """
         Then we set elastic limit
         When we get "/search"
-        Then we get list with 5 items
+        Then we get list with <6 items
 
     @auth
     Scenario: Search Invisible stages without desk membership

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ LONG_DESCRIPTION = "Superdesk Server Core"
 
 install_requires = [
     'eve>=0.6,<0.7',
-    'eve-elastic==2.0rc3',
+    'eve-elastic==2.0',
     'flask>=0.10,<0.11',
     'flask-mail>=0.9,<0.10',
     'flask-script>=2.0.5,<3.0',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ LONG_DESCRIPTION = "Superdesk Server Core"
 
 install_requires = [
     'eve>=0.6,<0.7',
-    'eve-elastic==2.0rc1',
+    'eve-elastic==2.0rc2',
     'flask>=0.10,<0.11',
     'flask-mail>=0.9,<0.10',
     'flask-script>=2.0.5,<3.0',

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ LONG_DESCRIPTION = "Superdesk Server Core"
 
 install_requires = [
     'eve>=0.6,<0.7',
-    'eve-elastic>=0.5.2,<0.7',
-    'elasticsearch>=1.9.0,<2.0',
+    'eve-elastic==2.0rc1',
     'flask>=0.10,<0.11',
     'flask-mail>=0.9,<0.10',
     'flask-script>=2.0.5,<3.0',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ LONG_DESCRIPTION = "Superdesk Server Core"
 
 install_requires = [
     'eve>=0.6,<0.7',
-    'eve-elastic==2.0rc2',
+    'eve-elastic==2.0rc3',
     'flask>=0.10,<0.11',
     'flask-mail>=0.9,<0.10',
     'flask-script>=2.0.5,<3.0',

--- a/superdesk/commands/rebuild_elastic_index.py
+++ b/superdesk/commands/rebuild_elastic_index.py
@@ -9,11 +9,11 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
-from superdesk.utils import get_random_string
-from elasticsearch.helpers import reindex
-from eve_elastic import get_es, get_indices
-import elasticsearch
 import superdesk
+import elasticsearch
+
+from superdesk.utils import get_random_string
+from eve_elastic import get_es, get_indices, reindex
 from apps.search import SearchService
 
 

--- a/superdesk/metadata/utils.py
+++ b/superdesk/metadata/utils.py
@@ -32,6 +32,7 @@ aggregations = {
 }
 
 elastic_highlight_query = {
+    'require_field_match': False,
     'pre_tags': ['<span class=\"es-highlight\">'],
     'post_tags': ['</span>'],
     'fields': {

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -848,10 +848,12 @@ def step_impl_then_get_error(context, code):
 def step_impl_then_get_list(context, total_count):
     assert_200(context.response)
     data = get_json_data(context.response)
-    int_count = int(total_count.replace('+', ''))
+    int_count = int(total_count.replace('+', '').replace('<', ''))
 
     if '+' in total_count:
         assert int_count <= data['_meta']['total'], '%d items is not enough' % data['_meta']['total']
+    elif total_count.startswith('<'):
+        assert int_count > data['_meta']['total'], '%d items is too much' % data['_meta']['total']
     else:
         assert int_count == data['_meta']['total'], 'got %d: %s' % (data['_meta']['total'],
                                                                     format_items(data['_items']))


### PR DESCRIPTION
seems like we can support 1 and 2 with same codebase, but for version 5 we would have to get rid of
deprecated queries like `and`, `or` and `filtered`.

requires https://github.com/petrjasek/eve-elastic/pull/73
