### PR TITLE
[VOCABULARIES] does not validate item if unique field is missing

### DIFF
--- a/superdesk/vocabularies/vocabularies.py
+++ b/superdesk/vocabularies/vocabularies.py
@@ -135,10 +135,12 @@ class VocabulariesService(BaseService):
             pass
         else:
             update.setdefault('unique_field', 'qcode')
+        unique_field = update.get('unique_field')
         if 'schema' in update and 'items' in update:
             for index, item in enumerate(update['items']):
                 for field, desc in update.get('schema', {}).items():
-                    if desc.get('required', False) and (field not in item or not item[field]):
+                    if ((desc.get('required', False) or unique_field == field) and (
+                            field not in item or not item[field])):
                         raise SuperdeskApiError.badRequestError('Required ' + field + ' in item ' + str(index))
 
     def on_create(self, docs):


### PR DESCRIPTION
In addition to checking required field, this patch also impose unique
field to be present in items to validate.

https://dev.sourcefabric.org/browse/SDESK-2763