### PR TITLE
fix(editor3): Set deleted image keys to None in order to reset the value

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -101,11 +101,11 @@ def update_image_caption(body, name, caption):
 
 
 def update_associations(doc):
-    if 'editor_state' not in doc:
+    if 'editor_state' not in doc or not doc['editor_state']:
         return
     entityMap = doc['editor_state'].get('entityMap', {})
     associations = doc.get(ASSOCIATIONS, {})
-    doc[ASSOCIATIONS] = {k: v for k, v in associations.items() if not k.startswith(EDITOR_KEY_PREFIX)}
+    doc[ASSOCIATIONS] = {k: None if k.startswith(EDITOR_KEY_PREFIX) else v for k, v in associations.items()}
 
     mediaList = {
         EDITOR_KEY_PREFIX + key: entity['data']['media']

--- a/apps/archive/archive_test.py
+++ b/apps/archive/archive_test.py
@@ -596,10 +596,11 @@ class ArchiveTestCase(TestCase):
 
         update_associations(doc)
 
-        self.assertEqual(len(doc['associations']), 4)
+        self.assertEqual(len(doc['associations']), 5)
         self.assertEqual(doc['associations']['editor_0'], {'guid': 'guid0', 'type': 'picture', 'alt_text': 'media 0'})
         self.assertEqual(doc['associations']['editor_1'], {'guid': 'guid1', 'type': 'picture', 'alt_text': 'media 1'})
         self.assertEqual(doc['associations']['editor_2'], {'guid': 'guid2', 'type': 'picture', 'alt_text': 'media 2'})
+        self.assertEqual(doc['associations']['editor_7'], None)
         self.assertEqual(doc['associations']['featuremedia'], {'guid': 'guid11', 'type': 'picture11'})
 
     def test_get_dateline_city_None(self):


### PR DESCRIPTION
On updating the dictionaries eve performs an update and not a replace so
for deleted items we have to set the key to None.