### PR TITLE
[SETTINGS] editor note overriding

### DIFF
--- a/apps/client_config.py
+++ b/apps/client_config.py
@@ -26,4 +26,6 @@ def init_app(app):
         'schema': app.config.get('SCHEMA'),
         'editor': app.config.get('EDITOR'),
         'feedback_url': app.config.get('FEEDBACK_URL'),
+        'override_ednote_for_corrections': app.config.get('OVERRIDE_EDNOTE_FOR_CORRECTIONS', True),
+        'override_ednote_template': app.config.get('OVERRIDE_EDNOTE_TEMPLATE'),
     })

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -574,3 +574,24 @@ Example::
         }
     }
 
+
+``OVERRIDE_EDNOTE_FOR_CORRECTIONS``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default: ``True``
+
+Set to False to disable editor note overriding on correction.
+
+``OVERRIDE_EDNOTE_TEMPLATE``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default: ``None``
+
+Template to use to override editor note (ignored if ``OVERRIDE_EDNOTE_FOR_CORRECTIONS`` is ``False``).
+If not set, default template will be used.
+In your template, you can use ``{date}`` to insert current date or ``{slugline}`` for slugline.
+
+Example::
+
+    OVERRIDE_EDNOTE_FOR_CORRECTIONS = True
+    OVERRIDE_EDNOTE_TEMPLATE = 'Story "{slugline}" corrected on {date}'

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -625,3 +625,10 @@ EXCLUDED_VOCABULARY_FIELDS = ['default_categories', 'signal', 'rightsinfo', 'sub
 #: allows overriding default schema by type, use picture/composite/text keys
 SCHEMA = {}
 EDITOR = {}
+
+# editor note overriding
+#: set to False if you don't want overriding on correction
+OVERRIDE_EDNOTE_FOR_CORRECTIONS = True
+#: template to use for overriding, you can use {date} and {slugline} placeholders
+#: if not set, a default template will be used
+# OVERRIDE_EDNOTE_TEMPLATE = 'Story "{slugline}" corrected on {date}'


### PR DESCRIPTION
add 2 new settings, and expose them to client:

- OVERRIDE_EDNOTE_FOR_CORRECTIONS: indicate if editor note should be
overriden (default: True)
- OVERRIDE_EDNOTE_TEMPLATE: template to use to override editor note
(default: use legacy template)

"{slugline}" and "{date}" placeholders can be used in template.

SDFID-261