### PR TITLE
[etree] added method to clean HTML content

### DIFF
--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -646,3 +646,7 @@ OVERRIDE_EDNOTE_FOR_CORRECTIONS = True
 #: template to use for overriding, you can use {date} and {slugline} placeholders
 #: if not set, a default template will be used
 # OVERRIDE_EDNOTE_TEMPLATE = 'Story "{slugline}" corrected on {date}'
+
+#: allowed HTML tag in client
+HTML_TAGS_WHITELIST = ('h1', 'h2', 'h3', 'h4', 'h6', 'blockquote', 'pre', 'figure', 'ul', 'ol', 'li', 'div', 'p', 'em',
+                       'strong', 'i', 'b')

--- a/tests/etree_test.py
+++ b/tests/etree_test.py
@@ -1,9 +1,10 @@
-
-import unittest
 from superdesk import etree as sd_etree
+from superdesk.tests import TestCase
+from lxml import etree, html
+from textwrap import dedent
 
 
-class ParseHtmlTestCase(unittest.TestCase):
+class ParseHtmlTestCase(TestCase):
     def test_encode_carriage_return(self):
         text = 'This is first line.\r\nThis is second line.\r\n'
         parsed = sd_etree.parse_html(text)
@@ -14,8 +15,35 @@ class ParseHtmlTestCase(unittest.TestCase):
         self.assertEqual(text.replace('\r', '&#13;'), sd_etree.to_string(parsed))
 
     def test_void_elements_fix(self):
-        html = '<p>this is a test with empty <h3/> non-void <em/> elements and a void <br/> one</p>'
+        html_raw = '<p>this is a test with empty <h3/> non-void <em/> elements and a void <br/> one</p>'
         expected = '<p>this is a test with empty <h3></h3> non-void <em></em> elements and a void <br/> one</p>'
-        parsed = sd_etree.parse_html(html)
+        parsed = sd_etree.parse_html(html_raw)
         sd_etree.fix_html_void_elements(parsed)
         self.assertEqual(sd_etree.to_string(parsed), expected)
+
+    def test_clean_html(self):
+        html_raw = dedent("""\
+        <div>
+           <header>this header must be removed</header>
+           <p class="class_to_remove">
+               <unknown_tag>bla
+                   <strong>keep it strong</strong>
+               </unknown_tag>
+               <script>no script here !</script>
+           </p>
+        </div>
+        """)
+        elem = html.fromstring(html_raw)
+        elem = sd_etree.clean_html(elem)
+        expected = dedent("""\
+        <div>
+           this header must be removed
+           <p>
+               bla
+                   <strong>keep it strong</strong>
+
+
+           </p>
+        </div>
+        """)
+        self.assertEqual(dedent(etree.tostring(elem, encoding="unicode")), expected)


### PR DESCRIPTION
the method will remove dangerous HTML (e.g. <script> elements) and
unknown tags.
The new setting "HTML_TAGS_WHITELIST" is used to set allowed tags

needed for SDNTB-464 and SDNTB-475 (and feed parsing in general)