### PR TITLE
[CODE QUALITY] disabled W503 in flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length=120
 exclude=env,bin,lib,include,src,docs
-ignore=F811,D200,D202,D205,D400,D401,D100,D101,D102,D103,D104,D105,D107
+ignore=F811,D200,D202,D205,D400,D401,D100,D101,D102,D103,D104,D105,D107,W503


### PR DESCRIPTION
W503 complains about "W503 line break before binary operator" but this
is the right way to do nowadays, the recommandations have changed in PEP
8 (cf.
https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator).

This patch disable this warning.