### PR TITLE
[FEED PARSER] [RITZAU] removed "place" field

### DIFF
--- a/superdesk/io/feed_parsers/ritzau.py
+++ b/superdesk/io/feed_parsers/ritzau.py
@@ -53,7 +53,6 @@ class RitzauFeedParser(XMLFeedParser):
                          'filter': lambda v: list(filter(None, v.split('/')))},
             'abstract': '//subtitle',
             'byline': '//origin',
-            'place': '//town',
             'version': {'xpath': '//version/text()',
                         'filter': int},
             'ednote': '//Tilredaktionen/text()',


### PR DESCRIPTION
"place" was not ingested with the right data type (a list is expected
while a string was used), resulting in ingestion troubles.
As the field is not really needed, it has been removed.

SDNTB-479