### PR TITLE
[VOCABULARIES] fixed priority and urgency qcodes

### DIFF
--- a/superdesk/vocabularies/vocabularies.py
+++ b/superdesk/vocabularies/vocabularies.py
@@ -71,7 +71,6 @@ class VocabulariesResource(Resource):
                 'allow_unknown': True,
                 'schema': {
                     'name': {'type': 'string', 'required': False, 'nullable': True},
-                    'qcode': {'type': 'string', 'required': False, 'nullable': True}
                 }
             }
         },


### PR DESCRIPTION
qcodes were stored as int instead of string for priority and urgency,
resulting in issues when trying to update vocabularies or to use
them in articles.

This patch fixes the prepopulate data and add a migration script to fix
existing values.

SDESK-2922