### PR TITLE
[ingestion] webhooks handling

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Superdesk'
-copyright = '2016, Sourcefabric'
+copyright = '2017, Sourcefabric'
 author = 'Sourcefabric'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/ingest.rst
+++ b/docs/ingest.rst
@@ -88,3 +88,15 @@ Add new Parser
 ^^^^^^^^^^^^^^
 
 .. autofunction:: superdesk.io.registry.register_feed_parser
+
+Add a Webhook
+^^^^^^^^^^^^^
+
+Webhook are a way to trigger ingestion without polling an ingest provider: the service do a POST HTTP request on a given URL to trigger the ingestion, resulting in resources saving and quicker ingestion.
+Webhooks are using ``webhook`` endpoint. The service triggering the webhook must use this endpoint with 2 URLs parameters:
+
+* ``provider_name`` which is the name of the provider to trigger
+* ``auth`` which is an authentication key. This key is set in a ``WEBHOOK_[PROVIDER_NAME]_AUTH`` environment variable, when ``[PROVIDER_NAME]`` is the name of the provider in uppercase.
+
+To activate the webhook, the ``WEBHOOK_[PROVIDER_NAME]_AUTH`` environment variable must be set.
+Note that because ``auth`` parameter is used in request, HTTPS protocol should be used to avoid the key being sent unencrypted.

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -339,6 +339,7 @@ CORE_APPS.extend([
     'superdesk.io',
     'superdesk.io.feeding_services',
     'superdesk.io.feed_parsers',
+    'superdesk.io.webhooks',
     'superdesk.io.subjectcodes',
     'superdesk.io.iptc',
     'apps.io',

--- a/superdesk/io/webhooks/__init__.py
+++ b/superdesk/io/webhooks/__init__.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013 - 2017 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.resource import Resource
+from superdesk.services import BaseService
+from superdesk.io.commands import update_ingest
+from flask import request, abort
+import os
+import superdesk
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class FeedinServiceWebhookAuth(object):
+
+    def authenticate(self):
+        abort(403, description='You are not authorized to access this resource')
+
+    def authorized(self, allowed_roles, resource, method):
+        try:
+            # provider's id may be used in the future
+            provider_name = request.args['provider_name']
+        except KeyError:
+            logger.warning('Got an invalid webhook request (missing provider name) ')
+            return False
+        # FIXME: there can be a conflict if 2 provider name are similar but with different case
+        #        this will be fixed when we'll use id instead of name
+        env_name = 'WEBHOOK_{}_AUTH'.format(provider_name.upper())
+        try:
+            auth_key = os.environ[env_name]
+        except KeyError:
+            logger.error('{} environment variable is not set'.format(env_name))
+            return False
+        return request.args.get('auth') == auth_key
+
+
+class FeedingServiceWebhookResource(Resource):
+    resource_methods = ['POST']
+    authentication = FeedinServiceWebhookAuth
+    # we don't want schema validation to accept any webhook data
+    allow_unknown = True
+
+
+class FeedingServiceWebhookService(BaseService):
+    """Service givin metadata on backend itself"""
+
+    def create(self, docs, **kwargs):
+        # we don't want to create anything
+        # we just use this service to trigget the provider
+        # and return a fake id
+        self.trigger_provider()
+        return [0]
+
+    def trigger_provider(self):
+        provider_name = request.args['provider_name']
+        lookup = {'name': provider_name}
+        for provider in superdesk.get_resource_service('ingest_providers').get(req=None, lookup=lookup):
+            kwargs = {
+                'provider': provider,
+                'rule_set': update_ingest.get_provider_rule_set(provider),
+                'routing_scheme': update_ingest.get_provider_routing_scheme(provider)
+            }
+            update_ingest.update_provider.apply_async(
+                expires=update_ingest.get_task_ttl(provider), kwargs=kwargs)
+
+
+def init_app(app):
+    service = FeedingServiceWebhookService()
+    FeedingServiceWebhookResource("webhook", app=app, service=service)

--- a/superdesk/resource.py
+++ b/superdesk/resource.py
@@ -41,6 +41,7 @@ class Resource():
     item_url = None
     additional_lookup = None
     schema = {}
+    allow_unknown = None
     item_methods = None
     resource_methods = None
     public_methods = None
@@ -67,6 +68,8 @@ class Resource():
         self.service = service
         if not endpoint_schema:
             endpoint_schema = {'schema': self.schema}
+            if self.allow_unknown is not None:
+                endpoint_schema.update({'allow_unknown': self.allow_unknown})
             if self.additional_lookup is not None:
                 endpoint_schema.update({'additional_lookup': self.additional_lookup})
             if self.extra_response_fields is not None:


### PR DESCRIPTION
this commit add a basic handling of webhooks.
For now settings is done on backend using FEEDING_WEBHOOKS where key is
provider name and value is endpoint suffix.

when adding a webhook, e.g. with FEEDING_WEBHOOKS = {'Personalia':
'wufoo'}, a webhook_[endpoint_suffix] will be used (the prefix help to
prevent conflicts), so here webhook_wufoo will be used.

When an GET or POST request is done on webhook_wufoo, this will trigger
the Personalia provider update.

This is a first step, improvments like client-side configuration and
new option in update schedule could follow.

This commit also add handling of transparent_schema_rules in Resource.

SDNTB-378