### PR TITLE
Activity: rename event on notification push

### DIFF
--- a/features/ingest_provider.feature
+++ b/features/ingest_provider.feature
@@ -31,7 +31,7 @@ Feature: Ingest Provider
         Then we get notifications
         """
         [
-          {"event": "create", "extra": {"_dest": [{"user_id": "#CONTEXT_USER_ID#", "read": false}]}},
+          {"event": "activity", "extra": {"_dest": [{"user_id": "#CONTEXT_USER_ID#", "read": false}]}},
           {"event": "ingest_provider:create", "extra": {"provider_id": "#ingest_providers._id#"}}
         ]
         """
@@ -99,7 +99,7 @@ Feature: Ingest Provider
          """
         Then we get notifications
         """
-        [{"event": "update", "extra": {"_dest": [{"user_id": "#CONTEXT_USER_ID#", "read": false}]}},
+        [{"event": "activity", "extra": {"_dest": [{"user_id": "#CONTEXT_USER_ID#", "read": false}]}},
          {"event": "ingest_provider:create", "extra": {"provider_id": "#ingest_providers._id#"}},
          {"event": "ingest_provider:update", "extra": {"provider_id": "#ingest_providers._id#"}}]
         """
@@ -153,7 +153,7 @@ Feature: Ingest Provider
          """
         And we get notifications
         """
-        [{"event": "create", "extra": {"_dest": [{"user_id": "#CONTEXT_USER_ID#", "read": false}]}},
+        [{"event": "activity", "extra": {"_dest": [{"user_id": "#CONTEXT_USER_ID#", "read": false}]}},
          {"event": "ingest_provider:create", "extra": {"provider_id": "#ingest_providers._id#"}},
          {"event": "ingest_provider:update", "extra": {"provider_id": "#ingest_providers._id#"}}]
         """
@@ -239,7 +239,7 @@ Feature: Ingest Provider
         And we get notifications
         """
         [
-          {"event": "delete", "extra": {"_dest": [{"user_id": "#CONTEXT_USER_ID#", "read": false}]}},
+          {"event": "activity", "extra": {"_dest": [{"user_id": "#CONTEXT_USER_ID#", "read": false}]}},
           {"event": "ingest_provider:delete", "extra": {"provider_id": "#ingest_providers._id#"}}
         ]
         """

--- a/superdesk/activity.py
+++ b/superdesk/activity.py
@@ -186,8 +186,6 @@ def add_activity(activity_name, msg, resource=None, item=None, notify=None, noti
         'resource': resource
     }
 
-    name = ActivityResource.endpoint_name
-
     user = getattr(g, 'user', None)
     if user:
         activity['user'] = user.get('_id')
@@ -197,11 +195,9 @@ def add_activity(activity_name, msg, resource=None, item=None, notify=None, noti
 
     if notify:
         activity['recipients'] = [{'user_id': ObjectId(_id), 'read': False} for _id in notify]
-        name = activity_name
 
     if notify_desks:
         activity['recipients'].extend([{'desk_id': ObjectId(_id), 'read': False} for _id in notify_desks])
-        name = activity_name
 
     if item:
         activity['item'] = str(item.get('guid', item.get('_id')))
@@ -212,7 +208,7 @@ def add_activity(activity_name, msg, resource=None, item=None, notify=None, noti
     get_resource_service(ActivityResource.endpoint_name).post([activity])
 
     if can_push_notification:
-        push_notification(name, _dest=activity['recipients'])
+        push_notification(ActivityResource.endpoint_name, _dest=activity['recipients'], activity=activity)
 
     return activity
 


### PR DESCRIPTION
The event name must be "activity" in order to trigger an activity reload on the client