### PR TITLE
[FEED PARSER] [WORDPRESS WXR] transform CRLF to HTML <p> paragraphs

### DIFF
--- a/superdesk/io/feed_parsers/wordpress_wxr.py
+++ b/superdesk/io/feed_parsers/wordpress_wxr.py
@@ -111,6 +111,13 @@ class WPWXRFeedParser(XMLFeedParser):
         if img are found in the content, they are uploaded.
         First image is used as feature media, then there are embeds
         """
+        # we need to convert CRLF to <p>
+        # cf. SDTS-22
+        html = html.replace('&#13;', '\r')
+        splitted = html.split('\r\n')
+        if len(splitted) > 1:
+            html = ''.join(['<p>{}</p>'.format(s) if not s.startswith('<hr') else s for s in splitted if s])
+
         if "img" in html:
             content = sd_etree.parse_html(html, 'html')
             for img in content.xpath('//img'):

--- a/superdesk/io/importers/__init__.py
+++ b/superdesk/io/importers/__init__.py
@@ -42,8 +42,10 @@ class ImportCommand(superdesk.Command):
                 profile_id = content_profile['_id']
 
         with open(path, 'rb') as f:
+            buf = f.read()
+            buf = buf.replace(b'\r', b'&#13;')
             parser = etree.XMLParser(recover=True)
-            parsed = etree.parse(f, parser)
+            parsed = etree.fromstring(buf, parser)
         articles = feed_parser.parse(parsed)
         if profile is not None:
             for article in articles:

--- a/tests/io/fixtures/wordpress_wxr.xml
+++ b/tests/io/fixtures/wordpress_wxr.xml
@@ -37,9 +37,9 @@
 		<dc:creator><![CDATA[admin]]></dc:creator>
 		<guid isPermaLink="false">http://sdnewtester.org/?p=216</guid>
 		<description></description>
-		<content:encoded><![CDATA[By Tester
+		<content:encoded><![CDATA[<p>By Tester
 Harare, July 19 (The SDNewTester) - Cash-strapped StarAfrica Corporation is set to dispose its transport company and its stake in Tongaat Hulett Botswana for $6 million to offset part of the companyâs $19.7 million debt.
-Bla bla test]]></content:encoded>
+Bla bla test</p>]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
 		<wp:post_id>216</wp:post_id>
 		<wp:post_date><![CDATA[2013-07-29 18:03:54]]></wp:post_date>
@@ -73,6 +73,36 @@ Bla bla test]]></content:encoded>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
 		<wp:ping_status><![CDATA[open]]></wp:ping_status>
 		<wp:post_name><![CDATA[test2]]></wp:post_name>
+		<wp:status><![CDATA[inherit]]></wp:status>
+		<wp:post_parent>0</wp:post_parent>
+		<wp:menu_order>0</wp:menu_order>
+		<wp:post_type><![CDATA[attachment]]></wp:post_type>
+		<wp:post_password><![CDATA[]]></wp:post_password>
+		<wp:is_sticky>0</wp:is_sticky>
+		<wp:attachment_url><![CDATA[http://example.net/image.png]]></wp:attachment_url>
+		<wp:postmeta>
+			<wp:meta_key><![CDATA[_wp_attached_file]]></wp:meta_key>
+			<wp:meta_value><![CDATA[image.png]]></wp:meta_value>
+		</wp:postmeta>
+	</item>
+	<item>
+		<title>test3</title>
+		<link>http://bla</link>
+		<pubDate>Sun, 07 Jul 3013 15:06:01 +0000</pubDate>
+		<dc:creator><![CDATA[admin]]></dc:creator>
+		<guid isPermaLink="false">http://sdnewtester.org/?p=test3</guid>
+		<description></description>
+		<content:encoded><![CDATA[By Tester
+Harare, July 19 (The SDNewTester) - Cash-strapped StarAfrica Corporation is set to dispose its transport company and its stake in Tongaat Hulett Botswana for $6 million to offset part of the companyâs $19.7 million debt.
+<hr>
+Bla bla test]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:post_id>9</wp:post_id>
+		<wp:post_date><![CDATA[3013-07-07 15:06:01]]></wp:post_date>
+		<wp:post_date_gmt><![CDATA[3013-07-07 15:06:01]]></wp:post_date_gmt>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:ping_status><![CDATA[open]]></wp:ping_status>
+		<wp:post_name><![CDATA[test3]]></wp:post_name>
 		<wp:status><![CDATA[inherit]]></wp:status>
 		<wp:post_parent>0</wp:post_parent>
 		<wp:menu_order>0</wp:menu_order>


### PR DESCRIPTION
Some <p> elements were missing in imported items, but they are not found
in source WXR file. It seems that Wordpress is transforming text blocks
separated by CRLF to HTML <p> elements, which is an undocumented feature.

This commit do that, and modify the importer so Carriage Return is kept
(else lxml will convert them, according to XML specifications).
If <hr> is found on a line, it will not be wrapped in <p> element.

fixes second issue in SDTS-22