### PR TITLE
[FEED PARSER] [IMAGE IPTC] type detection + decoding fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ install_requires = [
     'PyYAML>=3.11,<3.13',
     'lxml>=3.8,<4.2',
     'python-twitter==3.3',
+    'chardet<4.0'
 ]
 
 package_data = {

--- a/superdesk/io/feed_parsers/image_iptc.py
+++ b/superdesk/io/feed_parsers/image_iptc.py
@@ -25,7 +25,6 @@ from datetime import datetime
 import dateutil.parser
 import mimetypes
 import logging
-import imghdr
 import os.path
 
 logger = logging.getLogger(__name__)
@@ -53,11 +52,7 @@ class ImageIPTCFeedParser(FileFeedParser):
     def can_parse(self, image_path):
         if not isinstance(image_path, str):
             return False
-        try:
-            return imghdr.what(image_path) == 'jpeg'
-        except Exception as e:
-            logger.warning("Can't detect file type: {exc}".format(exc=e))
-            return False
+        return mimetypes.guess_type(image_path)[0] == 'image/jpeg'
 
     def parse(self, image_path, provider=None):
         try:

--- a/superdesk/media/image.py
+++ b/superdesk/media/image.py
@@ -11,6 +11,7 @@
 """Utilities for extractid metadata from image files."""
 
 import io
+from superdesk.text_utils import decode
 from PIL import Image, ExifTags
 from PIL import IptcImagePlugin
 from flask import json
@@ -112,14 +113,8 @@ def get_meta_iptc(file_stream):
         except KeyError:
             continue
         if isinstance(value, list):
-            try:
-                value = [v.decode('utf-8') for v in value]
-            except UnicodeDecodeError:
-                pass
+            value = [decode(v) for v in value]
         elif isinstance(value, bytes):
-            try:
-                value = value.decode('utf-8')
-            except UnicodeDecodeError:
-                pass
+            value = decode(value)
         metadata[tag] = value
     return metadata

--- a/tests/text_utils_test.py
+++ b/tests/text_utils_test.py
@@ -63,3 +63,9 @@ class WordCountTestCase(unittest.TestCase):
         and <strong>compound word (two-done)</strong> and <em>abbreviation (Washington D.C.)</p>
         <p>it should be the same word count as in client and backend</p>"""
         self.assertEqual(32, text_utils.get_word_count(text))
+
+    def test_decode(self):
+        """Test decoding with encoding detection"""
+        bytes_str = "téstôù".encode('latin-1')
+        decoded = text_utils.decode(bytes_str)
+        self.assertEqual(decoded, "téstôù")


### PR DESCRIPTION
imghdr is not working correctly on some images, resuling in exception
during ingestion. To fix this, a simple name check is now done.

Encoding may not be UTF-8 in some images, and it seems that encoding is
not specified in IPTC metadata. A new "decode" method has been added to text_utils to try
to decode bytes using UTF-8, try autodetect encoding in case of failure,
and finaly decode ignoring bad chars if nothing else worked. This method
is used to decode IPTC metadata in images.

SDANSA-130