### PR TITLE
[SDESK-706] - Adding missing history details to items

### DIFF
--- a/apps/archive/archive_link.py
+++ b/apps/archive/archive_link.py
@@ -15,13 +15,15 @@ from superdesk.metadata.item import EMBARGO, ITEM_STATE, CONTENT_STATE, ITEM_TYP
 from superdesk.resource import Resource, build_custom_hateoas
 from apps.packages import TakesPackageService, PackageService
 from apps.archive import ArchiveSpikeService
-from apps.archive.common import CUSTOM_HATEOAS, BROADCAST_GENRE, is_genre, insert_into_versions
+from apps.archive.common import CUSTOM_HATEOAS, BROADCAST_GENRE, is_genre, insert_into_versions, \
+    ITEM_OPERATION, ITEM_UNLINK, ITEM_TAKE
 from apps.auth import get_user
 from superdesk.metadata.utils import item_url, generate_guid
 from apps.archive.archive import SOURCE as ARCHIVE
 from superdesk.errors import SuperdeskApiError
 from superdesk.notification import push_notification
 import logging
+from eve.versioning import resolve_document_version
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +73,13 @@ class ArchiveLinkService(Service):
         insert_into_versions(id_=linked_item[config.ID_FIELD])
         doc.update(linked_item)
         build_custom_hateoas(CUSTOM_HATEOAS, doc)
+
+        updates = {ITEM_OPERATION: ITEM_TAKE}
+        resolve_document_version(updates, ARCHIVE, 'PATCH', target)
+        service.system_update(target_id, updates, target)
+        target.update(updates)
+        insert_into_versions(doc=target)
+
         return [linked_item['_id']]
 
     def _validate_link(self, target, target_id):
@@ -147,7 +156,12 @@ class ArchiveLinkService(Service):
             updates['sequence'] = None
 
         updates['event_id'] = generate_guid(type=GUID_TAG)
+        updates[ITEM_OPERATION] = ITEM_UNLINK
+
+        resolve_document_version(updates, ARCHIVE, 'PATCH', target)
 
         archive_service.system_update(target_id, updates, target)
+        target.update(updates)
+        insert_into_versions(doc=target)
         user = get_user(required=True)
         push_notification('item:unlink', item=target_id, user=str(user.get(config.ID_FIELD)))

--- a/apps/archive/archive_rewrite.py
+++ b/apps/archive/archive_rewrite.py
@@ -15,14 +15,20 @@ from superdesk import get_resource_service, Service, config
 from superdesk.metadata.item import ITEM_STATE, EMBARGO, CONTENT_STATE, CONTENT_TYPE, \
     ITEM_TYPE, PUBLISH_STATES, ASSOCIATIONS
 from superdesk.resource import Resource, build_custom_hateoas
-from apps.archive.common import CUSTOM_HATEOAS, ITEM_CREATE, ARCHIVE, BROADCAST_GENRE
+from apps.archive.common import insert_into_versions, CUSTOM_HATEOAS, ITEM_CREATE, ARCHIVE, BROADCAST_GENRE, \
+    item_operations, ITEM_OPERATION, ITEM_UNLINK
 from superdesk.metadata.utils import item_url
 from superdesk.workflow import is_workflow_state_transition_valid
 from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
 from apps.packages.takes_package_service import TakesPackageService
 from apps.tasks import send_to
+from eve.versioning import resolve_document_version
+
 
 logger = logging.getLogger(__name__)
+
+ITEM_REWRITE = 'rewrite'
+item_operations.append(ITEM_REWRITE)
 
 
 class ArchiveRewriteResource(Resource):
@@ -59,14 +65,19 @@ class ArchiveRewriteService(Service):
             archive_service.patch(update_document[config.ID_FIELD], rewrite)
             rewrite[config.ID_FIELD] = update_document[config.ID_FIELD]
             ids = [update_document[config.ID_FIELD]]
+            rewrite[ITEM_OPERATION] = ITEM_REWRITE
         else:
             ids = archive_service.post([rewrite])
             build_custom_hateoas(CUSTOM_HATEOAS, rewrite)
+            rewrite[ITEM_OPERATION] = ITEM_CREATE
 
         self._add_rewritten_flag(original, digital, rewrite)
         get_resource_service('archive_broadcast').on_broadcast_master_updated(ITEM_CREATE,
                                                                               item=original,
                                                                               rewrite_id=ids[0])
+
+        insert_into_versions(doc=rewrite)
+
         return [rewrite]
 
     def _validate_rewrite(self, original, update):
@@ -188,6 +199,7 @@ class ArchiveRewriteService(Service):
                     rewrite['body_html'] = original.get('body_html', '')
 
         rewrite[ITEM_STATE] = CONTENT_STATE.PROGRESS
+        rewrite[config.VERSION] = 1
         self._set_take_key(rewrite, original.get('event_id'))
         return rewrite
 
@@ -198,18 +210,27 @@ class ArchiveRewriteService(Service):
         :param dict digital: digital item
         :param dict rewrite: rewritten document
         """
+        updates = {'rewritten_by': rewrite[config.ID_FIELD], ITEM_OPERATION: ITEM_REWRITE}
+
         get_resource_service('published').update_published_items(original[config.ID_FIELD],
-                                                                 'rewritten_by', rewrite[config.ID_FIELD])
+                                                                 'rewritten_by',
+                                                                 rewrite[config.ID_FIELD],
+                                                                 operation=ITEM_REWRITE)
         if digital:
             # update the rewritten_by for digital
-            get_resource_service('published').update_published_items(digital[config.ID_FIELD], 'rewritten_by',
-                                                                     rewrite[config.ID_FIELD])
-            get_resource_service(ARCHIVE).system_update(digital[config.ID_FIELD],
-                                                        {'rewritten_by': rewrite[config.ID_FIELD]}, digital)
+            get_resource_service('published').update_published_items(digital[config.ID_FIELD],
+                                                                     'rewritten_by',
+                                                                     rewrite[config.ID_FIELD],
+                                                                     operation=ITEM_REWRITE)
+            get_resource_service(ARCHIVE).system_update(digital[config.ID_FIELD], updates, digital)
+
+        resolve_document_version(updates, ARCHIVE, 'PATCH', original)
 
         # modify the original item as well.
-        get_resource_service(ARCHIVE).system_update(original[config.ID_FIELD],
-                                                    {'rewritten_by': rewrite[config.ID_FIELD]}, original)
+        get_resource_service(ARCHIVE).system_update(original[config.ID_FIELD], updates, original)
+
+        original.update(updates)
+        insert_into_versions(doc=original)
 
     def _clear_rewritten_flag(self, event_id, rewrite_id, rewrite_field):
         """Clears rewritten_by or rewrite_of field from the existing published and archive items.
@@ -227,11 +248,16 @@ class ArchiveRewriteService(Service):
         processed_items = set()
         for doc in published_rewritten_stories:
             doc_id = doc.get(config.ID_FIELD)
-            publish_service.update_published_items(doc_id, rewrite_field, None)
+            publish_service.update_published_items(doc_id, rewrite_field, None, operation=ITEM_UNLINK)
             if doc_id not in processed_items:
                 # clear the flag from the archive as well.
                 archive_item = archive_service.find_one(req=None, _id=doc_id)
-                archive_service.system_update(doc_id, {rewrite_field: None}, archive_item)
+                updates = {rewrite_field: None}
+                resolve_document_version(updates, ARCHIVE, 'PATCH', archive_item)
+                archive_service.system_update(doc_id, updates, archive_item)
+                updates[ITEM_OPERATION] = ITEM_UNLINK
+                archive_item.update(updates)
+                insert_into_versions(doc=archive_item)
                 processed_items.add(doc_id)
 
     def _set_take_key(self, rewrite, event_id):

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -41,12 +41,14 @@ ARCHIVE = 'archive'
 CUSTOM_HATEOAS = {'self': {'title': 'Archive', 'href': '/archive/{_id}'}}
 ITEM_OPERATION = 'operation'
 ITEM_CREATE = 'create'
+ITEM_UNLINK = 'unlink'
+ITEM_TAKE = 'take'
 ITEM_UPDATE = 'update'
 ITEM_RESTORE = 'restore'
 ITEM_DUPLICATE = 'duplicate'
 ITEM_DESCHEDULE = 'deschedule'
 ITEM_EVENT_ID = 'event_id'
-item_operations = [ITEM_CREATE, ITEM_UPDATE, ITEM_RESTORE, ITEM_DUPLICATE, ITEM_DESCHEDULE]
+item_operations = [ITEM_CREATE, ITEM_UPDATE, ITEM_RESTORE, ITEM_DUPLICATE, ITEM_DESCHEDULE, ITEM_UNLINK, ITEM_TAKE]
 # part the task dict
 LAST_AUTHORING_DESK = 'last_authoring_desk'
 LAST_PRODUCTION_DESK = 'last_production_desk'

--- a/apps/packages/takes_package_service.py
+++ b/apps/packages/takes_package_service.py
@@ -18,7 +18,7 @@ from superdesk.metadata.packages import LINKED_IN_PACKAGES, PACKAGE_TYPE, TAKES_
     LAST_TAKE, REFS, MAIN_GROUP, SEQUENCE, RESIDREF, ASSOCIATED_TAKE_SEQUENCE
 from superdesk.metadata.item import CONTENT_TYPE, ITEM_TYPE, PUBLISH_STATES, ITEM_STATE, \
     CONTENT_STATE, EMBARGO, PUBLISH_SCHEDULE, SCHEDULE_SETTINGS, ASSOCIATIONS
-from apps.archive.common import insert_into_versions, ITEM_CREATE, RE_OPENS
+from apps.archive.common import insert_into_versions, ITEM_CREATE, RE_OPENS, ITEM_OPERATION, ITEM_TAKE
 from .package_service import get_item_ref, create_root_group
 
 logger = logging.getLogger(__name__)
@@ -114,6 +114,8 @@ class TakesPackageService():
         # if the original was flagged for SMS the new take should not be.
         if to.get('flags', {}).get('marked_for_sms', False):
             to['flags']['marked_for_sms'] = False
+
+        to[ITEM_OPERATION] = ITEM_TAKE
 
     def package_story_as_a_take(self, target, takes_package, link):
         """Makes a take from an item.

--- a/apps/publish/published_item.py
+++ b/apps/publish/published_item.py
@@ -26,7 +26,7 @@ from eve.utils import ParsedRequest, config
 from flask import current_app as app
 
 from apps.archive.archive import SOURCE as ARCHIVE
-from apps.archive.common import handle_existing_data, item_schema
+from apps.archive.common import handle_existing_data, item_schema, ITEM_OPERATION, insert_into_versions
 from apps.packages import TakesPackageService
 from superdesk.publish.publish_queue import PUBLISHED_IN_PACKAGE
 
@@ -309,11 +309,14 @@ class PublishedItemService(BaseService):
         doc = self.find_one(req=None, item_id=item_id)
         return doc and 'rewritten_by' in doc and doc['rewritten_by']
 
-    def update_published_items(self, _id, field, state):
+    def update_published_items(self, _id, field, state, operation=None):
         items = self.get_other_published_items(_id)
         for item in items:
             try:
                 super().system_update(ObjectId(item[config.ID_FIELD]), {field: state}, item)
+                if operation:
+                    item.update({ITEM_OPERATION: operation})
+                    insert_into_versions(doc=item)
             except:
                 # This part is used in unit testing
                 super().system_update(item[config.ID_FIELD], {field: state}, item)

--- a/features/archived_kill.feature
+++ b/features/archived_kill.feature
@@ -331,7 +331,7 @@ Feature: Kill a content item in the (dusty) archive
     When we enqueue published
     When we get "/legal_publish_queue"
     Then we get list with 8 items
-    When we patch "/archived/123:2"
+    When we patch "/archived/123:3"
     """
     {}
     """
@@ -348,10 +348,10 @@ Feature: Kill a content item in the (dusty) archive
     When we get "/legal_archive/123"
     Then we get existing resource
     """
-    {"_id": "123", "type": "text", "_current_version": 4, "state": "killed", "pubstatus": "canceled", "operation": "kill"}
+    {"_id": "123", "type": "text", "_current_version": 5, "state": "killed", "pubstatus": "canceled", "operation": "kill"}
     """
     When we get "/legal_archive/123?version=all"
-    Then we get list with 4 items
+    Then we get list with 5 items
     When we get "/legal_archive/#archive.123.take_package#"
     Then we get existing resource
     """
@@ -362,10 +362,10 @@ Feature: Kill a content item in the (dusty) archive
     When we get "/legal_archive/#take1#"
     Then we get existing resource
     """
-    {"_id": "#take1#", "type": "text", "_current_version": 4, "state": "killed", "pubstatus": "canceled", "operation": "kill"}
+    {"_id": "#take1#", "type": "text", "_current_version": 5, "state": "killed", "pubstatus": "canceled", "operation": "kill"}
     """
     When we get "/legal_archive/#take1#?version=all"
-    Then we get list with 4 items
+    Then we get list with 5 items
     When we get "/legal_archive/#take2#"
     Then we get existing resource
     """

--- a/features/content_expire_not_published.feature
+++ b/features/content_expire_not_published.feature
@@ -164,7 +164,7 @@ Feature: Content Expiry Not Published Items
       "_items": [
         {"_id": "123", "type": "text",
          "linked_in_packages": [{"package": "#TAKE_PACKAGE#", "package_type": "takes"}],
-         "_current_version": 1, "sequence": 1},
+         "_current_version": 2, "sequence": 1},
         {"_id": "#TAKE_PACKAGE#", "package_type": "takes", "type": "composite", "sequence": 2},
         {"_id": "#TAKE2#", "type": "text",
          "linked_in_packages": [{"package": "#TAKE_PACKAGE#", "package_type": "takes"}],
@@ -198,7 +198,7 @@ Feature: Content Expiry Not Published Items
       "_items": [
         {"_id": "123", "type": "text",
          "linked_in_packages": [{"package": "#TAKE_PACKAGE#", "package_type": "takes"}],
-         "_current_version": 1, "sequence": 1},
+         "_current_version": 2, "sequence": 1},
         {"_id": "#TAKE_PACKAGE#", "package_type": "takes", "type": "composite", "sequence": 2},
         {"_id": "#TAKE2#", "type": "text",
          "linked_in_packages": [{"package": "#TAKE_PACKAGE#", "package_type": "takes"}],

--- a/features/content_rewrite.feature
+++ b/features/content_rewrite.feature
@@ -1409,7 +1409,7 @@ Feature: Rewrite content
               {"state": "pending", "content_type": "composite",
               "subscriber_id": "#digital#", "item_id": "#take_package1#", "item_version": 2},
               {"state": "pending", "content_type": "text",
-              "subscriber_id": "#wire#", "item_id": "123", "item_version": 2}
+              "subscriber_id": "#wire#", "item_id": "123", "item_version": 3}
             ]
         }
         """
@@ -1425,7 +1425,7 @@ Feature: Rewrite content
               {"state": "pending", "content_type": "composite",
               "subscriber_id": "#digital#", "item_id": "#take_package1#", "item_version": 2},
               {"state": "pending", "content_type": "text",
-              "subscriber_id": "#wire#", "item_id": "123", "item_version": 2},
+              "subscriber_id": "#wire#", "item_id": "123", "item_version": 3},
               {"state": "pending", "content_type": "composite", "item_id": "#take_package2#",
               "subscriber_id": "#digital#", "item_version": 2},
               {"state": "pending", "content_type": "text",

--- a/features/http_push.feature
+++ b/features/http_push.feature
@@ -83,5 +83,5 @@ Feature: HTTP Push publishing
         When we transmit published
         Then we pushed 1 item
         """
-        [{"guid": "#archive.guid#", "type": "text", "pubstatus": "canceled", "version": "5"}]
+        [{"guid": "#archive.guid#", "type": "text", "pubstatus": "canceled", "version": "6"}]
         """

--- a/features/package_publish.feature
+++ b/features/package_publish.feature
@@ -1327,7 +1327,7 @@ Feature: Package Publishing
       When we get "/published"
       Then we get existing resource
       """
-      {"_items" : [{"_id": "123", "guid": "123", "headline": "Take-1 soccer headline", "_current_version": 3, "state": "published"},
+      {"_items" : [{"_id": "123", "guid": "123", "headline": "Take-1 soccer headline", "_current_version": 4, "state": "published"},
                    {"_id": "#TAKE2#", "guid": "#TAKE2#", "headline": "Take-2 soccer headline", "_current_version": 4, "state": "published"},
                    {"headline": "Take-1 soccer headline", "_current_version": 2, "state": "published", "package_type": "takes"},
                    {"headline": "Take-2 soccer headline", "_current_version": 3, "state": "published", "package_type": "takes"},
@@ -1493,7 +1493,7 @@ Feature: Package Publishing
       When we get "/published"
       Then we get existing resource
       """
-      {"_items" : [{"_id": "123", "guid": "123", "headline": "Take-1 soccer headline", "_current_version": 3, "state": "published"},
+      {"_items" : [{"_id": "123", "guid": "123", "headline": "Take-1 soccer headline", "_current_version": 4, "state": "published"},
                    {"_id": "#TAKE2#", "guid": "#TAKE2#", "headline": "Take-2 soccer headline", "_current_version": 4, "state": "published"},
                    {"headline": "Take-1 soccer headline", "_current_version": 2, "state": "published", "package_type": "takes"},
                    {"headline": "Take-2 soccer headline", "_current_version": 3, "state": "published", "package_type": "takes"},

--- a/features/resend.feature
+++ b/features/resend.feature
@@ -185,7 +185,7 @@ Feature: Resend
     """
     {
       "subscribers": ["#subscribers._id#"],
-      "version": 4
+      "version": 5
     }
     """
     Then we get error 400

--- a/features/takes_publish.feature
+++ b/features/takes_publish.feature
@@ -162,7 +162,7 @@ Feature: Take Package Publishing
       {
           "_items": [
               {
-                  "_current_version": 3,
+                  "_current_version": 4,
                   "state": "published",
                   "body_html": "Take-1"
               },
@@ -285,7 +285,7 @@ Feature: Take Package Publishing
           "_items": [
               {
                   "_id": "123",
-                  "_current_version": 3,
+                  "_current_version": 4,
                   "state": "published",
                   "body_html": "Take-1",
                   "archive_item": {
@@ -454,7 +454,7 @@ Feature: Take Package Publishing
           "_items": [
               {
                   "_id": "123",
-                  "_current_version": 3,
+                  "_current_version": 4,
                   "state": "published",
                   "body_html": "Take-1",
                   "last_published_version": true
@@ -469,7 +469,7 @@ Feature: Take Package Publishing
               },
               {
                   "_id": "#TAKE2#",
-                  "_current_version": 4,
+                  "_current_version": 5,
                   "state": "published",
                   "body_html": "Take-2",
                   "last_published_version": true
@@ -496,7 +496,7 @@ Feature: Take Package Publishing
           "_items": [
               {
                   "_id": "123",
-                  "_current_version": 3,
+                  "_current_version": 4,
                   "state": "published",
                   "body_html": "Take-1",
                   "last_published_version": false
@@ -530,7 +530,7 @@ Feature: Take Package Publishing
               },
               {
                   "_id": "#TAKE2#",
-                  "_current_version": 4,
+                  "_current_version": 5,
                   "state": "published",
                   "body_html": "Take-2",
                   "last_published_version": false
@@ -544,7 +544,7 @@ Feature: Take Package Publishing
               },
               {
                   "_id": "123",
-                  "_current_version": 4,
+                  "_current_version": 5,
                   "state": "killed",
                   "last_published_version": true,
                   "headline": "Kill/Takedown notice ~~~ Kill/Takedown notice",
@@ -552,7 +552,7 @@ Feature: Take Package Publishing
               },
               {
                   "_id": "#TAKE2#",
-                  "_current_version": 5,
+                  "_current_version": 6,
                   "state": "killed",
                   "last_published_version": true,
                   "headline": "Kill/Takedown notice ~~~ Kill/Takedown notice",
@@ -578,8 +578,8 @@ Feature: Take Package Publishing
                   "groups": [
                     {"refs": [{"idRef" : "main"}], "id": "root"},
                     {"refs":[
-                      {"_current_version": 4, "guid": "123"},
-                      {"_current_version": 5, "guid": "#TAKE2#"},
+                      {"_current_version": 5, "guid": "123"},
+                      {"_current_version": 6, "guid": "#TAKE2#"},
                       {"_current_version": 5, "guid": "#TAKE3#"}
                     ],
                     "id" : "main"}
@@ -710,7 +710,7 @@ Feature: Take Package Publishing
               "state" : "pending",
               "subscriber_id" : "#First_Wire_Subscriber#",
               "headline" : "Take-1 soccer headline=1",
-              "item_version": 3
+              "item_version": 4
             },
             {
               "item_id" : "#archive.123.take_package#",
@@ -748,7 +748,7 @@ Feature: Take Package Publishing
               "publishing_action" : "published",
               "content_type" : "text",
               "subscriber_id" : "#First_Wire_Subscriber#",
-              "item_version": 3
+              "item_version": 4
             },
             {
               "item_id" : "#archive.123.take_package#",
@@ -790,7 +790,7 @@ Feature: Take Package Publishing
               "content_type" : "text",
               "subscriber_id" : "#First_Wire_Subscriber#",
               "headline" : "Take-1 soccer headline=1",
-              "item_version": 3
+              "item_version": 4
             },
             {
               "item_id" : "#archive.123.take_package#",
@@ -1958,7 +1958,7 @@ Feature: Take Package Publishing
                   "marked_for_sms" : true
               },
               "type" : "text",
-              "_current_version" : 3
+              "_current_version" : 4
           },
           {
               "flags" : {


### PR DESCRIPTION
- Creating a new version in following scenarios:
  - when a story is rewritten
  - when there's a new take created
  - when an existing story is linked as a rewrite or take
  - when a story is unlinked (for takes and rewrites)