### PR TITLE
[SDESK-2173](fix): Re-enable checking (Stage) Global Read OFF for the Archived repository.

### DIFF
--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -63,7 +63,7 @@ class SearchService(superdesk.Service):
         elif repo == 'archived':
             query = {'and': [{'term': {'_type': 'archived'}}]}
 
-        if invisible_stages and (repo == 'archive' or repo == 'published'):
+        if invisible_stages and repo != 'ingest':
             query['and'].append({'not': {'terms': {'task.stage': invisible_stages}}})
 
         return query


### PR DESCRIPTION
This PR reverts the change done in the https://github.com/superdesk/superdesk-core/pull/816 

Now you need to be a member to see archived items in stage that are marked `Global Read Off`.