### PR TITLE
feat(attachments): deliver attachments in ninjs

### DIFF
--- a/content_api/items/resource.py
+++ b/content_api/items/resource.py
@@ -69,6 +69,12 @@ schema = {
     },
     'genre': {'type': 'list', 'mapping': code_mapping},
     'ancestors': Resource.not_analyzed_field('list'),
+    'attachments': {
+        'type': 'list',
+        'schema': {
+            'type': 'dict',
+        },
+    },
 }
 
 

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -197,6 +197,9 @@ class NINJSFormatter(Formatter):
         if article.get('flags', {}).get('marked_for_legal'):
             ninjs['signal'] = self._format_signal_cwarn()
 
+        if article.get('attachments'):
+            ninjs['attachments'] = self._format_attachments(article)
+
         return ninjs
 
     def _generate_renditions(self, article):
@@ -289,6 +292,23 @@ class NINJSFormatter(Formatter):
 
     def _format_signal_cwarn(self):
         return [{'name': 'Content Warning', 'code': 'cwarn', 'scheme': 'http://cv.iptc.org/newscodes/signal/'}]
+
+    def _format_attachments(self, article):
+        output = []
+        attachments_service = superdesk.get_resource_service('attachments')
+        for attachment_ref in article['attachments']:
+            attachment = attachments_service.find_one(req=None, _id=attachment_ref['attachment'])
+            output.append({
+                'id': str(attachment['_id']),
+                'title': attachment['title'],
+                'description': attachment['description'],
+                'filename': attachment['filename'],
+                'mimetype': attachment['mimetype'],
+                'length': attachment.get('length'),
+                'media': str(attachment['media']),
+                'href': '/assets/{}'.format(str(attachment['media'])),
+            })
+        return output
 
     def export(self, item):
         if self.can_format(self.format_type, item):


### PR DESCRIPTION
- to content api
- via http push

it assumes there will be some processing on the recieving system,
keeping the links in a form `<a data-attachmet="attachment-id">text</a>`
and attachments as list of objects:

```
{"attachments": [
    {
        "id": "attachment-id",
        "title": "Foo",
        "description": "Foo descrioption",
        "filename": "green.png",
        "mimetype": "image/png",
        "length": 3772918,
        "media": "media-id",
        "href": "/assets/media-id"
    }
]}
```

SDESK-1588