### PR TITLE
Fix pydocstyle version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ flake8-docstrings
 nose
 pep8
 pyflakes
-pydocstyle==1.0.0
+pydocstyle
 httmock
 wooper
 sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ flake8-docstrings
 nose
 pep8
 pyflakes
-pydocstyle==1.0.0
+pydocstyle
 httmock
 wooper
 sphinx


### PR DESCRIPTION
Fix for new error in CI:
```
+ flake8 --jobs=1
Traceback (most recent call last):
  File "/opt/superdesk/env/bin/flake8", line 11, in <module>
    sys.exit(main())
  File "/opt/superdesk/env/lib/python3.5/site-packages/flake8/main/cli.py", line 16, in main
    app.run(argv)
  File "/opt/superdesk/env/lib/python3.5/site-packages/flake8/main/application.py", line 328, in run
    self._run(argv)
  File "/opt/superdesk/env/lib/python3.5/site-packages/flake8/main/application.py", line 316, in _run
    self.run_checks()
  File "/opt/superdesk/env/lib/python3.5/site-packages/flake8/main/application.py", line 246, in run_checks
    self.file_checker_manager.run()
  File "/opt/superdesk/env/lib/python3.5/site-packages/flake8/checker.py", line 319, in run
    self.run_serial()
  File "/opt/superdesk/env/lib/python3.5/site-packages/flake8/checker.py", line 303, in run_serial
    checker.run_checks()
  File "/opt/superdesk/env/lib/python3.5/site-packages/flake8/checker.py", line 573, in run_checks
    self.run_ast_checks()
  File "/opt/superdesk/env/lib/python3.5/site-packages/flake8/checker.py", line 480, in run_ast_checks
    checker = self.run_check(plugin, tree=ast)
  File "/opt/superdesk/env/lib/python3.5/site-packages/flake8/checker.py", line 429, in run_check
    return plugin['plugin'](**arguments)
  File "/opt/superdesk/env/lib/python3.5/site-packages/flake8_docstrings.py", line 53, in __init__
    self.checker = pep257.ConventionChecker()
AttributeError: module 'pydocstyle' has no attribute 'ConventionChecker'
```
Because https://gitlab.com/pycqa/flake8-docstrings/blob/master/HISTORY.rst
```
1.1.0
Upgrade dependency on pydocstyle to 2.0.0
```