### PR TITLE
remove reuters ingest provider from init data

### DIFF
--- a/apps/prepopulate/data_sample/ingest_providers.json
+++ b/apps/prepopulate/data_sample/ingest_providers.json
@@ -1,26 +1,5 @@
 [
     {
-        "_id": "566e9e4ab6114067b3fc22e5",
-        "config": {
-            "username": "#ENV_REUTERS_USERNAME#",
-            "password": "#ENV_REUTERS_PASSWORD#",
-            "auth_url": "https://commerce.reuters.com/rmd/rest/xml/login",
-            "field_aliases": [],
-            "url": "http://rmb.reuters.com/rmd/rest/xml"
-        },
-        "feeding_service": "reuters_http",
-        "content_expiry": 2880,
-        "name": "Reuters",
-        "feed_parser": "newsml2",
-        "source": "Reuters",
-        "is_closed": false,
-        "update_schedule": {
-            "minutes": 5,
-            "seconds": 0
-        }
-    },
-
-    {
         "_id": "566ea626b611406b0de30e74",
         "source": "Forbes",
         "config": {


### PR DESCRIPTION
we don't have valid credentials anyhow