### PR TITLE
[FORMATTER] [EMAIL] fixed missing HTML part when dateline is not set

### DIFF
--- a/tests/publish/email_formatter_test.py
+++ b/tests/publish/email_formatter_test.py
@@ -210,7 +210,7 @@ class EmailFormatterTest(TestCase):
     def test_paragraphs(self):
         """Test that paragraphs (block elements) are followed by line feed in text version
 
-        SDPRO-85 regression test
+        SDESK-824 regression test
         """
         article = {
             'source': 'AAP',
@@ -234,3 +234,16 @@ class EmailFormatterTest(TestCase):
                                                ' take\n\n--------------------------------------'
                                                '--------------------\n\n\n\nparagraph 1\n\n\n'
                                                'paragraph 2\nparagraph 3\n\nAAP aa/bb\n')
+
+    def test_dateline_html(self):
+        """Check that message_html output is producted even without a dateline
+
+        SDESK-836 regression test
+        """
+        article = {
+            'format': 'HTML',
+            'type': 'text',
+            'body_html': '<p>some HTML</p>'}
+        _, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        item = json.loads(doc)
+        self.assertIsNotNone(item['message_html'])


### PR DESCRIPTION
This is a port of a fix already present in 1.6 branch
(a986bc4eba638799a1442ebcf132f87b5e8a08e4)

SDESK-836