### PR TITLE
[SDESK-919](fix): Fixing overlength headers issue due location header introduced in eve 0.7.2

### DIFF
--- a/apps/archive/archive_rewrite.py
+++ b/apps/archive/archive_rewrite.py
@@ -70,7 +70,10 @@ class ArchiveRewriteService(Service):
         get_resource_service('archive_broadcast').on_broadcast_master_updated(ITEM_CREATE,
                                                                               item=original,
                                                                               rewrite_id=ids[0])
-        return [rewrite]
+
+        doc.clear()
+        doc.update(rewrite)
+        return ids
 
     def _validate_rewrite(self, original, update):
         """Validates the article to be rewritten.

--- a/apps/content_filters/content_filter/content_filter_test.py
+++ b/apps/content_filters/content_filter/content_filter_test.py
@@ -71,4 +71,4 @@ class ContentFilterTestService(BaseService):
                     raise SuperdeskApiError.\
                         badRequestError('Error in testing archive: {}'.format(str(ex)))
 
-        return [doc['match_results'] for doc in docs]
+        return [len(docs)]

--- a/apps/products/product_test.py
+++ b/apps/products/product_test.py
@@ -52,17 +52,15 @@ class ProductTestService(BaseService):
             logger.exception(ex)
             raise SuperdeskApiError.badRequestError('Error in testing article: {}'.format(str(ex)))
 
-        return [results]
+        doc['_items'] = results
+        return [article_id]
 
     def test_products(self, article):
         req = ParsedRequest()
         results = []
         products = list(get_resource_service('products').get(req=req, lookup=None))
         for product in products:
-            result = {}
-            result['product_id'] = product['_id']
-            result['matched'] = True
-
+            result = {'product_id': product['_id'], 'matched': True}
             reason = ''
             if not EnqueueService().conforms_product_targets(product, article):
                 # Here it fails to match due to geo restriction

--- a/features/export.feature
+++ b/features/export.feature
@@ -32,9 +32,9 @@ Feature: Export
       Then we get response code 201
       Then we get new resource
       """
-      {"_id": {"failures": 0, "url": "__any_value__"}}
+      {"failures": 0, "url": "__any_value__"}
       """
-      When we get "#export._id.url#"
+      When we get "#export.url#"
       Then we get response code 200
       And we get "Content-Disposition" header with "attachment; filename="export.zip"" type
       And we get "Content-Type" header with "application/zip" type
@@ -64,5 +64,5 @@ Feature: Export
       Then we get response code 201
       Then we get new resource
       """
-      {"_id": {"failures": 1, "url": "__none__"}}
+      {"failures": 1, "url": "__none__"}
       """

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -1805,7 +1805,7 @@ def step_impl_when_rewrite(context, item_id):
 
     resp = parse_json_response(context.response)
     set_placeholder(context, 'REWRITE_OF', _id)
-    set_placeholder(context, 'REWRITE_ID', resp['_id']['_id'])
+    set_placeholder(context, 'REWRITE_ID', resp['_id'])
 
 
 @then('we get "{field_name}" does not exist')


### PR DESCRIPTION
Fixed the problem where response body is being added to the `location` header field 
see https://github.com/pyeve/eve/blob/master/eve/methods/post.py#L301
