### PR TITLE
[FEED PARSER] [WORDPRESS WXR] removed useless post to archive

### DIFF
--- a/superdesk/io/feed_parsers/wordpress_wxr.py
+++ b/superdesk/io/feed_parsers/wordpress_wxr.py
@@ -13,7 +13,6 @@ from superdesk.io.registry import register_feed_parser
 from superdesk.io.feed_parsers import XMLFeedParser
 from email.utils import parsedate_to_datetime
 from superdesk import etree as sd_etree
-from superdesk import get_resource_service
 from superdesk.upload import url_for_media
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE
 from superdesk.media.renditions import update_renditions
@@ -91,7 +90,6 @@ class WPWXRFeedParser(XMLFeedParser):
                 featuremedia = item['associations']['featuremedia']
                 item['renditions'] = featuremedia['renditions']
                 item[ITEM_TYPE] = featuremedia[ITEM_TYPE]
-                item['_id'] = featuremedia['_id']
                 item['alt_text'] = item['headline']
                 item['media'] = item['renditions']['original']['media']
                 item['mimetype'] = item['renditions']['original']['mimetype']
@@ -100,12 +98,10 @@ class WPWXRFeedParser(XMLFeedParser):
 
     def _add_image(self, item, url):
         associations = item.setdefault('associations', {})
-        as_item = {
+        association = {
             ITEM_TYPE: CONTENT_TYPE.PICTURE,
             'ingest_provider': self.NAME}
-        update_renditions(as_item, url, None)
-        archive_service = get_resource_service("archive")
-        archive_service.post([as_item])
+        update_renditions(association, url, None)
 
         # we use featuremedia for the first image, then embeddedX
         if 'featuremedia' not in associations:
@@ -113,8 +109,8 @@ class WPWXRFeedParser(XMLFeedParser):
         else:
             key = 'embedded' + str(len(associations) - 1)
 
-        associations[key] = as_item
-        return key, as_item
+        associations[key] = association
+        return key, association
 
     def body_hook(self, item, html):
         """Copy content to body_html

--- a/tests/io/feed_parsers/wordpress_wxr_test.py
+++ b/tests/io/feed_parsers/wordpress_wxr_test.py
@@ -40,12 +40,6 @@ FAKE_MEDIA_DATA = {'_created': datetime.datetime(2017, 4, 26, 13, 0, 33, tzinfo=
                                                 'width': 200}}}
 
 
-class FakeArchiveService(object):
-
-    def post(self, items):
-        return
-
-
 def fake_update_renditions(item, url, _):
     update = {
         # we use URL as _id so we can check the value easily
@@ -73,7 +67,6 @@ class WPWXRTestCase(TestCase):
 
     filename = 'wordpress_wxr.xml'
 
-    @mock.patch.object(wordpress_wxr, 'get_resource_service', lambda _: FakeArchiveService())
     @mock.patch.object(wordpress_wxr, 'update_renditions', fake_update_renditions)
     def __init__(self, methodname):
         super().__init__(methodname)


### PR DESCRIPTION
an item was created and uploaded to archive for each uploaded media, and
_id was mixed between archive and archived items, resulting in bad
behaviour when trying to use these items.

This commit fix.

SDTS-47