### PR TITLE
[storage] add file extension to url for local storage

### DIFF
--- a/superdesk/storage/desk_media_storage.py
+++ b/superdesk/storage/desk_media_storage.py
@@ -10,10 +10,10 @@
 
 import logging
 import json
+import mimetypes
 import bson
 import gridfs
 from eve.io.mongo.media import GridFSMediaStorage
-from superdesk.utils import sha
 
 
 logger = logging.getLogger(__name__)
@@ -34,24 +34,15 @@ class SuperdeskGridFSMediaStorage(GridFSMediaStorage):
                     logger.exception('Failed to load metadata for file: %s with key: %s and value: %s', _id, k, v)
         return media_file
 
-    def media_id(self, filename, content_type=None, version=True):
-        """Get media id for given filename.
-
-        It can be used by async task to first generate id upload file later.
-
-        :param filename: unique file name
-        """
-        try:
-            return bson.ObjectId(str(filename)[:24])  # keep content hash
-        except bson.errors.InvalidId:
-            return bson.ObjectId(sha(str(filename))[:24])
-
     def url_for_media(self, media_id, content_type=None):
         """Return url for given media id.
 
         :param media_id: media id from media_id method
         """
-        return self.app.upload_url(str(media_id))
+        ext = mimetypes.guess_extension(content_type or '') or ''
+        if ext in ('.jpe', '.jpeg'):
+            ext = '.jpg'
+        return self.app.upload_url(str(media_id) + ext)
 
     def url_for_download(self, media_id, content_type=None):
         """Return url for download.

--- a/superdesk/upload.py
+++ b/superdesk/upload.py
@@ -10,6 +10,7 @@
 
 """Upload module"""
 import logging
+import os.path
 import superdesk
 from eve.utils import config
 from superdesk.errors import SuperdeskApiError
@@ -38,6 +39,7 @@ def get_upload_as_data_uri_bc(media_id):
 
 @bp.route('/upload-raw/<path:media_id>', methods=['GET'])
 def get_upload_as_data_uri(media_id):
+    media_id, _ = os.path.splitext(media_id)
     media_file = app.media.get(media_id, 'upload')
     if media_file:
         data = wrap_file(request.environ, media_file, buffer_size=1024 * 256)

--- a/tests/storage/gridfs_media_storage_test.py
+++ b/tests/storage/gridfs_media_storage_test.py
@@ -8,6 +8,7 @@ from superdesk.upload import bp, upload_url
 from superdesk.datalayer import SuperdeskDataLayer
 from superdesk.storage import SuperdeskGridFSMediaStorage
 from superdesk.utc import utcnow
+from superdesk.utils import sha
 from datetime import timedelta
 
 
@@ -23,17 +24,18 @@ class GridFSMediaStorageTestCase(unittest.TestCase):
         self.app.register_blueprint(bp)
         self.app.upload_url = upload_url
 
-    def test_media_id(self):
-        filename = 'some-file'
-        media_id = self.media.media_id(filename)
-        self.assertIsInstance(media_id, bson.ObjectId)
-        self.assertEqual(media_id, self.media.media_id(filename))
-
     def test_url_for_media(self):
-        _id = self.media.media_id('test')
+        _id = bson.ObjectId(sha('test')[:24])
         with self.app.app_context():
             url = self.media.url_for_media(_id)
         self.assertEqual('http://localhost/upload-raw/%s' % _id, url)
+
+    def test_url_for_media_content_type(self):
+        _id_str = '1' * 24
+        _id = bson.ObjectId(_id_str)
+        with self.app.app_context():
+            url = self.media.url_for_media(_id, "image/jpeg")
+        self.assertEqual('http://localhost/upload-raw/{}.jpg'.format(_id_str), url)
 
     def test_put_media_with_id(self):
         data = io.StringIO("test data")


### PR DESCRIPTION
File extension is needed in local storage to avoid trouble with
Wordpress plugin.
As it is not possible to change ID (Mongo expect a unique ObjectID with 24 hex bytes), this patch work around id by adding the file extension to the URL, and ignoring it when getting the file.

media_id has also been removed from SuperdeskGridFSMediaStorage as it is
not used anymore.

SDFID-47