### PR TITLE
[content type] fixed overwritting of minlenght value

### DIFF
--- a/apps/content_types/content_types.py
+++ b/apps/content_types/content_types.py
@@ -163,7 +163,7 @@ class ContentTypesResource(superdesk.Resource):
         'updated_by': superdesk.Resource.rel('users', nullable=True),
     }
 
-    item_url = 'regex("[\w,.:-]+")'
+    item_url = r'regex("[\w,.:-]+")'
 
     privileges = {'POST': CONTENT_TYPE_PRIVILEGE,
                   'PATCH': CONTENT_TYPE_PRIVILEGE,
@@ -421,7 +421,8 @@ def init_editor_required(editor, schema):
     for field in schema:
         if editor[field] is not None and schema[field] is not None and schema[field].get('required') is not None:
             editor[field]['required'] = schema[field]['required']
-            schema[field]['minlength'] = 1 if schema[field]['required'] else 0
+            if schema[field]['required'] and schema[field].get('minlength', 0) == 0:
+                schema[field]['minlength'] = 1
             schema[field]['nullable'] = not schema[field]['required']
 
 

--- a/tests/content_types_test.py
+++ b/tests/content_types_test.py
@@ -1,8 +1,7 @@
-
-import unittest
-
-from unittest.mock import patch
-from apps.content_types import apply_schema
+from superdesk.tests import TestCase
+from unittest import mock
+import copy
+from apps.content_types import content_types, apply_schema
 
 
 class MockService():
@@ -15,13 +14,31 @@ class MockService():
         }
 
 
-class ContentTypesTestCase(unittest.TestCase):
+class ContentTypesTestCase(TestCase):
 
     def test_apply_schema_default(self):
         item = {'guid': 'guid', 'headline': 'foo'}
         self.assertEqual(item, apply_schema(item))
 
-    @patch('apps.content_types.content_types.get_resource_service', return_value=MockService())
+    @mock.patch('apps.content_types.content_types.get_resource_service', return_value=MockService())
     def test_apply_schema_profile(self, mock):
         item = {'headline': 'foo', 'slugline': 'bar', 'guid': '1', 'profile': 'test'}
         self.assertEqual({'headline': 'foo', 'guid': '1', 'profile': 'test'}, apply_schema(item))
+
+    @mock.patch.object(content_types, 'get_fields_map_and_names', lambda: ({}, {}))
+    def test_minlength(self):
+        """Check that minlength is not modified when it is set
+
+        check is done with required set
+        """
+        original = {
+            "schema": {
+                "body_html": {
+                    "required": True,
+                    "enabled": True
+                },
+            }}
+        updates = copy.deepcopy(original)
+        updates['schema']['body_html']['minlength'] = '99'
+        content_types.ContentTypesService().on_update(updates, original)
+        self.assertEqual(updates['schema']['body_html']['minlength'], '99')


### PR DESCRIPTION
minlength was overwritten when required was set, and always set to 1.
This commit fixes it by not overwritting minlenght if it is set and not
0.

fixes SDESK-698