### PR TITLE
(fix): Fixing the elasticsearch _type conflicts.

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -439,12 +439,16 @@ class ArchiveService(BaseService):
     def _remove_after_copy(self, copied_item):
         """Removes the properties which doesn't make sense to have for an item after copy.
         """
-        keys_to_delete = [config.ID_FIELD, 'guid', LINKED_IN_PACKAGES, EMBARGO, PUBLISH_SCHEDULE,
-                          SCHEDULE_SETTINGS, 'lock_time', 'lock_session', 'lock_user', SIGN_OFF,
-                          'rewritten_by', 'rewrite_of', 'rewrite_sequence', 'highlights', 'is_take_item',
-                          'item_id', 'publish_state', 'last_published_version', 'queue_state',
-                          'digital_item_id', 'publish_sequence_no', 'last_queue_event', 'moved_to_legal',
-                          'published_in_package', '_type', 'event_id']
+        # get the archive schema keys
+        archive_schema_keys = list(app.config['DOMAIN'][SOURCE]['schema'].keys())
+        archive_schema_keys.extend([config.ID_FIELD, config.LAST_UPDATED, config.DATE_CREATED,
+                                    config.VERSION, config.ETAG])
+
+        # Delete the keys that are not part of archive schema.
+        keys_to_delete = [key for key in copied_item.keys() if key not in archive_schema_keys]
+        keys_to_delete.extend([config.ID_FIELD, 'guid', LINKED_IN_PACKAGES, EMBARGO, PUBLISH_SCHEDULE,
+                               SCHEDULE_SETTINGS, 'lock_time', 'lock_session', 'lock_user', SIGN_OFF,
+                               'rewritten_by', 'rewrite_of', 'rewrite_sequence', 'highlights', '_type', 'event_id'])
 
         for key in keys_to_delete:
             copied_item.pop(key, None)

--- a/apps/archive/archive_rewrite.py
+++ b/apps/archive/archive_rewrite.py
@@ -191,7 +191,7 @@ class ArchiveRewriteService(Service):
                     rewrite['body_html'] = original.get('body_html', '')
 
         rewrite[ITEM_STATE] = CONTENT_STATE.PROGRESS
-        self._set_take_key(rewrite, original.get('event_id'))
+        self._set_take_key(rewrite)
         return rewrite
 
     def _add_rewritten_flag(self, original, digital, rewrite):
@@ -240,11 +240,10 @@ class ArchiveRewriteService(Service):
                 processed_items.add(doc_id)
                 app.on_archive_item_updated({rewrite_field: None}, archive_item, ITEM_UNLINK)
 
-    def _set_take_key(self, rewrite, event_id):
+    def _set_take_key(self, rewrite):
         """Sets the anpa take key of the rewrite with ordinal.
 
         :param rewrite: rewrite story
-        :param event_id: event id
         """
         rewrite_sequence = rewrite.get('rewrite_sequence') or 0
         if rewrite_sequence > 1:

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -197,7 +197,7 @@ def on_create_item(docs, repo_type=ARCHIVE):
         if 'family_id' not in doc:
             doc['family_id'] = doc[GUID_FIELD]
 
-        if 'event_id' not in doc:
+        if 'event_id' not in doc and repo_type != 'ingest':
             doc['event_id'] = generate_guid(type=GUID_TAG)
 
         set_default_state(doc, CONTENT_STATE.DRAFT)

--- a/features/content_duplication.feature
+++ b/features/content_duplication.feature
@@ -470,6 +470,7 @@ Feature: Duplication of Content
        "task": {"desk": "#desks._id#", "stage": "#desks.working_stage#", "user": "#CONTEXT_USER_ID#"},
        "original_id": "123", "headline": "test1", "type": "text"}
       """
+      Then we ensure that archived schema extra fields are not present in duplicated item
       When we get "/published"
       Then we get list with 0 items
       When we publish "#duplicate._id#" with "publish" type and "published" state
@@ -489,11 +490,11 @@ Feature: Duplication of Content
          """
          [{  "_id": "123_1", "state": "published", "type":"text", "headline": "test1", "guid": "123_1", "item_id": "123", "original_creator": "#CONTEXT_USER_ID#",
           "source": "REUTERS", "subject":[{"qcode": "17004000", "name": "Statistics"}],
-          "body_html": "Test Document body", "_current_version": 1,
+          "body_html": "Test Document body", "_current_version": 1, "archived_id": "123:1",
           "task": {"desk": "#desks._id#", "stage": "#desks.working_stage#", "user": "#CONTEXT_USER_ID#"}},
           {  "_id": "123_2", "state": "published", "type":"text", "headline": "test2", "guid": "123_2", "item_id": "123", "original_creator": "#CONTEXT_USER_ID#",
           "source": "REUTERS", "subject":[{"qcode": "17004000", "name": "Statistics"}],
-          "body_html": "Test Document body", "_current_version": 2,
+          "body_html": "Test Document body", "_current_version": 2, "archived_id": "123:2",
           "task": {"desk": "#desks._id#", "stage": "#desks.working_stage#", "user": "#CONTEXT_USER_ID#"}
          }]
          """
@@ -510,4 +511,4 @@ Feature: Duplication of Content
        "task": {"desk": "#desks._id#", "stage": "#desks.working_stage#", "user": "#CONTEXT_USER_ID#"},
        "original_id": "123", "headline": "test2"}
       """
-
+      Then we ensure that archived schema extra fields are not present in duplicated item


### PR DESCRIPTION
- fixing the conflicts between elasticsearch `_type` for fields `archived_id`, `item_id` and `event_id`.