### PR TITLE
[CONTENT API] fixed schema

### DIFF
--- a/content_api/items/resource.py
+++ b/content_api/items/resource.py
@@ -95,6 +95,9 @@ schema = {
     'copies': Resource.not_analyzed_field('list'),  # list of user ids who copied this item
     'extra': metadata_schema['extra'],
     'authors': metadata_schema['authors'],
+    'wordcount': metadata_schema['word_count'],
+    'charcount': {'type': 'integer'},
+    'readtime': {'type': 'integer'},
 }
 
 


### PR DESCRIPTION
"wordcount", "charcount" and "readtime" were missing in item schema

fix SDESK-2414