### PR TITLE
[FEEDING SERVICE] [RITZAU] URL override, aknowledge and exceptions fixes

### DIFF
--- a/superdesk/io/feed_parsers/__init__.py
+++ b/superdesk/io/feed_parsers/__init__.py
@@ -327,3 +327,4 @@ from superdesk.io.feed_parsers.efe_nitf import EFEFeedParser  # NOQA
 from superdesk.io.feed_parsers.wordpress_wxr import WPWXRFeedParser  # NOQA
 from superdesk.io.feed_parsers.ninjs import NINJSFeedParser  # NOQA
 from superdesk.io.feed_parsers.stt_newsml import STTNewsMLFeedParser  # NOQA
+from superdesk.io.feed_parsers.ritzau import RitzauFeedParser  # NOQA

--- a/superdesk/io/feeding_services/ritzau.py
+++ b/superdesk/io/feeding_services/ritzau.py
@@ -19,6 +19,7 @@ import requests
 
 logger = logging.getLogger(__name__)
 URL = 'https://services.ritzau.dk/ritzaurest/Services.svc/xml/news/NewsQueue'
+URL_ACK = 'https://services.ritzau.dk/ritzaurest/Services.svc/xml/news/QueueAcknowledge'
 
 
 class RitzauFeedingService(FeedingService):
@@ -36,24 +37,49 @@ class RitzauFeedingService(FeedingService):
             user = config['username']
             password = config['password']
         except KeyError as e:
-            SuperdeskIngestError.notConfiguredError(e, 'username and password are needed')
+            SuperdeskIngestError.notConfiguredError(Exception('username and password are needed'))
 
-        params = {'user': user, 'password': password, 'maksAntal': 50}
+        url_override = config.get('url', '').strip()
+        if not url_override.startswith('http'):
+            SuperdeskIngestError.notConfiguredError(Exception('if URL is set, it must be a valid http link'))
+
+        if url_override:
+            params = {'user': user, 'password': password, 'maksAntal': 50}
+        else:
+            params = {'user': user, 'password': password, 'maksAntal': 50, 'waitAcknowledge': 'true'}
+
         try:
-            r = requests.get(URL, params=params)
+            r = requests.get(url_override or URL, params=params)
         except Exception as e:
-            raise IngestApiError.apiRequestError(e, 'error while doing the request')
+            raise IngestApiError.apiRequestError(Exception('error while doing the request'))
 
         try:
             root_elt = etree.fromstring(r.text)
         except Exception as e:
-            raise IngestApiError.apiRequestError(e, 'error while parsing the request answer')
+            raise IngestApiError.apiRequestError(Exception('error while parsing the request answer'))
+
+        try:
+            if root_elt.xpath('(//error/text())[1]')[0] != '0':
+                err_msg = root_elt.xpath('(//errormsg/text())[1]')[0]
+                raise IngestApiError.apiRequestError(Exception('error code returned by API: {msg}'.format(msg=err_msg)))
+        except IndexError as e:
+            raise IngestApiError.apiRequestError(Exception('Invalid XML, <error> element not found'))
 
         parser = self.get_feed_parser(provider)
         items = []
         for elt in root_elt.xpath('//RBNews'):
             item = parser.parse(elt, provider)
             items.append(item)
+            if not url_override:
+                try:
+                    queue_id = elt.xpath('.//ServiceQueueId/text()')[0]
+                except IndexError:
+                    raise IngestApiError.apiRequestError(Exception('missing ServiceQueueId element'))
+                ack_params = {'user': user, 'password': password, 'servicequeueid': queue_id}
+                try:
+                    requests.get(URL_ACK, params=ack_params)
+                except Exception as e:
+                    raise IngestApiError.apiRequestError(Exception('error while doing the request'))
 
         return [items]
 

--- a/tests/io/fixtures/ritzau_feed.xml
+++ b/tests/io/fixtures/ritzau_feed.xml
@@ -76,6 +76,7 @@ WEB:&lt;/P&gt;&#xD;
         <Companies/>
         <Status>New news</Status>
         <ContentShort>PR / Spire Global, Inc.</ContentShort>
+        <ServiceQueueId>123</ServiceQueueId>
       </RBNews>
       <RBNews>
         <NewsID>4b9c198d-d6ec-4a7f-a4e9-551d9a5cba13</NewsID>
@@ -116,6 +117,7 @@ WEB:&lt;/P&gt;&#xD;
         <Companies/>
         <Status>New news</Status>
         <ContentShort>Kort om sport</ContentShort>
+        <ServiceQueueId>456</ServiceQueueId>
       </RBNews>
     </ListOfRBNews>
   </XMLNewsQueuedResult>


### PR DESCRIPTION
this patch fixes several issues:

- API exceptions were not using the right arguments: an exceptions is expected as
first argument, human readable text is put there

- new URL override field is handled

- if <error> elements has a value != 0, an exceptions is raised

- the "QueueAcknowledge" feature from Ritzau is used, this way items are
removed from queue only after successful parsing

- ritzau feed parser was not instantiated

SDESK-2328