### PR TITLE
[FEED PARSER] [WORDPRESS WXR] fixed bad field type

### DIFF
--- a/superdesk/io/feed_parsers/wordpress_wxr.py
+++ b/superdesk/io/feed_parsers/wordpress_wxr.py
@@ -45,7 +45,7 @@ class WPWXRFeedParser(XMLFeedParser):
         self.default_mapping = OrderedDict([
             ('guid', 'guid'),
             ('item_id', 'guid'),
-            ('_current_version', lambda _: "1"),
+            ('_current_version', lambda _: 1),
             ('versioncreated', {'xpath': 'pubDate/text()',
                                 'filter': parsedate_to_datetime}),
             ('author', 'dc:creator'),


### PR DESCRIPTION
_current_version was set as a string instead of a int, resulting in bad
behaviour afterwards

SDTS-56