### PR TITLE
SDESK-2680 contentapi is always reporting success even when something is going wrong

### DIFF
--- a/apps/publish/content/tests.py
+++ b/apps/publish/content/tests.py
@@ -546,7 +546,7 @@ class ArchivePublishTestCase(TestCase):
 
         enqueue_published()
         queue_items = self.app.data.find(PUBLISH_QUEUE, None, None)
-        self.assertEqual(6, queue_items.count())
+        self.assertEqual(11, queue_items.count())
 
         # this will delete queue transmission for the wire article
         publish_queue.PublishQueueService(PUBLISH_QUEUE, get_backend()).delete_by_article_id(doc['_id'])

--- a/apps/publish/enqueue/enqueue_killed.py
+++ b/apps/publish/enqueue/enqueue_killed.py
@@ -58,4 +58,3 @@ class EnqueueKilledService(EnqueueService):
 
         self.queue_transmission(item, subscribers)
         logger.info('Queued Transmission for article: {}'.format(item[config.ID_FIELD]))
-        self.publish_content_api(item, [subscriber for subscriber in subscribers if subscriber['api_enabled']])

--- a/content_api/publish/resource.py
+++ b/content_api/publish/resource.py
@@ -28,4 +28,4 @@ class PublishResource(Resource):
     elastic_prefix = ELASTIC_PREFIX
 
     item_methods = []
-    resource_methods = []
+    resource_methods = ['POST']

--- a/content_api/wsgi.py
+++ b/content_api/wsgi.py
@@ -1,3 +1,6 @@
 from content_api.app import get_app
 
 application = get_app()
+
+app = get_app()
+app.run(host='0.0.0.0', port=5400, debug=True, use_reloader=True)

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -609,7 +609,7 @@ EMAIL_TIMEOUT = 10
 #: This setting is used to overide the desk/stage expiry for items when spiked
 SPIKE_EXPIRY_MINUTES = None
 
-SECRET_KEY = env('SECRET_KEY', '')
+SECRET_KEY = env('SECRET_KEY', 'fUWvHPm69LFVPP9mAdHx3Jm1BPVzpnliGfHfiP9oub6BIGVEQ03IVw==')
 
 #: secure login
 XMPP_AUTH_URL = env('XMPP_AUTH_URL', '')

--- a/superdesk/publish/publish_content.py
+++ b/superdesk/publish/publish_content.py
@@ -86,7 +86,7 @@ def get_queue_items(retries=False):
     return get_resource_service(PUBLISH_QUEUE).get(req=request, lookup=lookup)
 
 
-@celery.task(soft_time_limit=600)
+# @celery.task(soft_time_limit=600)
 def transmit_subscriber_items(queue_items, subscriber):
     lock_name = get_lock_id('Subscriber', 'Transmit', subscriber)
     publish_queue_service = get_resource_service(PUBLISH_QUEUE)
@@ -147,7 +147,8 @@ def transmit_items(queue_items):
     # extract the queued items for each subscriber and transmit them
     for subscriber in subscribers:
         sub_queue_items = [item for item in queue_items if item['subscriber_id'] == subscriber]
-        transmit_subscriber_items.apply_async(kwargs={'queue_items': sub_queue_items, 'subscriber': str(subscriber)})
+        transmit_subscriber_items(queue_items=sub_queue_items, subscriber=str(subscriber))
+#         transmit_subscriber_items.apply_async(kwargs={'queue_items': sub_queue_items, 'subscriber': str(subscriber)})
 
 
 superdesk.command('publish:transmit', PublishContent())

--- a/superdesk/publish/publish_queue.py
+++ b/superdesk/publish/publish_queue.py
@@ -123,7 +123,7 @@ class PublishQueueService(BaseService):
         subscriber_service = get_resource_service('subscribers')
 
         for doc in docs:
-            self._set_queue_state(doc, {})
+            doc['state'] = doc.get('state') or QueueState.PENDING.value
             doc['moved_to_legal'] = False
 
             if 'published_seq_num' not in doc:
@@ -132,7 +132,7 @@ class PublishQueueService(BaseService):
 
     def on_updated(self, updates, original):
         if updates.get('state', '') != original.get('state', ''):
-            self._set_queue_state(updates, original)
+            updates['state'] = updates.get('state') or QueueState.PENDING.value
             push_notification('publish_queue:update',
                               queue_id=str(original['_id']),
                               completed_at=(updates.get('completed_at').isoformat()
@@ -140,11 +140,6 @@ class PublishQueueService(BaseService):
                               state=updates.get('state'),
                               error_message=updates.get('error_message')
                               )
-
-    def _set_queue_state(self, updates, original):
-        destination = updates.get('destination', original.get('destination')) or {}
-        updates['state'] = QueueState.SUCCESS.value if destination.get('delivery_type') == 'content_api' \
-            else updates.get('state') or QueueState.PENDING.value
 
     def delete(self, lookup):
         # as encoded item is added manually to storage

--- a/superdesk/publish/transmitters/__init__.py
+++ b/superdesk/publish/transmitters/__init__.py
@@ -13,3 +13,4 @@ from .email import EmailPublishService  # NOQA
 from .odbc import ODBCPublishService  # NOQA
 from .file_output import FilePublishService  # NOQA
 from .http_push import HTTPPushService  # NOQA
+from .content_api import ContentAPIService  # NOQA

--- a/superdesk/publish/transmitters/content_api.py
+++ b/superdesk/publish/transmitters/content_api.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2018 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.publish.publish_service import PublishService
+from superdesk.publish import register_transmitter
+from superdesk import get_resource_service
+import json
+
+
+class ContentAPIService(PublishService):
+    """Content API Publish Service.
+
+    The Content API push service publishes items to the resource service via the content API
+    publish method.
+    """
+
+    def _transmit(self, queued_item, subscriber):
+        """
+        @see: PublishService._transmit
+        """
+        item = get_resource_service('archive').find_one(req=None, _id=queued_item['item_id'])
+        get_resource_service('content_api').publish(json.loads(queued_item['formatted_item']), item, [subscriber])
+
+
+register_transmitter('content_api', ContentAPIService(), [])

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -295,7 +295,8 @@ def get_resource_name(url):
 def format_items(items):
     output = ['']  # insert empty line
     for item in items:
-        if item.get('formatted_item'):
+        if item.get('formatted_item') and \
+                item.get('destination', {}).get('format').lower() == 'ninjs':
             item['formatted_item'] = json.loads(item['formatted_item'])
         output.append(json.dumps(item, indent=4, sort_keys=True))
     return ',\n'.join(output)

--- a/tests/enqueue_test.py
+++ b/tests/enqueue_test.py
@@ -28,7 +28,5 @@ class NoTakesEnqueueTestCase(TestCase):
         subscribers = [s for s in self.app.data.find_all('subscribers')]
         subscriber_codes = self.service._get_subscriber_codes(subscribers)
         with patch.object(self.service, '_resend_to_subscribers') as resend:
-            with patch.object(self.service, 'publish_content_api') as content_api:
-                self.service.resend(doc, subscribers)
-                resend.assert_called_with(doc, subscribers, subscriber_codes, {})
-                content_api.assert_called_with(doc, [])
+            self.service.resend(doc, subscribers)
+            resend.assert_called_with(doc, subscribers, subscriber_codes, {})


### PR DESCRIPTION
The publishing to content API should be done through
the regular workflow, instead of custom implementation.