### PR TITLE
[VOCABULARIES] set qcode as unique_field for 'genre', 'priority', 're…

### DIFF
--- a/apps/prepopulate/data_init/vocabularies.json
+++ b/apps/prepopulate/data_init/vocabularies.json
@@ -36,6 +36,7 @@
         "_id": "genre",
         "display_name": "Genre",
         "type": "manageable",
+        "unique_field": "qcode",
         "items": [
             {"is_active": true, "name": "Article (news)", "qcode": "Article"},
             {"is_active": true, "name": "Sidebar", "qcode": "Sidebar"},
@@ -89,6 +90,7 @@
         "_id": "priority",
         "display_name": "Priority",
         "type": "manageable",
+        "unique_field": "qcode",
         "items": [
             {"is_active": true, "name": "1", "qcode": 1},
             {"is_active": true, "name": "2", "qcode": 2},
@@ -218,6 +220,7 @@
         "_id": "locators",
         "display_name": "Locators",
         "type": "manageable",
+        "unique_field": "qcode",
         "items": [
             {"is_active": true, "name": "NSW", "qcode": "NSW"}
         ],
@@ -244,6 +247,7 @@
         "_id": "annotation_types",
         "display_name": "Annotation Types",
         "type": "manageable",
+        "unique_field": "qcode",
         "items": [
             {"is_active": true, "name": "Regular", "qcode": "regular"},
             {"is_active": true, "name": "Remark", "qcode": "remark"}

--- a/superdesk/data_updates/00010_20180510-172012_vocabularies.py
+++ b/superdesk/data_updates/00010_20180510-172012_vocabularies.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : Jérôme
+# Creation: 2018-05-10 17:20
+
+from superdesk.commands.data_updates import DataUpdate
+
+
+class DataUpdate(DataUpdate):
+
+    resource = 'vocabularies'
+
+    def forwards(self, mongodb_collection, mongodb_database):
+        print(mongodb_collection.update_many({'_id': {'$in': ['genre',
+                                                              'priority',
+                                                              'replace_words',
+                                                              'annotation_types']}},
+                                             {'$set': {
+                                                 'unique_field': "qcode"
+                                             }}))
+
+    def backwards(self, mongodb_collection, mongodb_database):
+        print(mongodb_collection.update_many({'_id': {'$in': ['genre',
+                                                              'priority',
+                                                              'replace_words',
+                                                              'annotation_types']}},
+                                             {'$unset': {
+                                                 'unique_field': "qcode"
+                                             }}))


### PR DESCRIPTION
…place_words' and 'annotation_types'

this avoid the use of empty qcode for those data

SDESK-2763