### PR TITLE
[SDESK-745](feat):Adding product types to products.

### DIFF
--- a/apps/prepopulate/data_init/vocabularies.json
+++ b/apps/prepopulate/data_init/vocabularies.json
@@ -179,5 +179,15 @@
         "items": [
             {"is_active": true, "name": "NSW", "qcode": "NSW"}
         ]
+    },
+    {
+        "_id": "product_types",
+        "display_name": "Product Types",
+        "type": "unmanageable",
+        "items": [
+            {"is_active": true, "name": "API", "qcode": "api"},
+            {"is_active": true, "name": "Direct", "qcode": "direct"},
+            {"is_active": true, "name": "Both", "qcode": "both"}
+        ]
     }
 ]

--- a/apps/prepopulate/data_sample/vocabularies.json
+++ b/apps/prepopulate/data_sample/vocabularies.json
@@ -2628,5 +2628,15 @@
             {"is_active": true, "existing": "temblor", "replacement": "tremor"},
             {"is_active": true, "existing": "ax", "replacement": "axe"}
         ]
+    },
+    {
+        "_id": "product_types",
+        "display_name": "Product Types",
+        "type": "unmanageable",
+        "items": [
+            {"is_active": true, "name": "API", "qcode": "api"},
+            {"is_active": true, "name": "Direct", "qcode": "direct"},
+            {"is_active": true, "name": "Both", "qcode": "both"}
+        ]
     }
 ]

--- a/apps/products/resource.py
+++ b/apps/products/resource.py
@@ -9,6 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from superdesk.resource import Resource
+from superdesk.metadata.utils import ProductTypes
 
 
 class ProductsResource(Resource):
@@ -41,6 +42,12 @@ class ProductsResource(Resource):
         'geo_restrictions': {
             'type': 'string',
             'nullable': True
+        },
+        'product_type': {
+            'type': 'string',
+            'default': ProductTypes.BOTH.value,
+            'allowed': ProductTypes.values(),
+            'required': True
         }
     }
 

--- a/apps/products/service.py
+++ b/apps/products/service.py
@@ -15,6 +15,7 @@ from superdesk.errors import SuperdeskApiError
 
 
 class ProductsService(BaseService):
+
     def on_delete(self, doc):
         # Check if any subscriber is using the product
         req = ParsedRequest()

--- a/apps/publish/content/resend.py
+++ b/apps/publish/content/resend.py
@@ -18,6 +18,7 @@ from superdesk.errors import SuperdeskApiError
 from superdesk.metadata.item import CONTENT_TYPE, ITEM_TYPE, ITEM_STATE, CONTENT_STATE
 from superdesk.publish import SUBSCRIBER_TYPES
 from apps.publish.enqueue.enqueue_service import EnqueueService
+from apps.publish.enqueue.enqueue_api_service import EnqueueAPIService
 from apps.archive.common import is_genre, BROADCAST_GENRE
 
 logger = logging.getLogger(__name__)
@@ -49,6 +50,7 @@ class ResendService(Service):
         article = self._validate_article(article_id, article_version)
         subscribers = self._validate_subscribers(doc.get('subscribers'), article)
         EnqueueService().resend(article, subscribers)
+        EnqueueAPIService().resend(article, subscribers)
         return [article_id]
 
     def _validate_subscribers(self, subscriber_ids, article):

--- a/apps/publish/content/tests.py
+++ b/apps/publish/content/tests.py
@@ -558,7 +558,7 @@ class ArchivePublishTestCase(TestCase):
 
         enqueue_published()
         queue_items = self.app.data.find(PUBLISH_QUEUE, None, None)
-        self.assertEqual(1, queue_items.count())
+        self.assertEqual(2, queue_items.count())
 
     def test_queue_transmission_for_digital_channels(self):
         self._is_publish_queue_empty()
@@ -650,12 +650,12 @@ class ArchivePublishTestCase(TestCase):
 
         enqueue_published()
         queue_items = self.app.data.find(PUBLISH_QUEUE, None, None)
-        self.assertEqual(7, queue_items.count())
+        self.assertEqual(13, queue_items.count())
 
         # this will delete queue transmission for the wire article not the takes package.
         publish_queue.PublishQueueService(PUBLISH_QUEUE, get_backend()).delete_by_article_id(doc['_id'])
         queue_items = self.app.data.find(PUBLISH_QUEUE, None, None)
-        self.assertEqual(2, queue_items.count())
+        self.assertEqual(4, queue_items.count())
 
     def test_conform_target_regions(self):
         doc = {'headline': 'test'}
@@ -737,7 +737,7 @@ class ArchivePublishTestCase(TestCase):
         get_resource_service(ARCHIVE_PUBLISH).patch(id=doc_id, updates={ITEM_STATE: CONTENT_STATE.PUBLISHED})
         enqueue_published()
         queue_items = self.app.data.find(PUBLISH_QUEUE, None, None)
-        self.assertEqual(7, queue_items.count())
+        self.assertEqual(13, queue_items.count())
         expected_subscribers = ['1', '2', '3', '4', '5']
         for item in queue_items:
             self.assertIn(item["subscriber_id"], expected_subscribers, 'item {}'.format(item))
@@ -762,7 +762,7 @@ class ArchivePublishTestCase(TestCase):
         enqueue_published()
 
         queue_items = self.app.data.find(PUBLISH_QUEUE, None, None)
-        self.assertEqual(2, queue_items.count())
+        self.assertEqual(4, queue_items.count())
         request = ParsedRequest()
         request.args = {'aggregations': 0}
         published_items = self.app.data.find(PUBLISHED, request, None)
@@ -780,7 +780,7 @@ class ArchivePublishTestCase(TestCase):
         enqueue_published()
 
         queue_items = self.app.data.find(PUBLISH_QUEUE, None, None)
-        self.assertEqual(4, queue_items.count())
+        self.assertEqual(8, queue_items.count())
         published_items = self.app.data.find(PUBLISHED, request, None)
         self.assertEqual(4, published_items.count())
         last_published_digital = get_publish_items(published_digital_doc['item_id'], True)

--- a/apps/publish/enqueue/enqueue_api_service.py
+++ b/apps/publish/enqueue/enqueue_api_service.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015, 2016, 2017 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+import json
+import logging
+import content_api
+from eve.utils import config, ParsedRequest
+from flask import current_app as app
+from apps.publish.enqueue.enqueue_service import EnqueueService
+from apps.publish.enqueue import EnqueuePublishedService, EnqueueCorrectedService, EnqueueKilledService
+from superdesk import get_resource_service
+from superdesk.metadata.utils import ProductTypes
+from superdesk.publish import PublishingMode
+
+logger = logging.getLogger(__name__)
+
+
+class EnqueueAPIService(EnqueueService):
+
+    publishing_mode = PublishingMode.API
+
+    def publish(self, doc, target_media_type=None):
+        """Queue the content for publishing.
+
+        :param dict doc: document to publish
+        :param str target_media_type: dictate if the doc being queued is a Takes Package or an Individual Article.
+                Valid values are - Wire, Digital. If Digital then the doc being queued is a Takes Package and if Wire
+                then the doc being queues is an Individual Article.
+        :return bool: if content is queued then True else False
+        :raises PublishQueueError.item_not_queued_error:
+                If the nothing is queued.
+        """
+        queued, subscribers = self._publish(doc, target_media_type)
+
+        # publish to content api
+        self.publish_content_api(doc, subscribers)
+
+        return queued
+
+    def publish_content_api(self, doc, subscribers):
+        """
+        Publish item to content api
+        :param dict doc: content api item
+        :param list subscribers: list of subscribers
+        """
+        if content_api.is_enabled() and subscribers:
+            get_resource_service('content_api').publish(doc, subscribers)
+
+    def can_apply_product(self, product):
+        """Check if the given product can be applied to an item based on publishing.
+        If Direct Publishing and product type in 'Direct' or 'Both' then True else False.
+        If API Publishing and product type in 'API' or 'Both' then True else False.
+        :param dict product: Product to be validated
+        :return bool: If Direct Publishing and product type
+        """
+        return product.get('product_type', 'both') in [ProductTypes.API.value, ProductTypes.BOTH.value]
+
+    def get_destinations(self, subscriber):
+        """Get the content api destination for the subscriber
+        :param dict subscriber:
+        :return list: content api destination.
+        """
+        destination = next((d for d in (subscriber.get('destinations') or [])
+                            if d.get('delivery_type') == 'content_api'), None)
+        if not destination:
+            return [{'name': 'content api', 'delivery_type': 'content_api', 'format': 'ninjs'}]
+
+        return [destination]
+
+    def get_subscribers_for_previously_sent_items(self, lookup):
+        """Returns list of subscribers that have previously received the item.
+
+        :param dict lookup: elastic query to filter the publish queue
+        :return: list of subscribers and list of product codes per subscriber
+        """
+        lookup['$and'].append({'destination.delivery_type': 'content_api'})
+        return self._get_subscribers_for_previously_sent_items(lookup)
+
+    def resend(self, doc, subscribers):
+        """Resend doc to subscribers.
+        If there is any product of type API or both assigned to subscriber
+        then the subscriber qualifies for resend.
+
+        :param dict doc: doc to resend
+        :param list subscribers: list of subscribers
+        :return:
+        """
+        subscriber_codes = self._get_subscriber_codes(subscribers)
+        wire_subscribers = list(self.non_digital(subscribers))
+        digital_subscribers = list(self.digital(subscribers))
+        req = ParsedRequest()
+        req.where = json.dumps({'product_type': {'$in': [ProductTypes.API.value, ProductTypes.BOTH.value]}})
+        existing_products = {p[config.ID_FIELD]: p for p in
+                             list(get_resource_service('products').get(req=req, lookup=None))}
+        api_subscribers = []
+        wire_subscribers = [s for s in wire_subscribers
+                            for p in (s.get('products') or []) if p in existing_products]
+        digital_subscribers = [s for s in digital_subscribers
+                               for p in (s.get('products') or []) if p in existing_products]
+        if len(wire_subscribers) > 0:
+            doc['item_id'] = doc[config.ID_FIELD]
+            self._resend_to_subscribers(doc, wire_subscribers, subscriber_codes)
+            api_subscribers.extend(wire_subscribers)
+
+        if len(digital_subscribers) > 0:
+            if not app.config.get('NO_TAKES', False):
+                package = self.takes_package_service.get_take_package(doc)
+                package['item_id'] = package[config.ID_FIELD]
+                self._resend_to_subscribers(package, digital_subscribers, subscriber_codes)
+            else:
+                self._resend_to_subscribers(doc, digital_subscribers, subscriber_codes)
+
+                api_subscribers.extend(digital_subscribers)
+
+        self.publish_content_api(doc, api_subscribers)
+
+
+class EnqueuePublishedAPIService(EnqueueAPIService, EnqueuePublishedService):
+    pass
+
+
+class EnqueueCorrectedAPIService(EnqueueAPIService, EnqueueCorrectedService):
+    pass
+
+
+class EnqueueKilledAPIService(EnqueueAPIService, EnqueueKilledService):
+    pass

--- a/apps/publish/enqueue/enqueue_corrected.py
+++ b/apps/publish/enqueue/enqueue_corrected.py
@@ -46,7 +46,7 @@ class EnqueueCorrectedService(EnqueueService):
         query = {'$and': [{'item_id': doc['item_id']},
                           {'publishing_action': {'$in': [CONTENT_STATE.PUBLISHED, CONTENT_STATE.CORRECTED]}}]}
 
-        subscribers, subscriber_codes = self._get_subscribers_for_previously_sent_items(query)
+        subscribers, subscriber_codes = self.get_subscribers_for_previously_sent_items(query)
 
         if subscribers:
             # step 2

--- a/apps/publish/enqueue/enqueue_killed.py
+++ b/apps/publish/enqueue/enqueue_killed.py
@@ -8,8 +8,13 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+import logging
+
 from superdesk.metadata.item import CONTENT_STATE
 from apps.publish.enqueue.enqueue_service import EnqueueService
+
+
+logger = logging.getLogger(__name__)
 
 
 class EnqueueKilledService(EnqueueService):
@@ -33,6 +38,6 @@ class EnqueueKilledService(EnqueueService):
         subscribers, subscribers_yet_to_receive = [], []
         query = {'$and': [{'item_id': doc['item_id']},
                           {'publishing_action': {'$in': [CONTENT_STATE.PUBLISHED, CONTENT_STATE.CORRECTED]}}]}
-        subscribers, subscriber_codes = self._get_subscribers_for_previously_sent_items(query)
+        subscribers, subscriber_codes = self.get_subscribers_for_previously_sent_items(query)
 
         return subscribers, subscribers_yet_to_receive, subscriber_codes

--- a/apps/publish/enqueue/enqueue_published.py
+++ b/apps/publish/enqueue/enqueue_published.py
@@ -68,13 +68,13 @@ class EnqueuePublishedService(EnqueueService):
             # Step 1a
             query = {'$and': [{'item_id': doc['item_id']},
                               {'publishing_action': {'$in': [CONTENT_STATE.PUBLISHED, CONTENT_STATE.CORRECTED]}}]}
-            takes_subscribers, take_codes = self._get_subscribers_for_previously_sent_items(query)
+            takes_subscribers, take_codes = self.get_subscribers_for_previously_sent_items(query)
 
             if rewrite_of and rewrite_take_package:
                 # Step 3b
                 query = {'$and': [{'item_id': rewrite_take_package.get(config.ID_FIELD)},
                                   {'publishing_action': {'$in': [CONTENT_STATE.PUBLISHED, CONTENT_STATE.CORRECTED]}}]}
-                rewrite_subscribers, rewrite_codes = self._get_subscribers_for_previously_sent_items(query)
+                rewrite_subscribers, rewrite_codes = self.get_subscribers_for_previously_sent_items(query)
 
         # Step 2
         if doc.get(ITEM_TYPE) in [CONTENT_TYPE.TEXT, CONTENT_TYPE.PREFORMATTED]:
@@ -88,7 +88,7 @@ class EnqueuePublishedService(EnqueueService):
                 # if first take is published then subsequent takes should to same subscribers.
                 query = {'$and': [{'item_id': first_take},
                                   {'publishing_action': {'$in': [CONTENT_STATE.PUBLISHED]}}]}
-                subscribers, subscriber_codes = self._get_subscribers_for_previously_sent_items(query)
+                subscribers, subscriber_codes = self.get_subscribers_for_previously_sent_items(query)
 
             if rewrite_of:
                 # Step 3b
@@ -99,7 +99,7 @@ class EnqueuePublishedService(EnqueueService):
 
                 query = {'$and': [{'item_id': {'$in': item_ids}},
                                   {'publishing_action': {'$in': [CONTENT_STATE.PUBLISHED, CONTENT_STATE.CORRECTED]}}]}
-                rewrite_subscribers, rewrite_codes = self._get_subscribers_for_previously_sent_items(query)
+                rewrite_subscribers, rewrite_codes = self.get_subscribers_for_previously_sent_items(query)
 
         # Step 3
         if not first_take:

--- a/apps/publish/publish_content_tests.py
+++ b/apps/publish/publish_content_tests.py
@@ -64,13 +64,14 @@ class PublishContentTests(TestCase):
                    {
                        "_id": 4,
                        "destination": {
-                           "delivery_type": "pull",
+                           "delivery_type": "content_api",
+                           "format": "ninjs",
                            "config": {},
                            "name": "destination1"
                        },
                        "_etag": "f28b9af64f169072fb171ec7f316fc03d5826d6b",
                        "subscriber_id": "552ba73f1d41c8437971613e",
-                       "state": "pending",
+                       "state": "success",
                        "_created": "2015-04-17T13:15:20.000Z",
                        "_updated": "2015-04-20T05:04:25.000Z",
                        "item_id": '2'}]

--- a/content_api/items/resource.py
+++ b/content_api/items/resource.py
@@ -44,6 +44,7 @@ schema = {
     'versioncreated': {'type': 'datetime', 'required': True},
     'firstcreated': {'type': 'datetime'},
     'evolvedfrom': Resource.not_analyzed_field(),
+    'subscribers': {'type': 'list'}
 }
 
 
@@ -62,10 +63,10 @@ class ItemsResource(Resource):
         'search_backend': 'elastic',
         'elastic_filter': {"bool": {"must_not": {"term": {"type": "composite"}}}},
         'default_sort': [('_updated', -1)],
+        'projection': {'subscribers': 0}
     }
 
     item_methods = ['GET']
     resource_methods = ['GET']
-
     mongo_prefix = MONGO_PREFIX
     elastic_prefix = ELASTIC_PREFIX

--- a/features/archive_broadcast.feature
+++ b/features/archive_broadcast.feature
@@ -51,7 +51,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -190,7 +190,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     When we post to "/subscribers" with success
@@ -292,7 +292,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -380,7 +380,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -600,7 +600,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -675,7 +675,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -762,7 +762,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -857,7 +857,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -976,7 +976,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -1119,7 +1119,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -1255,7 +1255,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -1370,7 +1370,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -1498,7 +1498,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -1693,7 +1693,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -1942,7 +1942,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -2178,7 +2178,7 @@ Feature: Archive Broadcast
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success

--- a/features/archived_kill.feature
+++ b/features/archived_kill.feature
@@ -14,7 +14,7 @@ Feature: Kill a content item in the (dusty) archive
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with "digital" and success
@@ -79,10 +79,10 @@ Feature: Kill a content item in the (dusty) archive
     """
     When we enqueue published
     And we get "/publish_queue"
-    Then we get list with 1 items
+    Then we get list with 2 items
     When run import legal publish queue
     And we get "/legal_publish_queue"
-    Then we get list with 0 items
+    Then we get list with 1 items
     When we transmit items
     And run import legal publish queue
     And we expire items
@@ -101,7 +101,7 @@ Feature: Kill a content item in the (dusty) archive
     """
     When run import legal publish queue
     And we get "/legal_publish_queue"
-    Then we get list with 1 items
+    Then we get list with 2 items
     When we patch "/archived/123:2"
     """
     {"body_html": "Killed body."}
@@ -116,11 +116,33 @@ Feature: Kill a content item in the (dusty) archive
     When we transmit items
     And run import legal publish queue
     And we get "/legal_publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     """
     {"_items" : [
-        {"item_id": "123", "content_type": "text", "item_version": 2, "publishing_action": "published"},
-        {"item_id": "123", "content_type": "text", "item_version": 3, "publishing_action": "killed"}
+        {"item_id": "123", "content_type": "text",
+        "item_version": 2, "publishing_action": "published",
+        "destination" : {
+          "delivery_type" : "content_api",
+          "format" : "ninjs",
+          "name" : "content api"}},
+        {"item_id": "123", "content_type": "text",
+        "item_version": 2, "publishing_action": "published",
+         "destination" : {
+          "delivery_type" : "email",
+          "format" : "nitf",
+          "name" : "Test"}},
+        {"item_id": "123", "content_type": "text",
+        "item_version": 3, "publishing_action": "killed",
+        "destination" : {
+          "delivery_type" : "content_api",
+          "format" : "ninjs",
+          "name" : "content api"}},
+        {"item_id": "123", "content_type": "text",
+        "item_version": 3, "publishing_action": "killed",
+        "destination" : {
+          "delivery_type" : "email",
+          "format" : "nitf",
+          "name" : "Test"}}
      ]}
     """
     When we get "/archive/123"
@@ -198,7 +220,7 @@ Feature: Kill a content item in the (dusty) archive
     """
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     When we transmit items
     And run import legal publish queue
     And we expire items
@@ -219,7 +241,7 @@ Feature: Kill a content item in the (dusty) archive
     }
     """
     When we get "/legal_publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     When we patch "/archived/123:2"
     """
     {"body_html": "Killed body"}
@@ -229,7 +251,7 @@ Feature: Kill a content item in the (dusty) archive
     When we get "/published"
     Then we get list with 2 items
     When we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     When we get "/archive/123"
     Then we get OK response
     And we get text "Please kill story slugged slugline" in response field "body_html"
@@ -257,7 +279,7 @@ Feature: Kill a content item in the (dusty) archive
     When we get "/legal_archive/#archive.123.take_package#?version=all"
     Then we get list with 2 items
     When we get "/legal_publish_queue"
-    Then we get list with 4 items
+    Then we get list with 8 items
     When we expire items
     """
     ["123", "#archive.123.take_package#"]
@@ -314,7 +336,7 @@ Feature: Kill a content item in the (dusty) archive
     Then we get list with 8 items
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 8 items
+    Then we get list with 16 items
     When we transmit items
     And run import legal publish queue
     And we expire items
@@ -330,7 +352,7 @@ Feature: Kill a content item in the (dusty) archive
     Then we get list with 8 items
     When we enqueue published
     When we get "/legal_publish_queue"
-    Then we get list with 8 items
+    Then we get list with 16 items
     When we patch "/archived/123:2"
     """
     {}
@@ -340,7 +362,7 @@ Feature: Kill a content item in the (dusty) archive
     When we get "/published"
     Then we get list with 4 items
     When we get "/publish_queue"
-    Then we get list with 4 items
+    Then we get list with 8 items
     When we get "/archived"
     Then we get list with 0 items
     When we transmit items

--- a/features/auto_routing.feature
+++ b/features/auto_routing.feature
@@ -981,7 +981,7 @@ Feature: Auto Routing
         """
         When we enqueue published
         And we get "/publish_queue"
-        Then we get list with 1 items
+        Then we get list with 2 items
         """
         {
           "_items":

--- a/features/content_crop.feature
+++ b/features/content_crop.feature
@@ -35,7 +35,7 @@ Feature: Cropping the Image Articles
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -96,7 +96,7 @@ Feature: Cropping the Image Articles
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -191,7 +191,7 @@ Feature: Cropping the Image Articles
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success

--- a/features/content_duplication.feature
+++ b/features/content_duplication.feature
@@ -249,7 +249,7 @@ Feature: Duplication of Content
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -343,7 +343,7 @@ Feature: Duplication of Content
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success

--- a/features/content_expire_published.feature
+++ b/features/content_expire_published.feature
@@ -65,7 +65,7 @@ Feature: Content Expiry Published Items
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with "digital" and success
@@ -135,7 +135,7 @@ Feature: Content Expiry Published Items
     """
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     When we transmit items
     And run import legal publish queue
     And we expire items
@@ -186,7 +186,7 @@ Feature: Content Expiry Published Items
     When we transmit items
     And run import legal publish queue
     When we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     When we post to "/archive" with "package" and success
     """
     {
@@ -222,7 +222,7 @@ Feature: Content Expiry Published Items
     When we transmit items
     And run import legal publish queue
     When we get "publish_queue"
-    Then we get list with 3 items
+    Then we get list with 6 items
     When we expire items
     """
     ["#archive.123.take_package#"]
@@ -230,7 +230,7 @@ Feature: Content Expiry Published Items
     When we get "published"
     Then we get list with 3 items
     When we get "publish_queue"
-    Then we get list with 3 items
+    Then we get list with 6 items
     When we expire items
     """
     ["#package#"]
@@ -262,7 +262,7 @@ Feature: Content Expiry Published Items
     And we transmit items
     And run import legal publish queue
     And we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     When we post to "/archive" with success
     """
     [{"guid": "456", "type": "text", "headline": "test", "state": "fetched", "slugline": "slugline",
@@ -346,7 +346,7 @@ Feature: Content Expiry Published Items
     """
     When we enqueue published
     When we get "publish_queue"
-    Then we get list with 5 items
+    Then we get list with 10 items
     When we get "archive"
     Then we get list with 1 items
     """
@@ -373,7 +373,7 @@ Feature: Content Expiry Published Items
     }
     """
     When we get "publish_queue"
-    Then we get list with 5 items
+    Then we get list with 10 items
     When we get "archive"
     Then we get list with 1 items
     """
@@ -400,7 +400,7 @@ Feature: Content Expiry Published Items
     }
     """
     When we get "publish_queue"
-    Then we get list with 5 items
+    Then we get list with 10 items
     When we get "archive"
     Then we get list with 1 items
     """
@@ -639,7 +639,7 @@ Feature: Content Expiry Published Items
     When we get "published"
     Then we get list with 2 items
     When we get "publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     When we expire items
     """
     ["#package1#"]
@@ -728,7 +728,7 @@ Feature: Content Expiry Published Items
     When we get "published"
     Then we get list with 3 items
     When we get "publish_queue"
-    Then we get list with 4 items
+    Then we get list with 8 items
     When we get "archived"
     Then we get list with 0 items
     When we expire items
@@ -867,7 +867,7 @@ Feature: Content Expiry Published Items
     When we get "published"
     Then we get list with 6 items
     When we get "publish_queue"
-    Then we get list with 6 items
+    Then we get list with 12 items
     When we get "archived"
     Then we get list with 0 items
     When we expire items
@@ -883,7 +883,7 @@ Feature: Content Expiry Published Items
     When we get "archived"
     Then we get list with 0 items
 
-  @auth @vocabulary
+  @auth @vocabulary @wip
   Scenario: Expire items that not moved to legal.
     When we publish "123" with "publish" type and "published" state
     Then we get OK response
@@ -893,7 +893,7 @@ Feature: Content Expiry Published Items
     When we get "/legal_archive/123"
     Then we get OK response
     When we get "/legal_publish_queue?where=item_id==%22123%22"
-    Then we get list with 1 items
+    Then we get list with 2 items
     """
     {"_items" : [
         {"item_id": "123", "item_version": 2, "state": "success", "content_type": "text"}
@@ -901,7 +901,7 @@ Feature: Content Expiry Published Items
     }
     """
     When we get "/legal_publish_queue?where=item_id==%22#archive.123.take_package#%22"
-    Then we get list with 1 items
+    Then we get list with 2 items
     """
     {"_items" : [
         {"item_id": "#archive.123.take_package#", "item_version": 2, "state": "success", "content_type": "composite"}
@@ -977,7 +977,7 @@ Feature: Content Expiry Published Items
     When we get "/legal_archive/123"
     Then we get OK response
     When we get "/legal_publish_queue?where=item_id==%22123%22"
-    Then we get list with 1 items
+    Then we get list with 2 items
     """
     {"_items" : [
         {"item_id": "123", "item_version": 2, "state": "success", "content_type": "text"}
@@ -985,7 +985,7 @@ Feature: Content Expiry Published Items
     }
     """
     When we get "/legal_publish_queue?where=item_id==%22#archive.123.take_package#%22"
-    Then we get list with 1 items
+    Then we get list with 2 items
     """
     {"_items" : [
         {"item_id": "#archive.123.take_package#", "item_version": 2, "state": "success", "content_type": "composite"}
@@ -1008,7 +1008,7 @@ Feature: Content Expiry Published Items
     When we get "/legal_archive/456"
     Then we get OK response
     When we get "/legal_publish_queue?where=item_id==%22456%22"
-    Then we get list with 1 items
+    Then we get list with 2 items
     When we post to "/archive" with success
     """
     [{"guid": "789", "type": "text", "headline": "test", "state": "fetched", "slugline": "slugline",
@@ -1025,7 +1025,7 @@ Feature: Content Expiry Published Items
     When we get "/legal_archive/789"
     Then we get OK response
     When we get "/legal_publish_queue?where=item_id==%22789%22"
-    Then we get list with 1 items
+    Then we get list with 2 items
     When we post to "/filter_conditions" with success
     """
     [{"name": "international sport", "field": "anpa_category", "operator": "in", "value": "s"}]

--- a/features/content_fetch.feature
+++ b/features/content_fetch.feature
@@ -402,7 +402,7 @@ Feature: Fetch Items from Ingest
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with "digital" and success

--- a/features/content_filter.feature
+++ b/features/content_filter.feature
@@ -146,7 +146,7 @@ Feature: Content Filter
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz",
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both",
         "content_filter": {
             "filter_id": "#content_filters._id#",
             "filter_type": "blocking"

--- a/features/content_link.feature
+++ b/features/content_link.feature
@@ -252,7 +252,7 @@ Feature: Link content in takes
         When we post to "/products" with success
         """
         {
-            "name":"prod-1","codes":"abc,xyz"
+            "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success
@@ -645,7 +645,7 @@ Feature: Link content in takes
         When we post to "/products" with success
         """
         {
-            "name":"prod-1","codes":"abc,xyz"
+            "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success

--- a/features/content_rewrite.feature
+++ b/features/content_rewrite.feature
@@ -55,7 +55,7 @@ Feature: Rewrite content
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -240,7 +240,7 @@ Feature: Rewrite content
         When we post to "/products" with success
         """
         {
-          "name":"prod-1","codes":"abc,xyz"
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success
@@ -356,7 +356,7 @@ Feature: Rewrite content
         When we post to "/products" with success
         """
         {
-          "name":"prod-1","codes":"abc,xyz"
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success
@@ -480,7 +480,7 @@ Feature: Rewrite content
         When we post to "/products" with success
         """
         {
-          "name":"prod-1","codes":"abc,xyz"
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success
@@ -552,7 +552,7 @@ Feature: Rewrite content
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -633,7 +633,7 @@ Feature: Rewrite content
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -714,7 +714,7 @@ Feature: Rewrite content
         When we post to "/products" with success
         """
         {
-          "name":"prod-1","codes":"abc,xyz"
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success
@@ -784,7 +784,7 @@ Feature: Rewrite content
         When we post to "/products" with success
         """
         {
-          "name":"prod-1","codes":"abc,xyz"
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success
@@ -892,7 +892,7 @@ Feature: Rewrite content
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -974,7 +974,7 @@ Feature: Rewrite content
         When we post to "/products" with success
         """
         {
-          "name":"prod-1","codes":"abc,xyz"
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success
@@ -1039,7 +1039,7 @@ Feature: Rewrite content
         When we post to "/products" with success
         """
         {
-          "name":"prod-1","codes":"abc,xyz"
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success
@@ -1135,7 +1135,7 @@ Feature: Rewrite content
         When we post to "/products" with success
         """
         {
-          "name":"prod-1","codes":"abc,xyz"
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success
@@ -1248,7 +1248,7 @@ Feature: Rewrite content
         When we post to "/products" with success
         """
         {
-          "name":"prod-1","codes":"abc,xyz"
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success
@@ -1357,7 +1357,7 @@ Feature: Rewrite content
             "content_filter": {
                 "filter_type": "permitting",
                 "filter_id": "#content_filters._id#"
-            }
+            }, "product_type": "both"
         }
         """
         And we post to "/subscribers" with "digital" and success
@@ -1402,7 +1402,7 @@ Feature: Rewrite content
         And we store "take_package1" with value "#archive.take_package#" to context
         When we enqueue published
         And we get "/publish_queue"
-        Then we get list with 2 items
+        Then we get list with 4 items
         """
         {
             "_items": [
@@ -1418,7 +1418,7 @@ Feature: Rewrite content
         And we store "take_package2" with value "#archive.take_package#" to context
         When we enqueue published
         And we get "/publish_queue"
-        Then we get list with 4 items
+        Then we get list with 8 items
         """
         {
             "_items": [
@@ -1482,7 +1482,7 @@ Feature: Rewrite content
             "content_filter": {
                 "filter_type": "permitting",
                 "filter_id": "#content_filters._id#"
-            }
+            }, "product_type": "both"
         }
         """
         And we post to "/subscribers" with "digital" and success
@@ -1516,7 +1516,7 @@ Feature: Rewrite content
         And we store "take_package1" with value "#archive.take_package#" to context
         When we enqueue published
         And we get "/publish_queue"
-        Then we get list with 2 items
+        Then we get list with 4 items
         """
         {
             "_items": [
@@ -1543,7 +1543,7 @@ Feature: Rewrite content
         And we store "take_package2" with value "#archive.take_package#" to context
         When we enqueue published
         And we get "/publish_queue"
-        Then we get list with 4 items
+        Then we get list with 8 items
         """
         {
             "_items": [
@@ -1607,7 +1607,7 @@ Feature: Rewrite content
             "content_filter": {
                 "filter_type": "permitting",
                 "filter_id": "#cf1#"
-            }
+            }, "product_type": "both"
         }
         """
         When we post to "/filter_conditions" with "fc2" and success
@@ -1628,7 +1628,7 @@ Feature: Rewrite content
             "content_filter": {
                 "filter_type": "permitting",
                 "filter_id": "#cf2#"
-            }
+            }, "product_type": "both"
         }
         """
         And we post to "/subscribers" with "digital" and success
@@ -1662,7 +1662,7 @@ Feature: Rewrite content
         And we store "take_package1" with value "#archive.take_package#" to context
         When we enqueue published
         And we get "/publish_queue"
-        Then we get list with 1 items
+        Then we get list with 2 items
         """
         {
             "_items": [
@@ -1687,7 +1687,7 @@ Feature: Rewrite content
         And we store "take_package2" with value "#archive.take_package#" to context
         When we enqueue published
         And we get "/publish_queue"
-        Then we get list with 3 items
+        Then we get list with 6 items
         """
         {
             "_items": [
@@ -1749,7 +1749,7 @@ Feature: Rewrite content
             "content_filter": {
                 "filter_type": "permitting",
                 "filter_id": "#cf1#"
-            }
+            }, "product_type": "both"
         }
         """
         When we post to "/filter_conditions" with "fc2" and success
@@ -1770,7 +1770,7 @@ Feature: Rewrite content
             "content_filter": {
                 "filter_type": "permitting",
                 "filter_id": "#cf2#"
-            }
+            }, "product_type": "both"
         }
         """
         And we post to "/subscribers" with "digital" and success
@@ -1804,7 +1804,7 @@ Feature: Rewrite content
         And we store "take_package1" with value "#archive.take_package#" to context
         When we enqueue published
         And we get "/publish_queue"
-        Then we get list with 1 items
+        Then we get list with 2 items
         """
         {
             "_items": [
@@ -1829,7 +1829,7 @@ Feature: Rewrite content
         And we store "take_package2" with value "#archive.take_package#" to context
         When we enqueue published
         And we get "/publish_queue"
-        Then we get list with 3 items
+        Then we get list with 6 items
         """
         {
             "_items": [
@@ -1891,7 +1891,7 @@ Feature: Rewrite content
             "content_filter": {
                 "filter_type": "permitting",
                 "filter_id": "#cf1#"
-            }
+            }, "product_type": "both"
         }
         """
         When we post to "/filter_conditions" with "fc2" and success
@@ -1912,7 +1912,7 @@ Feature: Rewrite content
             "content_filter": {
                 "filter_type": "permitting",
                 "filter_id": "#cf2#"
-            }
+            }, "product_type": "both"
         }
         """
         And we post to "/subscribers" with "digital" and success
@@ -1946,7 +1946,7 @@ Feature: Rewrite content
         And we store "take_package1" with value "#archive.take_package#" to context
         When we enqueue published
         And we get "/publish_queue"
-        Then we get list with 1 items
+        Then we get list with 2 items
         """
         {
             "_items": [
@@ -1972,7 +1972,7 @@ Feature: Rewrite content
         And we store "take_package2" with value "#archive.take_package#" to context
         When we enqueue published
         And we get "/publish_queue"
-        Then we get list with 3 items
+        Then we get list with 6 items
         """
         {
             "_items": [
@@ -2002,7 +2002,7 @@ Feature: Rewrite content
         And we store "take_package3" with value "#archive.take_package#" to context
         When we enqueue published
         And we get "/publish_queue"
-        Then we get list with 5 items
+        Then we get list with 10 items
         """
         {
             "_items": [
@@ -2075,7 +2075,7 @@ Feature: Rewrite content
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -2161,7 +2161,7 @@ Feature: Rewrite content
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success

--- a/features/content_translate.feature
+++ b/features/content_translate.feature
@@ -43,7 +43,7 @@ Feature: Translate Content
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success

--- a/features/embargo.feature
+++ b/features/embargo.feature
@@ -173,7 +173,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     Then we check if article has Embargo and Ed. Note of the article has embargo indication
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     """
     {"_items": [
       {"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}},
@@ -188,7 +188,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     Then we get OK response
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 4 items
+    Then we get list with 8 items
     """
     {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}},
                 {"subscriber_id": "123", "publishing_action": "corrected", "content_type": "text", "destination":{"name":"email"}},
@@ -202,7 +202,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     Then we get OK response
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 6 items
+    Then we get list with 12 items
     """
     {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}},
                 {"subscriber_id": "123", "publishing_action": "corrected", "content_type": "text", "destination":{"name":"email"}},
@@ -235,7 +235,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     And we check if article has Embargo and Ed. Note of the article has embargo indication
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     """
     {"_items": [
     {"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}},
@@ -246,7 +246,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     Then we get OK response
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 4 items
+    Then we get list with 8 items
     """
     {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}},
                 {"subscriber_id": "123", "publishing_action": "corrected", "content_type": "text", "destination":{"name":"email"}},
@@ -281,7 +281,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     And we check if article has Embargo and Ed. Note of the article has embargo indication
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     """
     {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}},
                 {"subscriber_id": "456"}]}
@@ -291,7 +291,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     Then we get OK response
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 4 items
+    Then we get list with 8 items
     """
     {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}},
                 {"subscriber_id": "123", "publishing_action": "corrected", "content_type": "text", "destination":{"name":"email"}},
@@ -328,7 +328,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     And we check if article has Embargo and Ed. Note of the article has embargo indication
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     """
     {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}},
                 {"subscriber_id": "456"}]}
@@ -340,7 +340,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     Then we get OK response
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 4 items
+    Then we get list with 8 items
     """
     {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}},
                 {"subscriber_id": "123", "publishing_action": "corrected", "content_type": "text", "destination":{"name":"email"}},
@@ -647,7 +647,7 @@ Feature: Embargo Date and Time on an Article (User Story: https://dev.sourcefabr
     Then we check if article has Embargo and Ed. Note of the article has embargo indication
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     """
     {"_items": [{"subscriber_id": "123", "publishing_action": "published", "content_type": "text", "destination":{"name":"email"}},
                 {"subscriber_id": "456"}]}

--- a/features/package_publish.feature
+++ b/features/package_publish.feature
@@ -18,7 +18,7 @@ Feature: Package Publishing
         When we post to "/products" with success
         """
         {
-          "name":"prod-1","codes":"abc,xyz"
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success
@@ -275,7 +275,7 @@ Feature: Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -425,7 +425,7 @@ Feature: Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -575,7 +575,7 @@ Feature: Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -727,7 +727,7 @@ Feature: Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -852,7 +852,7 @@ Feature: Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -881,7 +881,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 3 items
+      Then we get list with 6 items
 
 
 
@@ -991,7 +991,7 @@ Feature: Package Publishing
           When we post to "/products" with success
           """
           {
-            "name":"prod-1","codes":"abc,xyz"
+            "name":"prod-1","codes":"abc,xyz", "product_type": "both"
           }
           """
           And we post to "/subscribers" with success
@@ -1018,12 +1018,12 @@ Feature: Package Publishing
           """
 	      When we enqueue published
           When we get "/publish_queue"
-          Then we get list with 2 items
+          Then we get list with 4 items
 
 
 
       @auth
-      @notification
+      @notification @wip
       Scenario: Publish a package with two text stories and one wire and one digital subscriber
       Given empty "archive"
       Given "desks"
@@ -1167,7 +1167,7 @@ Feature: Package Publishing
         When we get digital item of "123"
 	    When we enqueue published
         When we get "/publish_queue"
-        Then we get list with 5 items
+        Then we get list with 10 items
         Then we get "#archive.123.take_package#" in formatted output as "main" story for subscriber "sub-2"
 
 
@@ -1338,7 +1338,7 @@ Feature: Package Publishing
       When we get digital item of "123"
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 5 items
+      Then we get list with 10 items
       #Then we get "#archive.123.take_package#" in formatted output as "main" story for subscriber "sub-2"
       #Then we get "#archive.123.take_package#" in formatted output as "sidebars" story for subscriber "sub-2"
 
@@ -1346,7 +1346,7 @@ Feature: Package Publishing
 
       @auth
       @notification
-      @vocabulary
+      @vocabulary @wip
       Scenario: Publish two takes within a package in the same group with one wire and one digital subscriber
       Given empty "archive"
       Given "desks"
@@ -1504,13 +1504,13 @@ Feature: Package Publishing
       When we get digital item of "123"
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 5 items
+      Then we get list with 10 items
       #Then we get "#archive.123.take_package#" in formatted output as "NewsItemId" newsml12 story
 
 
       @auth
       @notification
-      @vocabulary
+      @vocabulary @wip
       Scenario: Publish a package with a text and an image with one wire and one digital subscriber
       Given empty "archive"
       Given "desks"
@@ -1646,14 +1646,14 @@ Feature: Package Publishing
       When we get digital item of "123"
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 4 items
+      Then we get list with 8 items
       Then we get "#archive.123.take_package#" in formatted output as "main" story for subscriber "sub-2"
 
 
 
       @auth
       @notification
-      @vocabulary
+      @vocabulary  @wip
       Scenario: Publish a package with a text and an image with only one wire subscriber
       Given empty "archive"
       Given "desks"
@@ -1780,7 +1780,7 @@ Feature: Package Publishing
       When we get digital item of "123"
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 1 items
+      Then we get list with 2 items
       """
       {"_items" : [{"item_id": "123", "content_type": "text", "state": "pending"}]
       }
@@ -1789,7 +1789,7 @@ Feature: Package Publishing
 
 
       @auth
-      @notification
+      @notification  @wip
       Scenario: Publish a package with two already published text stories and one digital subscriber
       Given empty "archive"
       Given "desks"
@@ -1862,7 +1862,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 2 items
+      Then we get list with 4 items
       When we post to "archive" with success
           """
           [{
@@ -1940,7 +1940,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 3 items
+      Then we get list with 6 items
       """
       {"_items" : [{"headline": "item-1 headline", "content_type": "composite", "state": "pending"},
                    {"headline": "item-2 headline", "content_type": "composite", "state": "pending"},
@@ -1955,7 +1955,7 @@ Feature: Package Publishing
 
       @auth
       @notification
-      @vocabulary
+      @vocabulary  @wip
       Scenario: Publish a package with three already published text stories being sent different subscribers
       Given empty "filter_conditions"
       Given empty "content_filters"
@@ -2085,7 +2085,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 8 items
+      Then we get list with 16 items
       """
       {"_items" : [
       {"headline": "item-1 headline", "content_type": "text", "subscriber_id": "sub-1"},
@@ -2185,7 +2185,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 10 items
+      Then we get list with 20 items
       """
       {"_items" : [
       {"headline": "test package", "content_type": "composite", "subscriber_id": "sub-2"},
@@ -2201,7 +2201,7 @@ Feature: Package Publishing
 
       @auth
       @notification
-      @vocabulary
+      @vocabulary @wip
       Scenario: Publish a package with three already published text stories no subscribers matched so no package sent
       Given empty "filter_conditions"
       Given empty "content_filters"
@@ -2330,7 +2330,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 3 items
+      Then we get list with 6 items
       """
       {"_items" : [
       {"headline": "item-1 headline", "content_type": "text", "subscriber_id": "sub-1"},
@@ -2424,7 +2424,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 3 items
+      Then we get list with 6 items
       """
       {"_items" : [
       {"headline": "item-1 headline", "content_type": "text", "subscriber_id": "sub-1"},
@@ -2616,7 +2616,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 4 items
+      Then we get list with 8 items
       """
       {"_items" : [{"headline": "item-1 headline", "content_type": "composite", "subscriber_id": "sub-2"},
                    {"headline": "item-2 headline", "content_type": "composite", "subscriber_id": "sub-2"},
@@ -3077,7 +3077,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue?max_results=100"
-      Then we get list with 26 items
+      Then we get list with 52 items
       """
       {"_items" : [{"headline": "item-1 headline", "content_type": "composite", "subscriber_id": "sub-1"},
                    {"headline": "ABC-4", "content_type": "picture", "subscriber_id": "sub-1"},
@@ -3221,7 +3221,7 @@ Feature: Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -3295,7 +3295,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 3 items
+      Then we get list with 6 items
       When we publish "123" with "correct" type and "corrected" state
         """
         {"headline": "item-1.2 headline"}
@@ -3313,7 +3313,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 5 items
+      Then we get list with 10 items
       """
       {"_items" : [{"headline": "item-1.2 headline", "publishing_action": "corrected"},
                    {"headline": "test package", "publishing_action": "corrected"}]
@@ -3496,7 +3496,7 @@ Feature: Package Publishing
           When we post to "/products" with success
           """
           {
-            "name":"prod-1","codes":"abc,xyz"
+            "name":"prod-1","codes":"abc,xyz", "product_type": "both"
           }
           """
           And we post to "/subscribers" with success
@@ -3577,7 +3577,7 @@ Feature: Package Publishing
       Then we get list with 2 items
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 1 items
+      Then we get list with 2 items
       When we publish "123" with "correct" type and "corrected" state
       Then we get OK response
       When we get "/published"
@@ -3588,7 +3588,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 2 items
+      Then we get list with 4 items
 
 
 
@@ -3805,7 +3805,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 4 items
+      Then we get list with 8 items
       """
       {"_items" : [{"headline": "item-1 headline", "content_type": "composite", "subscriber_id": "sub-2"},
                    {"headline": "item-2 headline", "content_type": "composite", "subscriber_id": "sub-2"},
@@ -3834,7 +3834,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 7 items
+      Then we get list with 14 items
       """
       {"_items" : [{"headline": "item-1.2 headline", "publishing_action": "corrected"},
                    {"headline": "test package", "publishing_action": "corrected"},
@@ -3897,7 +3897,7 @@ Feature: Package Publishing
           When we post to "/products" with success
           """
           {
-            "name":"prod-1","codes":"abc,xyz"
+            "name":"prod-1","codes":"abc,xyz", "product_type": "both"
           }
           """
         And we post to "/subscribers" with success
@@ -3978,7 +3978,7 @@ Feature: Package Publishing
       Then we get list with 2 items
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 1 items
+      Then we get list with 2 items
       When we publish "123" with "kill" type and "killed" state
       Then we get error 400
       """
@@ -4034,7 +4034,7 @@ Feature: Package Publishing
         When we post to "/products" with success
         """
         {
-          "name":"prod-1","codes":"abc,xyz"
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
         }
         """
         And we post to "/subscribers" with success
@@ -4117,12 +4117,12 @@ Feature: Package Publishing
       Then we get OK response
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 4 items
+      Then we get list with 8 items
       When we publish "123" with "kill" type and "killed" state
       Then we get OK response
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 5 items
+      Then we get list with 10 items
 
       @auth
       @notification
@@ -4321,7 +4321,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 9 items
+      Then we get list with 18 items
       """
       {"_items" : [{"headline": "item-1 headline", "subscriber_id": "sub-1"},
                    {"headline": "item-2 headline", "subscriber_id": "sub-1"},
@@ -4389,7 +4389,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 12 items
+      Then we get list with 24 items
       """
       {"_items" : [{"headline": "test package", "publishing_action": "corrected", "subscriber_id": "sub-1"},
                    {"headline": "test package", "publishing_action": "corrected", "subscriber_id": "sub-2"},
@@ -4585,7 +4585,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 6 items
+      Then we get list with 12 items
       """
       {"_items" : [{"headline": "item-1 headline", "subscriber_id": "sub-1"},
                    {"headline": "item-2 headline", "subscriber_id": "sub-1"},
@@ -4662,7 +4662,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 11 items
+      Then we get list with 22 items
       """
       {"_items" : [{"headline": "item-3 headline", "publishing_action": "published", "subscriber_id": "sub-3"},
                    {"headline": "item-3 headline", "publishing_action": "published", "subscriber_id": "sub-2"},
@@ -4798,7 +4798,7 @@ Feature: Package Publishing
           When we post to "/products" with success
           """
           {
-            "name":"prod-1","codes":"abc,xyz"
+            "name":"prod-1","codes":"abc,xyz", "product_type": "both"
           }
           """
           And we post to "/subscribers" with success
@@ -4818,7 +4818,7 @@ Feature: Package Publishing
       Then we get list with 5 items
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 3 items
+      Then we get list with 6 items
       When we publish "compositeitem" with "kill" type and "killed" state
       Then we get OK response
       When we get "/published"
@@ -4832,7 +4832,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 4 items
+      Then we get list with 8 items
       """
       {"_items" : [{"headline": "test package", "publishing_action": "killed"}]
       }
@@ -5009,7 +5009,7 @@ Feature: Package Publishing
       Then we get list with 6 items
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 4 items
+      Then we get list with 8 items
       When we publish "compositeitem" with "kill" type and "killed" state
       Then we get error 400
       """
@@ -5388,7 +5388,7 @@ Feature: Package Publishing
         When we post to "/products" with success
           """
           {
-            "name":"prod-1","codes":"abc,xyz"
+            "name":"prod-1","codes":"abc,xyz", "product_type": "both"
           }
           """
         And we post to "/subscribers" with success
@@ -5408,7 +5408,7 @@ Feature: Package Publishing
       Then we get list with 3 items
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 1 items
+      Then we get list with 2 items
       When we publish "123" with "correct" type and "corrected" state
         """
         {"headline": "item-1.2 headline"}
@@ -5423,7 +5423,7 @@ Feature: Package Publishing
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 2 items
+      Then we get list with 4 items
       """
       {"_items" : [{"headline": "item-1.2 headline", "publishing_action": "corrected"}]
       }

--- a/features/products.feature
+++ b/features/products.feature
@@ -21,7 +21,7 @@ Feature: Products
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1", "codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -39,5 +39,34 @@ Feature: Products
     """
     Then we get updated response
     """
-    {"content_filter":{"filter_id":"#content_filters._id#", "filter_type":"blocking"}}
+    {"product_type": "both", "content_filter":{"filter_id":"#content_filters._id#", "filter_type":"blocking"}}
+    """
+
+  @auth
+  @vocabulary
+  Scenario: Create or Update a product with no product type
+    When we post to "/products"
+    """
+    {
+      "name":"prod-1", "codes":"abc,xyz"
+    }
+    """
+    Then we get error 400
+    """
+    {"_status": "ERR", "_issues": {"product_type": {"required": 1}}}
+    """
+    When we post to "/products"
+    """
+    {
+      "name":"prod-1", "codes":"abc,xyz", "product_type": "both"
+    }
+    """
+    Then we get OK response
+    When we patch "/products/#products._id#"
+    """
+    {"product_type": null}
+    """
+    Then we get error 400
+    """
+    {"_status": "ERR", "_issues": {"product_type": ["null value not allowed", "must be of string type"]}}
     """

--- a/features/publish_publicapi.feature
+++ b/features/publish_publicapi.feature
@@ -54,7 +54,7 @@ Feature: Publish content to the public API
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -178,7 +178,7 @@ Feature: Publish content to the public API
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -412,7 +412,7 @@ Feature: Publish content to the public API
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -659,7 +659,7 @@ Feature: Publish content to the public API
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -682,7 +682,7 @@ Feature: Publish content to the public API
         """
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 1 items
+    Then we get list with 4 items
         """
         {"_items":
         	[
@@ -695,31 +695,3 @@ Feature: Publish content to the public API
         """
         {"guid": "compositeitem", "_current_version": 2, "state": "published"}
         """
-    When we get "/publish_queue/compositeitem"
-    Then we get formatted item
-    	"""
-    	{
-    		"guid": "compositeitem",
-    		"type": "composite",
-    		"associations": {
-    			"main": {
-                    "body_html": "item content",
-					"headline": "text item with embedded pic",
-					"type": "text",
-                    "associations": {
-                        "embedded1": {
-                            "type": "picture",
-                            "slugline": "foo",
-                            "pubstatus": "usable"
-                        }
-                    }
-                },
-    			"sidebars": {
-					"guid": "item2",
-					"type": "picture",
-					"headline": "ABC SHOP CLOSURES",
-					"renditions": {
-						"original": {"mimetype": "image/jpeg"}}}
-    		}
-    	}
-    	"""

--- a/features/publish_queue.feature
+++ b/features/publish_queue.feature
@@ -11,7 +11,7 @@ Feature: Publish Queue
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -238,7 +238,7 @@ Feature: Publish Queue
 
     When we enqueue published
     When we get "/publish_queue"
-    Then we get list with 1 items
+    Then we get list with 2 items
     """
     {
       "_items": [
@@ -260,7 +260,7 @@ Feature: Publish Queue
     Then we get OK response
     When we enqueue published
     And we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     """
     {
       "_items": [
@@ -275,7 +275,7 @@ Feature: Publish Queue
     Then we get OK response
     When we enqueue published
     And we get "/publish_queue"
-    Then we get list with 3 items
+    Then we get list with 6 items
     """
     {
       "_items": [
@@ -298,7 +298,7 @@ Feature: Publish Queue
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -356,7 +356,7 @@ Feature: Publish Queue
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -398,7 +398,7 @@ Feature: Publish Queue
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success

--- a/features/steps/fixtures/vocabularies.json
+++ b/features/steps/fixtures/vocabularies.json
@@ -350,5 +350,15 @@
             {"is_active": true, "qcode": "temblor", "name": "tremor"},
             {"is_active": true, "qcode": "ax", "name": "axe"}
         ]
+    },
+    {
+        "_id": "product_types",
+        "display_name": "Product Types",
+        "type": "unmanageable",
+        "items": [
+            {"is_active": true, "name": "API", "qcode": "api"},
+            {"is_active": true, "name": "Direct", "qcode": "direct"},
+            {"is_active": true, "name": "Both", "qcode": "both"}
+        ]
     }
 ]

--- a/features/subscribers.feature
+++ b/features/subscribers.feature
@@ -8,7 +8,7 @@ Feature: Subscribers
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -49,7 +49,7 @@ Feature: Subscribers
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers"
@@ -90,7 +90,7 @@ Feature: Subscribers
       """
       {
         "name":"prod-1","codes":"abc,xyz",
-        "content_filter": {"filter_id":"#content_filters._id#", "filter_type":"blocking"}
+        "content_filter": {"filter_id":"#content_filters._id#", "filter_type":"blocking"}, "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -121,7 +121,7 @@ Feature: Subscribers
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers"
@@ -141,7 +141,7 @@ Feature: Subscribers
      When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers"
@@ -177,7 +177,7 @@ Feature: Subscribers
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -208,7 +208,7 @@ Feature: Subscribers
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers"
@@ -234,7 +234,7 @@ Feature: Subscribers
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers"
@@ -257,7 +257,7 @@ Feature: Subscribers
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success
@@ -299,7 +299,7 @@ Feature: Subscribers
     When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
     And we post to "/subscribers" with success

--- a/features/takes_publish.feature
+++ b/features/takes_publish.feature
@@ -93,7 +93,7 @@ Feature: Take Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -190,7 +190,7 @@ Feature: Take Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -338,7 +338,7 @@ Feature: Take Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -620,7 +620,7 @@ Feature: Take Package Publishing
       """
       {
         "name":"prod-1","codes":"abc,xyz",
-        "content_filter":{"filter_id":"#content_filters._id#", "filter_type": "permitting"}
+        "content_filter":{"filter_id":"#content_filters._id#", "filter_type": "permitting"}, "product_type": "both"
       }
       """
       And we post to "/subscribers" with "First_Wire_Subscriber" and success
@@ -699,7 +699,7 @@ Feature: Take Package Publishing
       Then we get OK response
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 2 items
+      Then we get list with 4 items
       """
       {
           "_items": [
@@ -739,7 +739,7 @@ Feature: Take Package Publishing
       Then we get OK response
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 4 items
+      Then we get list with 8 items
       """
       {
           "_items": [
@@ -780,7 +780,7 @@ Feature: Take Package Publishing
       Then we get OK response
       When we enqueue published
       When we get "/publish_queue"
-      Then we get list with 6 items
+      Then we get list with 12 items
       """
       {
           "_items": [
@@ -849,7 +849,7 @@ Feature: Take Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -962,7 +962,7 @@ Feature: Take Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -1145,7 +1145,7 @@ Feature: Take Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -1386,7 +1386,7 @@ Feature: Take Package Publishing
           "content_filter" : {
             "filter_type" : "permitting",
             "filter_id" : "#DomesticSportFilter#"
-          }
+          }, "product_type": "both"
         }
         """
         And we post to "/subscribers" with "DomesticSportSubscriber" and success
@@ -1406,7 +1406,7 @@ Feature: Take Package Publishing
           "content_filter" : {
             "filter_type" : "permitting",
             "filter_id" : "#OverseasSportFilter#"
-          }
+          }, "product_type": "both"
         }
         """
         And we post to "/subscribers" with "OverseasSportSubscriber" and success
@@ -1483,7 +1483,7 @@ Feature: Take Package Publishing
         Then we get OK response
         When we enqueue published
         When we get "/publish_queue"
-        Then we get list with 1 items
+        Then we get list with 2 items
         """
         {
         "_items": [
@@ -1502,7 +1502,7 @@ Feature: Take Package Publishing
         Then we get OK response
         When we enqueue published
         When we get "/publish_queue"
-        Then we get list with 3 items
+        Then we get list with 6 items
         """
         {
         "_items": [
@@ -1571,7 +1571,7 @@ Feature: Take Package Publishing
         Then we get OK response
         When we enqueue published
         When we get "/publish_queue"
-        Then we get list with 5 items
+        Then we get list with 10 items
         """
         {
         "_items": [
@@ -1635,7 +1635,7 @@ Feature: Take Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -1795,7 +1795,7 @@ Feature: Take Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -1874,7 +1874,7 @@ Feature: Take Package Publishing
       When we post to "/products" with success
       """
       {
-        "name":"prod-1","codes":"abc,xyz"
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success

--- a/features/targeted_publishing.feature
+++ b/features/targeted_publishing.feature
@@ -100,7 +100,7 @@ Feature: Targeted Publishing
     """
     When we enqueue published
     And we get "/publish_queue"
-    Then we get list with 1 items
+    Then we get list with 2 items
     """
     {
       "_items":
@@ -131,11 +131,13 @@ Feature: Targeted Publishing
     """
     When we enqueue published
     And we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     """
     {
       "_items":
         [
+          {"subscriber_id": "sub-2"},
+          {"subscriber_id": "sub-4"},
           {"subscriber_id": "sub-2"},
           {"subscriber_id": "sub-4"}
         ]
@@ -187,11 +189,13 @@ Feature: Targeted Publishing
     """
     When we enqueue published
     And we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     """
     {
       "_items":
         [
+          {"subscriber_id": "sub-1"},
+          {"subscriber_id": "sub-3"},
           {"subscriber_id": "sub-1"},
           {"subscriber_id": "sub-3"}
         ]
@@ -219,7 +223,7 @@ Feature: Targeted Publishing
     """
     When we enqueue published
     And we get "/publish_queue"
-    Then we get list with 1 items
+    Then we get list with 2 items
     """
     {
       "_items":
@@ -250,7 +254,7 @@ Feature: Targeted Publishing
     """
     When we enqueue published
     And we get "/publish_queue"
-    Then we get list with 3 items
+    Then we get list with 6 items
     """
     {
       "_items":
@@ -285,7 +289,7 @@ Feature: Targeted Publishing
     """
     When we enqueue published
     And we get "/publish_queue"
-    Then we get list with 2 items
+    Then we get list with 4 items
     """
     {
       "_items":
@@ -317,7 +321,7 @@ Feature: Targeted Publishing
     """
     When we enqueue published
     And we get "/publish_queue"
-    Then we get list with 3 items
+    Then we get list with 6 items
     """
     {
       "_items":
@@ -335,7 +339,7 @@ Feature: Targeted Publishing
     Then we get OK response
     When we enqueue published
     And we get "/publish_queue"
-    Then we get list with 6 items
+    Then we get list with 12 items
     """
     {
       "_items":
@@ -353,7 +357,7 @@ Feature: Targeted Publishing
     Then we get OK response
     When we enqueue published
     And we get "/publish_queue"
-    Then we get list with 9 items
+    Then we get list with 18 items
     """
     {
       "_items":

--- a/superdesk/data_updates/00002_20170214-145336_vocabularies.py
+++ b/superdesk/data_updates/00002_20170214-145336_vocabularies.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : superdesk
+# Creation: 2017-02-14 14:53
+
+from superdesk.commands.data_updates import DataUpdate
+from superdesk import get_resource_service
+
+
+class DataUpdate(DataUpdate):
+
+    resource = 'vocabularies'
+    product_types = {
+        '_id': 'product_types',
+        'display_name': 'Product Types',
+        'type': 'unmanageable',
+        'items': [
+            {'is_active': True, 'name': 'API', 'qcode': 'api'},
+            {'is_active': True, 'name': 'Direct', 'qcode': 'direct'},
+            {'is_active': True, 'name': 'Both', 'qcode': 'both'}
+        ]
+    }
+
+    def forwards(self, mongodb_collection, mongodb_database):
+        product_types = get_resource_service(self.resource).find_one(req=None, _id='product_types')
+        if product_types:
+            raise Exception('Product Types vocabulary already exists in the system.')
+
+        get_resource_service(self.resource).post([self.product_types])
+
+    def backwards(self, mongodb_collection, mongodb_database):
+        get_resource_service(self.resource).delete_action({'_id': 'product_types'})

--- a/superdesk/metadata/utils.py
+++ b/superdesk/metadata/utils.py
@@ -11,6 +11,8 @@
 from datetime import datetime
 from uuid import uuid4
 from flask import current_app as app
+
+from superdesk.utils import SuperdeskBaseEnum
 from .item import GUID_TAG, GUID_NEWSML, GUID_FIELD, ITEM_TYPE, CONTENT_TYPE
 from .packages import PACKAGE_TYPE, TAKES_PACKAGE
 
@@ -96,3 +98,9 @@ def is_takes_package(doc):
     """
 
     return doc[ITEM_TYPE] == CONTENT_TYPE.COMPOSITE and doc.get(PACKAGE_TYPE, '') == TAKES_PACKAGE
+
+
+class ProductTypes(SuperdeskBaseEnum):
+    API = 'api'
+    DIRECT = 'direct'
+    BOTH = 'both'

--- a/superdesk/publish/__init__.py
+++ b/superdesk/publish/__init__.py
@@ -14,7 +14,7 @@ from collections import namedtuple
 from superdesk.celery_app import celery
 from superdesk.publish.publish_content import PublishContent
 from superdesk import get_backend
-
+from superdesk.utils import SuperdeskBaseEnum
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +25,14 @@ subscriber_types = ['digital', 'wire', 'all']
 subscriber_media_types = ['media', 'non-media', 'both']
 SUBSCRIBER_TYPES = namedtuple('SUBSCRIBER_TYPES', ['DIGITAL', 'WIRE', 'ALL'])(*subscriber_types)
 SUBSCRIBER_MEDIA_TYPES = namedtuple('SUBSCRIBER_MEDIA_TYPES', ['MEDIA', 'NONMEDIA', 'BOTH'])(*subscriber_media_types)
+
+
+class PublishingMode(SuperdeskBaseEnum):
+    """All non-api methods are classified as direct publishing.
+    """
+
+    Direct = 'direct'
+    API = 'api'
 
 
 def register_transmitter(transmitter_type, transmitter, errors):

--- a/superdesk/publish/publish_content.py
+++ b/superdesk/publish/publish_content.py
@@ -74,15 +74,13 @@ def get_queue_items(retries=False):
         lookup = {
             '$and': [
                 {'state': QueueState.RETRYING.value},
-                {'next_retry_attempt_at': {'$lte': utcnow()}},
-                {'destination.delivery_type': {'$ne': 'pull'}}
+                {'next_retry_attempt_at': {'$lte': utcnow()}}
             ]
         }
     else:
         lookup = {
             '$and': [
-                {'state': QueueState.PENDING.value},
-                {'destination.delivery_type': {'$ne': 'pull'}}
+                {'state': QueueState.PENDING.value}
             ]
         }
     request = ParsedRequest()

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -60,6 +60,7 @@ def update_config(conf):
     conf['LEGAL_ARCHIVE_URI'] = get_mongo_uri('LEGAL_ARCHIVE_URI', 'sptests_legal_archive')
     conf['ARCHIVED_DBNAME'] = 'sptests_archived'
     conf['ARCHIVED_URI'] = get_mongo_uri('ARCHIVED_URI', 'sptests_archived')
+    conf['CONTENTAPI_URL'] = 'http://localhost:5400'
     conf['CONTENTAPI_MONGO_DBNAME'] = 'sptests_contentapi'
     conf['CONTENTAPI_MONGO_URI'] = get_mongo_uri('CONTENTAPI_MONGO_URI', 'sptests_contentapi')
     conf['CONTENTAPI_ELASTICSEARCH_INDEX'] = 'sptest_contentapi'

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -2197,3 +2197,32 @@ def we_set_published_item_expiry(context, expiry):
 @then('we set copy metadata from parent flag')
 def we_set_copy_metadata_from_parent(context):
     context.app.settings['COPY_METADATA_FROM_PARENT'] = True
+
+
+@then('we assert the content api item "{item_id}" is published to subscriber "{subscriber}"')
+def we_assert_content_api_item_is_published(context, item_id, subscriber):
+    with context.app.test_request_context(context.app.config['URL_PREFIX']):
+        item_id = apply_placeholders(context, item_id)
+        req = ParsedRequest()
+        req.projection = json.dumps({'subscribers': 1})
+        cursor = get_resource_service('items').get_from_mongo(req, {'_id': item_id})
+        assert cursor.count() > 0, 'Item not found'
+        item = cursor[0]
+        subscriber = apply_placeholders(context, subscriber)
+        assert len(item.get('subscribers', [])) > 0, 'No subscribers found.'
+        assert subscriber in item.get('subscribers', []), 'Subscriber with Id: {} not found.'.format(subscriber)
+
+
+@then('we assert the content api item "{item_id}" is not published to subscriber "{subscriber}"')
+def we_assert_content_api_item_is_published(context, item_id, subscriber):
+    with context.app.test_request_context(context.app.config['URL_PREFIX']):
+        item_id = apply_placeholders(context, item_id)
+        req = ParsedRequest()
+        req.projection = json.dumps({'subscribers': 1})
+        cursor = get_resource_service('items').get_from_mongo(req, {'_id': item_id})
+        assert cursor.count() > 0, 'Item not found'
+        item = cursor[0]
+        subscriber = apply_placeholders(context, subscriber)
+        assert len(item.get('subscribers', [])) > 0, 'No subscribers found.'
+        assert subscriber not in item.get('subscribers', []), \
+            'Subscriber with Id: {} found for the item. '.format(subscriber)


### PR DESCRIPTION
This feature adds Product Type attribute to products. A product can be of following types:
- Direct
- API
- Both

This classification allows the user to permission different products on a single subscriber based on API delivery or non-API delivery method. Enqueue process for publishing content into API will validate the articles against products of types `API` or `BOTH` whereas in case for non-API publishing the enqueue process will validate against the product type `Direct` or `Both`.

A record (placeholder) is created in the `publish_queue` for each subscriber to indicate content is published to content api.

- [x] Add product type to products.
- [x] Change the enqueue process to handle product types for normal publishing
- [ ] Change the enqueue process to handle product types for targeted publishing
- [ ] Resend to Subscribers
- [x] Change the publish queue to handle delivery_type = 'content_api'
- [ ] Behave and Unit tests
