### PR TITLE
[SDESK-1521] fix(AP and DPA parsers) some files are failing to ingests

### DIFF
--- a/superdesk/io/feed_parsers/iptc7901.py
+++ b/superdesk/io/feed_parsers/iptc7901.py
@@ -35,7 +35,8 @@ class IPTC7901FeedParser(FileFeedParser):
         try:
             with open(file_path, 'rb') as f:
                 lines = [line for line in f]
-                return re.match(b'\x01([a-zA-Z]*)([0-9]*) (.) (.) ([0-9]*) ([a-zA-Z0-9 ]*)', lines[0], flags=re.I)
+                return re.match(b'\x01([a-zA-Z]*)([0-9]*) (.) ([A-Z]{1,3}) ([0-9]*) ([a-zA-Z0-9 ]*)',
+                                lines[0], flags=re.I)
         except:
             return False
 
@@ -47,7 +48,7 @@ class IPTC7901FeedParser(FileFeedParser):
             with open(file_path, 'rb') as f:
                 lines = [line for line in f]
             # parse first header line
-            m = re.match(b'\x01([a-zA-Z]*)([0-9]*) (.) (.) ([0-9]*) ([a-zA-Z0-9 ]*)', lines[0], flags=re.I)
+            m = re.match(b'\x01([a-zA-Z]*)([0-9]*) (.) ([A-Z]{1,3}) ([0-9]*) ([a-zA-Z0-9 ]*)', lines[0], flags=re.I)
             if m:
                 item['original_source'] = m.group(1).decode('latin-1', 'replace')
                 item['ingest_provider_sequence'] = m.group(2).decode()

--- a/tests/io/feed_parsers/ap_anpa_test.py
+++ b/tests/io/feed_parsers/ap_anpa_test.py
@@ -59,3 +59,8 @@ class ANPATestCase(TestCase):
         item = self.open('ap_anpa-4.tst')
         self.assertEqual(item['ednote'], '(Minor edits. A longer version of this story is available. '
                                          'With AP Photos. With BC-AS--China-Lawyer Trial.)')
+
+    def test_alert(self):
+        item = self.open('ap_anpa-5.tst')
+        self.assertTrue(item['headline'], 'Hawaii files court challenge to Trump administration''s definition of '
+                                          'close U.S. relationship needed to avoid travel ban.')

--- a/tests/io/feed_parsers/dpa_test.py
+++ b/tests/io/feed_parsers/dpa_test.py
@@ -43,3 +43,11 @@ class DPAIptcTestCase(TestCase):
             self.assertTrue(item['ednote'].find('## Editorial contacts'))
             self.assertEqual(item['dateline']['source'], 'dpa')
             self.assertEqual(item['dateline']['located']['city'], 'Berlin')
+
+    def test_open_dpa_copyright(self):
+        with self.app.app_context():
+            item = self.open('dpa_copyright.txt')
+            self.assertEqual('text', item['type'])
+            self.assertEqual('rs', item['anpa_category'][0]['qcode'])
+            self.assertEqual('(Achtung)', item['headline'])
+            self.assertEqual('Impressum', item['slugline'])

--- a/tests/io/fixtures/ap_anpa-5.tst
+++ b/tests/io/fixtures/ap_anpa-5.tst
@@ -1,0 +1,9 @@
+W1645asian
+b a BC-US--APNewsAlert     06-29 0358
+^BC-US--APNewsAlert,17<
+	   HONOLULU (AP) _ Hawaii files court challenge to Trump administration's definition of close U.S. relationship needed to avoid travel ban.
+
+	   AP-WF-06-29-17 2350GMT<
+
+
+

--- a/tests/io/fixtures/dpa_copyright.txt
+++ b/tests/io/fixtures/dpa_copyright.txt
@@ -1,0 +1,15 @@
+eca0001 4 rs 46  dpa 0027
+
+Impressum/
+(Achtung)
+Impressum =
+
+ryryryry copyright by dpa ryryryry copyright by dpa ryryryry
+ryryryry copyright by dpa ryryryry copyright by dpa ryryryry
+dpa Deutsche Presse-Agentur dpa dpa Deutsche Presse-Agentur
+dpa the deutsche presse-agentur hamburg federal republic of germany
+dpa dpa dpa dpa international service in english dpa dpa dpa dpa
+
+242200 GMT Jun 17
+
+


### PR DESCRIPTION
AP Alerts do not have headlines, so the first par is used if it is missing.
DPA send a copyright file that has multiple characters in the category, this is in compliance with the IPTC7901 standard, so the parser will now accept these. 