### PR TITLE
[FORMATTER] [EMAIL] [TEMPLATE] add line feed on block element in emai…

### DIFF
--- a/apps/templates/__init__.py
+++ b/apps/templates/__init__.py
@@ -10,6 +10,7 @@
 
 import superdesk
 from superdesk import register_jinja_filter
+from superdesk.etree import get_text
 from .content_templates import ContentTemplatesResource, ContentTemplatesService, CONTENT_TEMPLATE_PRIVILEGE
 from .content_templates import ContentTemplatesApplyResource, ContentTemplatesApplyService
 from .content_templates import create_scheduled_content  # noqa
@@ -28,3 +29,4 @@ def init_app(app):
 
     register_jinja_filter('format_datetime', format_datetime_filter)
     register_jinja_filter('first_paragraph', first_paragraph_filter)
+    register_jinja_filter('get_text', get_text)

--- a/superdesk/templates/email_article_body.txt
+++ b/superdesk/templates/email_article_body.txt
@@ -6,6 +6,6 @@ Published At : {{ article.versioncreated | format_datetime(date_format='%c') }}
 {{ article.abstract | striptags}}
 
 {{ article.byline }}
-{{article.body_html | striptags}}
+{{article.body_html | default | get_text('html', lf_on_block=True)}}
 {{ article.source }} {{ article.sign_off}}
 {{ article.body_footer | striptags}}


### PR DESCRIPTION
…l template

email template was only stripping tags, but it is requested to skip
lines on paragraphs. superdesk.etree.get_text is able to handle that, so
get_text has been added to jinja filters, and used in
email_article_body.txt template.

fix SDPRO-85