### PR TITLE
[etree] backported get_text lf_on_block attribute from master

### DIFF
--- a/superdesk/etree.py
+++ b/superdesk/etree.py
@@ -33,6 +33,45 @@ inline_elements = set([
     'object',
 ])
 
+# from https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements
+BLOCK_ELEMENTS = (
+    "address",
+    "article",
+    "aside",
+    "blockquote",
+    "br",
+    "canvas",
+    "dd",
+    "div",
+    "dl",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "hgroup",
+    "hr",
+    "li",
+    "main",
+    "nav",
+    "noscript",
+    "ol",
+    "output",
+    "p",
+    "pre",
+    "section",
+    "table",
+    "tfoot",
+    "ul",
+    "video")
+
 
 def get_text_word_count(text):
     """Get word count for given plain text.
@@ -42,14 +81,24 @@ def get_text_word_count(text):
     return len(text.split())
 
 
-def get_text(html):
+def get_text(html, content='xml', lf_on_block=False):
     """Get plain text version of HTML element
 
     if the HTML string can't be parsed, it will be returned unchanged
     :param html: html string to convert to plain text
+    :param str content: 'xml' or 'html'
+    :param bool lf_on_block: if True, add a line feed on block elements' tail
     """
     try:
+        if content == 'html':
+            # FIXME: this is a fragile way of handling HTML, it will be properly fixed
+            #        when lxml patch will be used
+            html = html.replace('<br>', '<br/>').replace('</br>', '').replace('<hr>', ' ')
         root = etree.fromstringlist('<doc>{0}</doc>'.format(html))
+        if lf_on_block:
+            for elem in root.iterfind('.//'):
+                if elem.tag in BLOCK_ELEMENTS:
+                    elem.tail = (elem.tail or '') + '\n'
         text = etree.tostring(root, encoding='unicode', method='text')
         return text
     except ParseError:

--- a/superdesk/publish/formatters/email_formatter.py
+++ b/superdesk/publish/formatters/email_formatter.py
@@ -46,13 +46,14 @@ class EmailFormatter(Formatter):
         pub_seq_num = superdesk.get_resource_service('subscribers').generate_sequence_number(subscriber)
         doc = {}
         try:
-            # If there is a dateline inject it into the body
-            if formatted_article.get(FORMAT) == FORMATS.HTML and formatted_article.get('dateline', {}).get('text'):
-                soup = BeautifulSoup(formatted_article.get('body_html'), "html.parser")
-                ptag = soup.find('p')
-                if ptag is not None:
-                    ptag.insert(0, NavigableString('{} '.format(formatted_article.get('dateline').get('text'))))
-                    formatted_article['body_html'] = str(soup)
+            if formatted_article.get(FORMAT) == FORMATS.HTML:
+                # If there is a dateline inject it into the body
+                if formatted_article.get('dateline', {}).get('text'):
+                    soup = BeautifulSoup(formatted_article.get('body_html'), "html.parser")
+                    ptag = soup.find('p')
+                    if ptag is not None:
+                        ptag.insert(0, NavigableString('{} '.format(formatted_article.get('dateline').get('text'))))
+                        formatted_article['body_html'] = str(soup)
                 doc['message_html'] = render_template('email_article_body.html', article=formatted_article)
             else:
                 doc['message_html'] = None

--- a/tests/publish/email_formatter_test.py
+++ b/tests/publish/email_formatter_test.py
@@ -218,6 +218,7 @@ class EmailFormatterTest(TestCase):
             'subject': [{'qcode': '02011001'}],
             'format': 'HTML',
             'type': 'text',
+            'dateline': {'text': 'BERN, July 13  -'},
             'body_html': '<p>paragraph 1</p><br><br><p>paragraph 2</p><p>paragraph 3</p>',
             'word_count': '1',
             'priority': 1,
@@ -232,5 +233,5 @@ class EmailFormatterTest(TestCase):
         item = json.loads(doc)
         self.assertEqual(item['message_text'], 'VIC: \nPublished At : Fri Feb 24 17:40:56 2017\n'
                                                ' take\n\n--------------------------------------'
-                                               '--------------------\n\n\n\nparagraph 1\n\n\n'
+                                               '--------------------\n\n\n\nBERN, July 13  - paragraph 1\n\n\n'
                                                'paragraph 2\nparagraph 3\n\nAAP aa/bb\n')


### PR DESCRIPTION
lf_on_block attribute add line feed on blocks elements in get_text, but
it is only available in master where lxml is used instead of
BeautifulSoup. This patch backport it, but use a more fragile method to
handle HTML content.

Also fix a bug in handling HTML content (HTML body was not used if
dateline was not present).

SDESK-824