### PR TITLE
fix(ninjs): fix formatter with new category items

### DIFF
--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -61,7 +61,10 @@ def filter_empty_vals(data):
 
 
 def get_locale_name(item, language):
-    return item.get('translations', {}).get('name', {}).get(language, None) or item.get('name', '')
+    try:
+        return item['translations']['name'][language]
+    except (KeyError, TypeError):
+        return item.get('name', '')
 
 
 def format_cv_item(item, language):

--- a/tests/publish/ninjs_formatter_test.py
+++ b/tests/publish/ninjs_formatter_test.py
@@ -920,7 +920,15 @@ class NinjsFormatterTest(TestCase):
                         }
                     },
                     "scheme": "region_custom"
-                }]}
+                },
+                {
+                    "name": "no translations",
+                    "qcode": "test",
+                    "translations": None,
+                    "scheme": "test"
+                }
+            ]
+        }
         seq, doc = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
         ninjs = json.loads(doc)
         expected_genre = [{'code': 'genre_custom:Education',
@@ -935,5 +943,9 @@ class NinjsFormatterTest(TestCase):
                              'scheme': 'country_custom'},
                             {'code': 'region_custom:Asia ex Japan',
                              'name': '日本除くアジア',
-                             'scheme': 'region_custom'}]
+                             'scheme': 'region_custom'},
+                            {'code': 'test',
+                             'name': 'no translations',
+                             'scheme': 'test',
+                             }]
         self.assertEqual(ninjs['subject'], expected_subject)


### PR DESCRIPTION
when you add an item it has `translations` set to `null`
whick breaks formatting.