### PR TITLE
[Potential BC break] move tweet url from ednote to extra field

### DIFF
--- a/superdesk/io/feeding_services/twitter.py
+++ b/superdesk/io/feeding_services/twitter.py
@@ -112,7 +112,7 @@ class TwitterFeedingService(FeedingService):
                 headline = "%s: %s" % (status.user.screen_name, status.text)
                 item = {}
                 item['source'] = 'twitter'
-                item['ednote'] = "https://twitter.com/%s/status/%s" % (status.user.screen_name, status.id)
+                item['extra'] = {'tweet_url': "https://twitter.com/%s/status/%s" % (status.user.screen_name, status.id)}
                 item['headline'] = headline
                 item['type'] = 'text'
                 item['guid'] = guid


### PR DESCRIPTION
Ednote is overwritten by Superdesk on article correction. We need to keep tweet url in extra field. To see this value in output - content profile need to have this extra field configured. 