### PR TITLE
[SDESK-582] (feat):Allow filtering associated item based on products

### DIFF
--- a/apps/publish/enqueue/enqueue_killed.py
+++ b/apps/publish/enqueue/enqueue_killed.py
@@ -33,16 +33,15 @@ class EnqueueKilledService(EnqueueService):
         :param target_media_type: dictate if the doc being queued is a Takes Package or an Individual Article.
                 Valid values are - Wire, Digital. If Digital then the doc being queued is a Takes Package and if Wire
                 then the doc being queued is an Individual Article.
-        :return: (list, list) List of filtered subscribers,
-                List of subscribers that have not received item previously (empty list in this case).
+        :return: (list, dict, dict) List of filtered subscribers, product codes per subscriber,
+                associations per subscriber
         """
 
-        subscribers, subscribers_yet_to_receive = [], []
         query = {'$and': [{'item_id': doc['item_id']},
                           {'publishing_action': {'$in': [CONTENT_STATE.PUBLISHED, CONTENT_STATE.CORRECTED]}}]}
-        subscribers, subscriber_codes = self._get_subscribers_for_previously_sent_items(query)
+        subscribers, subscriber_codes, associations = self._get_subscribers_for_previously_sent_items(query)
 
-        return subscribers, subscribers_yet_to_receive, subscriber_codes
+        return subscribers, subscriber_codes, associations
 
     def enqueue_archived_kill_item(self, item, transmission_details):
         """Enqueue items that are killed from dusty archive.

--- a/apps/publish/enqueue_service_tests.py
+++ b/apps/publish/enqueue_service_tests.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.tests import TestCase
+from .enqueue.enqueue_service import EnqueueService
+
+
+class EnqueueServiceTest(TestCase):
+    queue_items = [
+        {
+            "_id": 1,
+            "destination": {
+                "delivery_type": "ftp",
+                "config": {},
+                "name": "destination1"
+            },
+            "_etag": "f28b9af64f169072fb171ec7f316fc03d5826d6b",
+            "subscriber_id": "sub1",
+            "state": "pending",
+            "associated_items": ["123"],
+            "_created": "2015-04-17T13:15:20.000Z",
+            "_updated": "2015-04-20T05:04:25.000Z",
+            "item_id": '1',
+            "item_version": 1,
+            "publishing_action": "published"
+        },
+        {
+            "_id": 2,
+            "destination": {
+                "delivery_type": "ftp",
+                "config": {},
+                "name": "destination1"
+            },
+            "_etag": "f28b9af64f169072fb171ec7f316fc03d5826d6b",
+            "subscriber_id": "sub1",
+            "state": "pending",
+            "_created": "2015-04-17T13:15:20.000Z",
+            "_updated": "2015-04-20T05:04:25.000Z",
+            "item_id": '1',
+            "item_version": 1,
+            "publishing_action": "corrected",
+            "associated_items": ["123"]
+        },
+        {
+            "_id": 3,
+            "destination": {
+                "delivery_type": "ftp",
+                "config": {},
+                "name": "destination1"
+            },
+            "_etag": "f28b9af64f169072fb171ec7f316fc03d5826d6b",
+            "subscriber_id": "sub2",
+            "state": "pending",
+            "_created": "2015-04-17T13:15:20.000Z",
+            "_updated": "2015-04-20T05:04:25.000Z",
+            "item_id": '2',
+            "item_version": 1,
+            "publishing_action": "published",
+            "associated_items": ["123"]
+        },
+        {
+            "_id": 4,
+            "destination": {
+                "delivery_type": "content_api",
+                "format": "ninjs",
+                "config": {},
+                "name": "destination1"
+            },
+            "_etag": "f28b9af64f169072fb171ec7f316fc03d5826d6b",
+            "subscriber_id": "sub2",
+            "state": "success",
+            "_created": "2015-04-17T13:15:20.000Z",
+            "_updated": "2015-04-20T05:04:25.000Z",
+            "item_id": '2',
+            "item_version": 2,
+            "publishing_action": "corrected",
+            "associated_items": ["456"]
+        },
+        {
+            "_id": 5,
+            "destination": {
+                "delivery_type": "ftp",
+                "config": {},
+                "name": "destination1"
+            },
+            "_etag": "f28b9af64f169072fb171ec7f316fc03d5826d6b",
+            "subscriber_id": "sub3",
+            "state": "pending",
+            "_created": "2015-04-17T13:15:20.000Z",
+            "_updated": "2015-04-20T05:04:25.000Z",
+            "item_id": '3',
+            "item_version": 1,
+            "publishing_action": "published",
+            "associated_items": ["786"]
+        },
+        {
+            "_id": 6,
+            "destination": {
+                "delivery_type": "content_api",
+                "format": "ninjs",
+                "config": {},
+                "name": "destination1"
+            },
+            "_etag": "f28b9af64f169072fb171ec7f316fc03d5826d6b",
+            "subscriber_id": "sub3",
+            "state": "success",
+            "_created": "2015-04-17T13:15:20.000Z",
+            "_updated": "2015-04-20T05:04:25.000Z",
+            "item_id": '3',
+            "item_version": 2,
+            "publishing_action": "corrected"
+        },
+        {
+            "_id": 7,
+            "destination": {
+                "delivery_type": "ftp",
+                "config": {},
+                "name": "destination1"
+            },
+            "_etag": "f28b9af64f169072fb171ec7f316fc03d5826d6b",
+            "subscriber_id": "sub4",
+            "state": "pending",
+            "_created": "2015-04-17T13:15:20.000Z",
+            "_updated": "2015-04-20T05:04:25.000Z",
+            "item_id": '2',
+            "item_version": 1,
+            "publishing_action": "published",
+            "associated_items": ["123"]
+        },
+        {
+            "_id": 8,
+            "destination": {
+                "delivery_type": "content_api",
+                "format": "ninjs",
+                "config": {},
+                "name": "destination1"
+            },
+            "_etag": "f28b9af64f169072fb171ec7f316fc03d5826d6b",
+            "subscriber_id": "sub4",
+            "state": "success",
+            "_created": "2015-04-17T13:15:20.000Z",
+            "_updated": "2015-04-20T05:04:25.000Z",
+            "item_id": '2',
+            "item_version": 2,
+            "publishing_action": "corrected",
+            "associated_items": ["456"]
+        },
+        {
+            "_id": 9,
+            "destination": {
+                "delivery_type": "content_api",
+                "format": "ninjs",
+                "config": {},
+                "name": "destination1"
+            },
+            "_etag": "f28b9af64f169072fb171ec7f316fc03d5826d6b",
+            "subscriber_id": "sub5",
+            "state": "success",
+            "_created": "2015-04-17T13:15:20.000Z",
+            "_updated": "2015-04-20T05:04:25.000Z",
+            "item_id": '5',
+            "item_version": 1,
+            "publishing_action": "published"
+        }
+    ]
+
+    def setUp(self):
+        with self.app.app_context():
+            self.app.data.insert('publish_queue', self.queue_items)
+
+    def test_previously_sent_item_association_for_one_subscriber(self):
+        service = EnqueueService()
+        subscribers, subscriber_codes, associated_items = \
+            service._get_subscribers_for_previously_sent_items({'item_id': '1'})
+        self.assertEqual(len(associated_items.keys()), 1)
+        self.assertIn('sub1', list(associated_items.keys()))
+        self.assertIn('123', associated_items['sub1'])
+
+    def test_previously_sent_item_association_for_multiple_subscribers(self):
+        service = EnqueueService()
+        subscribers, subscriber_codes, associated_items = \
+            service._get_subscribers_for_previously_sent_items({'item_id': '2'})
+        self.assertEqual(len(associated_items.keys()), 2)
+        self.assertIn('sub2', associated_items)
+        self.assertIn('sub4', associated_items)
+        self.assertIn('123', associated_items['sub2'])
+        self.assertIn('456', associated_items['sub2'])
+        self.assertIn('123', associated_items['sub4'])
+        self.assertIn('456', associated_items['sub4'])
+
+    def test_previously_sent_item_association_for_removed_associations(self):
+        service = EnqueueService()
+        subscribers, subscriber_codes, associated_items = \
+            service._get_subscribers_for_previously_sent_items({'item_id': '3'})
+        self.assertEqual(len(associated_items.keys()), 1)
+        self.assertIn('sub3', list(associated_items.keys()))
+        self.assertIn('786', associated_items['sub3'])
+
+    def test_previously_sent_item_association_for_no_associations(self):
+        service = EnqueueService()
+        subscribers, subscriber_codes, associated_items = \
+            service._get_subscribers_for_previously_sent_items({'item_id': '5'})
+        self.assertEqual(len(associated_items.keys()), 0)

--- a/content_api/items/service.py
+++ b/content_api/items/service.py
@@ -223,9 +223,17 @@ class ItemsService(BaseService):
 
     def _process_item_associations(self, item):
         hrefs = {}
+        allowed_items = {}
         if item.get('associations'):
             for _k, v in item.get('associations', {}).items():
-                hrefs.update(self._process_item_renditions(v))
+                # only allow subscribers
+                if g.get('user') in v.get('subscribers', []):
+                    hrefs.update(self._process_item_renditions(v))
+                    v.pop('subscribers', None)
+                    allowed_items[_k] = v
+
+        item['associations'] = allowed_items
+
         if item.get('body_html'):
             for k, v in hrefs.items():
                 item['body_html'] = item['body_html'].replace(k, v)

--- a/features/content_publish.feature
+++ b/features/content_publish.feature
@@ -472,7 +472,8 @@ Feature: Content Publishing
       ]}
       """
       When we get "/items/123"
-      Then we get error 404
+      Then we get OK response
+      Then we assert the content api item "123" is not published to any subscribers
       When we publish "456" with "publish" type and "published" state
       Then we get OK response
       When we get "/published"

--- a/features/publish_embedded.feature
+++ b/features/publish_embedded.feature
@@ -1,65 +1,164 @@
 Feature: Publish embedded items feature
-
-    @auth
-    Scenario: Publish embedded picture together with text item
-        Given "vocabularies"
-        """
-        [{"_id": "crop_sizes", "items": [{"is_active": true, "name": "3:2", "width": 3, "height": 2}]}]
-        """
-        Given "validators"
-        """
-        [
-            {
-                "_id": "publish_text",
-                "act": "publish",
-                "type": "text",
-                "schema": {
-                    "headline": {"type": "string",
-                        "required": true,
-                        "nullable": false,
-                        "empty": false,
-                        "maxlength": 42
-                    }
-                }
-            },
-            {
-                "_id": "publish_embedded_picture",
-                "act": "publish",
-                "type": "picture",
-                "embedded": true,
-                "schema": {
-                    "type": {
-                        "type": "string",
-                        "required": "true",
-                        "allowed": ["picture"]
-                    },
-                    "pubstatus": {
-                        "type": "string",
-                        "required": true,
-                        "allowed": ["usable"]
-                    },
-                    "slugline": {
-                        "type": "string",
-                        "required": true,
-                        "nullable": false,
-                        "empty": false,
-                        "maxlength": 24
-                    }
+  Background: Setup data
+    Given "desks"
+    """
+    [{"name": "Sports", "members": [{"user": "#CONTEXT_USER_ID#"}], "source": "foo"}]
+    """
+    And "validators"
+    """
+    [
+        {
+            "_id": "publish_text",
+            "act": "publish",
+            "type": "text",
+            "schema": {
+                "headline": {"type": "string",
+                    "required": true,
+                    "nullable": false,
+                    "empty": false,
+                    "maxlength": 42
                 }
             }
-        ]
-        """
-        Given "desks"
-        """
-        [{"name": "sports"}]
-        """
+        },
+        {
+            "_id": "publish_embedded_picture",
+            "act": "publish",
+            "type": "picture",
+            "embedded": true,
+            "schema": {
+                "type": {
+                    "type": "string",
+                    "required": "true",
+                    "allowed": ["picture"]
+                },
+                "pubstatus": {
+                    "type": "string",
+                    "required": true,
+                    "allowed": ["usable"]
+                },
+                "slugline": {
+                    "type": "string",
+                    "required": true,
+                    "nullable": false,
+                    "empty": false,
+                    "maxlength": 24
+                }
+            }
+        },
+        {
+            "_id": "correct_text",
+            "act": "correct",
+            "type": "text",
+            "schema": {
+                "headline": {"type": "string",
+                    "required": true,
+                    "nullable": false,
+                    "empty": false,
+                    "maxlength": 42
+                }
+            }
+        },
+        {
+            "_id": "correct_embedded_picture",
+            "act": "correct",
+            "type": "picture",
+            "embedded": true,
+            "schema": {
+                "type": {
+                    "type": "string",
+                    "required": "true",
+                    "allowed": ["picture"]
+                },
+                "pubstatus": {
+                    "type": "string",
+                    "required": true,
+                    "allowed": ["usable"]
+                },
+                "slugline": {
+                    "type": "string",
+                    "required": true,
+                    "nullable": false,
+                    "empty": false,
+                    "maxlength": 24
+                }
+            }
+        }
+    ]
+    """
+    And "filter_conditions"
+    """
+    [
+    {"_id": "source-foo", "name": "source-foo", "field": "source", "operator": "eq", "value": "foo"},
+    {"_id": "source-aap", "name": "source-aap", "field": "source", "operator": "eq", "value": "AAP"},
+    {"_id": "type-text", "name": "type-text", "field": "type", "operator": "eq", "value": "text"},
+    {"_id": "type-picture", "name": "type-picture", "field": "type", "operator": "eq", "value": "picture"}
+    ]
+    """
+    And "content_filters"
+    """
+    [
+    {"content_filter": [{"expression": {"fc": ["source-foo", "type-text"]}}], "name": "text-source-foo", "_id": "text-source-foo"},
+    {"content_filter": [{"expression": {"fc": ["source-aap", "type-picture"]}}], "name": "pic-source-aap", "_id": "pic-source-aap"},
+    {"content_filter": [{"expression": {"fc": ["type-text"]}}], "name": "type-text", "_id": "type-text"},
+    {"content_filter": [{"expression": {"fc": ["type-picture"]}}], "name": "type-picture", "_id": "type-picture"}
+    ]
+    """
+    And "products"
+    """
+    [{"_id": "text-source-foo", "name":"text-source-foo",
+     "content_filter":{"filter_id":"text-source-foo", "filter_type": "permitting"}, "product_type": "both"},
+     {"_id": "pic-source-aap", "name":"pic-source-aap",
+     "content_filter":{"filter_id":"pic-source-aap", "filter_type": "permitting"}, "product_type": "both"},
+     {"_id": "58f6120488ea94d000369a32", "name":"type-text",
+     "content_filter":{"filter_id":"type-text", "filter_type": "permitting"}, "product_type": "both"},
+     {"_id": "type-picture", "name":"type-picture",
+     "content_filter":{"filter_id":"type-picture", "filter_type": "permitting"}, "product_type": "both"}
+    ]
+    """
+    And "subscribers"
+    """
+    [{
+      "_id": "58f6110d88ea94d000369a2f",
+      "name":"Channel 1",
+      "media_type": "media",
+      "subscriber_type": "wire",
+      "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
+      "products": ["text-source-foo"],
+      "codes": "Aaa",
+      "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}],
+      "api_products": ["text-source-foo"]
+    },
+    {
+      "_id": "58f6113988ea94d000369a30",
+      "name":"Channel 2",
+      "media_type":"media",
+      "subscriber_type": "wire",
+      "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
+      "products": ["pic-source-aap"],
+      "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}]
+    },
+    {
+      "_id": "58f6115b88ea94d000369a31",
+      "name":"Channel 3",
+      "media_type":"media",
+      "subscriber_type": "wire",
+      "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
+      "api_products": ["58f6120488ea94d000369a32", "pic-source-aap"]
+    }]
+    """
+    And "vocabularies"
+    """
+    [{"_id": "crop_sizes", "items": [{"is_active": true, "name": "3:2", "width": 3, "height": 2}]}]
+    """
 
+    @auth
+    @vocabulary
+    Scenario: Publish embedded picture together with text item
         When we post to "archive"
         """
-        {"type": "text", "task": {"desk": "#desks._id#"}, "guid": "foo"}
+        {"type": "text", "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}, "guid": "foo"}
         """
         Then we get OK response
-
         When we upload a file "bike.jpg" to "archive"
         Then we get OK response
 
@@ -93,62 +192,197 @@ Feature: Publish embedded items feature
         {"headline": "foo", "associations": {"embedded1": {"_id": "#archive._id#", "type": "picture", "headline": "test", "state": "draft"}}}
         """
         Then we get OK response
-
+        When we get "published"
+        Then we get list with 2 items
+        When we get "publish_queue"
+        Then we get list with 3 items
+        """
+        {"_items": [
+        {"subscriber_id": "58f6115b88ea94d000369a31", "destination": {"delivery_type" : "content_api"}},
+        {"subscriber_id": "58f6110d88ea94d000369a2f", "destination": {"delivery_type" : "content_api"}},
+        {"subscriber_id": "58f6110d88ea94d000369a2f", "destination": {"delivery_type" : "email"}}
+        ]}
+        """
+        When we get "/items/foo"
+        Then we get OK response
+        Then we assert the content api item "foo" is published to subscriber "58f6110d88ea94d000369a2f"
+        Then we assert the content api item "foo" is published to subscriber "58f6115b88ea94d000369a31"
+        Then we assert the content api item "foo" is not published to subscriber "58f6113988ea94d000369a30"
+        Then we assert content api item "foo" with associated item "embedded1" is published to "58f6115b88ea94d000369a31"
+        Then we assert content api item "foo" with associated item "embedded1" is not published to "58f6110d88ea94d000369a2f"
 
     @auth
-    Scenario: Publish embedded picture together with text item with copy metadata from text item
-        Given "vocabularies"
+    @vocabulary
+    Scenario: Publish embedded picture together with text item and correct the item
+        When we post to "archive"
         """
-        [{"_id": "crop_sizes", "items": [{"is_active": true, "name": "3:2", "width": 3, "height": 2}]}]
+        {"type": "text", "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}, "guid": "foo"}
         """
-        Given "validators"
+        Then we get OK response
+        When we upload a file "bike.jpg" to "archive"
+        Then we get OK response
+
+        When we patch "archive/foo"
         """
-        [
-            {
-                "_id": "publish_text",
-                "act": "publish",
-                "type": "text",
-                "schema": {
-                    "headline": {"type": "string",
-                        "required": true,
-                        "nullable": false,
-                        "empty": false,
-                        "maxlength": 42
-                    }
-                }
-            },
-            {
-                "_id": "publish_embedded_picture",
-                "act": "publish",
-                "type": "picture",
-                "embedded": true,
-                "schema": {
-                    "type": {
-                        "type": "string",
-                        "required": "true",
-                        "allowed": ["picture"]
-                    },
-                    "pubstatus": {
-                        "type": "string",
-                        "required": true,
-                        "allowed": ["usable"]
-                    },
-                    "slugline": {
-                        "type": "string",
-                        "required": true,
-                        "nullable": false,
-                        "empty": false,
-                        "maxlength": 24
-                    }
-                }
-            }
-        ]
+        {"headline": "foo",
+        "slugline": "bar",
+        "state": "in_progress",
+        "associations": {"embedded1":
+        {"_id": "#archive._id#",
+         "type": "picture",
+         "headline": "test",
+         "state": "draft"}}}
         """
-        Given "desks"
+        Then we get OK response
+
+        When we publish "foo" with "publish" type and "published" state
+        Then we get error 400
         """
-        [{"name": "sports"}]
+        {"_issues": {"validator exception": "['Associated item  test: SLUGLINE is a required field']"}}
         """
 
+        When we patch "archive/#archive._id#"
+        """
+        {"slugline": "bike"}
+        """
+        Then we get OK response
+
+        When we publish "foo" with "publish" type and "published" state
+        """
+        {"headline": "foo", "associations": {"embedded1": {"_id": "#archive._id#", "type": "picture", "headline": "test", "state": "draft"}}}
+        """
+        Then we get OK response
+        When we get "published"
+        Then we get list with 2 items
+        When we get "publish_queue"
+        Then we get list with 3 items
+        """
+        {"_items": [
+        {"subscriber_id": "58f6115b88ea94d000369a31", "destination": {"delivery_type" : "content_api"}},
+        {"subscriber_id": "58f6110d88ea94d000369a2f", "destination": {"delivery_type" : "content_api"}},
+        {"subscriber_id": "58f6110d88ea94d000369a2f", "destination": {"delivery_type" : "email"}}
+        ]}
+        """
+        When we get "/items/foo"
+        Then we get OK response
+        Then we assert the content api item "foo" is published to subscriber "58f6110d88ea94d000369a2f"
+        Then we assert the content api item "foo" is published to subscriber "58f6115b88ea94d000369a31"
+        Then we assert the content api item "foo" is not published to subscriber "58f6113988ea94d000369a30"
+        Then we assert content api item "foo" with associated item "embedded1" is published to "58f6115b88ea94d000369a31"
+        Then we assert content api item "foo" with associated item "embedded1" is not published to "58f6110d88ea94d000369a2f"
+        When we patch "/subscribers/58f6115b88ea94d000369a31"
+        """
+        {"api_products": ["58f6120488ea94d000369a32"]}
+        """
+        Then we get OK response
+        When we publish "foo" with "correct" type and "corrected" state
+        """
+        {"headline": "foo corrected"}
+        """
+        Then we get OK response
+        When we get "published"
+        Then we get list with 4 items
+        When we get "publish_queue"
+        Then we get list with 6 items
+        When we get "/items/foo"
+        Then we get OK response
+        Then we assert the content api item "foo" is published to subscriber "58f6110d88ea94d000369a2f"
+        Then we assert the content api item "foo" is published to subscriber "58f6115b88ea94d000369a31"
+        Then we assert the content api item "foo" is not published to subscriber "58f6113988ea94d000369a30"
+        Then we assert content api item "foo" with associated item "embedded1" is published to "58f6115b88ea94d000369a31"
+        Then we assert content api item "foo" with associated item "embedded1" is not published to "58f6110d88ea94d000369a2f"
+
+    @auth
+    @vocabulary
+    Scenario: Publish embedded picture together with text item and resend to another subscriber
+        When we post to "archive"
+        """
+        {"type": "text", "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}, "guid": "foo"}
+        """
+        Then we get OK response
+        When we upload a file "bike.jpg" to "archive"
+        Then we get OK response
+
+        When we patch "archive/foo"
+        """
+        {"headline": "foo",
+        "slugline": "bar",
+        "state": "in_progress",
+        "associations": {"embedded1":
+        {"_id": "#archive._id#",
+         "type": "picture",
+         "headline": "test",
+         "state": "draft"}}}
+        """
+        Then we get OK response
+
+        When we publish "foo" with "publish" type and "published" state
+        Then we get error 400
+        """
+        {"_issues": {"validator exception": "['Associated item  test: SLUGLINE is a required field']"}}
+        """
+
+        When we patch "archive/#archive._id#"
+        """
+        {"slugline": "bike"}
+        """
+        Then we get OK response
+
+        When we publish "foo" with "publish" type and "published" state
+        """
+        {"headline": "foo", "associations": {"embedded1": {"_id": "#archive._id#", "type": "picture", "headline": "test", "state": "draft"}}}
+        """
+        Then we get OK response
+        When we get "published"
+        Then we get list with 2 items
+        When we get "publish_queue"
+        Then we get list with 3 items
+        """
+        {"_items": [
+        {"subscriber_id": "58f6115b88ea94d000369a31", "destination": {"delivery_type" : "content_api"}},
+        {"subscriber_id": "58f6110d88ea94d000369a2f", "destination": {"delivery_type" : "content_api"}},
+        {"subscriber_id": "58f6110d88ea94d000369a2f", "destination": {"delivery_type" : "email"}}
+        ]}
+        """
+        When we get "/items/foo"
+        Then we get OK response
+        Then we assert the content api item "foo" is published to subscriber "58f6110d88ea94d000369a2f"
+        Then we assert the content api item "foo" is published to subscriber "58f6115b88ea94d000369a31"
+        Then we assert the content api item "foo" is not published to subscriber "58f6113988ea94d000369a30"
+        Then we assert content api item "foo" with associated item "embedded1" is published to "58f6115b88ea94d000369a31"
+        Then we assert content api item "foo" with associated item "embedded1" is not published to "58f6110d88ea94d000369a2f"
+        When we post to "subscribers" with "sub-4" and success
+        """
+        [{
+          "name":"Channel 4",
+          "media_type":"media",
+          "subscriber_type": "wire",
+          "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
+          "api_products": ["58f6120488ea94d000369a32"]
+        }]
+        """
+        Then we get OK response
+        When we post to "/archive/foo/resend"
+        """
+        {
+          "subscribers": ["#subscribers._id#"],
+          "version": 3
+        }
+        """
+        Then we get OK response
+        When we get "/items/foo"
+        Then we get OK response
+        Then we assert the content api item "foo" is published to subscriber "58f6110d88ea94d000369a2f"
+        Then we assert the content api item "foo" is published to subscriber "58f6115b88ea94d000369a31"
+        Then we assert the content api item "foo" is published to subscriber "#subscribers._id#"
+        Then we assert the content api item "foo" is not published to subscriber "58f6113988ea94d000369a30"
+        Then we assert content api item "foo" with associated item "embedded1" is published to "58f6115b88ea94d000369a31"
+        Then we assert content api item "foo" with associated item "embedded1" is published to "#subscribers._id#"
+        Then we assert content api item "foo" with associated item "embedded1" is not published to "58f6110d88ea94d000369a2f"
+
+    @auth
+    @vocabulary
+    Scenario: Publish embedded picture together with text item with copy metadata from text item
         When we post to "archive"
         """
         {"type": "text", "task": {"desk": "#desks._id#"}, "guid": "foo", "slugline": "text item slugline"}
@@ -175,3 +409,5 @@ Feature: Publish embedded items feature
         {"headline": "foo", "associations": {"embedded1": {"_id": "#archive._id#", "slugline": "text item slugline", "type": "picture", "headline": "test", "state": "draft"}}}
         """
         Then we get OK response
+
+

--- a/features/resend.feature
+++ b/features/resend.feature
@@ -715,14 +715,14 @@ Feature: Resend
         "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}]
       }
     """
-    When we post to "/archive/#archive._id#/resend"
-    """
-    {
-      "subscribers": ["#subscribers._id#"],
-      "version": 4
-    }
-    """
-    Then we get OK response
+      When we post to "/archive/#archive._id#/resend"
+      """
+      {
+        "subscribers": ["#subscribers._id#"],
+        "version": 4
+      }
+      """
+      Then we get OK response
     When we get "/publish_queue"
     Then we get list with 2 items
     """

--- a/features/targeted_publishing.feature
+++ b/features/targeted_publishing.feature
@@ -126,6 +126,10 @@ Feature: Targeted Publishing
         ]
     }
     """
+    When we get "/items/123"
+    Then we get OK response
+    Then we assert the content api item "123" is not published to subscriber "sub-4"
+    Then we assert the content api item "123" is published to subscriber "sub-4-api"
 
   @auth @notification
   Scenario: Publish a story to a target region with negation
@@ -160,6 +164,15 @@ Feature: Targeted Publishing
         ]
     }
     """
+    When we get "/items/123"
+    Then we get OK response
+    Then we assert the content api item "123" is not published to subscriber "sub-4"
+    Then we assert the content api item "123" is not published to subscriber "sub-2"
+    Then we assert the content api item "123" is not published to subscriber "sub-1"
+    Then we assert the content api item "123" is not published to subscriber "sub-3"
+    Then we assert the content api item "123" is not published to subscriber "sub-5"
+    Then we assert the content api item "123" is published to subscriber "sub-4-api"
+    Then we assert the content api item "123" is published to subscriber "sub-2-api"
 
   @auth @notification
   Scenario: Publish a story to a target region doesn't publish if no product
@@ -183,7 +196,9 @@ Feature: Targeted Publishing
     When we enqueue published
     And we get "/publish_queue"
     Then we get list with 0 items
-
+    When we get "/items/123"
+    Then we get OK response
+    Then we assert the content api item "123" is not published to any subscribers
 
 
   @auth @notification
@@ -216,6 +231,10 @@ Feature: Targeted Publishing
         ]
     }
     """
+    When we get "/items/123"
+    Then we get OK response
+    Then we assert the content api item "123" is not published to any subscribers
+
 
   @auth @notification
   Scenario: Publish a story to a target subscriber type
@@ -247,6 +266,9 @@ Feature: Targeted Publishing
         ]
     }
     """
+    When we get "/items/123"
+    Then we get OK response
+    Then we assert the content api item "123" is not published to any subscribers
 
   @auth @notification
   Scenario: Publish a story to target subscribers even no products
@@ -280,7 +302,9 @@ Feature: Targeted Publishing
         ]
     }
     """
-
+    When we get "/items/123"
+    Then we get OK response
+    Then we assert the content api item "123" is not published to any subscribers
 
   @auth @notification
   Scenario: Publish a story to target subscribers and region
@@ -315,6 +339,11 @@ Feature: Targeted Publishing
         ]
     }
     """
+    When we get "/items/123"
+    Then we get OK response
+    Then we assert the content api item "123" is published to subscriber "sub-4-api"
+    Then we assert the content api item "123" is not published to subscriber "sub-4"
+    Then we assert the content api item "123" is not published to subscriber "sub-3"
 
   @auth @notification
   Scenario: Correct a targeted story with a added target ignores the change

--- a/superdesk/publish/publish_queue.py
+++ b/superdesk/publish/publish_queue.py
@@ -103,7 +103,8 @@ class PublishQueueResource(Resource):
         'next_retry_attempt_at': {
             'type': 'datetime'
         },
-        'ingest_provider': Resource.rel('ingest_providers', nullable=True)
+        'ingest_provider': Resource.rel('ingest_providers', nullable=True),
+        'associated_items': {'type': 'list', 'nullable': True}
     }
 
     additional_lookup = {

--- a/tests/enqueue_test.py
+++ b/tests/enqueue_test.py
@@ -28,6 +28,8 @@ class NoTakesEnqueueTestCase(TestCase):
         subscribers = [s for s in self.app.data.find_all('subscribers')]
         subscriber_codes = self.service._get_subscriber_codes(subscribers)
         with patch.object(self.service, '_resend_to_subscribers') as resend:
-            with patch.dict('apps.publish.enqueue.enqueue_service.app.config', {'NO_TAKES': True}):
-                self.service.resend(doc, subscribers)
-            resend.assert_called_with(doc, subscribers, subscriber_codes)
+            with patch.object(self.service, 'publish_content_api') as content_api:
+                with patch.dict('apps.publish.enqueue.enqueue_service.app.config', {'NO_TAKES': True}):
+                    self.service.resend(doc, subscribers)
+                resend.assert_called_with(doc, subscribers, subscriber_codes, {})
+                content_api.assert_called_with(doc, [])


### PR DESCRIPTION
- Filters are applied to associated item (featuremedia) to identify if it can be delivered to the subscriber or not. Currently, the block is applied on content api only but individual formatters can be modified to include or exclude associated item.
