### PR TITLE
[SDESK-1206] [SDESK-1178] - Deleted and disabled content profiles

### DIFF
--- a/apps/desks.py
+++ b/apps/desks.py
@@ -468,3 +468,16 @@ class SluglineDeskService(BaseService):
                 else:
                     return (True, [])
         return (False, older_sluglines)
+
+
+def remove_profile_from_desks(item):
+    """Removes the profile data from desks that are using the profile
+
+    :param item: deleted content profile
+    """
+    req = ParsedRequest()
+    desks = list(superdesk.get_resource_service('desks').get(req=req, lookup={}))
+    for desk in desks:
+        if desk.get('default_content_profile') == str(item.get(config.ID_FIELD)):
+            desk['default_content_profile'] = None
+            superdesk.get_resource_service('desks').patch(desk[config.ID_FIELD], desk)

--- a/features/templates.feature
+++ b/features/templates.feature
@@ -508,3 +508,85 @@ Feature: Templates
         """
         {"_items": [{"template_name": "foo", "template_type": "create", "is_public": true, "data": {"profile": "#content_types._id#"}}]}
         """
+        When we post to "/desks"
+        """
+        {"name": "Sports Desk", "default_content_profile": "#content_types._id#"}
+        """
+        When we delete "content_types/#content_types._id#"
+        Then we get response code 204
+        When we get "content_templates"
+        Then we get list with 1 items
+        And there is no "profile" in data
+        When we get "/desks/#desks._id#"
+        Then we get existing resource
+        """
+        {"default_content_profile": "__none__"}
+        """
+
+    @auth
+    Scenario: Changing content profile removes unnecessary fields
+        Given "content_types"
+        """
+        [{
+            "_id": "foo",
+            "label": "Foo",
+            "schema": {
+                "headline": {
+                    "maxlength" : 64,
+                    "type" : "string",
+                    "required" : false,
+                    "nullable" : true
+                },
+                "slugline" : {
+                    "type" : "string",
+                    "nullable" : true,
+                    "maxlength" : 24,
+                    "required" : false
+                }
+            }
+        }, {
+            "_id": "bar",
+            "label": "Bar",
+            "schema": {
+                "headline": {
+                    "maxlength" : 64,
+                    "type" : "string",
+                    "required" : false,
+                    "nullable" : true
+                }
+            }
+        }]
+        """
+        And "content_templates"
+        """
+        [{
+            "template_name": "foo",
+            "data": {
+                "slugline": "Testing the slugline",
+                "headline": "Testing the headline",
+                "profile": "foo"
+            }
+        }]
+        """
+        When we patch "content_templates/foo"
+        """
+        {"data": {
+                "slugline": "Testing the slugline",
+                "headline": "Testing the headline",
+                "profile": "bar"
+        }}
+        """
+        Then we get OK response
+        When we get "content_templates"
+        Then we get list with 1 items
+        """
+        {"_items": [{
+            "template_name": "foo",
+            "data": {
+                "headline": "Testing the headline",
+                "slugline": "",
+                "profile": "bar"
+            }
+          }]
+        }
+        """

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -2017,6 +2017,12 @@ def there_is_no_key_in_preferences(context, key):
     assert key not in data, 'key "%s" is in task' % key
 
 
+@then('there is no "{key}" in data')
+def there_is_no_profile_in_data(context, key):
+    data = get_json_data(context.response)['_items'][0]['data']
+    assert key not in data, 'key "%s" is in data' % key
+
+
 @then('broadcast "{key}" has value "{value}"')
 def broadcast_key_has_value(context, key, value):
     data = get_json_data(context.response).get('broadcast', {})


### PR DESCRIPTION
- [x] Deleting a content profile will remove profile data from template
- [x] Deleting a content profile will remove default_content_profile from desks
- [x] Content profile won't be disabled (as this creates issues in templates and desk i.e. fetched stories)
- [x] Remove the value from referencing templates if a field is removed from content profile
- [x] Remove the values of missing fields in template if content profile field of the template is changed


