### PR TITLE
[etree] [FORMATTER] [NewsMLG2] added fix_html_void_elements to superd…

### DIFF
--- a/superdesk/etree.py
+++ b/superdesk/etree.py
@@ -59,6 +59,39 @@ BLOCK_ELEMENTS = (
     "ul",
     "video")
 
+# from https://www.w3.org/TR/html/syntax.html#void-elements
+VOID_ELEMENTS = (
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "keygen",
+    "link",
+    "menuitem",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr")
+
+
+def fix_html_void_elements(element):
+    """Use self-closing elements for HTML void elements, and start/end pairs otherwise
+
+    :param element: Element to fix
+    :type element: lxml.etree.Element
+    :return: fixed Element
+    """
+    # we want self closing for HTML void elemends and start/end tags otherwise
+    # so we set element.text to None for void ones, and empty string otherwise
+    for e in element.xpath("//*[not(node())]"):
+        e.text = None if e.tag in VOID_ELEMENTS else ''
+    return element
+
 
 def parse_html(html, content='xml', lf_on_block=False, space_on_elements=False):
     """Parse element and return etreeElement

--- a/superdesk/publish/formatters/newsml_g2_formatter.py
+++ b/superdesk/publish/formatters/newsml_g2_formatter.py
@@ -14,7 +14,7 @@ import superdesk
 from lxml import etree
 from lxml.etree import SubElement
 
-from superdesk.etree import get_text
+from superdesk import etree as sd_etree
 from flask import current_app as app
 
 from superdesk.publish.formatters import Formatter
@@ -74,6 +74,7 @@ class NewsMLG2Formatter(Formatter):
                 newsItem = self._format_item_set(article, item_set, 'newsItem')
                 self._format_content(article, newsItem, nitf)
 
+            sd_etree.fix_html_void_elements(news_message)
             return [(pub_seq_num, self.XML_ROOT + etree.tostring(news_message).decode('utf-8'))]
         except Exception as ex:
             raise FormatterError.newmsmlG2FormatterError(ex, subscriber)
@@ -160,7 +161,7 @@ class NewsMLG2Formatter(Formatter):
         """
         content_set = SubElement(news_item, 'contentSet')
         if article.get(FORMAT) == FORMATS.PRESERVED:
-            inline_data = get_text(self.append_body_footer(article))
+            inline_data = sd_etree.get_text(self.append_body_footer(article))
             SubElement(content_set, 'inlineData',
                        attrib={'contenttype': 'text/plain'}).text = inline_data
         elif article[ITEM_TYPE] in [CONTENT_TYPE.TEXT, CONTENT_TYPE.COMPOSITE]:

--- a/tests/etree_test.py
+++ b/tests/etree_test.py
@@ -1,23 +1,23 @@
 
 import unittest
-from superdesk.etree import get_word_count, parse_html, to_string
+from superdesk import etree as sd_etree
 
 
 class WordCountTestCase(unittest.TestCase):
 
     def test_word_count_p_tags(self):
-        self.assertEqual(2, get_word_count('<p>foo<strong>s</strong></p><p>bar</p>'))
+        self.assertEqual(2, sd_etree.get_word_count('<p>foo<strong>s</strong></p><p>bar</p>'))
 
     def test_word_count_brs(self):
-        self.assertEqual(2, get_word_count('<p>foo<br><br>bar</p>'))
-        self.assertEqual(2, get_word_count('<p>foo<br /><br />bar</p>'))
+        self.assertEqual(2, sd_etree.get_word_count('<p>foo<br><br>bar</p>'))
+        self.assertEqual(2, sd_etree.get_word_count('<p>foo<br /><br />bar</p>'))
 
     def test_word_count_hrs(self):
-        self.assertEqual(2, get_word_count('<p>foo<br><hr>bar</p>'))
-        self.assertEqual(2, get_word_count('<p>foo<br /><hr />bar</p>'))
+        self.assertEqual(2, sd_etree.get_word_count('<p>foo<br><hr>bar</p>'))
+        self.assertEqual(2, sd_etree.get_word_count('<p>foo<br /><hr />bar</p>'))
 
     def test_word_count_ul(self):
-        self.assertEqual(3, get_word_count("""
+        self.assertEqual(3, sd_etree.get_word_count("""
             <ul>
                 <li>foo</li>
                 <li>bar</li>
@@ -27,14 +27,14 @@ class WordCountTestCase(unittest.TestCase):
         """))
 
     def test_word_count_nitf(self):
-        self.assertEqual(40, get_word_count("""
+        self.assertEqual(40, sd_etree.get_word_count("""
         <p>2014: Northern Ireland beat <location>Greece</location> 2-0 in <location>Athens</location>
         with goals from <person>Jamie Ward</person> and <person>Kyle Lafferty</person> to boost their
         hopes of qualifying for <money>Euro 2016</money>. <person>Michael O'Neill's</person> side
         sealed their place at the finals in <chron>October 2015</chron>.</p>"""))
 
     def test_word_count_nitf_2(self):
-        self.assertEqual(316, get_word_count("""
+        self.assertEqual(316, sd_etree.get_word_count("""
         <p>Rio Tinto has kept intact its target for iron ore shipments in 2017 after hitting the mid-point
         of its revised guidance range for 2016. </p><p>The world's second largest iron ore exporter shipped
         327.6 million tonnes of iron ore from its Pilbara operations in 2016, in line with the slightly lowered
@@ -59,9 +59,16 @@ class WordCountTestCase(unittest.TestCase):
 class ParseHtmlTestCase(unittest.TestCase):
     def test_encode_carriage_return(self):
         text = 'This is first line.\r\nThis is second line.\r\n'
-        parsed = parse_html(text)
-        self.assertEqual(text.replace('\r', '&#13;'), to_string(parsed))
+        parsed = sd_etree.parse_html(text)
+        self.assertEqual(text.replace('\r', '&#13;'), sd_etree.to_string(parsed))
 
         text = '<pre>This is first line.\r\nThis is second line.\r\n</pre>'
-        parsed = parse_html(text, content='html')
-        self.assertEqual('<html><body>{}</body></html>'.format(text.replace('\r', '&#13;')), to_string(parsed))
+        parsed = sd_etree.parse_html(text, content='html')
+        self.assertEqual('<html><body>{}</body></html>'.format(text.replace('\r', '&#13;')), sd_etree.to_string(parsed))
+
+    def test_void_elements_fix(self):
+        html = '<p>this is a test with empty <h3/> non-void <em/> elements and a void <br/> one</p>'
+        expected = '<p>this is a test with empty <h3></h3> non-void <em></em> elements and a void <br/> one</p>'
+        parsed = sd_etree.parse_html(html)
+        sd_etree.fix_html_void_elements(parsed)
+        self.assertEqual(sd_etree.to_string(parsed), expected)


### PR DESCRIPTION
…esk.etree and use it in NewsMLG2Formatter

fix_html_void_elements insure that we use self-closing tags for HTML void elements, and start/end pairs otherwise.

SDESK-947