### PR TITLE
[FORMATTER] [NINJS] Don't crash anymore when parent is missing

### DIFF
--- a/tests/publish/ninjs_formatter_test.py
+++ b/tests/publish/ninjs_formatter_test.py
@@ -600,6 +600,52 @@ class NinjsFormatterTest(TestCase):
              'biography': 'bio 2'}]
         self.assertEqual(data['authors'], expected)
 
+    def test_author_missing_parent(self):
+        """Test that older items with missing parent don't make the formatter crashing"""
+        article = {
+            '_id': 'urn:bar',
+            '_current_version': 1,
+            'guid': 'urn:bar',
+            'type': 'text',
+            'authors': [
+                {
+                    '_id': [
+                        'test_id',
+                        'writer'
+                    ],
+                    'role': 'writer',
+                    'name': 'Writer',
+                    'sub_label': 'author 1',
+                },
+                {
+                    '_id': [
+                        'test_id_2',
+                        'writer'
+                    ],
+                    'role': 'photographer',
+                    'name': 'photographer',
+                    'sub_label': 'author 2',
+                }
+            ],
+
+        }
+
+        seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        data = json.loads(doc)
+
+        expected = {'guid': 'urn:bar',
+                    'version': '1',
+                    'type': 'text',
+                    'priority': 5,
+                    'authors': [{'name': 'Writer',
+                                 'role': 'writer',
+                                 'biography': ''},
+                                {'name': 'photographer',
+                                 'role': 'photographer',
+                                 'biography': ''}]}
+
+        self.assertEqual(data, expected)
+
     def test_annotations(self):
         """Test parsing of simple annotations using editor_state"""
         article = {


### PR DESCRIPTION
On some older stories, "parent" key may be missing. This patch avoid
crash in this case, and use data given in author dict instead of user
when it's not possible to find the user.

fix SDFID-309