### PR TITLE
Reverted soft_delete option

### DIFF
--- a/superdesk/vocabularies/vocabularies.py
+++ b/superdesk/vocabularies/vocabularies.py
@@ -100,8 +100,8 @@ class VocabulariesResource(Resource):
         }
     }
 
-    soft_delete = True
-    item_url = 'regex("[-_\w]+")'
+    soft_delete = False
+    item_url = r'regex("[-_\w]+")'
     item_methods = ['GET', 'PATCH', 'DELETE']
     resource_methods = ['GET', 'POST']
     privileges = {'PATCH': 'vocabularies', 'POST': 'vocabularies', 'DELETE': 'vocabularies'}


### PR DESCRIPTION
SOFT_DELETE option is documented at
http://python-eve.org/features.html#soft-delete it allows to keep
"deleted" documents in database so they can be restored, and it has been
introduced in rev. 3b63b198c .

But this option add a _delete field which is then returned by client,
resulting in request not validating against schema, and bugs like SDESK-2140 .

So this option is disabled here to have a quick fix to SDESK-2140, and
it needs further testing before being activated again.

fix SDESK-2140