### PR TITLE
[SDESK-970] - Unwanted items are highlighted in Elastic 2.x

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -12,7 +12,7 @@ import json
 import flask
 from superdesk.resource import Resource
 from superdesk.metadata.utils import extra_response_fields, item_url, aggregations, \
-    is_normal_package, elastic_highlight_query
+    is_normal_package, get_elastic_highlight_query
 from .common import remove_unwanted, update_state, set_item_expiry, remove_media_files, \
     on_create_item, on_duplicate_item, get_user, update_version, set_sign_off, \
     handle_existing_data, item_schema, validate_schedule, is_item_in_package, update_schedule_settings, \
@@ -108,7 +108,7 @@ class ArchiveResource(Resource):
     datasource = {
         'search_backend': 'elastic',
         'aggregations': aggregations,
-        'es_highlight': elastic_highlight_query,
+        'es_highlight': get_elastic_highlight_query,
         'projection': {
             'old_version': 0,
             'last_version': 0

--- a/apps/publish/published_item.py
+++ b/apps/publish/published_item.py
@@ -16,7 +16,7 @@ from superdesk import get_resource_service
 import superdesk
 from superdesk.errors import SuperdeskApiError
 from superdesk.metadata.item import not_analyzed, ITEM_STATE, PUBLISH_STATES
-from superdesk.metadata.utils import aggregations, elastic_highlight_query
+from superdesk.metadata.utils import aggregations, get_elastic_highlight_query
 from superdesk.resource import Resource
 from superdesk.services import BaseService
 from superdesk.utc import utcnow
@@ -112,7 +112,7 @@ class PublishedItemResource(Resource):
     datasource = {
         'search_backend': 'elastic',
         'aggregations': aggregations,
-        'es_highlight': elastic_highlight_query,
+        'es_highlight': get_elastic_highlight_query,
         'default_sort': [('_updated', -1)],
         'elastic_filter_callback': get_content_filter,
         'projection': {

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ LONG_DESCRIPTION = "Superdesk Server Core"
 
 install_requires = [
     'eve>=0.6,<=0.7.2',
-    'eve-elastic==2.0',
+    'eve-elastic==2.1',
     'flask>=0.10,<0.13',
     'flask-mail>=0.9,<0.10',
     'flask-script>=2.0.5,<3.0',

--- a/superdesk/io/ingest.py
+++ b/superdesk/io/ingest.py
@@ -11,7 +11,7 @@
 from superdesk.resource import Resource
 from superdesk.services import BaseService
 from superdesk.metadata.item import metadata_schema
-from superdesk.metadata.utils import extra_response_fields, item_url, aggregations, elastic_highlight_query
+from superdesk.metadata.utils import extra_response_fields, item_url, aggregations, get_elastic_highlight_query
 from eve.defaults import resolve_default_values
 from eve.methods.common import resolve_document_etag
 from superdesk import get_resource_service
@@ -36,7 +36,7 @@ class IngestResource(Resource):
     datasource = {
         'search_backend': 'elastic',
         'aggregations': aggregations,
-        'es_highlight': elastic_highlight_query
+        'es_highlight': get_elastic_highlight_query
     }
     privileges = {'DELETE': 'fetch'}
 

--- a/superdesk/metadata/utils.py
+++ b/superdesk/metadata/utils.py
@@ -33,18 +33,26 @@ aggregations = {
     'genre': {'terms': {'field': 'genre.name', 'size': 0}}
 }
 
-elastic_highlight_query = {
-    'require_field_match': False,
-    'pre_tags': ['<span class=\"es-highlight\">'],
-    'post_tags': ['</span>'],
-    'fields': {
-        'body_html': {'number_of_fragments': 0},
-        'body_footer': {'number_of_fragments': 0},
-        'headline': {'number_of_fragments': 0},
-        'slugline': {'number_of_fragments': 0},
-        'abstract': {'number_of_fragments': 0}
-    }
-}
+
+def get_elastic_highlight_query(query_string):
+    if query_string:
+        field_settings = {'highlight_query': {'query_string': query_string},
+                          'number_of_fragments': 0}
+
+        elastic_highlight_query = {
+            'require_field_match': False,
+            'pre_tags': ['<span class=\"es-highlight\">'],
+            'post_tags': ['</span>'],
+            'fields': {
+                'body_html': field_settings,
+                'body_footer': field_settings,
+                'headline': field_settings,
+                'slugline': field_settings,
+                'abstract': field_settings
+            }
+        }
+
+        return elastic_highlight_query
 
 
 def generate_guid(**hints):


### PR DESCRIPTION
- Started using `highlight_query` in highlight definitions to match against the `query_string` instead of the whole query