### PR TITLE
fix(unlock): it requires privileges to modify unique name

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -695,7 +695,8 @@ class ArchiveService(BaseService):
             raise SuperdeskApiError.badRequestError("Package doesn't support Public Service Announcements")
 
         if 'unique_name' in updates and not is_admin(user) \
-                and (user['active_privileges'].get('metadata_uniquename', 0) == 0):
+                and (user['active_privileges'].get('metadata_uniquename', 0) == 0) \
+                and not force_unlock:
             raise SuperdeskApiError.forbiddenError("Unauthorized to modify Unique Name")
 
         # if broadcast then update to genre is not allowed.

--- a/features/content_lock.feature
+++ b/features/content_lock.feature
@@ -219,7 +219,7 @@ Feature: Content Locking
 
         When we post to "/archive_autosave"
         """
-        {"_id": "item-1", "guid": "item-1", "body_html": "autosaved"}
+        {"_id": "item-1", "guid": "item-1", "body_html": "autosaved", "unique_name": "foo"}
         """
         Then we get new resource
 
@@ -235,7 +235,8 @@ Feature: Content Locking
             "guid": "item-1",
             "headline": "test",
             "body_html": "autosaved",
-            "_current_version": 3
+            "_current_version": 3,
+            "unique_name": "foo"
         }
         """
         And item "item-1" is unlocked


### PR DESCRIPTION
on unlocking now when it creates a new version using autosave.
avoid such check when unlocking an item.