### PR TITLE
[FEED PARSER] [WORDPRESS WXR] added _current_version

### DIFF
--- a/superdesk/io/feed_parsers/wordpress_wxr.py
+++ b/superdesk/io/feed_parsers/wordpress_wxr.py
@@ -46,6 +46,7 @@ class WPWXRFeedParser(XMLFeedParser):
         self.default_mapping = OrderedDict([
             ('guid', 'guid'),
             ('item_id', 'guid'),
+            ('_current_version', lambda _: "1"),
             ('versioncreated', {'xpath': 'pubDate/text()',
                                 'filter': parsedate_to_datetime}),
             ('author', 'dc:creator'),


### PR DESCRIPTION
when _current_version is missing in all metadata in archived DB, some
troubles happen like the impossibility to duplicate an item.

This commit add this metadata for Wordpress WXR feed parser, because it
is used by TheSource to initially fill archived DB, resulting in the
above mentioned trouble.

SDTS-28