### PR TITLE
[SDESK-878] - Purge exported files from storage.

### DIFF
--- a/apps/export/service.py
+++ b/apps/export/service.py
@@ -5,6 +5,7 @@ from superdesk.services import BaseService
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError
 from superdesk.publish.formatters import get_all_formatters
+from superdesk.utils import get_random_string
 from eve.validation import ValidationError
 from io import BytesIO
 from zipfile import ZipFile
@@ -46,7 +47,12 @@ class ExportService(BaseService):
             # Store the zip file on media_storage
             # only if at least one item is formatted successfully
             if unsuccessful_exports < len(doc.get('item_ids')):
-                zip_id = app.media.put(in_memory_zip.getvalue(), filename='export.zip', content_type='application/zip')
+                zip_id = app.media.put(
+                    in_memory_zip.getvalue(),
+                    filename='export_{}.zip'.format(get_random_string()),
+                    content_type='application/zip',
+                    folder='temp'
+                )
                 url = app.media.url_for_download(zip_id, 'application/zip')
 
             doc['url'] = url

--- a/superdesk/commands/__init__.py
+++ b/superdesk/commands/__init__.py
@@ -5,3 +5,11 @@ from .run_macro import RunMacro  # noqa
 from .data_updates import *  # noqa
 from .delete_archived_document import *  # noqa
 from .update_archived_document import *  # noqa
+from .remove_exported_files import RemoveExportedFiles  # noqa
+
+from superdesk.celery_app import celery
+
+
+@celery.task()
+def temp_file_expiry():
+    RemoveExportedFiles()

--- a/superdesk/commands/remove_exported_files.py
+++ b/superdesk/commands/remove_exported_files.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015, 2016, 2017 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import logging
+import superdesk
+from datetime import timedelta
+
+from flask import current_app as app
+from superdesk.celery_task_utils import get_lock_id
+from superdesk.lock import lock, unlock
+from superdesk.utc import utcnow
+
+logger = logging.getLogger(__name__)
+
+
+class RemoveExportedFiles(superdesk.Command):
+    """Remove files from storage that were used for exporting items"""
+
+    log_msg = ''
+    expire_hours = 24
+
+    option_list = [
+        superdesk.Option('--expire-hours', '-e', dest='expire_hours', required=False, type=int)
+    ]
+
+    def run(self, expire_hours=None):
+        if expire_hours:
+            self.expire_hours = expire_hours
+        elif 'TEMP_FILE_EXPIRY_HOURS' in app.config:
+            self.expire_hours = app.config['TEMP_FILE_EXPIRY_HOURS']
+
+        expire_at = utcnow() - timedelta(hours=self.expire_hours)
+        self.log_msg = 'Expiry Time: {}.'.format(expire_at)
+        logger.info('{} Starting to remove exported files from storage'.format(self.log_msg))
+
+        lock_name = get_lock_id('storage', 'remove_exported')
+        if not lock(lock_name, expire=300):
+            logger.info('Remove exported files from storage task is already running')
+            return
+
+        try:
+            logger.info('{} Removing expired temporary media files'.format(self.log_msg))
+            self._remove_exported_files(expire_at)
+        finally:
+            unlock(lock_name)
+
+        logger.info('{} Completed removing exported files from storage'.format(self.log_msg))
+
+    def _remove_exported_files(self, expire_at):
+        logger.info('{} Beginning to remove exported files from storage'.format(self.log_msg))
+        for file_id in self._get_file_ids(expire_at):
+            app.media.delete(file_id)
+
+    def _get_file_ids(self, expire_at):
+        files = app.media.find(folder='temp', upload_date={'$lte': expire_at})
+        return [file['_id'] for file in files]
+
+
+superdesk.command('storage:remove_exported', RemoveExportedFiles())

--- a/superdesk/commands/remove_exported_files_test.py
+++ b/superdesk/commands/remove_exported_files_test.py
@@ -1,0 +1,85 @@
+from unittest.mock import Mock, call
+from datetime import timedelta
+
+from superdesk.tests import TestCase
+from superdesk.utc import utcnow
+from superdesk.utc import query_datetime
+
+from .remove_exported_files import RemoveExportedFiles
+
+
+class MockMediaFS:
+    """Simple Mocked Media FS"""
+
+    def __init__(self, files):
+        self.files = files
+        self.delete = Mock()
+        self.delete.side_effect = self._delete
+        self.find = Mock()
+        self.find.side_effect = self._find
+
+    def _delete(self, _id):
+        del self.files[_id]
+
+    def _find(self, folder=None, upload_date=None):
+        files = []
+        for file in self.files.values():
+            if (upload_date is not None and not query_datetime(file['upload_date'], upload_date)) \
+                    or not file['filename'].startswith(folder):
+                continue
+            files.append(file)
+        return files
+
+
+class RemoveExportedFilesTest(TestCase):
+
+    def setUp(self):
+        # Create a backup of the original media reference so we can set it back up again later
+        self.original_media = self.app.media
+        self.now = utcnow()
+        self.app.media = MockMediaFS({
+            'a1': {'_id': 'a1', 'filename': 'aa', 'upload_date': self.now},
+            'b2': {'_id': 'b2', 'filename': 'bb', 'upload_date': self.now - timedelta(hours=20)},
+            'c3': {'_id': 'c3', 'filename': 'cc', 'upload_date': self.now - timedelta(hours=25)},
+            'd4': {'_id': 'd4', 'filename': 'dd', 'upload_date': self.now - timedelta(hours=36)},
+            'e5': {'_id': 'e5', 'filename': 'temp/ee', 'upload_date': self.now},
+            'f6': {'_id': 'f6', 'filename': 'temp/ff', 'upload_date': self.now - timedelta(hours=20)},
+            'g7': {'_id': 'g7', 'filename': 'temp/gg', 'upload_date': self.now - timedelta(hours=25)},
+            'h8': {'_id': 'h8', 'filename': 'temp/hh', 'upload_date': self.now - timedelta(hours=36)}
+        })
+        self.can_expire = ['g7', 'h8']
+
+        self.command = RemoveExportedFiles()
+
+    def tearDown(self):
+        """Ensure to restore the original media reference"""
+        self.app.media = self.original_media
+
+    def test_get_file_ids(self):
+        expire_at = utcnow() - timedelta(hours=24)
+        for file_id in self.command._get_file_ids(expire_at):
+            self.assertIn(file_id, self.can_expire)
+
+        kwargs = {
+            'folder': 'temp',
+            'upload_date': {'$lte': expire_at}
+        }
+        self.app.media.find.assert_called_once_with(**kwargs)
+
+    def test_remove_exported_files(self):
+        expire_at = utcnow() - timedelta(hours=24)
+        self.command._remove_exported_files(expire_at)
+
+        for file_id in self.app.media.files:
+            self.assertNotIn(file_id, self.can_expire)
+
+        self.app.media.delete.assert_has_calls([call('g7'), call('h8')], any_order=True)
+        self.assertEqual(self.app.media.delete.call_count, 2)
+
+    def test_run(self):
+        self.command.run()
+        for file_id in self.app.media.files:
+            self.assertNotIn(file_id, self.can_expire)
+
+        self.app.media.delete.assert_has_calls([call('g7'), call('h8')], any_order=True)
+        self.assertEqual(self.app.media.delete.call_count, 2)

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -196,6 +196,10 @@ CELERY_TASK_ROUTES = {
         'queue': celery_queue('expiry'),
         'routing_key': 'expiry.session'
     },
+    'superdesk.commands.remove_exported_files': {
+        'queue': celery_queue('expiry'),
+        'routing_key': 'expiry.temp_files'
+    },
     'apps.legal_archive.import_legal_publish_queue': {
         'queue': celery_queue('legal'),
         'routing_key': 'legal.publish_queue'
@@ -250,6 +254,10 @@ CELERY_BEAT_SCHEDULE = {
     'content:gc': {
         'task': 'apps.archive.content_expiry',
         'schedule': crontab(minute='*/30')
+    },
+    'temp_files:gc': {
+        'task': 'superdesk.commands.temp_file_expiry',
+        'schedule': crontab(minute='0', hour='2')
     },
     'publish:transmit': {
         'task': 'superdesk.publish.transmit',
@@ -579,3 +587,6 @@ XMPP_AUTH_DOMAIN = env('XMPP_AUTH_DOMAIN', 'Superdesk')
 
 #: copies basic metadata from parent of associated items
 COPY_METADATA_FROM_PARENT = (env('COPY_METADATA_FROM_PARENT', 'false').lower() == 'true')
+
+#: The number of hours before temporary media files are purged
+TEMP_FILE_EXPIRY_HOURS = int(env('TEMP_FILE_EXPIRY_HOURS', 24))

--- a/superdesk/download.py
+++ b/superdesk/download.py
@@ -21,9 +21,12 @@ bp = superdesk.Blueprint('download_raw', __name__)
 logger = logging.getLogger(__name__)
 
 
-@bp.route('/download/<id>', methods=['GET'])
-def download_file(id):
-    file = app.media.get(id, 'download')
+@bp.route('/download/<id>', methods=['GET'], defaults={'folder': None})
+@bp.route('/download/<path:folder>/<id>', methods=['GET'])
+def download_file(id, folder=None):
+    filename = '{}/{}'.format(folder, id) if folder else id
+
+    file = app.media.get(filename, 'download')
     if file:
         data = wrap_file(request.environ, file, buffer_size=1024 * 256)
         response = app.response_class(

--- a/superdesk/storage/desk_media_storage.py
+++ b/superdesk/storage/desk_media_storage.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 class SuperdeskGridFSMediaStorage(GridFSMediaStorage):
 
-    def get(self, _id, resource):
+    def get(self, _id, resource=None):
         logger.debug('Getting media file with id= %s' % _id)
         _id = bson.ObjectId(_id)
         media_file = super().get(_id, resource)
@@ -63,7 +63,7 @@ class SuperdeskGridFSMediaStorage(GridFSMediaStorage):
     def fetch_rendition(self, rendition):
         return self.get(rendition.get('media'), 'upload')
 
-    def put(self, content, filename=None, content_type=None, metadata=None, resource=None, **kwargs):
+    def put(self, content, filename=None, content_type=None, metadata=None, resource=None, folder=None, **kwargs):
         """Store content in gridfs.
 
         :param content: binary stream
@@ -71,16 +71,27 @@ class SuperdeskGridFSMediaStorage(GridFSMediaStorage):
         :param content_type: mime type
         :param metadata: file metadata
         :param resource: type of resource
+        :param str folder: Folder that the file will be stored in
+        :return str: The ID that was generated for this object
         """
         if '_id' in kwargs:
             kwargs['_id'] = bson.ObjectId(kwargs['_id'])
+
+        if folder:
+            if folder[-1] == '/':
+                folder = folder[:-1]
+
+            if filename:
+                filename = '{}/{}'.format(folder, filename)
+
         try:
+            logger.info('Adding file {} to the GridFS'.format(filename))
             return self.fs(resource).put(content, content_type=content_type,
                                          filename=filename, metadata=metadata, **kwargs)
         except gridfs.errors.FileExists:
             logger.info('File exists filename=%s id=%s' % (filename, kwargs['_id']))
 
-    def fs(self, resource):
+    def fs(self, resource=None):
         resource = resource or 'upload'
         driver = self.app.data.mongo
         px = driver.current_mongo_prefix(resource)
@@ -88,10 +99,48 @@ class SuperdeskGridFSMediaStorage(GridFSMediaStorage):
             self._fs[px] = gridfs.GridFS(driver.pymongo(prefix=px).db)
         return self._fs[px]
 
-    def remove_unreferenced_files(self, existing_files):
-        """Get the files from Grid FS and compare agains existing files and delete the orphans."""
-        current_files = self.fs('upload').find({'_id': {'$nin': list(existing_files)}})
+    def remove_unreferenced_files(self, existing_files, resource=None):
+        """Get the files from Grid FS and compare against existing files and delete the orphans."""
+        current_files = self.fs(resource).find({'_id': {'$nin': list(existing_files)}})
         for file_id in (file._id for file in current_files if str(file._id) not in existing_files):
             print('Removing unused file: ', file_id)
             self.delete(file_id)
         print('Image cleaning completed successfully.')
+
+    def find(self, folder=None, upload_date=None, resource=None):
+        """Search for files in the GridFS
+
+        Searches for files in the GridFS using a combination of folder name and/or upload date
+        comparisons. The upload date comparisons uses the same mongodb BSON comparison operators,
+        i.e. `$eq`, `$gt`, `$gte`, `$lt`, `$lte` and `$ne`, and can be combined together.
+
+        :param str folder: Folder name
+        :param dict upload_date: Upload date with comparison operator (i.e. $lt, $lte, $gt or $gte)
+        :param resource: The resource type to use
+        :return list: List of files that matched the provided parameters
+        """
+        folder_query = {'filename': {'$regex': '^{}/'.format(folder)}} if folder else None
+        date_query = {'uploadDate': upload_date} if upload_date else None
+
+        if folder and upload_date:
+            query = {'$and': [folder_query, date_query]}
+        elif folder:
+            query = folder_query
+        elif date_query:
+            query = date_query
+        else:
+            query = {}
+
+        files = []
+        for file in self.fs(resource).find(query):
+            try:
+                files.append({
+                    '_id': file._id,
+                    'filename': file.filename,
+                    'upload_date': file.upload_date,
+                    'size': file.length,
+                    '_etag': file.md5
+                })
+            except AttributeError as e:
+                logging.warning('Failed to get file attributes. {}'.format(e))
+        return files

--- a/superdesk/utc.py
+++ b/superdesk/utc.py
@@ -100,3 +100,30 @@ def get_timezone_offset(local_tz_name, utc_datetime):
         return local_dt.strftime('%z')
     except:
         return utcnow().strftime('%z')
+
+
+def query_datetime(datetime_value, query):
+    """Checks the datetime_value against the query provided.
+
+    The query format is similar to that of MongoDB BSON comparison operators.
+    It uses `$eq`, `$gt`, `$gte`, `$lt`, `$lte` and `$ne`. Combine these operators together in a dictionary
+    to provide the datetime checking functionality. This is currently used when finding files from Amazon S3, but
+    could possibly be used in other areas.
+
+    :param datetime.datetime datetime_value: The datetime value used to check against the query
+    :param dict query: The query parameters used to check against the datetime_value
+    :return boolean: True if all comparison operators pass, else False
+    """
+    if '$lte' in query and datetime_value > query['$lte']:
+        return False
+    elif '$lt' in query and datetime_value >= query['$lt']:
+        return False
+    elif '$gte' in query and datetime_value < query['$gte']:
+        return False
+    elif '$gt' in query and datetime_value <= query['$gt']:
+        return False
+    elif '$eq' in query and datetime_value != query['$eq']:
+        return False
+    elif '$ne' in query and datetime_value == query['$ne']:
+        return False
+    return True


### PR DESCRIPTION
The following functionality was added to both **superdesk.storage.SuperdeskGridFSMediaStorage** and **superdesk.storage.amazon.AmazonMediaStorage**:

- **.put()** Ability to store the file in a 'folder' when calling 'put' on the service
- **.find()** Ability to 'find' files using a combination of 'prefix' and 'upload_date'

The **superdesk.download** blueprint now also supports the folder in the url via a second route rule.

The **apps.export.service** service now uses the folder functionality to store the temporary files under the 'temp' folder.
The **superdesk.commands.remove_exported_files** command is then able to efficiently find the files under 'temp' and ones that are older than 24hrs.