### PR TITLE
[NINJS] [FORMATTER]: handle annotations

### DIFF
--- a/content_api/items/resource.py
+++ b/content_api/items/resource.py
@@ -76,6 +76,17 @@ schema = {
             'type': 'dict',
         },
     },
+    'annotations': {
+        'type': 'list',
+        'mapping': {
+            'type': 'object',
+            'properties': {
+                'id': not_analyzed,
+                'type': not_analyzed,
+                'body': not_analyzed
+            }
+        }
+    },
     'bookmarks': Resource.not_analyzed_field('list'),
     'extra': metadata_schema['extra'],
 }
@@ -89,7 +100,7 @@ class ItemsResource(Resource):
     #     "tag:example.com,0000:newsml_BRE9A605"
     #     "tag:localhost:2015:f4b35e12-559b-4a2b-b1f2-d5e64048bde8"
     #
-    item_url = 'regex("[\w,.:-]+")'
+    item_url = r'regex("[\w,.:-]+")'
     schema = schema
 
     datasource = {

--- a/docs/superdesk-ninjs-schema.json
+++ b/docs/superdesk-ninjs-schema.json
@@ -398,6 +398,28 @@
 					}
 				}
 			}
+		},
+		"annotations" : {
+			"description" : "Small messages linked to parts of the body",
+			"type" : "array",
+			"items" : {
+				"type" : "object",
+				"additionalProperties" : false,
+				"properties" : {
+					"id" : {
+						"description" : "The id of the annotation, same id as used in annotation-id attribute of <span> element in body_html",
+						"type" : "number"
+					},
+					"type" : {
+						"description": "Annotation type",
+						"type" : "string"
+					},
+					"body": {
+						"description" : "Content of the annotation, formatted with HTML",
+						"type" : "string"
+					}
+				}
+			}
 		}
 	}
 }

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ install_requires = [
     'mongolock>=1.3.4,<1.4',
     'PyYAML>=3.11,<3.13',
     'lxml>=3.8,<3.9',
+    'draftjs_exporter[lxml]',
 ]
 
 package_data = {

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -42,9 +42,14 @@ from superdesk.utils import json_serialize_datetime_objectId
 from superdesk.media.renditions import get_renditions_spec
 from apps.archive.common import get_utc_schedule
 from superdesk import text_utils
-
+from draftjs_exporter.html import HTML
+from draftjs_exporter.dom import DOM
+from draftjs_exporter.constants import ENTITY_TYPES
 
 logger = logging.getLogger(__name__)
+
+ANNOTATION = 'ANNOTATION'
+MEDIA = 'MEDIA'
 
 
 def filter_empty_vals(data):
@@ -116,6 +121,9 @@ class NINJSFormatter(Formatter):
             'version': str(article.get(config.VERSION, 1)),
             'type': self._get_type(article)
         }
+
+        if article.get('editor_state'):
+            self._parse_editor_state(article, ninjs)
 
         if article.get('byline'):
             ninjs['byline'] = article['byline']
@@ -351,6 +359,105 @@ class NINJSFormatter(Formatter):
 
             authors.append(author)
         return authors
+
+    def _render_annotation(self, props):
+        return DOM.create_element('span', {'annotation-id': props['id']}, props['children'])
+
+    def _render_media(self, props):
+        media_props = props['media']
+        if media_props.get('type', 'picture') == 'picture':
+            elt = DOM.create_element('img', {'src': media_props['renditions']['original']['href'],
+                                             'alt': media_props.get('alt_text')}, props['children'])
+        else:
+            elt = DOM.create_element('video', {'control': 'control',
+                                               'src': media_props['renditions']['original']['href'],
+                                               'alt': media_props.get('alt_text'),
+                                               'width': '100%',
+                                               'height': '100%'}, props['children'])
+        return DOM.create_element('div', {'class': 'media-block'}, elt)
+
+    def _render_link(self, props):
+        return DOM.create_element('a', {'href': props.get('link', {}).get('href', '')}, props['children'])
+
+    def _parse_editor_state(self, article, ninjs):
+        """Parse editor_state (DraftJs internals) to retrieve annotations
+
+        body_html will be rewritten with HTML generated from DraftJS representation
+        and annotation will be included in <span> elements
+        :param article: item to modify, must contain "editor_state" data
+        :param ninjs: ninjs item which will be formatted
+        """
+        blocks = article['editor_state']['blocks']
+        blocks_map = {}
+        ann_idx = 0
+        data = {}
+        config = {
+            'engine': 'lxml',
+            'entity_decorators': {
+                ENTITY_TYPES.LINK: self._render_link,
+                ENTITY_TYPES.HORIZONTAL_RULE: lambda props: DOM.create_element('hr'),
+                ENTITY_TYPES.EMBED: None,
+                MEDIA: self._render_media,
+                ANNOTATION: self._render_annotation}}
+        renderer = HTML(config)
+
+        for block in blocks:
+            blocks_map[block['key']] = block
+            data.update(block['data'])
+
+        # we sort data keys to have consistent annotations ids
+        for key in sorted(data):
+            data_block = data[key]
+            if data_block['type'] == ANNOTATION:
+                ninjs.setdefault('annotations', []).append(
+                    {'id': ann_idx,
+                     'type': data_block['annotationType'],
+                     'body': renderer.render(json.loads(data_block['msg']))})
+                entity_key = '_annotation_{}'.format(ann_idx)
+                article['editor_state']['entityMap'][entity_key] = {
+                    'type': ANNOTATION,
+                    'data': {'id': ann_idx}}
+                ann_idx += 1
+                selection = json.loads(key)
+                if selection['isBackward']:
+                    first, second = 'focus', 'anchor'
+                else:
+                    first, second = 'anchor', 'focus'
+                first_key = selection[first + 'Key']
+                second_key = selection[second + 'Key']
+                first_offset = selection[first + 'Offset']
+                second_offset = selection[second + 'Offset']
+                # we want to style annotation with <span>, so we put them as entities
+                if first_key == second_key:
+                    # selection is done in a single block
+                    annotated_block = blocks_map[first_key]
+                    annotated_block.setdefault('entityRanges', []).append(
+                        {'key': entity_key,
+                         'offset': first_offset,
+                         'length': second_offset - first_offset})
+                else:
+                    # selection is done on multiple blocks, we have to select them
+                    started = False
+                    for block in blocks:
+                        if block['key'] == first_key:
+                            started = True
+                            block.setdefault('entityRanges', []).append(
+                                {'key': entity_key,
+                                 'offset': first_offset,
+                                 'length': len(block['text']) - first_offset})
+                        elif started:
+                            inline = {'key': entity_key, 'offset': 0}
+                            block.setdefault('entityRanges', []).append(inline)
+                            if block['key'] == second_key:
+                                # last block, we end the annotation here
+                                inline['length'] = second_offset
+                                break
+                            else:
+                                # intermediate block, we annotate it whole
+                                inline['length'] = len(block['text'])
+        # HTML rendering
+        # now we have annotation ready, we can render HTML
+        article['body_html'] = renderer.render(article['editor_state'])
 
     def export(self, item):
         if self.can_format(self.format_type, item):

--- a/tests/publish/ninjs_formatter_test.py
+++ b/tests/publish/ninjs_formatter_test.py
@@ -545,3 +545,147 @@ class NinjsFormatterTest(TestCase):
                           'name': 'Reporter'},
              'biography': 'bio 2'}]
         self.assertEqual(data['authors'], expected)
+
+    def test_annotations(self):
+        """Test parsing of simple annotations using editor_state"""
+        article = {
+            '_current_version': 1,
+            '_id': 'test:annotations',
+            'abstract': '<p>test</p>',
+            'body_html': '<p>bla bla</p><p>1 2 3</p><p>ceci est un test</p>',
+            'editor_state': {
+                'blocks': [{'data': {
+                    '{"anchorKey":"5lipn","anchorOffset":4,'
+                    '"focusKey":"5lipn","focusOffset":7,'
+                    '"isBackward":false,"hasFocus":false}':
+                    {'annotationType': 'Regular',
+                     'author': 'first name last name',
+                     'date': '2017-11-22T16:13:09.426Z',
+                     'email': 'a@a.com',
+                     'msg': '{"entityMap":{},"blocks":[{"key":"ds21a",'
+                     '"text":"test annotation","type":"unstyled",'
+                     '"depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]}',
+                     'type': 'ANNOTATION'},
+                    '{"anchorKey":"8ssph","anchorOffset":11,'
+                    '"focusKey":"8ssph","focusOffset":0,'
+                    '"isBackward":true,"hasFocus":false}': {'annotationType': 'Remark',
+                                                            'author': 'first name last name',
+                                                            'date': '2017-11-22T16:13:27.517Z',
+                                                            'email': 'a@a.com',
+                                                            'msg': '{"entityMap":{},"blocks":[{"key":"406bc",'
+                                                            '"text":"test remark","type":"unstyled",'
+                                                            '"depth":0,"inlineStyleRanges":[],"entityRanges":[],'
+                                                            '"data":{}}]}',
+                                                            'type': 'ANNOTATION'}},
+                    'depth': 0,
+                    'entityRanges': [],
+                    'inlineStyleRanges': [],
+                    'key': '5lipn',
+                    'text': 'bla bla',
+                    'type': 'unstyled'},
+                    {'data': {},
+                     'depth': 0,
+                     'entityRanges': [],
+                     'inlineStyleRanges': [],
+                     'key': 'atj8f',
+                     'text': '1 2 3',
+                     'type': 'unstyled'},
+                    {'data': {},
+                     'depth': 0,
+                     'entityRanges': [],
+                     'inlineStyleRanges': [],
+                     'key': '8ssph',
+                     'text': 'ceci est un test',
+                     'type': 'unstyled'}],
+                'entityMap': {}},
+            'format': 'HTML',
+            'guid': 'test_annotation',
+            'headline': 'test',
+            'item_id': 'test_annotation',
+            'slugline': 'test',
+            'type': 'text',
+            'version': 1}
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        expected = {
+            'guid': 'test_annotation',
+            'version': '1',
+            'type': 'text',
+            'annotations': [{'id': 0, 'type': 'Regular',
+                            'body': '<p>test annotation</p>'}, {'id': 1,
+                            'type': 'Remark', 'body': '<p>test remark</p>'}],
+            'headline': 'test',
+            'body_html': '<p>bla <span annotation-id="0">bla</span></p><p>1 2 3</p>'
+                         '<p><span annotation-id="1">ceci est un</span> test</p>',
+            'slugline': 'test',
+            'priority': 5,
+            'description_html': '<p>test</p>',
+            'description_text': 'test',
+            'readtime': 0}
+        self.assertEqual(json.loads(doc), expected)
+
+    def test_annotations_multi_blocks(self):
+        """Test parsing of complex annotations spanning several blocks"""
+
+        article = {
+            '_current_version': 1,
+            'body_html': '<p>paragraph1 - line 1\nline 2\nline 3\n\nparagraph2 '
+            '- line 1\nline 2\nline 3\n\nparagraph3 - line 1\nline 2\nline 3</p>',
+            'editor_state': {'blocks': [{'data': {'{"anchorKey":"btrsm","anchorOffset":20,"focusKey":"btrsm",'
+                                                  '"focusOffset":61,"isBackward":false,"hasFocus":false}':
+                                                  {'annotationType': 'Regular',
+                                                   'author': 'first name last name',
+                                                   'date': '2017-11-24T15:08:55.990Z',
+                                                   'email': 'a@a.com',
+                                                   'msg': '{"entityMap":{},"blocks":[{"key":"aveeg","text":'
+                                                   '"this annotation use bold and must start on paragraph '
+                                                   'line 2 and finish on paragraph 2 line 2","type":"unstyled"'
+                                                   ',"depth":0,"inlineStyleRanges":[{"offset":20,"length":4,'
+                                                   '"style":"BOLD"}],"entityRanges":[],"data":{}}]}',
+                                                   'type': 'ANNOTATION'},
+                                                  '{"anchorKey":"btrsm","anchorOffset":90,"focusKey":"btrsm",'
+                                                  '"focusOffset":94,"isBackward":false,"hasFocus":false}':
+                                                  {'annotationType': 'Regular',
+                                                   'author': 'first name last name',
+                                                   'date': '2017-11-24T15:10:34.880Z',
+                                                   'email': 'a@a.com',
+                                                   'msg': '{"entityMap":{"0":{"type":"LINK","mutability":'
+                                                           '"MUTABLE","data":{"link":{"href":"https://www'
+                                                           '.sourcefabric.org/"}}}},"blocks":[{"key":"5juv0"'
+                                                           ',"text":"this annotation use a link and must only'
+                                                           ' span around the word \\"line\\" on paragraph 3 -'
+                                                           ' line 2","type":"unstyled","depth":0,"inlineStyleR'
+                                                           'anges":[],"entityRanges":[{"offset":22,"length":4,'
+                                                           '"key":0}],"data":{}}]}',
+                                                   'type': 'ANNOTATION'}},
+                                         'depth': 0,
+                                         'entityRanges': [],
+                                         'inlineStyleRanges': [],
+                                         'key': 'btrsm',
+                                         'text': 'paragraph1 - line 1\nline 2\nline 3\n\nparagraph2 -'
+                                         ' line 1\nline 2\nline 3\n\nparagraph3 - line 1\nline 2\nline 3',
+                                         'type': 'unstyled'}],
+                             'entityMap': {}},
+            'format': 'HTML',
+            'guid': 'test_annotation2',
+            'item_id': 'test_annotation2',
+            'type': 'text'}
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        expected = {
+            'guid': 'test_annotation2',
+            'version': '1',
+            'type': 'text',
+            'body_html': '<p>paragraph1 - line 1\n<span annotation-id="0">line 2\nline 3\n\nparagraph2'
+                         ' - line 1\nline 2</span>\nline 3\n\nparagraph3 - line 1\n<span annotation-id'
+                         '="1">line</span> 2\nline 3</p>',
+            'annotations': [{'id': 0,
+                             'type': 'Regular',
+                             'body': '<p>this annotation use <strong>bold</strong> and must start on'
+                                     ' paragraph line 2 and finish on paragraph 2 line 2</p>'},
+                            {'id': 1,
+                             'type': 'Regular',
+                             'body': '<p>this annotation use a <a href="https://www.sourcefabric.org/">'
+                                     'link</a> and must only span around the word "line" on paragraph 3'
+                                     ' - line 2</p>'}],
+            'priority': 5,
+            'readtime': 0}
+        self.assertEqual(json.loads(doc), expected)


### PR DESCRIPTION
Annotations are transmitted using DraftJS internal editor
representation, which separate content from style instead of using HTML.
To handle that, the drafsjs_exporter module has been choosen: after some
testing, it seems to work quite well, so it is a new dependency (using
lxml version).

To render annotations in the body_html, annotation are converted to
special entities, which are then rendered as <span> elements in the
body, using an identifier (annotation-id) local to the item.

The Superdesk ninjs schema extension has been updated accordingly.

SDFID-201