### PR TITLE
feat(publish): allow transmitting media when formatting

### DIFF
--- a/apps/publish/enqueue/enqueue_service.py
+++ b/apps/publish/enqueue/enqueue_service.py
@@ -401,6 +401,7 @@ class EnqueueService:
                             no_formatters.append(destination['format'])
                             continue
 
+                        formatter.set_destination(destination, subscriber)
                         formatted_docs = formatter.format(apply_schema(doc),
                                                           subscriber,
                                                           subscriber_codes.get(subscriber[config.ID_FIELD]))

--- a/superdesk/publish/publish_service.py
+++ b/superdesk/publish/publish_service.py
@@ -39,6 +39,10 @@ class PublishServiceBase():
         """
         raise NotImplementedError()
 
+    def _transmit_media(self, media, destination):
+        """Transmit media file. Implement in subclass"""
+        raise NotImplementedError()
+
     def transmit(self, queue_item):
         subscriber = get_resource_service('subscribers').find_one(req=None, _id=queue_item['subscriber_id'])
 
@@ -62,6 +66,10 @@ class PublishServiceBase():
                 self.update_item_status(queue_item, 'error', error)
                 self.close_transmitter(subscriber, error)
                 raise error
+
+    def transmit_media(self, media, subscriber=None, destination=None):
+        if subscriber and destination and subscriber.get('is_active'):
+            return self._transmit_media(media, destination)
 
     def close_transmitter(self, subscriber, error):
         """


### PR DESCRIPTION
it allows formatter to publish custom media files, like attachments
required for https://github.com/superdesk/superdesk-planning/pull/932