### PR TITLE
SDFID-313 Change email address field not to be case sensitive

### DIFF
--- a/apps/auth/db/reset_password.py
+++ b/apps/auth/db/reset_password.py
@@ -71,6 +71,7 @@ class ResetPasswordService(BaseService):
             if key and password:
                 return self.reset_password(doc)
             if email:
+                email = email.lower()
                 return self.initialize_reset_password(doc, email)
             if key:
                 token_req = self.check_if_valid_token(key)

--- a/features/auth.feature
+++ b/features/auth.feature
@@ -58,7 +58,7 @@ Feature: Authentication
         [{"username": "foo", "password": "bar", "email": "foo@bar.org", "is_active": true}]
         """
 
-        When we post to reset_password we get email with token
+        When we post "foo@bar.org" to reset_password we get email with token
         Then we can check if token is valid
         And we update token to be expired
         Then token is invalid
@@ -69,7 +69,16 @@ Feature: Authentication
         [{"username": "foo", "password": "bar", "email": "foo@bar.org", "is_active": true}]
         """
 
-        When we post to reset_password we get email with token
+        When we post "foo@bar.org" to reset_password we get email with token
+        Then we reset password for user
+
+    Scenario: Reset password existing user - mixed case email
+        Given "users"
+        """
+        [{"username": "foo", "password": "bar", "email": "foo@bar.org", "is_active": true}]
+        """
+
+        When we post "fOo@BAr.oRG" to reset_password we get email with token
         Then we reset password for user
 
     Scenario: Reset password disabled user
@@ -91,7 +100,7 @@ Feature: Authentication
         [{"username": "foo", "password": "bar", "email": "foo@bar.org", "is_active": true}]
         """
 
-        When we post to reset_password we get email with token
+        When we post "foo@bar.org" to reset_password we get email with token
         When we change user status to "enabled but inactive" using "/users/foo"
         """
         {"is_active": false}

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -1380,9 +1380,9 @@ def then_we_get_deleted_response(context):
     assert_200(context.response)
 
 
-@when('we post to reset_password we get email with token')
-def we_post_to_reset_password(context):
-    data = {'email': 'foo@bar.org'}
+@when('we post "{email}" to reset_password we get email with token')
+def we_post_to_reset_password(context, email):
+    data = {'email': email}
     headers = [('Content-Type', 'multipart/form-data')]
     headers = unique_headers(headers, context.headers)
     with context.app.mail.record_messages() as outbox:


### PR DESCRIPTION
Since API [forces](https://github.com/superdesk/superdesk-core/blob/master/superdesk/users/users.py#L53) email to be in lower case, it makes sense to do the same for password reset.