### PR TITLE
refactor(formatter): generate seq num before formatting it

### DIFF
--- a/apps/publish/enqueue/enqueue_service.py
+++ b/apps/publish/enqueue/enqueue_service.py
@@ -344,8 +344,11 @@ class EnqueueService:
                             no_formatters.append(destination['format'])
                             continue
 
+                        pub_seq_num = get_resource_service('subscribers').generate_sequence_number(subscriber)
+
                         formatted_docs = formatter.format(doc,
                                                           subscriber,
+                                                          pub_seq_num,
                                                           subscriber_codes.get(subscriber[config.ID_FIELD]))
 
                         for idx, publish_data in enumerate(formatted_docs):

--- a/superdesk/publish/formatters/__init__.py
+++ b/superdesk/publish/formatters/__init__.py
@@ -35,7 +35,7 @@ class Formatter(metaclass=FormatterRegistry):
         self.can_preview = False
         self.can_export = False
 
-    def format(self, article, subscriber, codes=None):
+    def format(self, article, subscriber, pub_seq_num, codes=None):
         """Formats the article and returns the transformed string"""
         raise NotImplementedError()
 

--- a/superdesk/publish/formatters/email_formatter.py
+++ b/superdesk/publish/formatters/email_formatter.py
@@ -9,7 +9,6 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import json
-import superdesk
 
 from superdesk.publish.formatters import Formatter
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE, FORMAT, FORMATS
@@ -49,9 +48,8 @@ class EmailFormatter(Formatter):
             ptag.text = formatted_article['dateline']['text'] + ' ' + (ptag.text or '')
             formatted_article['body_html'] = sd_etree.to_string(body_html_elem)
 
-    def format(self, article, subscriber, codes=None):
+    def format(self, article, subscriber, pub_seq_num, codes=None):
         formatted_article = deepcopy(article)
-        pub_seq_num = superdesk.get_resource_service('subscribers').generate_sequence_number(subscriber)
         doc = {}
         try:
             if formatted_article.get(FORMAT) == FORMATS.HTML:

--- a/superdesk/publish/formatters/newsml_1_2_formatter.py
+++ b/superdesk/publish/formatters/newsml_1_2_formatter.py
@@ -46,20 +46,19 @@ class NewsML12Formatter(Formatter):
         CONTENT_TYPE.TEXT: 'Text'
     }
 
-    def format(self, article, subscriber, codes=None):
+    def format(self, article, subscriber, pub_seq_num, codes=None):
         """
         Create article in NewsML1.2 format
 
         :param dict article:
         :param dict subscriber:
+        :param int pub_seq_num:
         :param list codes:
         :return [(int, str)]: return a List of tuples. A tuple consist of
             publish sequence number and formatted article string.
         :raises FormatterError: if the formatter fails to format an article
         """
         try:
-            pub_seq_num = superdesk.get_resource_service('subscribers').generate_sequence_number(subscriber)
-
             newsml = etree.Element("NewsML")
             SubElement(newsml, "Catalog", {'Href': 'http://www.iptc.org/std/catalog/catalog.IptcMasterCatalog.xml'})
             news_envelope = SubElement(newsml, "NewsEnvelope")

--- a/superdesk/publish/formatters/newsml_g2_formatter.py
+++ b/superdesk/publish/formatters/newsml_g2_formatter.py
@@ -46,18 +46,18 @@ class NewsMLG2Formatter(Formatter):
     _debug_message_extra = {'{{{}}}schemaLocation'.format(_message_nsmap['xsi']): 'http://iptc.org/std/nar/2006-10-01/ \
     http://www.iptc.org/std/NewsML-G2/2.18/specification/NewsML-G2_2.18-spec-All-Power.xsd'}
 
-    def format(self, article, subscriber, codes=None):
+    def format(self, article, subscriber, pub_seq_num, codes=None):
         """Create article in NewsML G2 format
 
         :param dict article:
         :param dict subscriber:
+        :param int pub_seq_num:
         :param list codes: selector codes
         :return [(int, str)]: return a List of tuples. A tuple consist of
             publish sequence number and formatted article string.
         :raises FormatterError: if the formatter fails to format an article
         """
         try:
-            pub_seq_num = superdesk.get_resource_service('subscribers').generate_sequence_number(subscriber)
             is_package = self._is_package(article)
             news_message = etree.Element('newsMessage', attrib=self._debug_message_extra, nsmap=self._message_nsmap)
             self._format_header(article, news_message, pub_seq_num)

--- a/superdesk/publish/formatters/newsml_g2_formatter_test.py
+++ b/superdesk/publish/formatters/newsml_g2_formatter_test.py
@@ -9,7 +9,6 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import datetime
-from unittest import mock
 
 from lxml import etree
 
@@ -19,7 +18,6 @@ from superdesk.utc import utcnow
 from superdesk.publish.formatters import NewsMLG2Formatter
 
 
-@mock.patch('superdesk.publish.subscribers.SubscribersService.generate_sequence_number', lambda self, subscriber: 1)
 class NewsMLG2FormatterTest(TestCase):
     embargo_ts = (utcnow() + datetime.timedelta(days=2))
     article = {
@@ -637,7 +635,7 @@ class NewsMLG2FormatterTest(TestCase):
         self.app.data.insert('archive', self.packaged_articles)
 
     def test_formatter(self):
-        seq, doc = self.formatter.format(self.article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(self.article, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(doc.encode('utf-8'))
         self.assertEqual(xml.find(
             '{http://iptc.org/std/nar/2006-10-01/}header/{http://iptc.org/std/nar/2006-10-01/}sender').text,
@@ -713,7 +711,7 @@ class NewsMLG2FormatterTest(TestCase):
     def testPreservedFomat(self):
         article = dict(self.article)
         article['format'] = 'preserved'
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(doc.encode('utf-8'))
         self.assertEqual(xml.find(
             '{http://iptc.org/std/nar/2006-10-01/}itemSet/{http://iptc.org/std/nar/2006-10-01/}newsItem/' +
@@ -723,7 +721,7 @@ class NewsMLG2FormatterTest(TestCase):
     def testDefaultRightsFomatter(self):
         article = dict(self.article)
         article['source'] = 'BOGUS'
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(doc.encode('utf-8'))
         self.assertEqual(xml.find(
             '{http://iptc.org/std/nar/2006-10-01/}itemSet/{http://iptc.org/std/nar/2006-10-01/}newsItem/' +
@@ -734,7 +732,7 @@ class NewsMLG2FormatterTest(TestCase):
         article = dict(self.package)
         article['firstcreated'] = self.now
         article['versioncreated'] = self.now
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(doc.encode('utf-8'))
         self.assertEqual(xml.find(
             '{http://iptc.org/std/nar/2006-10-01/}header/{http://iptc.org/std/nar/2006-10-01/}priority').text,
@@ -754,7 +752,7 @@ class NewsMLG2FormatterTest(TestCase):
         article = dict(self.picture_package)
         article['firstcreated'] = self.now
         article['versioncreated'] = self.now
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(doc.encode('utf-8'))
         self.assertEqual(xml.find(
             '{http://iptc.org/std/nar/2006-10-01/}header/{http://iptc.org/std/nar/2006-10-01/}priority').text,
@@ -774,7 +772,7 @@ class NewsMLG2FormatterTest(TestCase):
         article = dict(self.picture)
         article['firstcreated'] = self.now
         article['versioncreated'] = self.now
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(doc.encode('utf-8'))
         self.assertEqual(xml.find(
             '{http://iptc.org/std/nar/2006-10-01/}header/{http://iptc.org/std/nar/2006-10-01/}priority').text,
@@ -804,7 +802,7 @@ class NewsMLG2FormatterTest(TestCase):
         article = dict(self.video)
         article['firstcreated'] = self.now
         article['versioncreated'] = self.now
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(doc.encode('utf-8'))
         self.assertEqual(xml.find(
             '{http://iptc.org/std/nar/2006-10-01/}header/{http://iptc.org/std/nar/2006-10-01/}priority').text,
@@ -839,7 +837,7 @@ class NewsMLG2FormatterTest(TestCase):
         article = dict(self.picture_text_package)
         article['firstcreated'] = self.now
         article['versioncreated'] = self.now
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(doc.encode('utf-8'))
         item_refs = xml.findall('.//{http://iptc.org/std/nar/2006-10-01/}itemRef')
         self.assertEqual(len(item_refs), 2)
@@ -858,7 +856,7 @@ class NewsMLG2FormatterTest(TestCase):
         article = dict(self.picture_text_package_multi_group)
         article['firstcreated'] = self.now
         article['versioncreated'] = self.now
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(doc.encode('utf-8'))
         item_refs = xml.findall('.//{http://iptc.org/std/nar/2006-10-01/}itemRef')
         self.assertEqual(len(item_refs), 2)
@@ -888,7 +886,7 @@ class NewsMLG2FormatterTest(TestCase):
 
     def testPlace(self):
         article = self.article.copy()
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(doc.encode('utf-8'))
         content_meta = xml.find('{http://iptc.org/std/nar/2006-10-01/}itemSet'
                                 '/{http://iptc.org/std/nar/2006-10-01/}newsItem/'
@@ -903,7 +901,7 @@ class NewsMLG2FormatterTest(TestCase):
         article['place'] = [{"name": "ACT", "qcode": "ACT",
                              "state": "Australian Capital Territory",
                              "country": "Australia", "world_region": "Oceania"}]
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(doc.encode('utf-8'))
         content_meta = xml.find('{http://iptc.org/std/nar/2006-10-01/}itemSet'
                                 '/{http://iptc.org/std/nar/2006-10-01/}newsItem/'
@@ -920,7 +918,7 @@ class NewsMLG2FormatterTest(TestCase):
 
         article['place'] = [{"name": "EUR", "qcode": "EUR",
                              "state": "", "country": "", "world_region": "Europe"}]
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(doc.encode('utf-8'))
         content_meta = xml.find('{http://iptc.org/std/nar/2006-10-01/}itemSet'
                                 '/{http://iptc.org/std/nar/2006-10-01/}newsItem/'

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -81,10 +81,8 @@ class NINJSFormatter(Formatter):
         self.can_preview = True
         self.can_export = True
 
-    def format(self, article, subscriber, codes=None):
+    def format(self, article, subscriber, pub_seq_num, codes=None):
         try:
-            pub_seq_num = superdesk.get_resource_service('subscribers').generate_sequence_number(subscriber)
-
             ninjs = self._transform_to_ninjs(article, subscriber)
             return [(pub_seq_num, json.dumps(ninjs, default=json_serialize_datetime_objectId))]
         except Exception as ex:

--- a/superdesk/publish/formatters/nitf_formatter.py
+++ b/superdesk/publish/formatters/nitf_formatter.py
@@ -8,7 +8,6 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-import superdesk
 from lxml import etree as etree
 from lxml.etree import SubElement
 from flask import current_app as app
@@ -130,10 +129,8 @@ class NITFFormatter(Formatter):
         'th': {},
     }
 
-    def format(self, article, subscriber, codes=None):
+    def format(self, article, subscriber, pub_seq_num, codes=None):
         try:
-            pub_seq_num = superdesk.get_resource_service('subscribers').generate_sequence_number(subscriber)
-
             nitf = self.get_nitf(article, subscriber, pub_seq_num)
             return [(pub_seq_num, self.XML_ROOT + etree.tostring(nitf, pretty_print=True).decode('utf-8'))]
         except Exception as ex:

--- a/tests/publish/email_formatter_test.py
+++ b/tests/publish/email_formatter_test.py
@@ -7,9 +7,9 @@
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
+
 import json
 import datetime
-from unittest import mock
 
 from superdesk.publish import init_app
 from superdesk.publish.formatters.email_formatter import EmailFormatter
@@ -17,7 +17,6 @@ from superdesk.tests import TestCase
 from superdesk.utc import utc
 
 
-@mock.patch('superdesk.publish.subscribers.SubscribersService.generate_sequence_number', lambda self, subscriber: 1)
 class EmailFormatterTest(TestCase):
     def setUp(self):
         self.formatter = EmailFormatter()
@@ -47,7 +46,7 @@ class EmailFormatterTest(TestCase):
 
         article['versioncreated'] = datetime.datetime(year=2015, month=1, day=30, hour=2, minute=40, second=56,
                                                       tzinfo=utc)
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         item = json.loads(doc)
         self.assertEqual(item['message_subject'], 'This is a test headline')
         self.assertEqual(item['message_html'], '<html>\n<body>\n<h1>VIC:&nbsp;This is a test headline</h1>\n'
@@ -84,7 +83,7 @@ class EmailFormatterTest(TestCase):
 
         article['versioncreated'] = datetime.datetime(year=2015, month=1, day=30, hour=2, minute=40, second=56,
                                                       tzinfo=utc)
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         item = json.loads(doc)
         self.assertEqual(item['message_subject'], 'This is a test headline')
         self.assertEqual(item['message_html'], None)
@@ -111,7 +110,7 @@ class EmailFormatterTest(TestCase):
 
         article['versioncreated'] = datetime.datetime(year=2015, month=1, day=30, hour=2, minute=40, second=56,
                                                       tzinfo=utc)
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         item = json.loads(doc)
         self.assertEqual(item['message_subject'], 'This is a test headline')
         self.assertEqual(item['message_html'], '<html>\n<body>\n<h1>This is a test headline</h1>\n'
@@ -149,7 +148,7 @@ class EmailFormatterTest(TestCase):
 
         article['versioncreated'] = datetime.datetime(year=2015, month=1, day=30, hour=2, minute=40, second=56,
                                                       tzinfo=utc)
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         item = json.loads(doc)
         self.assertEqual(item['message_subject'], 'This is a test headline')
         self.assertEqual(item['message_html'], '<html>\n<body>\n<h1>This is a test headline</h1>\n'
@@ -187,7 +186,7 @@ class EmailFormatterTest(TestCase):
 
         article['versioncreated'] = datetime.datetime(year=2015, month=1, day=30, hour=2, minute=40, second=56,
                                                       tzinfo=utc)
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         item = json.loads(doc)
         self.assertEqual(item['message_subject'], 'This is a test headline')
         self.assertEqual(item['message_html'], '<html>\n<body>\n<h1>This is a test headline</h1>\n'
@@ -203,7 +202,7 @@ class EmailFormatterTest(TestCase):
 
     def test_subject_cyrilic(self):
         article = {'headline': 'Неправильная музыка Джамала Али'}
-        seq, doc = self.formatter.format(article, {'name': 'Test'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test'}, 1)[0]
         item = json.loads(doc)
         self.assertEqual(article['headline'], item['message_subject'])
 
@@ -227,7 +226,7 @@ class EmailFormatterTest(TestCase):
         }
         article['versioncreated'] = datetime.datetime(year=2017, month=2, day=24, hour=16, minute=40, second=56,
                                                       tzinfo=utc)
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
 
         item = json.loads(doc)
         self.assertEqual(item['message_text'], 'VIC: \nPublished At : Fri Feb 24 17:40:56 2017\n'
@@ -244,6 +243,6 @@ class EmailFormatterTest(TestCase):
             'format': 'HTML',
             'type': 'text',
             'body_html': '<p>some HTML</p>'}
-        _, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        _, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         item = json.loads(doc)
         self.assertIsNotNone(item['message_html'])

--- a/tests/publish/newsml_1_2_formatter_tests.py
+++ b/tests/publish/newsml_1_2_formatter_tests.py
@@ -7,7 +7,6 @@
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
-from unittest import mock
 
 from superdesk.utc import utcnow
 
@@ -18,7 +17,6 @@ import datetime
 from superdesk.publish import init_app
 
 
-@mock.patch('superdesk.publish.subscribers.SubscribersService.generate_sequence_number', lambda self, subscriber: 1)
 class Newsml12FormatterTest(TestCase):
     article = {
         '_id': 'urn:localhost.abc',
@@ -796,7 +794,7 @@ class Newsml12FormatterTest(TestCase):
 
     def test_format_picture(self):
         doc = self.picture.copy()
-        seq, xml_str = self.formatter.format(doc, {'name': 'Test Subscriber'})[0]
+        seq, xml_str = self.formatter.format(doc, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(xml_str)
 
         self.assertEqual(xml.find('NewsItem/NewsComponent/NewsComponent/NewsLines/HeadLine').text,
@@ -821,7 +819,7 @@ class Newsml12FormatterTest(TestCase):
 
     def test_format_video(self):
         doc = self.video.copy()
-        seq, xml_str = self.formatter.format(doc, {'name': 'Test Subscriber'})[0]
+        seq, xml_str = self.formatter.format(doc, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(xml_str)
         self.assertEqual(xml.find('NewsItem/NewsComponent/NewsComponent/NewsLines/HeadLine').text, 'test video')
         self.assertEqual(xml.find('NewsItem/NewsComponent/NewsComponent/NewsLines/ByLine').text, 'test video')
@@ -843,7 +841,7 @@ class Newsml12FormatterTest(TestCase):
 
     def test_format_package(self):
         doc = self.package.copy()
-        seq, xml_str = self.formatter.format(doc, {'name': 'Test Subscriber'})[0]
+        seq, xml_str = self.formatter.format(doc, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(xml_str)
         self.assertEqual(xml.find('.//Role[@FormalName="root"]/../NewsComponent/Role').get('FormalName'),
                          'grpRole:main')
@@ -852,7 +850,7 @@ class Newsml12FormatterTest(TestCase):
 
     def test_format_picture_package(self):
         doc = self.picture_package.copy()
-        seq, xml_str = self.formatter.format(doc, {'name': 'Test Subscriber'})[0]
+        seq, xml_str = self.formatter.format(doc, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(xml_str)
         self.assertEqual(xml.find('.//Role[@FormalName="root"]/../NewsComponent/Role').get('FormalName'),
                          'grpRole:main')
@@ -861,7 +859,7 @@ class Newsml12FormatterTest(TestCase):
 
     def test_format_picture_text_package(self):
         doc = self.picture_text_package.copy()
-        seq, xml_str = self.formatter.format(doc, {'name': 'Test Subscriber'})[0]
+        seq, xml_str = self.formatter.format(doc, {'name': 'Test Subscriber'}, 1)[0]
         xml = etree.fromstring(xml_str)
         news_component = xml.find('.//Role[@FormalName="root"]/../NewsComponent')
         self.assertEqual(news_component.find('Role').get('FormalName'), 'grpRole:main')

--- a/tests/publish/ninjs_formatter_test.py
+++ b/tests/publish/ninjs_formatter_test.py
@@ -7,9 +7,10 @@
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
-from unittest import mock
-from datetime import timedelta
+
 import json
+
+from datetime import timedelta
 
 from superdesk.utc import utcnow
 from superdesk.tests import TestCase
@@ -17,7 +18,6 @@ from superdesk.publish.formatters.ninjs_formatter import NINJSFormatter
 from superdesk.publish import init_app
 
 
-@mock.patch('superdesk.publish.subscribers.SubscribersService.generate_sequence_number', lambda self, subscriber: 1)
 class NinjsFormatterTest(TestCase):
     def setUp(self):
         self.formatter = NINJSFormatter()
@@ -55,7 +55,7 @@ class NinjsFormatterTest(TestCase):
             'body_footer': '<p>call helpline 999 if you are planning to quit smoking</p>',
             'company_codes': [{'name': 'YANCOAL AUSTRALIA LIMITED', 'qcode': 'YAL', 'security_exchange': 'ASX'}]
         }
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         expected = {
             "guid": "tag:aap.com.au:20150613:12345",
             "version": "1",
@@ -110,7 +110,7 @@ class NinjsFormatterTest(TestCase):
             'guid': '20150723001158606583',
             'body_footer': '<p>call helpline 999 if you are planning to quit smoking</p>'
         }
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         expected = {
             "byline": "MICKEY MOUSE",
             "renditions": {
@@ -246,7 +246,7 @@ class NinjsFormatterTest(TestCase):
             'version': 2,
         }
 
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         expected = {
             "headline": "WA:Navy steps in with WA asylum-seeker boat",
             "version": "2",
@@ -299,7 +299,7 @@ class NinjsFormatterTest(TestCase):
             }
         }
 
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         formatted = json.loads(doc)
         self.assertIn('associations', formatted)
         self.assertIn('image', formatted['associations'])
@@ -347,7 +347,7 @@ class NinjsFormatterTest(TestCase):
                 }
             }
         }
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         expected = {
             "guid": "tag:aap.com.au:20150613:12345",
             "version": "1",

--- a/tests/publish/nitf_formatter_tests.py
+++ b/tests/publish/nitf_formatter_tests.py
@@ -9,7 +9,6 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from superdesk.tests import TestCase
-from unittest import mock
 from superdesk.publish.formatters.nitf_formatter import NITFFormatter
 from superdesk.publish.formatters import Formatter
 from superdesk.publish import init_app
@@ -17,7 +16,6 @@ from lxml import etree
 from textwrap import dedent
 
 
-@mock.patch('superdesk.publish.subscribers.SubscribersService.generate_sequence_number', lambda self, subscriber: 1)
 class NitfFormatterTest(TestCase):
     def setUp(self):
         self.formatter = NITFFormatter()
@@ -54,7 +52,7 @@ class NitfFormatterTest(TestCase):
             'urgency': 2
         }
 
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         nitf_xml = etree.fromstring(doc)
         self.assertEqual(nitf_xml.find('head/title').text, article['headline'])
         self.assertEqual(nitf_xml.find('body/body.content/p').text, 'test body')
@@ -178,7 +176,7 @@ class NitfFormatterTest(TestCase):
             'company_codes': [{'name': 'YANCOAL AUSTRALIA LIMITED', 'qcode': 'YAL', 'security_exchange': 'ASX'}]
         }
 
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         nitf_xml = etree.fromstring(doc)
         company = nitf_xml.find('body/body.head/org')
         self.assertEqual(company.text, 'YANCOAL AUSTRALIA LIMITED')
@@ -207,6 +205,6 @@ class NitfFormatterTest(TestCase):
                 }
             ],
         }
-        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'}, 1)[0]
         nitf_xml = etree.fromstring(doc)
         self.assertEqual(nitf_xml.find('body/body.content/p').text, 'Tommi Mäkinen crashes a Škoda in Äppelbo')


### PR DESCRIPTION
this part seems generic so there should be no need to do this inside formatter.
next step would be to avoid returning seq_num from format call, just
checking here if anyone can see any issue with that?
ping @akintolga @mdhaman @marwoodandrew 