### PR TITLE
[SDESK-746] - Separation of history from versions

### DIFF
--- a/apps/archive/archive_link.py
+++ b/apps/archive/archive_link.py
@@ -8,14 +8,14 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 from eve.utils import config
-from flask import request
+from flask import request, current_app as app
 
 from superdesk import get_resource_service, Service
 from superdesk.metadata.item import EMBARGO, ITEM_STATE, CONTENT_STATE, ITEM_TYPE, CONTENT_TYPE, GUID_TAG
 from superdesk.resource import Resource, build_custom_hateoas
 from apps.packages import TakesPackageService, PackageService
 from apps.archive import ArchiveSpikeService
-from apps.archive.common import CUSTOM_HATEOAS, BROADCAST_GENRE, is_genre, insert_into_versions
+from apps.archive.common import CUSTOM_HATEOAS, BROADCAST_GENRE, is_genre, insert_into_versions, ITEM_UNLINK
 from apps.auth import get_user
 from superdesk.metadata.utils import item_url, generate_guid
 from apps.archive.archive import SOURCE as ARCHIVE
@@ -151,3 +151,4 @@ class ArchiveLinkService(Service):
         archive_service.system_update(target_id, updates, target)
         user = get_user(required=True)
         push_notification('item:unlink', item=target_id, user=str(user.get(config.ID_FIELD)))
+        app.on_archive_item_updated(updates, target, ITEM_UNLINK)

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -41,12 +41,24 @@ ARCHIVE = 'archive'
 CUSTOM_HATEOAS = {'self': {'title': 'Archive', 'href': '/archive/{_id}'}}
 ITEM_OPERATION = 'operation'
 ITEM_CREATE = 'create'
+ITEM_FETCH = 'fetch'
 ITEM_UPDATE = 'update'
+ITEM_REWRITE = 'rewrite'
 ITEM_RESTORE = 'restore'
+ITEM_LINK = 'link'
+ITEM_UNLINK = 'unlink'
+ITEM_TAKE = 'take'
+ITEM_REOPEN = 'reopen'
 ITEM_DUPLICATE = 'duplicate'
+ITEM_DUPLICATED_FROM = 'duplicated_from'
 ITEM_DESCHEDULE = 'deschedule'
+ITEM_MARK = 'mark'
+ITEM_UNMARK = 'unmark'
+ITEM_RESEND = 'resend'
 ITEM_EVENT_ID = 'event_id'
-item_operations = [ITEM_CREATE, ITEM_UPDATE, ITEM_RESTORE, ITEM_DUPLICATE, ITEM_DESCHEDULE]
+item_operations = [ITEM_CREATE, ITEM_FETCH, ITEM_UPDATE, ITEM_RESTORE,
+                   ITEM_DUPLICATE, ITEM_DUPLICATED_FROM, ITEM_DESCHEDULE,
+                   ITEM_REWRITE, ITEM_LINK, ITEM_UNLINK, ITEM_TAKE, ITEM_MARK, ITEM_UNMARK, ITEM_RESEND]
 # part the task dict
 LAST_AUTHORING_DESK = 'last_authoring_desk'
 LAST_PRODUCTION_DESK = 'last_production_desk'

--- a/apps/archive_history/__init__.py
+++ b/apps/archive_history/__init__.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from apps.archive_history.service import ArchiveHistoryService, ArchiveHistoryResource
+import logging
+from superdesk import get_backend
+
+log = logging.getLogger(__name__)
+
+
+def init_app(app):
+    endpoint_name = 'archive_history'
+
+    service = ArchiveHistoryService(endpoint_name, backend=get_backend())
+    ArchiveHistoryResource(endpoint_name, app=app, service=service)
+
+    app.on_updated_archive += service.on_item_updated
+
+    app.on_archive_item_updated -= service.on_item_updated
+    app.on_archive_item_updated += service.on_item_updated
+
+    app.on_archive_item_deleted -= service.on_item_deleted
+    app.on_archive_item_deleted += service.on_item_deleted

--- a/apps/archive_history/service.py
+++ b/apps/archive_history/service.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import logging
+from flask import g
+from eve.utils import config
+from copy import deepcopy
+from superdesk.resource import Resource
+from superdesk.services import BaseService
+from apps.archive.common import ITEM_UPDATE
+
+log = logging.getLogger(__name__)
+
+fields_to_remove = ['_id', '_etag', 'versioncreator', 'originalcreator', 'versioncreated',
+                    '_current_version', 'version', '_updated', 'lock_session', 'lock_user', 'lock_time',
+                    'force_unlock', '_created', 'guid', 'family_id', 'firstcreated', 'original_creator']
+
+
+class ArchiveHistoryResource(Resource):
+    endpoint_name = 'archive_history'
+    resource_methods = ['GET']
+    item_methods = ['GET']
+    schema = {
+        'item_id': {'type': 'string'},
+        'user_id': Resource.rel('users', True),
+        'operation': {'type': 'string'},
+        'update': {'type': 'dict', 'nullable': True},
+        'version': {'type': 'integer'}
+    }
+
+
+class ArchiveHistoryService(BaseService):
+
+    def on_item_updated(self, updates, original, operation=None):
+        item = deepcopy(original)
+        if updates:
+            item.update(updates)
+        self._save_history(item, updates, operation or ITEM_UPDATE)
+
+    def on_item_deleted(self, doc):
+        lookup = {'item_id': doc[config.ID_FIELD]}
+        self.delete(lookup=lookup)
+
+    def get_user_id(self, item):
+        user = getattr(g, 'user', None)
+        if user:
+            return user.get('_id')
+
+    def _save_history(self, item, update, operation):
+        history = {
+            'item_id': item[config.ID_FIELD],
+            'user_id': self.get_user_id(item),
+            'operation': operation,
+            'update': self._remove_unwanted_fields(update, item),
+            'version': item.get(config.VERSION, 1)
+        }
+
+        self.post([history])
+
+    def _remove_unwanted_fields(self, update, original):
+        if update:
+            update_copy = deepcopy(update)
+            for field in fields_to_remove:
+                update_copy.pop(field, None)
+
+            if original.get('sms_message') == update_copy.get('sms_message'):
+                update_copy.pop('sms_message', None)
+
+            return update_copy

--- a/apps/duplication/archive_fetch.py
+++ b/apps/duplication/archive_fetch.py
@@ -17,7 +17,7 @@ from apps.archive.archive import SOURCE as ARCHIVE
 from apps.content import push_item_move_notification
 from superdesk.metadata.utils import item_url
 from apps.archive.common import generate_unique_id_and_name, remove_unwanted, \
-    set_original_creator, insert_into_versions, ITEM_OPERATION, item_operations
+    set_original_creator, insert_into_versions, ITEM_OPERATION, ITEM_FETCH
 from superdesk.metadata.utils import generate_guid
 from superdesk.metadata.item import GUID_TAG, INGEST_ID, FAMILY_ID, ITEM_STATE, \
     CONTENT_STATE, GUID_FIELD
@@ -31,8 +31,6 @@ from superdesk.metadata.packages import RESIDREF, REFS, GROUPS
 from superdesk.metadata.item import MEDIA_TYPES
 
 custom_hateoas = {'self': {'title': 'Archive', 'href': '/archive/{_id}'}}
-ITEM_FETCH = 'fetch'
-item_operations.extend([ITEM_FETCH])
 
 
 class FetchResource(Resource):

--- a/apps/duplication/archive_move.py
+++ b/apps/duplication/archive_move.py
@@ -10,7 +10,7 @@
 
 from eve.utils import config
 from eve.versioning import resolve_document_version
-from flask import request
+from flask import request, current_app as app
 from copy import deepcopy
 
 import superdesk
@@ -121,6 +121,7 @@ class MoveService(BaseService):
         archive_service.update(original[config.ID_FIELD], archived_doc, original)
         insert_into_versions(id_=original[config.ID_FIELD])
         push_item_move_notification(original, archived_doc)
+        app.on_archive_item_updated(archived_doc, original, ITEM_MOVE)
 
     def _validate(self, archived_doc, doc):
         """Validate that the item can be move.

--- a/apps/highlights/service.py
+++ b/apps/highlights/service.py
@@ -7,13 +7,14 @@ import apps.archive  # NOQA
 # When that issue is resolved, the workaround should be removed.
 
 import apps.packages.package_service as package
-
+from flask import current_app as app
 from superdesk import get_resource_service
 from superdesk.services import BaseService
 from eve.utils import ParsedRequest
 from superdesk.notification import push_notification
 from superdesk.utc import get_timezone_offset, utcnow
 from eve.utils import config
+from apps.archive.common import ITEM_MARK, ITEM_UNMARK
 
 
 def init_parsed_request(elastic_query):
@@ -113,6 +114,11 @@ class MarkedForHighlightsService(BaseService):
                         '_etag': publishedItem['_etag']
                     }
                     publishedService.update(publishedItem['_id'], updates, publishedItem)
+
+            if highlight_on:
+                app.on_archive_item_updated({'highlight_id': doc['highlights']}, item, ITEM_MARK)
+            else:
+                app.on_archive_item_updated({'highlight_id': doc['highlights']}, item, ITEM_UNMARK)
 
             push_notification(
                 'item:highlights',

--- a/apps/legal_archive/__init__.py
+++ b/apps/legal_archive/__init__.py
@@ -12,8 +12,10 @@ import logging
 from superdesk.celery_app import celery
 from superdesk import get_backend, privilege
 from .resource import LegalArchiveResource, LegalArchiveVersionsResource, LegalPublishQueueResource, \
-    LEGAL_ARCHIVE_NAME, LEGAL_ARCHIVE_VERSIONS_NAME, LEGAL_PUBLISH_QUEUE_NAME
-from .service import LegalArchiveService, LegalArchiveVersionsService, LegalPublishQueueService
+    LegalArchiveHistoryResource, LEGAL_ARCHIVE_NAME, LEGAL_ARCHIVE_VERSIONS_NAME, \
+    LEGAL_ARCHIVE_HISTORY_NAME, LEGAL_PUBLISH_QUEUE_NAME
+from .service import LegalArchiveService, LegalArchiveVersionsService, LegalPublishQueueService, \
+    LegalArchiveHistoryService
 from .commands import ImportLegalPublishQueueCommand, ImportLegalArchiveCommand  # noqa
 
 logger = logging.getLogger(__name__)
@@ -27,6 +29,10 @@ def init_app(app):
     endpoint_name = LEGAL_ARCHIVE_VERSIONS_NAME
     service = LegalArchiveVersionsService(endpoint_name, backend=get_backend())
     LegalArchiveVersionsResource(endpoint_name, app=app, service=service)
+
+    endpoint_name = LEGAL_ARCHIVE_HISTORY_NAME
+    service = LegalArchiveHistoryService(endpoint_name, backend=get_backend())
+    LegalArchiveHistoryResource(endpoint_name, app=app, service=service)
 
     endpoint_name = LEGAL_PUBLISH_QUEUE_NAME
     service = LegalPublishQueueService(endpoint_name, backend=get_backend())

--- a/apps/legal_archive/resource.py
+++ b/apps/legal_archive/resource.py
@@ -9,6 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from apps.archive.archive import ArchiveResource, ArchiveVersionsResource
+from apps.archive_history import ArchiveHistoryResource
 
 from superdesk.publish.publish_queue import PublishQueueResource
 from superdesk.resource import Resource
@@ -16,6 +17,7 @@ from superdesk.resource import Resource
 
 LEGAL_ARCHIVE_NAME = 'legal_archive'
 LEGAL_ARCHIVE_VERSIONS_NAME = 'legal_archive_versions'
+LEGAL_ARCHIVE_HISTORY_NAME = 'legal_archive_history'
 LEGAL_PUBLISH_QUEUE_NAME = 'legal_publish_queue'
 
 
@@ -40,6 +42,13 @@ class LegalArchiveVersionsResource(LegalResource, ArchiveVersionsResource):
     datasource = {'source': LEGAL_ARCHIVE_VERSIONS_NAME,
                   'projection': {'old_version': 0, 'last_version': 0}
                   }
+
+
+class LegalArchiveHistoryResource(LegalResource, ArchiveHistoryResource):
+    endpoint_name = LEGAL_ARCHIVE_HISTORY_NAME
+    resource_title = endpoint_name
+
+    datasource = {'source': LEGAL_ARCHIVE_HISTORY_NAME}
 
 
 class LegalPublishQueueResource(LegalResource, PublishQueueResource):

--- a/apps/legal_archive/service.py
+++ b/apps/legal_archive/service.py
@@ -167,6 +167,10 @@ class LegalArchiveVersionsService(LegalService):
             if config.ID_FIELD in doc:  # This happens when inserting docs from pre-populate command
                 doc_if_exists = self.find_one(req=None, _id=doc['_id'])
 
+            # This also happens when inserting docs from pre-populate command
+            if not doc.get('operation'):
+                doc['operation'] = 'create'
+
             if doc_if_exists is None:
                 ids.extend(super().create([doc]))
 
@@ -191,3 +195,20 @@ class LegalArchiveVersionsService(LegalService):
             self.enhance(doc)
 
         return ListCursor(version_history)
+
+
+class LegalArchiveHistoryService(LegalService):
+    def create(self, docs, **kwargs):
+        """
+        Overriding this from preventing the same version again. This happens when an item is published more than once.
+        """
+
+        ids = []
+        for doc in docs:
+            doc_if_exists = None
+            if doc.get('item_id'):
+                doc_if_exists = self.find_one(req=None, _id=doc.get('_id'))
+            if doc_if_exists is None:
+                ids.extend(super().create([doc]))
+
+        return ids

--- a/apps/marked_desks/service.py
+++ b/apps/marked_desks/service.py
@@ -9,6 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import json
+from flask import current_app as app
 from superdesk import get_resource_service
 from superdesk.services import BaseService
 from eve.utils import ParsedRequest
@@ -16,6 +17,7 @@ from superdesk.notification import push_notification
 from apps.archive.common import get_user
 from eve.utils import config
 from superdesk.utc import utcnow
+from apps.archive.common import ITEM_MARK, ITEM_UNMARK
 
 
 def get_marked_items(desk_id):
@@ -76,5 +78,10 @@ class MarkedForDesksService(BaseService):
                 marked=int(marked_desks_on),
                 item_id=item['_id'],
                 mark_id=str(doc['marked_desk']))
+
+            if marked_desks_on:
+                app.on_archive_item_updated({'desk_id': doc['marked_desk']}, item, ITEM_MARK)
+            else:
+                app.on_archive_item_updated({'desk_id': doc['marked_desk']}, item, ITEM_UNMARK)
 
         return ids

--- a/apps/packages/package_service.py
+++ b/apps/packages/package_service.py
@@ -20,7 +20,7 @@ from superdesk import get_resource_service
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE, EMBARGO
 from superdesk.metadata.packages import LINKED_IN_PACKAGES, PACKAGE_TYPE, TAKES_PACKAGE, PACKAGE, LAST_TAKE, \
     REFS, RESIDREF, GROUPS, ID_REF, MAIN_GROUP, SEQUENCE, ROOT_GROUP, ROLE, ROOT_ROLE, MAIN_ROLE, GROUP_ID
-from apps.archive.common import insert_into_versions
+from apps.archive.common import insert_into_versions, ITEM_UNLINK
 from apps.archive.archive import SOURCE as ARCHIVE
 from superdesk.utc import utcnow
 from superdesk.default_settings import VERSION
@@ -402,10 +402,13 @@ class PackageService():
 
                 if last_take_group:
                     updates[LAST_TAKE] = last_take_group.get(RESIDREF)
+                    last_take_item = get_resource_service(ARCHIVE).find_one(req=None, _id=updates[LAST_TAKE])
+                    app.on_archive_item_updated({}, last_take_item, ITEM_UNLINK)
 
         if not delete_package:
             resolve_document_version(updates, ARCHIVE, 'PATCH', package)
             get_resource_service(ARCHIVE).patch(package[config.ID_FIELD], updates)
+            app.on_archive_item_updated(updates, package, ITEM_UNLINK)
             insert_into_versions(id_=package[config.ID_FIELD])
 
         sub_package_ids.append(package[config.ID_FIELD])

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -573,6 +573,7 @@ class BasePublishService(BaseService):
         """
 
         self.backend.update(self.datasource, original[config.ID_FIELD], updates, original)
+        app.on_archive_item_updated(updates, original, updates[ITEM_OPERATION])
 
         if should_insert_into_versions:
             if versioned_doc is None:

--- a/apps/publish/content/resend.py
+++ b/apps/publish/content/resend.py
@@ -12,13 +12,13 @@ from apps.archive.archive import ArchiveResource, SOURCE as ARCHIVE
 from superdesk.metadata.utils import item_url
 import logging
 from functools import partial
-from flask import request
+from flask import request, current_app as app
 from superdesk import get_resource_service, Service, config
 from superdesk.errors import SuperdeskApiError
 from superdesk.metadata.item import CONTENT_TYPE, ITEM_TYPE, ITEM_STATE, CONTENT_STATE
 from superdesk.publish import SUBSCRIBER_TYPES
 from apps.publish.enqueue.enqueue_service import EnqueueService
-from apps.archive.common import is_genre, BROADCAST_GENRE
+from apps.archive.common import is_genre, BROADCAST_GENRE, ITEM_RESEND
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +49,7 @@ class ResendService(Service):
         article = self._validate_article(article_id, article_version)
         subscribers = self._validate_subscribers(doc.get('subscribers'), article)
         EnqueueService().resend(article, subscribers)
+        app.on_archive_item_updated({'subscribers': doc.get('subscribers')}, article, ITEM_RESEND)
         return [article_id]
 
     def _validate_subscribers(self, subscriber_ids, article):

--- a/features/archive_history.feature
+++ b/features/archive_history.feature
@@ -1,0 +1,804 @@
+Feature: Archive history
+
+    @auth @notification
+    Scenario: History of duplicated stories
+      Given "desks"
+      """
+      [{"name": "Sports"}]
+      """
+      And "archive"
+      """
+      [{  "type":"text", "event_id": "abc123", "headline": "test1", "guid": "123",
+          "original_creator": "#CONTEXT_USER_ID#",
+          "state": "submitted", "source": "REUTERS", "subject":[{"qcode": "17004000", "name": "Statistics"}],
+          "body_html": "Test Document body",
+          "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}]
+      """
+      When we patch given
+      """
+      {"headline": "test2"}
+      """
+      And we patch latest
+      """
+      {"headline": "test3"}
+      """
+      Then we get updated response
+      """
+      {"headline": "test3", "state": "in_progress", "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}}
+      """
+      And we get version 3
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 3 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "update"},
+        {"version": 3, "operation": "update"}
+      ]}
+      """
+      When we post to "/archive/123/duplicate"
+      """
+      {"desk": "#desks._id#","type": "archive"}
+      """
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 4 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "update"},
+        {"version": 3, "operation": "update"},
+        {"version": 3, "operation": "duplicate"}
+      ]}
+      """
+      When we get "/archive/#duplicate._id#"
+      Then we get existing resource
+      """
+      {"state": "submitted", "_current_version": 4, "source": "AAP",
+       "task": {"desk": "#desks._id#", "stage": "#desks.working_stage#", "user": "#CONTEXT_USER_ID#"},
+       "original_id": "123"}
+      """
+      When we get "/archive_history?where=item_id==%22#duplicate._id#%22"
+      Then we get list with 4 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "update"},
+        {"version": 3, "operation": "update"},
+        {"version": 4, "operation": "duplicated_from"}
+      ]}
+      """
+
+    @auth
+    Scenario: History of rewrite activities
+      Given "desks"
+      """
+      [{"name": "Sports"}]
+      """
+      And "archive"
+      """
+      [{"guid": "123", "type": "text", "headline": "test", "_current_version": 1, "state": "fetched",
+        "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
+        "subject":[{"qcode": "17004000", "name": "Statistics"}],
+        "body_html": "Test Document body", "genre": [{"name": "Article", "qcode": "Article"}],
+        "flags": {"marked_for_legal": true, "marked_for_sms": true}, "priority": 2, "urgency": 2,
+        "body_footer": "Suicide Call Back Service 1300 659 467", "sms_message": "test",
+        "place": [{"qcode" : "ACT", "world_region" : "Oceania", "country" : "Australia",
+        "name" : "ACT", "state" : "Australian Capital Territory"}],
+        "company_codes" : [{"qcode" : "1PG", "security_exchange" : "ASX", "name" : "1-PAGE LIMITED"}]
+      }]
+      """
+      When we rewrite "123"
+      """
+      {"desk_id": "#desks._id#"}
+      """
+      Then we get OK response
+      When we get "/archive/#REWRITE_ID#"
+      Then we get OK response
+      When we get "/archive"
+      Then we get existing resource
+      """
+      {"_items" : [{"_id": "#REWRITE_ID#", "anpa_take_key": "update", "rewrite_of": "123"}]}
+      """
+      When we get "/archive/123"
+      Then we get existing resource
+      """
+      {"_id": "123", "rewritten_by": "#REWRITE_ID#", "place": [{"qcode" : "ACT"}]}
+      """
+      When we get "/archive_history?where=item_id==%22#REWRITE_ID#%22"
+      Then we get list with 2 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 1, "operation": "link"}
+      ]}
+      """
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 2 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 1, "operation": "rewrite"}
+      ]}
+      """
+      When we spike "#REWRITE_ID#"
+      Then we get OK response
+      When we get "/archive_history?where=item_id==%22#REWRITE_ID#%22"
+      Then we get list with 3 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 1, "operation": "link"},
+        {"version": 2, "operation": "spike"}
+      ]}
+      """
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 3 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 1, "operation": "rewrite"},
+        {"version": 1, "operation": "unlink"}
+      ]}
+      """
+      When we unspike "#REWRITE_ID#"
+      When we get "/archive_history?where=item_id==%22#REWRITE_ID#%22"
+      Then we get list with 4 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 1, "operation": "link"},
+        {"version": 2, "operation": "spike"},
+        {"version": 3, "operation": "unspike"}
+      ]}
+      """
+      When we rewrite "123"
+      """
+      {"update": {"_id": "#REWRITE_ID#", "type": "text", "headline": "test",
+      "_current_version": 3, "state": "submitted", "priority": 2}}
+      """
+      When we get "/archive_history?where=item_id==%22#REWRITE_ID#%22"
+      Then we get list with 5 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 1, "operation": "link"},
+        {"version": 2, "operation": "spike"},
+        {"version": 3, "operation": "unspike"},
+        {"version": 3, "operation": "link"}
+      ]}
+      """
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 4 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 1, "operation": "rewrite"},
+        {"version": 1, "operation": "unlink"},
+        {"version": 1, "operation": "rewrite"}
+      ]}
+      """
+
+    @auth
+    Scenario: History of take activities
+      Given "desks"
+      """
+      [{"name": "Sports"}]
+      """
+      When we post to "archive" with success
+      """
+      [{
+          "guid": "123",
+          "type": "text",
+          "headline": "Take-1 headline",
+          "abstract": "Take-1 abstract",
+          "task": {
+              "user": "#CONTEXT_USER_ID#"
+          },
+          "body_html": "Take-1",
+          "state": "draft",
+          "slugline": "Take-1 slugline",
+          "urgency": "4",
+          "pubstatus": "usable",
+          "subject":[{"qcode": "17004000", "name": "Statistics"}],
+          "anpa_category": [{"qcode": "A", "name": "Sport"}],
+          "anpa_take_key": "Take"
+      }]
+      """
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 1 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"}
+      ]}
+      """
+      When we post to "/archive/123/move"
+      """
+      [{"task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}]
+      """
+      Then we get OK response
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 2 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "move"}
+      ]}
+      """
+      When we post to "archive/123/link"
+      """
+      [{}]
+      """
+      Then we get next take as "TAKE"
+      """
+      {
+          "type": "text",
+          "headline": "Take-1 headline",
+          "slugline": "Take-1 slugline",
+          "anpa_take_key": "Take=2",
+          "state": "draft",
+          "original_creator": "#CONTEXT_USER_ID#"
+      }
+      """
+      When we get "/archive_history?where=item_id==%22#TAKE#%22"
+      Then we get list with 2 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 1, "operation": "link"}
+      ]}
+      """
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 3 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "move"},
+        {"version": 2, "operation": "take"}
+      ]}
+      """
+      When we spike "#TAKE#"
+      Then we get OK response
+      When we get "/archive_history?where=item_id==%22#TAKE#%22"
+      Then we get list with 3 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 1, "operation": "link"},
+        {"version": 2, "operation": "spike"}
+      ]}
+      """
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 4 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "move"},
+        {"version": 2, "operation": "take"},
+        {"version": 2, "operation": "unlink"}
+      ]}
+      """
+      When we unspike "#TAKE#"
+      When we get "/archive_history?where=item_id==%22#TAKE#%22"
+      Then we get list with 4 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 1, "operation": "link"},
+        {"version": 2, "operation": "spike"},
+        {"version": 3, "operation": "unspike"}
+      ]}
+      """
+      When we post to "archive/123/link"
+      """
+      [{"link_id": "#TAKE#"}]
+      """
+      When we get "/archive_history?where=item_id==%22#TAKE#%22"
+      Then we get list with 5 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 1, "operation": "link"},
+        {"version": 2, "operation": "spike"},
+        {"version": 3, "operation": "unspike"},
+        {"version": 3, "operation": "link"}
+      ]}
+      """
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 5 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "move"},
+        {"version": 2, "operation": "take"},
+        {"version": 2, "operation": "unlink"},
+        {"version": 2, "operation": "take"}
+      ]}
+      """
+      When we delete link "archive/#TAKE#/link"
+      When we get "/archive_history?where=item_id==%22#TAKE#%22"
+      Then we get list with 6 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 1, "operation": "link"},
+        {"version": 2, "operation": "spike"},
+        {"version": 3, "operation": "unspike"},
+        {"version": 3, "operation": "link"},
+        {"version": 3, "operation": "unlink"}
+      ]}
+      """
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 6 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "move"},
+        {"version": 2, "operation": "take"},
+        {"version": 2, "operation": "unlink"},
+        {"version": 2, "operation": "take"},
+        {"version": 2, "operation": "unlink"}
+      ]}
+      """
+
+    @auth
+    Scenario: History of publish activities
+      Given the "validators"
+      """
+      [{"_id": "publish_text", "act": "publish", "type": "text", "schema":{}},
+      {"_id": "correct_text", "act": "correct", "type": "text", "schema":{}},
+      {"_id": "kill_text", "act": "kill", "type": "text", "schema":{}}]
+      """
+      And "desks"
+      """
+      [{"name": "Sports", "members":[{"user":"#CONTEXT_USER_ID#"}]}]
+      """
+      When we post to "/archive" with success
+      """
+      [{"guid": "123", "headline": "test", "state": "fetched",
+        "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
+        "subject":[{"qcode": "17004000", "name": "Statistics"}],
+        "slugline": "test",
+        "body_html": "Test Document body"}]
+      """
+      When we post to "/products" with success
+      """
+      {
+        "name":"prod-1","codes":"abc,xyz"
+      }
+      """
+      And we post to "/subscribers" with success
+      """
+      {
+        "name":"Channel 3","media_type":"media", "subscriber_type": "wire", "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
+        "products": ["#products._id#"],
+        "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}]
+      }
+      """
+      And we publish "#archive._id#" with "publish" type and "published" state
+      Then we get OK response
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 2 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "publish"}
+      ]}
+      """
+      When we enqueue published
+      When we get "/legal_archive/123"
+      Then we get OK response
+      And we get existing resource
+      """
+      {"_current_version": 2, "state": "published"}
+      """
+      When we get "/legal_archive_history?where=item_id==%22123%22"
+      Then we get list with 2 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "publish"}
+      ]}
+      """
+      When we publish "#archive._id#" with "correct" type and "corrected" state
+      Then we get OK response
+      And we get existing resource
+      """
+      {"_current_version": 3, "state": "corrected", "operation": "correct", "task":{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}
+      """
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 3 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "publish"},
+        {"version": 3, "operation": "correct"}
+      ]}
+      """
+      When we enqueue published
+      When we get "/legal_archive/123"
+      Then we get OK response
+      When we get "/legal_archive_history?where=item_id==%22123%22"
+      Then we get list with 3 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "publish"},
+        {"version": 3, "operation": "correct"}
+      ]}
+      """
+      When we publish "#archive._id#" with "kill" type and "killed" state
+      Then we get OK response
+      And we get existing resource
+      """
+      {"_current_version": 4, "state": "killed", "operation": "kill", "pubstatus": "canceled", "task":{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}
+      """
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 4 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "publish"},
+        {"version": 3, "operation": "correct"},
+        {"version": 4, "operation": "kill"}
+      ]}
+      """
+      When we enqueue published
+      When we get "/legal_archive/123"
+      Then we get OK response
+      When we get "/legal_archive_history?where=item_id==%22123%22"
+      Then we get list with 4 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "publish"},
+        {"version": 3, "operation": "correct"},
+        {"version": 4, "operation": "kill"}
+      ]}
+      """
+
+    @auth
+    Scenario: History of reopening a story
+      Given the "validators"
+      """
+        [{"_id": "publish_text", "act": "publish", "type": "text", "schema":{}}]
+      """
+      And "desks"
+      """
+      [{"name": "Sports"}]
+      """
+      When we post to "/products" with success
+      """
+      {
+        "name":"prod-1","codes":"abc,xyz"
+      }
+      """
+      And we post to "/subscribers" with success
+      """
+      {
+        "name":"Channel 3","media_type":"media", "subscriber_type": "digital", "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
+        "products": ["#products._id#"],
+        "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}]
+      }
+      """
+      When we post to "archive" with success
+      """
+      [{
+          "guid": "123",
+          "type": "text",
+          "headline": "Take-1 headline",
+          "abstract": "Take-1 abstract",
+          "task": {
+              "user": "#CONTEXT_USER_ID#"
+          },
+          "body_html": "Take-1",
+          "state": "draft",
+          "slugline": "Take-1 slugline",
+          "urgency": "4",
+          "pubstatus": "usable",
+          "subject":[{"qcode": "17004000", "name": "Statistics"}],
+          "anpa_category": [{"qcode": "A", "name": "Sport"}],
+          "anpa_take_key": null,
+          "target_subscribers": [{"_id": "#subscribers._id#"}]
+      }]
+      """
+      And we post to "/archive/123/move"
+      """
+      [{"task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}]
+      """
+      Then we get OK response
+      When we publish "#archive._id#" with "publish" type and "published" state
+      Then we get OK response
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 3 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "move"},
+        {"version": 3, "operation": "publish"}
+      ]}
+      """
+      When we post to "archive/123/link"
+      """
+      [{}]
+      """
+      Then we get next take as "TAKE"
+      """
+      {
+          "type": "text",
+          "headline": "Take-1 headline",
+          "slugline": "Take-1 slugline",
+          "anpa_take_key": "(reopens)=2",
+          "state": "draft",
+          "original_creator": "#CONTEXT_USER_ID#",
+          "target_subscribers": [{"_id": "#subscribers._id#"}]
+      }
+      """
+      When we patch "/archive/#TAKE#"
+      """
+      {"body_html": "Take-2", "abstract": "Take-2 Abstract"}
+      """
+      And we post to "/archive/#TAKE#/move"
+      """
+      [{"task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}]
+      """
+      And we get "/archive"
+      Then we get list with 1 items
+      When we publish "#TAKE#" with "publish" type and "published" state
+      Then we get OK response
+      When we get "/archive_history?where=item_id==%22123%22"
+      Then we get list with 4 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "create"},
+        {"version": 2, "operation": "move"},
+        {"version": 3, "operation": "publish"},
+        {"version": 3, "operation": "reopen"}
+      ]}
+      """
+
+    @auth
+    @provider
+    Scenario: History of fetched story
+      Given empty "archive"
+      And "desks"
+      """
+      [{"name": "Sports"}]
+      """
+      And ingest from "reuters"
+      """
+      [{"guid": "tag_reuters.com_2014_newsml_LOVEA6M0L7U2E"}]
+      """
+      When we post to "/ingest/tag_reuters.com_2014_newsml_LOVEA6M0L7U2E/fetch"
+      """
+      {"desk": "#desks._id#"}
+      """
+      Then we get "_id"
+      When we get "/archive_history?where=item_id==%22#_id#%22"
+      Then we get list with 1 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "fetch"}
+      ]}
+      """
+      When we post to "/archive/#_id#/lock"
+      """
+      {}
+      """
+      And we patch "/archive/#_id#"
+      """
+      {"headline": "test 2"}
+      """
+      Then we get existing resource
+      """
+      {"headline": "test 2", "state": "in_progress", "task": {"desk": "#desks._id#"}}
+      """
+      When we get "/archive_history?where=item_id==%22#_id#%22"
+      Then we get list with 2 items
+      """
+      {"_items": [
+        {"version": 1, "operation": "fetch"},
+        {"version": 2, "operation": "update", "update":{"headline": "test 2"}}
+      ]}
+      """
+
+    @auth
+    Scenario: History of marking for highlights and desks
+        Given "desks"
+		"""
+		[{"name": "desk1"}]
+		"""
+        When we post to "highlights"
+        """
+        {"name": "highlight1", "desks": ["#desks._id#"]}
+        """
+        Then we get new resource
+        """
+        {"name": "highlight1", "desks": ["#desks._id#"]}
+        """
+        When we post to "archive"
+		"""
+		[{"headline": "test"}]
+		"""
+        When we get "/archive_history?where=item_id==%22#archive._id#%22"
+        Then we get list with 1 items
+        """
+        {"_items": [
+          {"version": 1, "operation": "create"}
+        ]}
+        """
+		When we post to "marked_for_highlights"
+		"""
+		[{"highlights": "#highlights._id#", "marked_item": "#archive._id#"}]
+		"""
+		Then we get new resource
+        """
+        {"highlights": "#highlights._id#", "marked_item": "#archive._id#"}
+        """
+        When we get "archive"
+        Then we get list with 1 items
+        """
+        {"_items": [{"headline": "test", "highlights": ["#highlights._id#"],
+                    "_updated": "#archive._updated#", "_etag": "#archive._etag#"}]}
+        """
+        When we get "/archive_history?where=item_id==%22#archive._id#%22"
+        Then we get list with 2 items
+        """
+        {"_items": [
+          {"version": 1, "operation": "create"},
+          {"version": 1, "operation": "mark", "update":{"highlight_id":"#highlights._id#"}}
+        ]}
+        """
+        When we post to "marked_for_highlights"
+        """
+        [{"highlights": "#highlights._id#", "marked_item": "#archive._id#"}]
+        """
+        And we get "archive"
+        Then we get list with 1 items
+        """
+        {"_items": [{"highlights": [], "_updated": "#archive._updated#", "_etag": "#archive._etag#"}]}
+        """
+        When we get "/archive_history?where=item_id==%22#archive._id#%22"
+        Then we get list with 3 items
+        """
+        {"_items": [
+          {"version": 1, "operation": "create"},
+          {"version": 1, "operation": "mark", "update":{"highlight_id":"#highlights._id#"}},
+          {"version": 1, "operation": "unmark", "update":{"highlight_id":"#highlights._id#"}}
+        ]}
+        """
+        When we post to "/marked_for_desks" with success
+        """
+        [{"marked_desk": "#desks._id#", "marked_item": "#archive._id#"}]
+        """
+        Then we get new resource
+        """
+        {"marked_desk": "#desks._id#", "marked_item": "#archive._id#"}
+        """
+        When we get "/archive_history?where=item_id==%22#archive._id#%22"
+        Then we get list with 4 items
+        """
+        {"_items": [
+          {"version": 1, "operation": "create"},
+          {"version": 1, "operation": "mark", "update":{"highlight_id":"#highlights._id#"}},
+          {"version": 1, "operation": "unmark", "update":{"highlight_id":"#highlights._id#"}},
+          {"version": 1, "operation": "mark", "update":{"desk_id":"#desks._id#"}}
+        ]}
+        """
+        When we post to "marked_for_desks"
+        """
+        [{"marked_desk": "#desks._id#", "marked_item": "#archive._id#"}]
+        """
+        And we get "archive"
+        Then we get list with 1 items
+        """
+        {"_items": [{"marked_desks": []}]}
+        """
+        When we get "/archive_history?where=item_id==%22#archive._id#%22"
+        Then we get list with 5 items
+        """
+        {"_items": [
+          {"version": 1, "operation": "create"},
+          {"version": 1, "operation": "mark", "update":{"highlight_id":"#highlights._id#"}},
+          {"version": 1, "operation": "unmark", "update":{"highlight_id":"#highlights._id#"}},
+          {"version": 1, "operation": "mark", "update":{"desk_id":"#desks._id#"}},
+          {"version": 1, "operation": "unmark", "update":{"desk_id":"#desks._id#"}}
+        ]}
+        """
+
+  @auth
+  @vocabulary
+  Scenario: History of resend
+    Given the "validators"
+    """
+    [{"_id": "publish_text", "act": "publish", "type": "text", "schema":{}},
+    {"_id": "correct_text", "act": "correct", "type": "text", "schema":{}}]
+    """
+    And "desks"
+    """
+    [{"name": "Sports", "members":[{"user":"#CONTEXT_USER_ID#"}]}]
+    """
+    And "archive"
+    """
+    [{"guid": "123", "headline": "test", "_current_version": 3, "state": "fetched",
+      "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
+      "subject":[{"qcode": "17004000", "name": "Statistics"}],
+      "slugline": "test",
+      "body_html": "Test Document body"}]
+    """
+    And "products"
+      """
+      [{
+        "_id":"570340ef1d41c89b50716dad", "name":"prod-1","codes":"abc"
+      },
+      {
+        "_id":"570340ef1d41c89b50716dae", "name":"prod-2","codes":"def,xyz"
+      },
+      {
+        "_id":"570340ef1d41c89b50716daf", "name":"prod-3"
+      }]
+      """
+    And "subscribers"
+      """
+      [{
+        "_id": "sub-1",
+        "name":"Channel 3",
+        "media_type":"media",
+        "subscriber_type": "wire",
+        "sequence_num_settings":{"min" : 1, "max" : 10},
+        "email": "test@test.com",
+        "products": ["570340ef1d41c89b50716dad"],
+        "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}]
+      }
+      ]
+      """
+    When we publish "#archive._id#" with "publish" type and "published" state
+    Then we get OK response
+    When we get "/archive_history?where=item_id==%22123%22"
+    Then we get list with 2 items
+    """
+    {"_items": [
+      {"version": 3, "operation": "create"},
+      {"version": 4, "operation": "publish"}
+    ]}
+    """
+    When we enqueue published
+    When we get "/publish_queue"
+    Then we get list with 1 items
+    """
+    {
+      "_items": [
+        {"state": "pending", "content_type": "text",
+        "subscriber_id": "sub-1", "item_id": "123", "item_version": 4}
+      ]
+    }
+    """
+    When we post to "/subscribers"
+    """
+    {
+        "name":"Channel 10",
+        "media_type":"media",
+        "subscriber_type": "wire",
+        "sequence_num_settings":{"min" : 1, "max" : 10},
+        "email": "test@test.com",
+        "products": ["570340ef1d41c89b50716dad"],
+        "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}]
+      }
+    """
+
+    When we post to "/archive/#archive._id#/resend"
+    """
+    {
+      "subscribers": ["#subscribers._id#"],
+      "version": 4
+    }
+    """
+    Then we get OK response
+    When we get "/archive_history?where=item_id==%22123%22"
+    Then we get list with 3 items
+    """
+    {"_items": [
+      {"version": 3, "operation": "create"},
+      {"version": 4, "operation": "publish"},
+      {"version": 4, "operation": "resend", "update":{"subscribers":["#subscribers._id#"]}}
+    ]}
+    """

--- a/features/auto_routing.feature
+++ b/features/auto_routing.feature
@@ -123,6 +123,14 @@ Feature: Auto Routing
           "ingest": "#AAP.AAP.123253116.6697929#"
         }
         """
+        When we get "/archive_history"
+        Then we get list with 2 items
+        """
+        {"_items": [
+          {"version": 1, "operation": "fetch", "user_id": "__none__"},
+          {"version": 1, "operation": "fetch", "user_id": "__none__"}
+        ]}
+        """
         Then the ingest item is not routed based on routing scheme and rule "Finance Rule"
         """
         {
@@ -314,6 +322,7 @@ Feature: Auto Routing
           "ingest": "#AAP.AAP.0.6703189#"
         }
         """
+
 
     @auth @provider @vocabulary
     Scenario: Content is fetched and published to different stages 2
@@ -1109,4 +1118,4 @@ Feature: Auto Routing
         """
          {"_issues": {"validator exception": "[['HEADLINE is too long']]"}, "_status": "ERR"}
         """
-        
+

--- a/features/content_expire_not_published.feature
+++ b/features/content_expire_not_published.feature
@@ -21,6 +21,13 @@ Feature: Content Expiry Not Published Items
   @auth
   @notification
   Scenario: Item on a desk and not part of any package is expired .
+    When we get "/archive_history?where=item_id==%22123%22"
+    Then we get list with 1 items
+    """
+    {"_items": [
+      {"version": 1, "operation": "create"}
+    ]}
+    """
     When we expire items
     """
     ["#archive._id#"]
@@ -29,6 +36,8 @@ Feature: Content Expiry Not Published Items
     Then we get error 404
     When we get "archive/123?versions=all"
     Then we get error 404
+    When we get "/archive_history?where=item_id==%22123%22"
+    Then we get list with 0 items
     And we get notifications
     """
     [

--- a/features/content_expire_published.feature
+++ b/features/content_expire_published.feature
@@ -138,7 +138,15 @@ Feature: Content Expiry Published Items
     Then we get list with 2 items
     When we transmit items
     And run import legal publish queue
-    And we expire items
+    When we get "/archive_history?where=item_id==%22123%22"
+    Then we get list with 2 items
+    """
+    {"_items": [
+      {"version": 1, "operation": "create"},
+      {"version": 2, "operation": "publish"}
+    ]}
+    """
+    When we expire items
     """
     ["123"]
     """
@@ -152,6 +160,8 @@ Feature: Content Expiry Published Items
     Then we get list with 0 items
     When we enqueue published
     When we get "/publish_queue"
+    Then we get list with 0 items
+    When we get "/archive_history?where=item_id==%22123%22"
     Then we get list with 0 items
     When we get "/archived"
     Then we get list with 2 items

--- a/superdesk/audit/audit.py
+++ b/superdesk/audit/audit.py
@@ -26,7 +26,7 @@ class AuditResource(Resource):
         'extra': {'type': 'dict'},
         'user': Resource.rel('users', False)
     }
-    exclude = {endpoint_name, 'activity', 'dictionaries', 'macros'}
+    exclude = {endpoint_name, 'activity', 'dictionaries', 'macros', 'archive_history'}
 
 
 class AuditService(BaseService):

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -350,6 +350,7 @@ CORE_APPS.extend([
     'apps.auth',
     'apps.archive',
     'apps.archive.item_comments',
+    'apps.archive_history',
     'apps.stages',
     'apps.desks',
     'apps.tasks',

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -115,7 +115,8 @@ def assert_is_now(val, key):
 
 def json_match(context_data, response_data):
     if isinstance(context_data, dict):
-        assert isinstance(response_data, dict), 'response data is not dict, but %s' % type(response_data)
+        if (not isinstance(response_data, dict)):
+            return False
         for key in context_data:
             if context_data[key] == "__none__":
                 assert response_data[key] is None


### PR DESCRIPTION
With this change history of a story doesn't need to be inferred from versions. Now item history will be saved into its collection `Archive_History`.

There will be history records created for following events:
- [x] Item Created
- [x] Item Fetched
- [x] Item Updated
- [x] Item Duplicated
- [x] Item Spiked / Unspiked
- [x] Item Updated (Rewritten)
- [x] New Take / Reopen
- [x] Publish
- [x] Correction
- [x] Kill
- [x] Resend
- [x] Link / Unlink (Updates & Takes)
- [x] Mark / Unmark Desk
- [x] Mark / Unmark Highlight

There will be management tasks:
- [x] Move history to legal archive
- [x] Clean history with the content expiry