### PR TITLE
added wufoo service provider and feed parser

### DIFF
--- a/apps/io/feeding_services/__init__.py
+++ b/apps/io/feeding_services/__init__.py
@@ -10,3 +10,4 @@
 
 
 import apps.io.feeding_services.reuters  # NOQA
+import apps.io.feeding_services.wufoo  # NOQA

--- a/apps/io/feeding_services/wufoo.py
+++ b/apps/io/feeding_services/wufoo.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.io.registry import register_feeding_service
+from superdesk.io.feeding_services import FeedingService
+from superdesk.errors import IngestApiError
+import requests
+import traceback
+# from pytz import timezone
+
+
+WUFOO_URL = 'https://{subdomain}.wufoo.com/api/v3/'
+WUFOO_QUERY_FORM = 'forms/{form_hash}/'
+WUFOO_QUERY_FIELDS = 'fields.json'
+WUFOO_QUERY_ENTRIES = 'entries.json'
+
+
+class WufooFeedingService(FeedingService):
+    """
+    Feeding Service class which can read article(s) using Wufoo API
+    """
+
+    NAME = 'wufoo'
+
+    ERRORS = [IngestApiError.apiTimeoutError().get_error_description(),
+              IngestApiError.apiRedirectError().get_error_description(),
+              IngestApiError.apiRequestError().get_error_description(),
+              IngestApiError.apiGeneralError().get_error_description()]
+
+    def __init__(self):
+        self.fields_cache = {}
+
+    def _update(self, provider, update):
+        user = provider['config']['wufoo_username']
+        wufoo_data = {
+            "url": WUFOO_URL.format(subdomain=user),
+            "user": user,
+            "api_key": provider['config']['wufoo_api_key'],
+            "form_query_entries_tpl": WUFOO_QUERY_FORM + WUFOO_QUERY_ENTRIES,
+            "update": update}
+        try:
+            parser = self.get_feed_parser(provider, None)
+        except requests.exceptions.Timeout as ex:
+            raise IngestApiError.apiTimeoutError(ex, provider)
+        except requests.exceptions.TooManyRedirects as ex:
+            raise IngestApiError.apiRedirectError(ex, provider)
+        except requests.exceptions.RequestException as ex:
+            raise IngestApiError.apiRequestError(ex, provider)
+        except Exception as error:
+            traceback.print_exc()
+            raise IngestApiError.apiGeneralError(error, self.provider)
+        items = parser.parse(wufoo_data, provider)
+        return [items]
+
+
+register_feeding_service(WufooFeedingService.NAME, WufooFeedingService(), WufooFeedingService.ERRORS)

--- a/docs/ingest.rst
+++ b/docs/ingest.rst
@@ -46,10 +46,12 @@ Handle transport protocols when ingesting.
 
 .. autoclass:: RSSFeedingService
 
+.. autoclass:: apps.io.feeding_services.wufoo.WufooFeedingService
+
 Add new Service
 ^^^^^^^^^^^^^^^
 
-.. autofunction:: superdesk.io.register_feeding_service
+.. autofunction:: superdesk.io.registry.register_feeding_service
 
 Feed Parsers
 ------------
@@ -85,4 +87,4 @@ Parse items from services.
 Add new Parser
 ^^^^^^^^^^^^^^
 
-.. autofunction:: superdesk.io.register_feed_parser
+.. autofunction:: superdesk.io.registry.register_feed_parser

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -38,6 +38,7 @@ from superdesk.filemeta import set_filemeta
 
 UPDATE_SCHEDULE_DEFAULT = {'minutes': 5}
 LAST_UPDATED = 'last_updated'
+LAST_INGESTED_ID = 'last_ingested_id'
 LAST_ITEM_UPDATE = 'last_item_update'
 IDLE_TIME_DEFAULT = {'hours': 0, 'minutes': 0}
 

--- a/superdesk/io/ingest_provider_model.py
+++ b/superdesk/io/ingest_provider_model.py
@@ -119,6 +119,7 @@ class IngestProviderResource(Resource):
                 }
             },
             'last_updated': {'type': 'datetime'},
+            'last_ingested_id': {'type': 'string'},  # this id is ingest provider internal value
             'last_item_update': {'type': 'datetime'},
             'rule_set': Resource.rel('rule_sets', nullable=True),
             'routing_scheme': Resource.rel('routing_schemes', nullable=True),

--- a/superdesk/io/registry.py
+++ b/superdesk/io/registry.py
@@ -36,7 +36,7 @@ def register_feeding_service(service_name, service_class, errors):
     :raises: AlreadyExistsError if a feeding service with same name already been registered
     """
 
-    if service_name in registered_feed_parsers:
+    if service_name in registered_feeding_services:
         raise AlreadyExistsError('Feeding Service: {} already registered by {}'
                                  .format(service_name, type(registered_feeding_services[service_name])))
 

--- a/tests/io/feeding_services/http_tests.py
+++ b/tests/io/feeding_services/http_tests.py
@@ -21,12 +21,15 @@ from superdesk.tests import TestCase
 from superdesk.errors import IngestApiError
 
 
+TEST_FEEDING_SERVICE_NAME = 'test_feeding_service'
+
+
 def setup_provider(token, hours):
     return {
         '_id': 'foo',
         'name': 'test http',
         'source': 'test http',
-        'feeding_service': 'test',
+        'feeding_service': TEST_FEEDING_SERVICE_NAME,
         'feed_parser': 'newsml2',
         'content_expiry': 2880,
         'tokens': {
@@ -37,7 +40,7 @@ def setup_provider(token, hours):
 
 
 class TestFeedingService(HTTPFeedingService):
-    NAME = 'test'
+    NAME = TEST_FEEDING_SERVICE_NAME
     ERRORS = []
 
     def _update(self, provider, update):


### PR DESCRIPTION
Wufoo is form building service, this commit add feeding service and
feed parser using its API.

this also fix a bug in superdesk/io/registry.py forbidding using a
feeding service and a feed parser with the same name.

It also add a last_ingested_id field for feeding services which can be
used to only ingest new items, this is more resilient than using a date.

Fixed documentation for register_feeding_service and register_feed_parser

SDNTB-377