### PR TITLE
Remove SERVER_NAME and URL_PROTOCOL settings

### DIFF
--- a/content_api/app/settings.py
+++ b/content_api/app/settings.py
@@ -39,8 +39,9 @@ CONTENTAPI_DOMAIN = {}
 
 # NOTE: no trailing slash for the CONTENTAPI_URL setting!
 CONTENTAPI_URL = env('CONTENTAPI_URL', 'http://localhost:5400')
+MEDIA_PREFIX = '%s/assets' % CONTENTAPI_URL.rstrip('/')
 server_url = urlparse(CONTENTAPI_URL)
-URL_PREFIX = server_url.path.strip('/')
+URL_PREFIX = env('CONTENTAPI_URL_PREFIX', server_url.path.strip('/')) or ''
 VERSION = '_current_version'
 
 XML = False

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -8,7 +8,7 @@ We use ``flask.app.config``, so to use it do::
 
     from flask import current_app as app
 
-    print(app.config['SERVER_NAME'])
+    print(app.config['SERVER_DOMAIN'])
 
 Configuration is combination of default settings module and settings module
 in `application repo <https://github.com/superdesk/superdesk/blob/master/server/settings.py>`_.
@@ -22,11 +22,6 @@ Default settings
 ^^^^^^^^^^^^^^^^^^^^
 
 Default: ``'Superdesk'``
-
-``SERVER_NAME``
-^^^^^^^^^^^^^^^
-
-Default: ``'localhost:5000'``
 
 ``CLIENT_URL``
 ^^^^^^^^^^^^^^

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -88,17 +88,13 @@ LOG_SERVER_PORT = int(env('LOG_SERVER_PORT', 5555))
 
 #: application name - used in email footers, ``APP_NAME`` env
 APPLICATION_NAME = env('APP_NAME', 'Superdesk')
-server_url = urlparse(env('SUPERDESK_URL', 'http://localhost:5000/api'))
 #: public client url - used to create links within emails etc, ``SUPERDESK_CLIENT_URL`` env
 CLIENT_URL = env('SUPERDESK_CLIENT_URL', 'http://localhost:9000')
-URL_PROTOCOL = server_url.scheme or None
 
-#: public server url (not proxy), ``SUPERDESK_URL`` env
-SERVER_NAME = server_url.netloc or None
+SERVER_URL = env('SUPERDESK_URL', 'http://localhost:5000/api')
+server_url = urlparse(SERVER_URL)
 SERVER_DOMAIN = server_url.netloc or 'localhost'
-URL_PREFIX = server_url.path.lstrip('/') or ''
-if SERVER_NAME.endswith(':80'):
-    SERVER_NAME = SERVER_NAME[:-3]
+URL_PREFIX = env('URL_PREFIX', server_url.path.lstrip('/')) or ''
 
 VALIDATION_ERROR_STATUS = 400
 JSON_SORT_KEYS = False
@@ -437,7 +433,7 @@ RETURN_MEDIA_AS_BASE64_STRING = False
 VERSION = '_current_version'
 
 #: uses for generation of media url ``(<media_prefix>/<media_id>)``::
-MEDIA_PREFIX = env('MEDIA_PREFIX', '')
+MEDIA_PREFIX = env('MEDIA_PREFIX', '%s/upload-raw' % SERVER_URL.rstrip('/'))
 MEDIA_PREFIXES_TO_FIX = None
 
 #: amazon access key
@@ -464,8 +460,6 @@ RENDITIONS = {
         'viewImage': {'width': 200, 'height': 200},
     }
 }
-
-SERVER_DOMAIN = 'localhost'
 
 
 #: BCRYPT work factor

--- a/superdesk/factory/sentry.py
+++ b/superdesk/factory/sentry.py
@@ -9,7 +9,7 @@ class SuperdeskSentry():
 
     def __init__(self, app):
         if app.config.get('SENTRY_DSN'):
-            app.config.setdefault('SENTRY_NAME', app.config.get('SERVER_NAME'))
+            app.config.setdefault('SENTRY_NAME', app.config.get('SERVER_DOMAIN'))
             self.sentry = Sentry(app, register_signal=False, wrap_wsgi=False, logging=True, level=logging.WARNING)
             register_logger_signal(self.sentry.client)
             register_signal(self.sentry.client)

--- a/superdesk/upload.py
+++ b/superdesk/upload.py
@@ -17,7 +17,7 @@ from superdesk.errors import SuperdeskApiError
 from werkzeug.wsgi import wrap_file
 from .resource import Resource
 from .services import BaseService
-from flask import url_for, request, current_app as app, redirect
+from flask import request, current_app as app, redirect
 from superdesk.media.renditions import generate_renditions, delete_file_on_error
 from superdesk.media.media_operations import (
     download_file_from_url, download_file_from_encoded_str,
@@ -67,10 +67,8 @@ def url_for_media(media_id, mimetype=None):
 
 
 def upload_url(media_id, view='upload_raw.get_upload_as_data_uri'):
-    media_prefix = app.config.get('MEDIA_PREFIX')
-    if media_prefix:
-        return '%s/%s' % (media_prefix.rstrip('/'), media_id)
-    return url_for(view, media_id=media_id, _external=True)
+    media_prefix = app.config.get('MEDIA_PREFIX').rstrip('/')
+    return '%s/%s' % (media_prefix, media_id)
 
 
 def init_app(app):

--- a/tests/content_api_test.py
+++ b/tests/content_api_test.py
@@ -21,8 +21,8 @@ class ContentAPITestCase(TestCase):
         self.app.config['SECRET_KEY'] = 'secret'
         config = copy(self.app.config)
         config['AMAZON_CONTAINER_NAME'] = None  # force gridfs
-        config['SERVER_NAME'] = 'localhost:5400'
         config['URL_PREFIX'] = ''
+        config['MEDIA_PREFIX'] = '/assets'
         self.capi = get_app(config)
         self.capi.testing = True
         self.subscriber = {'_id': 'sub1'}

--- a/tests/storage/gridfs_media_storage_test.py
+++ b/tests/storage/gridfs_media_storage_test.py
@@ -16,7 +16,7 @@ class GridFSMediaStorageTestCase(unittest.TestCase):
 
     def setUp(self):
         self.app = eve.Eve(__name__, {'DOMAIN': {}})
-        self.app.config['SERVER_NAME'] = 'localhost'
+        self.app.config['MEDIA_PREFIX'] = 'http://localhost/upload-raw'
         self.app.config['DOMAIN'] = {'upload': {}}
         self.app.config['MONGO_DBNAME'] = 'sptests'
         self.app.data = SuperdeskDataLayer(self.app)


### PR DESCRIPTION
- they outdated since [eve==0.5](https://github.com/pyeve/eve/blob/98a1febdae04312e9f4be96e3b2394ca2efb2315/eve/default_settings.py#L33-L35)
- SERVER_NAME is used in Flask, but seems we don't need such usage, so
  using SERVER_DOMAIN instead (it's already in use in some places)
- possibility to specify URL_PREFIX and CONTENTAPI_URL_PREFIX from env
  variables, can be useful in some deployment schemes

[SDESK-1892](https://dev.sourcefabric.org/browse/SDESK-1892)