### PR TITLE
[CONTENT_API] [PUBLISH_QUEUE]: fixed packages publishing for content_api subscribers

### DIFF
--- a/superdesk/publish/publish_queue.py
+++ b/superdesk/publish/publish_queue.py
@@ -108,7 +108,7 @@ class PublishQueueResource(Resource):
     }
 
     additional_lookup = {
-        'url': 'regex("[\w,.:-]+")',
+        'url': r'regex("[\w,.:-]+")',
         'field': 'item_id'
     }
 


### PR DESCRIPTION
packages were not correctly published to content_api, but delivery
status was always set to success. This patch fixes it by publishing the
package just before changing the delivery state.

SDESK-2073
