### PR TITLE
[VOCABULARIES] default unique_field to qcode when suitable

### DIFF
--- a/superdesk/data_updates/00011_20180516-175617_vocabularies.py
+++ b/superdesk/data_updates/00011_20180516-175617_vocabularies.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : Jérôme
+# Creation: 2018-05-16 17:56
+
+from superdesk.commands.data_updates import DataUpdate
+
+
+class DataUpdate(DataUpdate):
+
+    resource = 'vocabularies'
+
+    def forwards(self, mongodb_collection, mongodb_database):
+        print(mongodb_collection.update_many({'unique_field': {'$exists': False},
+                                              'schema.qcode': {'$exists': True}},
+                                             {'$set': {
+                                                 'unique_field': "qcode"
+                                             }}))
+
+    def backwards(self, mongodb_collection, mongodb_database):
+        pass

--- a/superdesk/vocabularies/vocabularies.py
+++ b/superdesk/vocabularies/vocabularies.py
@@ -113,7 +113,7 @@ class VocabulariesResource(Resource):
     }
 
     soft_delete = True
-    item_url = 'regex("[-_\w]+")'
+    item_url = r'regex("[-_\w]+")'
     item_methods = ['GET', 'PATCH', 'DELETE']
     resource_methods = ['GET', 'POST']
     privileges = {'PATCH': 'vocabularies', 'POST': 'vocabularies', 'DELETE': 'vocabularies'}
@@ -125,6 +125,13 @@ class VocabulariesService(BaseService):
     system_keys = set(DEFAULT_SCHEMA.keys()).union(set(DEFAULT_EDITOR.keys()))
 
     def _validate_items(self, update):
+        # if we have qcode and not unique_field set, we want it to be qcode
+        try:
+            update['schema']['qcode']
+        except KeyError:
+            pass
+        else:
+            update.setdefault('unique_field', 'qcode')
         if 'schema' in update and 'items' in update:
             for index, item in enumerate(update['items']):
                 for field, desc in update.get('schema', {}).items():


### PR DESCRIPTION
if "unique_field" is not set and "qcode" is present in schema, this patch will use it as "unique_field".
A data migration script is also present to update existing vocabularies.

SDESK-2763