### PR TITLE
[DICTIONARIES] catch RuntimeError in Eve workaround

### DIFF
--- a/apps/dictionaries/service.py
+++ b/apps/dictionaries/service.py
@@ -150,7 +150,7 @@ class DictionaryService(BaseService):
             # We also test request.data because it is not set in behave tests, and they would fail without it
             try:
                 docs[0]['content'] = json.loads(request.data.decode('utf-8'))['content']
-            except (KeyError, JSONDecodeError):
+            except (KeyError, JSONDecodeError, RuntimeError):
                 # request.data is not set during tests, so we ignore those errors
                 pass
 
@@ -239,7 +239,7 @@ class DictionaryService(BaseService):
             # cf. SDESK-3083
             try:
                 updates['content'] = json.loads(request.data.decode('utf-8'))['content']
-            except (KeyError, JSONDecodeError):
+            except (KeyError, JSONDecodeError, RuntimeError):
                 # request.data is not set during tests, so we ignore those errors
                 pass
         # parse json list


### PR DESCRIPTION
The workaound needed to avoid Eve behaviour with dictionary keys uses
Flask request object.
This object is not initialized when there is not HTTP request involved,
which is the case when app:prepopulate command is executed, resulting in
a RuntimeError and the prepopulation failing.

This patch fixes this by catching RuntimeError.

SDESK-3083