### PR TITLE
[VALIDATION] [MEDIA] media metadata validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Superdesk Server Changelog
 
+## [1.24] NOT RELEASED YET
+
+### Changed
+
+- associations are now validated in backend
+- new setting `VALIDATOR_MEDIA_METADATA` to indicate which fields are mandatory in media
+
 ## [1.23] 2018-08-07
 
 ### Fixed

--- a/apps/client_config.py
+++ b/apps/client_config.py
@@ -30,4 +30,5 @@ def init_app(app):
         'override_ednote_template': app.config.get('OVERRIDE_EDNOTE_TEMPLATE'),
         'default_genre': app.config.get('DEFAULT_GENRE_VALUE_FOR_MANUAL_ARTICLES'),
         'japanese_characters_per_minute': app.config.get('JAPANESE_CHARACTERS_PER_MINUTE'),
+        'validator_media_metadata': app.config.get('VALIDATOR_MEDIA_METADATA', {})
     })

--- a/apps/validate/tests.py
+++ b/apps/validate/tests.py
@@ -11,6 +11,12 @@
 from apps.validate.validate import SchemaValidator, ValidateService
 from superdesk.tests import TestCase
 from superdesk.metadata.item import ITEM_TYPE
+from superdesk.default_settings import VALIDATOR_MEDIA_METADATA
+
+
+# dict of fields mandatory in media during validation
+# this is build dynamically to stay in sync with VALIDATOR_MEDIA_METADATA
+MEDIA_MANDATORY = {k: k for k, v in VALIDATOR_MEDIA_METADATA.items() if v.get("required")}
 
 
 class ValidateMandatoryInListTest(TestCase):
@@ -164,7 +170,7 @@ class ValidateMandatoryInListTest(TestCase):
                 'validate': {'profile': 'foo', 'slugline': 'foo', 'associations': {'featuremedia': {}}},
             }
         ])
-        self.assertEqual(['MEDIA_DESCRIPTION is a required field'], errors[0])
+        self.assertIn('MEDIA_DESCRIPTION is a required field', errors[0])
 
     def test_validate_field_required_media_description_null(self):
         self.app.data.insert('content_types', [{'_id': 'foo', 'schema': {
@@ -224,6 +230,8 @@ class ValidateMandatoryInListTest(TestCase):
             'media_description': {'required': True},
         }}])
         service = ValidateService()
+        feature_media = MEDIA_MANDATORY
+        feature_media.update({'description_text': 'test'})
         errors = service.create([
             {
                 'act': 'test',
@@ -231,7 +239,7 @@ class ValidateMandatoryInListTest(TestCase):
                 'validate': {
                     'profile': 'foo',
                     'slugline': 'foo',
-                    'associations': {'featuremedia': {'description_text': 'test'}}
+                    'associations': {'featuremedia': feature_media}
                 },
             },
         ])

--- a/features/content_expire_published.feature
+++ b/features/content_expire_published.feature
@@ -867,7 +867,10 @@ Feature: Content Expiry Published Items
         "associations": {
           "featuremedia": {
             "_id": "bike",
-            "poi": {"x": 0.2, "y": 0.3}
+            "poi": {"x": 0.2, "y": 0.3},
+            "headline": "headline",
+            "alt_text": "alt_text",
+            "description_text": "description_text"
           }
         }
       }
@@ -927,7 +930,10 @@ Feature: Content Expiry Published Items
         "associations": {
           "featuremedia": {
             "_id": "bike",
-            "poi": {"x": 0.2, "y": 0.3}
+            "poi": {"x": 0.2, "y": 0.3},
+            "headline": "headline",
+            "alt_text": "alt_text",
+            "description_text": "description_text"
           }
         }
       }
@@ -989,7 +995,10 @@ Feature: Content Expiry Published Items
         "associations": {
           "featuremedia": {
             "_id": "bike",
-            "poi": {"x": 0.2, "y": 0.3}
+            "poi": {"x": 0.2, "y": 0.3},
+            "headline": "headline",
+            "alt_text": "alt_text",
+            "description_text": "description_text"
           }
         }
       }
@@ -1053,7 +1062,10 @@ Feature: Content Expiry Published Items
         "associations": {
           "featuremedia": {
             "_id": "bike",
-            "poi": {"x": 0.2, "y": 0.3}
+            "poi": {"x": 0.2, "y": 0.3},
+            "headline": "headline",
+            "alt_text": "alt_text",
+            "description_text": "description_text"
           }
         }
       }

--- a/features/content_publish.feature
+++ b/features/content_publish.feature
@@ -2303,7 +2303,15 @@ Feature: Content Publishing
       [{"guid": "123", "type": "text", "headline": "test", "_current_version": 1, "state": "in_progress",
         "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
         "subject":[{"qcode": "17004000", "name": "Statistics"}], "body_html": "Test Document body",
-        "associations": {"featureimage": {"_id": "234", "guid": "234", "type": "picture", "slugline": "s234", "state": "in_progress"}}}]
+        "associations": {
+            "featureimage": {
+                "_id": "234",
+                "guid": "234",
+                "alt_text": "alt_text",
+                "description_text": "description_text",
+                "type": "picture",
+                "slugline": "s234",
+                "state": "in_progress"}}}]
       """
       When we post to "/products" with success
       """
@@ -2322,7 +2330,7 @@ Feature: Content Publishing
       And we publish "#archive._id#" with "publish" type and "published" state
       Then we get error 400
       """
-      {"_issues": {"validator exception": "['Associated item s234 234: HEADLINE is a required field']"}, "_status": "ERR"}
+      {"_issues": {"validator exception": "[[\"MEDIA'S HEADLINE is a required field\"]]"}, "_status": "ERR"}
       """
 
     @auth
@@ -2410,30 +2418,30 @@ Feature: Content Publishing
       And "vocabularies"
       """
       [{
-      	"_id": "vocabulary1",
-      	"display_name": "Vocabulary 1",
-      	"schema": {"name" : {}, "qcode": {}, "parent": {}},
-      	"service": {"all": 1},
-      	"type": "manageable",
-      	"items": [{"name": "Option 1", "qcode": "o1", "is_active": true}, {"name": "Option 2", "qcode": "o2", "is_active": true}]
+          "_id": "vocabulary1",
+          "display_name": "Vocabulary 1",
+          "schema": {"name" : {}, "qcode": {}, "parent": {}},
+          "service": {"all": 1},
+          "type": "manageable",
+          "items": [{"name": "Option 1", "qcode": "o1", "is_active": true}, {"name": "Option 2", "qcode": "o2", "is_active": true}]
       },{
-      	"_id": "custom_field_1",
-      	"display_name": "Custom Field 1",
-      	"field_type": "text",
-      	"schema": {"name" : {}, "qcode": {}, "parent": {}},
-      	"service": {"all": 1},
-      	"type": "manageable",
-      	"items": [],
-      	"field_options": {"single": true}
+          "_id": "custom_field_1",
+          "display_name": "Custom Field 1",
+          "field_type": "text",
+          "schema": {"name" : {}, "qcode": {}, "parent": {}},
+          "service": {"all": 1},
+          "type": "manageable",
+          "items": [],
+          "field_options": {"single": true}
       }]
       """
       And "content_types"
       """
       [{
-      	"enabled": true, "priority": 0, "label": "Profile 1",
-      	"schema": {
-      		"custom_field_1": {"type": "string", "required": true, "enabled": true},
-      		"subject": {
+          "enabled": true, "priority": 0, "label": "Profile 1",
+          "schema": {
+              "custom_field_1": {"type": "string", "required": true, "enabled": true},
+              "subject": {
                 "schema": {
                     "schema": {
                         "qcode": {},
@@ -2456,15 +2464,15 @@ Feature: Content Publishing
                 "type": "list",
                 "minlength": 1
             }
-      	}
+          }
       }]
       """
       And "archive"
       """
       [{
-      	"type": "text", "profile": "#content_types._id#", "state": "in_progress",
-      	"subject": [{"scheme": "vocabulary1", "name": "Option 1", "qcode": "o1"}],
-      	"extra": {"custom_field_1": "some text"}
+          "type": "text", "profile": "#content_types._id#", "state": "in_progress",
+          "subject": [{"scheme": "vocabulary1", "name": "Option 1", "qcode": "o1"}],
+          "extra": {"custom_field_1": "some text"}
       }]
       """
       When we post to "/products" with success
@@ -2498,28 +2506,28 @@ Feature: Content Publishing
       Given "vocabularies"
       """
       [{
-      	"_id": "media1", "field_type": "media",
-      	"display_name": "Media 1", "type": "manageable",
-      	"service": {"all": 1}, "items": [],
-      	"field_options": {"allowed_types": {"picture": true}},
-      	"schema": {"parent": {}, "name": {}, "qcode": {}}
+          "_id": "media1", "field_type": "media",
+          "display_name": "Media 1", "type": "manageable",
+          "service": {"all": 1}, "items": [],
+          "field_options": {"allowed_types": {"picture": true}},
+          "schema": {"parent": {}, "name": {}, "qcode": {}}
       }]
       """
       And "content_types"
       """
       [{
-      	"_id": "profile1", "label": "Profile 1",
-      	"is_used": true, "enabled": true, "priority": 0, "editor": {},
-      	"schema": {"media1": {"required": true, "nullable": false, "enabled": true, "type": "media"}}
+          "_id": "profile1", "label": "Profile 1",
+          "is_used": true, "enabled": true, "priority": 0, "editor": {},
+          "schema": {"media1": {"required": true, "nullable": false, "enabled": true, "type": "media"}}
       }]
       """
-	  And "validators"
-	  """
-	  [
-	  	{"_id": "publish_picture", "act": "publish", "type": "picture", "schema":{}},
-	  	{"_id": "publish_text", "act": "publish", "type": "text", "schema":{}}
-	  ]
-	  """
+      And "validators"
+      """
+      [
+          {"_id": "publish_picture", "act": "publish", "type": "picture", "schema":{}},
+          {"_id": "publish_text", "act": "publish", "type": "text", "schema":{}}
+      ]
+      """
       And "desks"
       """
       [{"name": "Sports"}]
@@ -2527,7 +2535,7 @@ Feature: Content Publishing
       When we post to "/products" with success
       """
       {
-      	"name":"prod-1","codes":"abc,xyz", "product_type": "both"
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
       }
       """
       And we post to "/subscribers" with success
@@ -2541,22 +2549,30 @@ Feature: Content Publishing
       And we post to "archive" with success
       """
       [
-      	{
-       	    "guid": "234", "type": "picture", "slugline": "234", "headline": "234", "state": "in_progress",
-        	"task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
-       	    "renditions": {}
+          {
+               "guid": "234", "type": "picture", "slugline": "234", "headline": "234", "state": "in_progress",
+            "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
+               "renditions": {}
         },
-      	{
-      		"guid": "123", "type": "text", "headline": "test", "state": "in_progress",
-        	"task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
-        	"subject":[{"qcode": "17004000", "name": "Statistics"}], "body_html": "Test Document body",
-        	"associations": {
-        		"media--1": {"_id": "234", "guid": "234", "type": "picture", "slugline": "234",
-        		"headline": "234", "state": "in_progress", "renditions": {},
-	        	"task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}
-        		}
-        	}
-       	}
+          {
+              "guid": "123", "type": "text", "headline": "test", "state": "in_progress",
+            "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
+            "subject":[{"qcode": "17004000", "name": "Statistics"}], "body_html": "Test Document body",
+            "associations": {
+                "media--1": {
+                    "_id": "234",
+                    "guid": "234",
+                    "type": "picture",
+                    "slugline": "234",
+                    "headline": "234",
+                    "alt_text": "alt_text",
+                    "description_text": "description_text",
+                    "state": "in_progress",
+                    "renditions": {},
+                    "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}
+                }
+            }
+           }
       ]
       """
       And we publish "123" with "publish" type and "published" state
@@ -2568,7 +2584,7 @@ Feature: Content Publishing
         "type": "text",
         "state": "published",
         "associations": {
-        	"media--1": {"state": "published"}
+            "media--1": {"state": "published"}
         },
         "task":{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}
       }
@@ -2577,9 +2593,9 @@ Feature: Content Publishing
       Then we get existing resource
       """
       {
-      	"guid": "234",
-      	"state": "published",
-      	"task":{"desk": "#desks._id#"}
+          "guid": "234",
+          "state": "published",
+          "task":{"desk": "#desks._id#"}
       }
       """
       And we get null stage
@@ -2604,8 +2620,16 @@ Feature: Content Publishing
         "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
         "subject":[{"qcode": "17004000", "name": "Statistics"}], "body_html": "Test Document body",
         "associations": {"editor_0": {
-        	"_id": "234", "guid": "234", "type": "picture", "slugline": "s234", "state": "in_progress",
-        	"headline": "some headline", "_type": "archive", "_current_version": 1
+            "_id": "234",
+            "guid": "234",
+            "type": "picture",
+            "slugline": "s234",
+            "state": "in_progress",
+            "headline": "some headline",
+            "alt_text": "alt_text",
+            "description_text": "description_text",
+            "_type": "archive",
+            "_current_version": 1
         }}}]
       """
       When we post to "/products" with success
@@ -2630,7 +2654,7 @@ Feature: Content Publishing
         "guid": "123",
         "state": "published",
         "associations": {
-        	"editor_0": {"state": "published"}
+            "editor_0": {"state": "published"}
         }
       }
       """
@@ -2651,16 +2675,16 @@ Feature: Content Publishing
       [{"_id": "234", "guid": "234", "type": "picture", "slugline": "s234", "state": "in_progress",
         "headline": "some headline", "_current_version": 1,
         "renditions": {"original": {"mimetype": "audio/mp3", "media": "5ae35d0095cc644f859a94c2",
-        	"href": "http://localhost:5000/api/upload-raw/5ae35d0095cc644f859a94c2"
+            "href": "http://localhost:5000/api/upload-raw/5ae35d0095cc644f859a94c2"
         }}},
        {"guid": "123", "type": "text", "headline": "fc_api", "_current_version": 1, "state": "in_progress",
         "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
         "subject":[{"qcode": "17004000", "name": "Statistics"}], "body_html": "Test Document body",
         "associations": {"media--1": {
-        	"_id": "234", "guid": "234", "type": "picture", "slugline": "s234", "state": "in_progress",
-        	"headline": "some headline", "_type": "archive", "_current_version": 1,
-        	"renditions": {"original": {"mimetype": "audio/mp3", "media": "5ae35d0095cc644f859a94c2",
-        		"href": "http://localhost:5000/api/upload-raw/5ae35d0095cc644f859a94c2"
+            "_id": "234", "guid": "234", "type": "picture", "slugline": "s234", "state": "in_progress",
+            "headline": "some headline", "_type": "archive", "_current_version": 1,
+            "renditions": {"original": {"mimetype": "audio/mp3", "media": "5ae35d0095cc644f859a94c2",
+                "href": "http://localhost:5000/api/upload-raw/5ae35d0095cc644f859a94c2"
         }}}}}]
       """
       When we post to "/filter_conditions" with "fc_api" and success
@@ -2672,13 +2696,13 @@ Feature: Content Publishing
       [{"content_filter": [{"expression": {"fc": ["#fc_api#"]}}], "name": "cf_api"}]
       """
       And we post to "/products" with "p_api" and success
-	  """
-	  [{
-	    "name":"prod-2","codes":"api",
-	    "content_filter":{"filter_id":"#cf_api#", "filter_type": "permitting"},
-	    "product_type": "api"
-	  }]
-	  """
+      """
+      [{
+        "name":"prod-2","codes":"api",
+        "content_filter":{"filter_id":"#cf_api#", "filter_type": "permitting"},
+        "product_type": "api"
+      }]
+      """
       And we post to "/subscribers" with "sub_api" and success
       """
       {
@@ -2765,7 +2789,7 @@ Feature: Content Publishing
                     }
                 }
             }
-      	]
+          ]
       }
       """
 

--- a/features/publish_embedded.feature
+++ b/features/publish_embedded.feature
@@ -179,6 +179,8 @@ Feature: Publish embedded items feature
         {"_id": "#archive._id#",
          "type": "picture",
          "headline": "test",
+         "alt_text": "alt_text",
+         "description_text": "description_text",
          "state": "in_progress"}}}
         """
         Then we get OK response
@@ -197,7 +199,14 @@ Feature: Publish embedded items feature
 
         When we publish "foo" with "publish" type and "published" state
         """
-        {"headline": "foo", "associations": {"embedded1": {"_id": "#archive._id#", "type": "picture", "headline": "test", "state": "in_progress"}}}
+        {"headline": "foo", "associations": {
+            "embedded1": {
+                "_id": "#archive._id#",
+                "type": "picture",
+                "headline": "test",
+                "alt_text": "alt_text",
+                "description_text": "description_text",
+                "state": "in_progress"}}}
         """
         Then we get OK response
         When we get "published"
@@ -248,6 +257,8 @@ Feature: Publish embedded items feature
         {"_id": "#archive._id#",
          "type": "picture",
          "headline": "test",
+         "alt_text": "alt_text",
+         "description_text": "description_text",
          "state": "in_progress"}}}
         """
         Then we get OK response
@@ -266,7 +277,14 @@ Feature: Publish embedded items feature
 
         When we publish "foo" with "publish" type and "published" state
         """
-        {"headline": "foo", "associations": {"embedded1": {"_id": "#archive._id#", "type": "picture", "headline": "test", "state": "in_progress"}}}
+        {"headline": "foo", "associations": {
+            "embedded1": {
+                "_id": "#archive._id#",
+                "type": "picture",
+                "headline": "test",
+                "alt_text": "alt_text",
+                "description_text": "description_text",
+                "state": "in_progress"}}}
         """
         Then we get OK response
         When we get "published"
@@ -338,6 +356,8 @@ Feature: Publish embedded items feature
         {"_id": "#archive._id#",
          "type": "picture",
          "headline": "test",
+         "alt_text": "alt_text",
+         "description_text": "description_text",
          "state": "in_progress"}}}
         """
         Then we get OK response
@@ -356,7 +376,14 @@ Feature: Publish embedded items feature
 
         When we publish "foo" with "publish" type and "published" state
         """
-        {"headline": "foo", "associations": {"embedded1": {"_id": "#archive._id#", "type": "picture", "headline": "test", "state": "in_progress"}}}
+        {"headline": "foo", "associations": {
+            "embedded1": {
+                "_id": "#archive._id#",
+                "type": "picture",
+                "headline": "test",
+                "alt_text": "alt_text",
+                "description_text": "description_text",
+                "state": "in_progress"}}}
         """
         Then we get OK response
         When we get "published"
@@ -429,7 +456,14 @@ Feature: Publish embedded items feature
 
         When we patch "archive/foo"
         """
-        {"headline": "foo", "slugline": "bar", "state": "in_progress", "associations": {"embedded1": {"_id": "#archive._id#", "type": "picture", "headline": "test", "state": "in_progress"}}}
+        {"headline": "foo", "slugline": "bar", "state": "in_progress", "associations": {
+            "embedded1": {
+                "_id": "#archive._id#",
+                "type": "picture",
+                "headline": "test",
+                "alt_text": "alt_text",
+                "description_text": "description_text",
+                "state": "in_progress"}}}
         """
         Then we get OK response
 
@@ -441,7 +475,15 @@ Feature: Publish embedded items feature
         Then we set copy metadata from parent flag
         When we publish "foo" with "publish" type and "published" state
         """
-        {"headline": "foo", "associations": {"embedded1": {"_id": "#archive._id#", "slugline": "test", "type": "picture", "headline": "test", "state": "in_progress"}}}
+        {"headline": "foo", "associations": {
+            "embedded1": {
+                "_id": "#archive._id#",
+                "slugline": "test",
+                "type": "picture",
+                "headline": "test",
+                "alt_text": "alt_text",
+                "description_text": "description_text",
+                "state": "in_progress"}}}
         """
         Then we get OK response
 

--- a/features/publish_publicapi.feature
+++ b/features/publish_publicapi.feature
@@ -498,7 +498,10 @@ Feature: Publish content to the public API
                         "state": "submitted",
                         "pubstatus": "usable",
                         "mimetype": "image/jpeg",
-                        "slugline": "foo"
+                        "slugline": "foo",
+                        "headline": "headline",
+                        "alt_text": "alt_text",
+                        "description_text": "description_text"
                     }
                 }
             }

--- a/features/validate.feature
+++ b/features/validate.feature
@@ -250,10 +250,10 @@ Feature: Validate
     Given "vocabularies"
     """
     [
-    	{"_id": "text1", "field_type": "text", "display_name": "Text 1"},
-    	{"_id": "media1", "field_type": "media", "display_name": "Media 1"},
-    	{"_id": "embed1", "field_type": "embed", "display_name": "Embed 1"},
-    	{"_id": "date1", "field_type": "date", "display_name": "Date 1"}
+        {"_id": "text1", "field_type": "text", "display_name": "Text 1"},
+        {"_id": "media1", "field_type": "media", "display_name": "Media 1"},
+        {"_id": "embed1", "field_type": "embed", "display_name": "Embed 1"},
+        {"_id": "date1", "field_type": "date", "display_name": "Date 1"}
     ]
     """
     And "content_types"
@@ -273,25 +273,30 @@ Feature: Validate
     Then we get existing resource
     """
     {"errors": ["Text 1 is a required field", "MEDIA1 is a required field",
-    	"Embed 1 is a required field", "Date 1 is a required field"
+        "Embed 1 is a required field", "Date 1 is a required field"
     ]}
     """
 
     When we post to "/validate"
     """
     {
-    	"act": "publish", "type": "text",
-    	"validate": {
-    		"profile": "foo",
-    		"extra": {
-    			"text1": "foo",
-    			"embed1": {"foo": "bar"},
-    			"date1": "2018-01-22T00:00:00+0000"
-    		},
-    		"associations": {
-    			"media1": {"foo": "bar"}
-    		}
-    	}
+        "act": "publish", "type": "text",
+        "validate": {
+            "profile": "foo",
+            "extra": {
+                "text1": "foo",
+                "embed1": {"foo": "bar"},
+                "date1": "2018-01-22T00:00:00+0000"
+            },
+            "associations": {
+                "media1": {
+                    "foo": "bar",
+                    "headline": "headline",
+                    "alt_text": "alt_text",
+                    "description_text": "description_text"
+                    }
+            }
+        }
     }
     """
     Then we get existing resource

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -679,3 +679,31 @@ ERROR_NOTIFICATIONS = strtobool(env('SUPERDESK_ERROR_NOTIFICATIONS', 'true'))
 
 #: geonames credentials
 GEONAMES_USERNAME = env('GEONAMES_USERNAME')
+
+# media required fields
+VALIDATOR_MEDIA_METADATA = {
+    "headline": {
+        "required": True,
+    },
+    "alt_text": {
+        "required": True,
+    },
+    "archive_description": {
+        "required": False,
+    },
+    "description_text": {
+        "required": True,
+    },
+    "copyrightholder": {
+        "required": False,
+    },
+    "byline": {
+        "required": False,
+    },
+    "usageterms": {
+        "required": False,
+    },
+    "copyrightnotice": {
+        "required": False,
+    },
+}


### PR DESCRIPTION
VALIDATOR_MEDIA_METADATA is a schema indicating which metadata are
available and which fields are required, it was previously in client and
has been moved to backend. Client can retrieve this data using deployConfig.

During validation, if associations are present, those metadata are
checked, and an error message is returned if any required field is
missing.

SDFID-431