### PR TITLE
SDFID-138 Custom vocabulary cause to stop publishing

### DIFF
--- a/apps/content_types/content_types.py
+++ b/apps/content_types/content_types.py
@@ -359,7 +359,8 @@ def compose_subject_schema(schema, fields_map):
     default = []
     for old_field, field in fields_map.items():
         if (old_field == field or old_field == 'subject') and schema.get(field, None):
-            allowed.append(field)
+            if old_field != 'subject':
+                allowed.append(field)
             if schema[field].get('required', False):
                 mandatory[old_field] = field
             else:
@@ -368,7 +369,7 @@ def compose_subject_schema(schema, fields_map):
                 default.extend(schema[field]['default'])
         else:
             mandatory[old_field] = None
-    if allowed:
+    if allowed or mandatory or default:
         init_subject_schema(schema, default, mandatory, allowed, fields_map)
 
 

--- a/tests/content_types_test.py
+++ b/tests/content_types_test.py
@@ -5,6 +5,7 @@ import bson
 from superdesk.tests import TestCase
 from unittest import mock
 from apps.content_types import content_types, apply_schema
+from apps.content_types.content_types import compose_subject_schema
 
 
 class MockService():
@@ -45,6 +46,17 @@ class ContentTypesTestCase(TestCase):
         updates['schema']['body_html']['minlength'] = '99'
         content_types.ContentTypesService().on_update(updates, original)
         self.assertEqual(updates['schema']['body_html']['minlength'], '99')
+
+    def test_subject_allowed_values(self):
+        """
+        """
+        test_schema = {'subject_custom': {'mandatory_in_list': {'scheme': {}},
+                                          'default': [],
+                                          'required': True,
+                                          'schema': {},
+                                          'type': 'list'}}
+        compose_subject_schema(test_schema, {'subject': 'subject_custom'})
+        self.assertEqual(test_schema['subject_custom']['schema']['schema']['scheme']['allowed'], [])
 
     def test_get_output_name(self):
         _id = bson.ObjectId()


### PR DESCRIPTION
When adding subject_custom to a content type the allowed values are
restricted to 'subject_custom'. Custom vocabularies, which are saved
also in the subject field generate an error on publishing as the scheme
allowed values does not contain the custom vocabularies.