### PR TITLE
[PUBLISHING] [CONTENT_API] [NINJS]: added "firstpublished" field

### DIFF
--- a/apps/publish/content/publish.py
+++ b/apps/publish/content/publish.py
@@ -14,6 +14,7 @@ from superdesk.metadata.item import CONTENT_TYPE, ITEM_TYPE, ITEM_STATE, CONTENT
 
 from apps.archive.common import set_sign_off, ITEM_OPERATION
 from apps.archive.archive import update_word_count
+from superdesk.utc import utcnow
 
 from .common import BasePublishService, BasePublishResource, ITEM_PUBLISH
 
@@ -39,6 +40,8 @@ class ArchivePublishService(BasePublishService):
                 raise SuperdeskApiError.badRequestError("Empty package cannot be published!")
 
     def on_update(self, updates, original):
+        if 'firstpublished' not in original:
+            updates.setdefault('firstpublished', utcnow())
         updates[ITEM_OPERATION] = ITEM_PUBLISH
         super().on_update(updates, original)
         set_sign_off(updates, original)
@@ -50,7 +53,6 @@ class ArchivePublishService(BasePublishService):
         :param dict original: original document
         :param dict updates: updates related to original document
         """
-
         updates.setdefault(ITEM_OPERATION, ITEM_PUBLISH)
         if original.get(PUBLISH_SCHEDULE) or updates.get(PUBLISH_SCHEDULE):
             updates[ITEM_STATE] = CONTENT_STATE.SCHEDULED

--- a/content_api/items/resource.py
+++ b/content_api/items/resource.py
@@ -53,6 +53,7 @@ schema = {
     'version': {'type': 'string', 'required': True, 'empty': False, 'nullable': False},
     'versioncreated': {'type': 'datetime', 'required': True},
     'firstcreated': {'type': 'datetime'},
+    'firstpublished': {'type': 'datetime', 'required': False},
     'evolvedfrom': Resource.not_analyzed_field(),
     'nextversion': Resource.not_analyzed_field(),
     'subscribers': Resource.not_analyzed_field('list'),

--- a/docs/superdesk-ninjs-schema.json
+++ b/docs/superdesk-ninjs-schema.json
@@ -48,6 +48,11 @@
 			"type" : "string",
 			"format" : "date-time"
 		},
+		"firstpublished" : {
+			"description" : "The date and time when the item has been published for the first time",
+			"type" : "string",
+			"format" : "date-time"
+		},
 		"embargoed" : {
 			"description" : "The date and time before which all versions of the news object are embargoed. If absent, this object is not embargoed.",
 			"type" : "string",

--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -101,6 +101,10 @@ metadata_schema = {
     'versioncreated': {
         'type': 'datetime'
     },
+    'firstpublished': {
+        'type': 'datetime',
+        'required': False
+    },
 
     # Ingest Details
     'ingest_provider': Resource.rel('ingest_providers'),

--- a/superdesk/metadata/utils.py
+++ b/superdesk/metadata/utils.py
@@ -16,9 +16,9 @@ from superdesk.utils import SuperdeskBaseEnum
 from .item import GUID_TAG, GUID_NEWSML, GUID_FIELD, ITEM_TYPE, CONTENT_TYPE
 
 
-item_url = 'regex("[\w,.:_-]+")'
+item_url = r'regex("[\w,.:_-]+")'
 
-extra_response_fields = [GUID_FIELD, 'headline', 'firstcreated', 'versioncreated', 'archived']
+extra_response_fields = [GUID_FIELD, 'headline', 'firstcreated', 'versioncreated', 'firstpublished', 'archived']
 
 aggregations = {
     'type': {'terms': {'field': 'type'}},

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -90,7 +90,7 @@ class NINJSFormatter(Formatter):
     direct_copy_properties = ('versioncreated', 'usageterms', 'language', 'headline', 'copyrightnotice',
                               'urgency', 'pubstatus', 'mimetype', 'copyrightholder', 'ednote',
                               'body_text', 'body_html', 'slugline', 'keywords',
-                              'firstcreated', 'source', 'extra')
+                              'firstcreated', 'firstpublished', 'source', 'extra')
 
     rendition_properties = ('href', 'width', 'height', 'mimetype', 'poi', 'media')
     vidible_fields = {field: field for field in rendition_properties}


### PR DESCRIPTION
"firstpublished" is set to current datetime on first publication, then
it is kept unchanged.
NINJS schema extension has been updated accordingly

SDFID-175