### PR TITLE
fix(validate): avoid markup removal on custom fields when validating

### DIFF
--- a/apps/validate/validate.py
+++ b/apps/validate/validate.py
@@ -10,6 +10,7 @@
 
 import superdesk
 
+from copy import deepcopy
 from flask import current_app as app
 from eve.io.mongo import Validator
 from superdesk.metadata.item import ITEM_TYPE
@@ -138,7 +139,8 @@ class ValidateService(superdesk.Service):
 
     def create(self, docs, **kwargs):
         for doc in docs:
-            doc['errors'] = self._validate(doc, **kwargs)
+            test_doc = deepcopy(doc)
+            doc['errors'] = self._validate(test_doc, **kwargs)
 
         return [doc['errors'] for doc in docs]
 

--- a/features/content_profile.feature
+++ b/features/content_profile.feature
@@ -1418,6 +1418,10 @@ Feature: Content Profile
 
     @auth
     Scenario: Validate using content profile when publishing
+        Given "vocabularies"
+        """
+        [{"_id": "foo", "field_type": "text"}]
+        """
         Given "content_types"
         """
         [{
@@ -1441,6 +1445,10 @@ Feature: Content Profile
                     "required" : true,
                     "maxlength" : 24,
                     "type" : "string"
+                },
+                "foo": {
+                    "required": true,
+                    "maxlength": 20
                 }
             }
         }]
@@ -1458,11 +1466,17 @@ Feature: Content Profile
 
         When we patch "/archive/#archive._id#"
         """
-        {"body_html": "body", "headline": "head", "slugline": "slug"}
+        {"body_html": "body", "headline": "head", "slugline": "slug", "extra": {"foo": "<b>test</b>"}}
         """
 
         And we publish "#archive._id#" with "publish" type and "published" state
         Then we get OK response
+
+        When we get "/published/#archive._id#"
+        Then we get existing resource
+        """
+        {"extra": {"foo": "<b>test</b>"}}
+        """
 
     @auth
     Scenario: Mark profile when used and prevent delete


### PR DESCRIPTION
make a copy of data before doing validation to avoid changes done when
validating to be preserved.

SDFID-250