### PR TITLE
fix(annotations): fix annotations field mapping

### DIFF
--- a/features/archive.feature
+++ b/features/archive.feature
@@ -766,3 +766,19 @@ Feature: News Items Archive
         """
         {"guid": "123", "associations": {"editor_0": {"_updated": "__now__"}}}
         """
+
+    @auth
+    Scenario: It can save annotations
+        When we post to "/archive"
+        """
+        [{
+            "guid": "123", "type": "text", "headline": "test", "state": "in_progress",
+            "dateline": {
+              "date": "#DATE#"
+            },
+            "annotations": [
+                {"id": "1", "type": "regular", "body": "<p>foo</p>"}
+            ]
+        }]
+        """
+        Then we get OK response

--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -536,9 +536,14 @@ metadata_schema = {
 
     'annotations': {
         'type': 'list',
+        'mapping': not_enabled,
         'schema': {
             'type': 'dict',
-            'mapping': not_enabled,
+            'schema': {
+                'id': {'type': 'string'},
+                'type': {'type': 'string'},
+                'body': {'type': 'string'},
+            },
         },
     },
 


### PR DESCRIPTION
`mapping` doesn't work in `schema`, it makes [serialize](https://github.com/pyeve/eve/blob/master/eve/methods/common.py#L141-L144) fail and leave the updates as is before validation, then any `datetime` type field would cause a problem because it wouldn't be datetime class instance, like `datetime.date`