### PR TITLE
[SDESK-969] - On changing the original in the modify crop screen it c…

### DIFF
--- a/apps/archive/archive_media.py
+++ b/apps/archive/archive_media.py
@@ -45,7 +45,7 @@ class ArchiveMediaService():
 
             try:
                 doc[ITEM_TYPE] = self.type_av.get(file_type)
-                rendition_spec = get_renditions_spec()
+                rendition_spec = get_renditions_spec(no_custom_crops=True)
                 renditions = generate_renditions(file, doc['media'], inserted, file_type,
                                                  content_type, rendition_spec, url_for_media)
                 doc['renditions'] = renditions

--- a/apps/picture_crop/__init__.py
+++ b/apps/picture_crop/__init__.py
@@ -1,9 +1,9 @@
 
 import superdesk
 
-from flask import current_app as app
+from flask import current_app as app, json
 from superdesk.utils import get_random_string
-from superdesk.media.media_operations import crop_image
+from superdesk.media.media_operations import crop_image, process_image, encode_metadata
 from apps.search_providers.proxy import PROXY_ENDPOINT
 
 
@@ -58,7 +58,9 @@ class PictureCropService(superdesk.Service):
             filename = get_random_string()
             ok, output = crop_image(orig_file, filename, crop, size)
             if ok:
-                media = app.media.put(output, filename, orig['mimetype'])
+                metadata = encode_metadata(process_image(orig_file))
+                metadata.update({'length': json.dumps(len(output.getvalue()))})
+                media = app.media.put(output, filename, orig['mimetype'], metadata=metadata)
                 doc['href'] = app.media.url_for_media(media, orig['mimetype'])
                 doc['width'] = output.width
                 doc['height'] = output.height

--- a/apps/picture_renditions.py
+++ b/apps/picture_renditions.py
@@ -18,7 +18,8 @@ class PictureRenditionsService(superdesk.Service):
             item = doc.pop('item')
             orig = item['renditions']['original']
             orig_file = get_file(orig, item)
-            rendition_spec = get_renditions_spec()
+            no_custom_crops = doc.get('no_custom_crops', False)
+            rendition_spec = get_renditions_spec(no_custom_crops=no_custom_crops)
             inserted = []
             mimetype = item.get('mimetype', orig.get('mimetype', '/'))
             media_type, content_type = mimetype.split('/')
@@ -34,7 +35,8 @@ class PictureRenditionsResource(superdesk.Resource):
     resource_methods = ['POST']
     privileges = {'POST': 'archive'}
     schema = {
-        'item': {'type': 'dict', 'required': True}
+        'item': {'type': 'dict', 'required': True},
+        'no_custom_crops': {'type': 'boolean'}
     }
 
 

--- a/features/archive.feature
+++ b/features/archive.feature
@@ -696,28 +696,6 @@ Feature: News Items Archive
         Then we get list with 0 items
 
     @auth
-    Scenario: Upload image with custom crops
-        Given "vocabularies"
-        """
-        [{"_id": "crop_sizes", "items": [{"is_active": true, "name": "4:3", "width": 400, "height": 300}]}]
-        """
-
-        When we upload a file "bike.jpg" to "archive"
-        Then we get new resource
-        And we get rendition "4:3" with mimetype "image/jpeg"
-
-    @auth
-    Scenario: Upload image with custom crops with original size less than custom crop
-        Given "vocabularies"
-        """
-        [{"_id": "crop_sizes", "items": [{"is_active": true, "name": "4:3", "width": 4000, "height": 3000}]}]
-        """
-
-        When we upload a file "bike.jpg" to "archive"
-        Then we get new resource
-        And we get "4:3" not in renditions
-
-    @auth
     Scenario: Create content on a desk that has set default language
         Given "desks"
         """

--- a/features/content_crop.feature
+++ b/features/content_crop.feature
@@ -2,55 +2,6 @@ Feature: Cropping the Image Articles
 
     @auth
     @vocabulary
-    Scenario: Crops generated automatically for pictures
-      Given the "validators"
-      """
-        [
-        {
-            "_id": "publish_picture",
-            "act": "publish",
-            "type": "picture",
-            "schema": {
-                "renditions": {
-                    "type": "dict",
-                    "required": true,
-                    "schema": {
-                        "4-3": {"type": "dict", "required": true},
-                        "16-9": {"type": "dict", "required": true}
-                    }
-                }
-            }
-        }
-        ]
-      """
-      And "desks"
-      """
-      [{"name": "Sports"}]
-      """
-      When upload a file "bike.jpg" to "archive" with "123"
-      And we post to "/archive/123/move"
-      """
-      [{"task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}]
-      """
-      When we post to "/products" with success
-      """
-      {
-        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
-      }
-      """
-      And we post to "/subscribers" with success
-      """
-      {
-        "name":"Channel 3","media_type":"media", "subscriber_type": "digital", "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
-        "products": ["#products._id#"],
-        "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}]
-      }
-      """
-      When we publish "123" with "publish" type and "published" state
-      Then we get response code 200
-
-    @auth
-    @vocabulary
     Scenario: Publish a picture with the crops succeeds
       Given the "validators"
       """
@@ -124,7 +75,6 @@ Feature: Cropping the Image Articles
       And we get OK response
       And we fetch a file "#rendition.16-9.href#"
       And we get OK response
-
 
     @auth
     @vocabulary
@@ -229,7 +179,6 @@ Feature: Cropping the Image Articles
       And we fetch a file "#rendition.4-3.href#"
       And we get OK response
 
-
     @auth
     @vocabulary
     Scenario: Create a story with a featured image
@@ -258,14 +207,6 @@ Feature: Cropping the Image Articles
             "_id": "bike",
             "poi": {"x": 0.2, "y": 0.3},
             "renditions": {
-              "16-9" : {
-                "poi" : {"y" : 18, "x" : 240},
-                "width": 1200, "height": 675
-              },
-              "4-3" : {
-                "poi" : {"y" : 130, "x" : 240},
-                "width": 1200, "height": 900
-              },
               "original" : {
                 "poi" : {"y" : 480, "x" : 240},
                 "width": 1200, "height": 1600
@@ -314,8 +255,7 @@ Feature: Cropping the Image Articles
             "poi": {"x": 0.1, "y": 0.1},
             "renditions": {
               "16-9" : {
-                "poi" : {"y" : 160, "x" : 120},
-                "width": 1200, "height": 675
+                "poi" : {"y" : 160, "x" : 120}
               }
             }
           }
@@ -441,14 +381,6 @@ Feature: Cropping the Image Articles
             "_id": "bike",
             "poi": {"x": 0.2, "y": 0.3},
             "renditions": {
-              "16-9" : {
-                "poi" : {"y" : 18, "x" : 240},
-                "width": 1200, "height": 675
-              },
-              "4-3" : {
-                "poi" : {"y" : 130, "x" : 240},
-                "width": 1200, "height": 900
-              },
               "original" : {
                 "poi" : {"y" : 480, "x" : 240},
                 "width": 1200, "height": 1600

--- a/features/content_renditions.feature
+++ b/features/content_renditions.feature
@@ -30,3 +30,33 @@ Feature: Create renditions
     And we fetch a file "#rendition.viewImage.href#"
     And we fetch a file "#rendition.16-9.href#"
     And we get OK response
+
+
+    @auth
+    @vocabulary
+    Scenario: Only system crops are generated
+      When we upload a file "bike.jpg" to "archive"
+      When we post to "/picture_renditions"
+      """
+      {
+          "item": {
+              "_id": 123,
+              "renditions": {
+                  "original": {
+                      "media": "#archive.renditions.viewImage.media#",
+                      "mimetype": "image/jpeg"
+                  }
+              }
+          },
+          "no_custom_crops": true
+      }
+      """
+      Then we get response code 201
+      Then we get rendition "baseImage" with mimetype "image/jpeg"
+      Then we get rendition "original" with mimetype "image/jpeg"
+      Then we get rendition "thumbnail" with mimetype "image/jpeg"
+      Then we get rendition "viewImage" with mimetype "image/jpeg"
+      And we fetch a file "#rendition.viewImage.href#"
+      And we get OK response
+      And we fetch a file "#rendition.16-9.href#"
+      Then we get error 404

--- a/tests/media/picture_crop_service_test.py
+++ b/tests/media/picture_crop_service_test.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from io import BytesIO
+from unittest import mock
+
+from superdesk.tests import TestCase
+from superdesk import get_resource_service
+from ..media import get_picture_fixture
+
+
+def get_file_mock(rendition, item):
+    filename = get_picture_fixture()
+    with open(filename, 'rb') as imgfile:
+        data = BytesIO(imgfile.read())
+    return data
+
+
+def crop_image_mock(content, file_name, cropping_data, exact_size=None, image_format=None):
+    setattr(content, 'width', 1)
+    setattr(content, 'height', 1)
+    return True, content
+
+
+def media_put_mock(content, filename=None, content_type=None, metadata=None, resource=None, **kwargs):
+    media = mock.MagicMock()
+    media.name = 'test.jpg'
+    media.metadata = metadata
+    return media
+
+
+class PictureCropServiceTest(TestCase):
+    @mock.patch('apps.picture_crop.get_file', side_effect=get_file_mock)
+    @mock.patch('apps.picture_crop.crop_image', side_effect=crop_image_mock)
+    @mock.patch('superdesk.app.media.put', side_effect=media_put_mock)
+    def test_crop_image_copies_metadata(self, get_file_function, crop_image_function, media_put_function):
+        service = get_resource_service('picture_crop')
+
+        images = service.post([{
+            'item': {
+                'renditions': {
+                    'original': {
+                        'mimetype': 'image/jpeg'
+                    }
+                }
+            },
+            'crop': {
+                'CropLeft': 10,
+                'CropRight': 10,
+                'CropTop': 5,
+                'CropBottom': 5
+            }
+        }])
+
+        self.assertEqual(images[0].metadata.get('datetime'), '"2015:07:06 16:30:23"')
+        self.assertEqual(images[0].metadata.get('exifimagewidth'), '400')
+        self.assertEqual(images[0].metadata.get('exifimageheight'), '300')


### PR DESCRIPTION
…reates duplicate crops.

Feature changes:
- On initial upload of an image, we no longer auto-generate custom crops defined in **_vocabularies.crop_sizes_**, only the system ones defined in **_settings.RENDITIONS.picture_**
- New parameter when posting to **_/api/picture_renditions_** to control if custom crops should be generated along with the system ones
- When posting to **_/api/picture_crop_** make sure to copy the metadata from the original picture

Removed feature tests for the auto-generated custom crops on initial upload.