### PR TITLE
[SDESK-3113](fix): Adding registry for restricted parser for feeding service.

### DIFF
--- a/apps/io/feeding_services/reuters.py
+++ b/apps/io/feeding_services/reuters.py
@@ -16,7 +16,7 @@ from flask import current_app as app
 
 from superdesk.errors import IngestApiError
 from superdesk.etree import etree, ParseError
-from superdesk.io.registry import register_feeding_service
+from superdesk.io.registry import register_feeding_service, register_feeding_service_parser
 from superdesk.io.feeding_services.http_service import HTTPFeedingService
 from superdesk.logging import logger
 from superdesk.utc import utcnow
@@ -64,8 +64,6 @@ class ReutersHTTPFeedingService(HTTPFeedingService):
             'placeholder': 'Password', 'required': True
         }
     ]
-
-    parser_restricted_values = ['newsml2']
 
     session = None
 
@@ -302,3 +300,4 @@ class ReutersHTTPFeedingService(HTTPFeedingService):
 
 
 register_feeding_service(ReutersHTTPFeedingService)
+register_feeding_service_parser(ReutersHTTPFeedingService.NAME, 'newsml2')

--- a/apps/io/feeding_services/wufoo.py
+++ b/apps/io/feeding_services/wufoo.py
@@ -8,7 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from superdesk.io.registry import register_feeding_service
+from superdesk.io.registry import register_feeding_service, register_feeding_service_parser
 from superdesk.io.feeding_services import FeedingService
 from superdesk.errors import IngestApiError
 import requests
@@ -47,8 +47,6 @@ class WufooFeedingService(FeedingService):
         }
     ]
 
-    parser_restricted_values = ['wufoo']
-
     def __init__(self):
         self.fields_cache = {}
 
@@ -76,3 +74,4 @@ class WufooFeedingService(FeedingService):
 
 
 register_feeding_service(WufooFeedingService)
+register_feeding_service_parser(WufooFeedingService.NAME, 'wufoo')

--- a/superdesk/io/feeding_services/email.py
+++ b/superdesk/io/feeding_services/email.py
@@ -13,7 +13,7 @@ import imaplib
 
 from flask import current_app as app
 from superdesk.errors import IngestEmailError
-from superdesk.io.registry import register_feeding_service
+from superdesk.io.registry import register_feeding_service, register_feeding_service_parser
 from superdesk.io.feeding_services import FeedingService
 from superdesk.upload import url_for_media
 
@@ -64,8 +64,6 @@ class EmailFeedingService(FeedingService):
             'placeholder': 'Filter', 'required': True
         }
     ]
-
-    parser_restricted_values = ['email_rfc822']
 
     def _test(self, provider):
         self._update(provider, update=None, test=True)
@@ -120,3 +118,4 @@ class EmailFeedingService(FeedingService):
 
 
 register_feeding_service(EmailFeedingService)
+register_feeding_service_parser(EmailFeedingService.NAME, 'email_rfc822')

--- a/superdesk/io/feeding_services/ritzau.py
+++ b/superdesk/io/feeding_services/ritzau.py
@@ -11,7 +11,7 @@
 
 import logging
 
-from superdesk.io.registry import register_feeding_service
+from superdesk.io.registry import register_feeding_service, register_feeding_service_parser
 from superdesk.io.feeding_services import FeedingService
 from superdesk.errors import IngestApiError, SuperdeskIngestError
 from lxml import etree
@@ -48,8 +48,6 @@ class RitzauFeedingService(FeedingService):
             'placeholder': 'fill this field only for advanced uses', 'required': False
         }
     ]
-
-    parser_restricted_values = ['ritzau']
 
     def _update(self, provider, update):
         try:
@@ -105,3 +103,4 @@ class RitzauFeedingService(FeedingService):
 
 
 register_feeding_service(RitzauFeedingService)
+register_feeding_service_parser(RitzauFeedingService.NAME, 'ritzau')

--- a/superdesk/io/feeding_services/rss.py
+++ b/superdesk/io/feeding_services/rss.py
@@ -82,8 +82,6 @@ class RSSFeedingService(FeedingService):
         }
     ]
 
-    parser_restricted_values = None
-
     field_groups = {'auth_data': {'label': 'Authentication Info', 'fields': ['username', 'password']}}
 
     ItemField = namedtuple('ItemField', ['name', 'name_in_data', 'type'])

--- a/superdesk/io/feeding_services/twitter.py
+++ b/superdesk/io/feeding_services/twitter.py
@@ -56,8 +56,6 @@ class TwitterFeedingService(FeedingService):
         }
     ]
 
-    parser_restricted_values = None
-
     ERRORS = [IngestTwitterError.TwitterLoginError().get_error_description(),
               IngestTwitterError.TwitterNoScreenNamesError().
               get_error_description()]

--- a/superdesk/io/registry.py
+++ b/superdesk/io/registry.py
@@ -21,6 +21,7 @@ registered_feeding_services = {}
 allowed_feeding_services = []
 feeding_service_errors = {}
 publish_errors = []
+restricted_feeding_service_parsers = {}
 
 
 def register_feeding_service(service_class):
@@ -75,6 +76,19 @@ def register_feed_parser(parser_name, parser_class):
     allowed_feed_parsers.append(parser_name)
 
 
+def register_feeding_service_parser(service_name, parser_name):
+    """
+    Registers the Feed Parser with the Feeding service.
+
+    :param service_name: unique name to identify the Feeding Service class
+    :param parser_name: unique name to identify the Feed Parser class
+    """
+    if not restricted_feeding_service_parsers.get(service_name):
+        restricted_feeding_service_parsers[service_name] = {}
+
+    restricted_feeding_service_parsers[service_name][parser_name] = True
+
+
 def get_feed_parser(parser_name):
     """
     Retrieve registered feed parser class from its name
@@ -117,12 +131,14 @@ class FeedingServiceAllowedService(Service):
     def get(self, req, lookup):
         def service(service_id):
             registered = registered_feeding_services[service_id]
+            restricted_parsers = list(restricted_feeding_service_parsers.get(service_id, {}).keys())
+
             return {
                 'feeding_service': service_id,
                 'label': getattr(registered, 'label', service_id),
                 'fields': getattr(registered, 'fields', []),
                 'field_groups': getattr(registered, 'field_groups', {}),
-                'parser_restricted_values': getattr(registered, 'parser_restricted_values', [])
+                'parser_restricted_values': restricted_parsers
             }
 
         return ListCursor(

--- a/tests/feeding_services_test.py
+++ b/tests/feeding_services_test.py
@@ -1,18 +1,21 @@
+from unittest.mock import patch
 from superdesk.tests import TestCase
 from superdesk.io.feeding_services import FeedingService
 from superdesk.errors import SuperdeskIngestError
 
 
 class TestFeedingService(FeedingService):
-    parser_restricted_values = ['ninjs']
+    Name = 'test_feeding'
 
     def _update(self, provider, update):
         pass
 
 
-class ContentAPITestCase(TestCase):
-    def test_publish_to_content_api(self):
-        feeding_service = TestFeedingService()
+class FeedingServiceParserTestCase(TestCase):
 
-        with self.assertRaises(SuperdeskIngestError):
-            feeding_service.config_test({'feed_parser': 'foo'})
+    def test_restricted_parser(self):
+        feeding_service = TestFeedingService()
+        with patch.dict('superdesk.io.feeding_services.restricted_feeding_service_parsers',
+                        {'test_feeding': {'ninjs': True}}):
+            with self.assertRaises(SuperdeskIngestError):
+                feeding_service.config_test({'feed_parser': 'foo', 'feeding_service': 'test_feeding'})


### PR DESCRIPTION
Adding registry for the `restricted parsers` for feeding service so that different parser can be used for then`restricted parser feed service`.

@petrjasek @jerome-poisson 