### PR TITLE
fix(schema): disable dynamic elastic mapping for associations

### DIFF
--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -346,6 +346,10 @@ metadata_schema = {
     },
     ASSOCIATIONS: {
         'type': 'dict',
+        'mapping': {
+            'dynamic': False,
+            'type': 'object',
+        }
     },
     'alt_text': {
         'type': 'string',


### PR DESCRIPTION
otherwise it would update mapping for every item embedded, which would create **large** mapping over time and where cluster mapping sync takes forever on item update.. no good