### PR TITLE
fix(ninjs): avoid empty assocations in ninjs output

### DIFF
--- a/features/http_push.feature
+++ b/features/http_push.feature
@@ -61,7 +61,7 @@ Feature: HTTP Push publishing
 
         When we patch "archive/#archive._id#"
         """
-        {"slugline": "slug", "body_html": "body", "headline": "Foo"}
+        {"slugline": "slug", "body_html": "body", "headline": "Foo", "associations": {"embedded123": null}}
         """
 
         When we publish "#archive._id#" with "publish" type and "published" state
@@ -70,7 +70,19 @@ Feature: HTTP Push publishing
         When we transmit published
         Then we pushed 1 item
         """
-        [{"guid": "#archive.guid#", "profile": "foo", "type": "text", "byline": "__no_value__", "headline": "__no_value__", "body_html": "body", "version": "3", "copyrightholder": "copyright holder", "copyrightnotice": "copyright notice", "language": "en"}]
+        [{
+            "guid": "#archive.guid#",
+            "profile": "foo",
+            "type": "text",
+            "byline": "__no_value__",
+            "headline": "__no_value__",
+            "body_html": "body",
+            "version": "3",
+            "copyrightholder": "copyright holder",
+            "copyrightnotice": "copyright notice",
+            "language": "en",
+            "associations": "__empty__"
+        }]
         """
 
         When we publish "#archive._id#" with "correct" type and "corrected" state

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -289,8 +289,6 @@ class NINJSFormatter(Formatter):
         for key, item in (article.get(ASSOCIATIONS) or {}).items():
             if item:
                 associations[key] = self._transform_to_ninjs(item, subscriber)
-            else:
-                associations[key] = None
         return associations
 
     def _get_genre(self, article):

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -136,7 +136,7 @@ def json_match(context_data, response_data):
                 assert_is_now(response_data[key], key)
                 continue
             if context_data[key] == "__empty__":
-                assert len(response_data[key]) == 0, '%s is not empty' % key
+                assert len(response_data[key]) == 0, '%s is not empty (%s)' % (key, response_data[key])
                 continue
             if not json_match(context_data[key], response_data[key]):
                 return False

--- a/tests/publish/ninjs_formatter_test.py
+++ b/tests/publish/ninjs_formatter_test.py
@@ -357,8 +357,7 @@ class NinjsFormatterTest(TestCase):
         _, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
         formatted = json.loads(doc)
         self.assertIn('associations', formatted)
-        self.assertIn('image', formatted['associations'])
-        self.assertEqual(formatted['associations']['image'], None)
+        self.assertNotIn('image', formatted['associations'])
 
     def test_vidible_formatting(self):
         article = {


### PR DESCRIPTION
when embed is removed it shouldn't be in ninjs as `null`

SDESK-2376