### PR TITLE
fix(ingest): handle dst in ritzau parser

### DIFF
--- a/superdesk/io/feed_parsers/ritzau.py
+++ b/superdesk/io/feed_parsers/ritzau.py
@@ -15,10 +15,10 @@ from superdesk.errors import ParserError
 from superdesk import etree as sd_etree
 from collections import OrderedDict
 from superdesk import text_utils
+from superdesk.utc import local_to_utc
 import superdesk
 import dateutil.parser
 import logging
-from pytz import timezone
 
 logger = logging.getLogger(__name__)
 NS = {'r': 'http://tempuri.org/',
@@ -34,6 +34,7 @@ class RitzauFeedParser(XMLFeedParser):
 
     NAME = 'ritzau'
     label = "Ritzau feed"
+    TIMEZONE = 'Europe/Copenhagen'
 
     def __init__(self):
         super().__init__()
@@ -101,8 +102,8 @@ class RitzauFeedParser(XMLFeedParser):
         return {'qcode': qcode, 'name': name, 'scheme': 'subject_custom'}
 
     def _publish_date_filter(self, date_string):
-        dt = dateutil.parser.parse(date_string)
-        return dt.replace(tzinfo=timezone('CET'))
+        local = dateutil.parser.parse(date_string)
+        return local_to_utc(self.TIMEZONE, local)
 
     def _set_headline(self, item, value):
         if not value:

--- a/tests/io/feed_parsers/ritzau_test.py
+++ b/tests/io/feed_parsers/ritzau_test.py
@@ -49,4 +49,8 @@ class RitzauTestCase(BaseRitzauTestCase):
                                             'tidspunkt, hvor tyske bilfabrikanter er udsat for massiv '
                                             'kritik, fordi de har finansieret lignende forsøg.</p>')
         self.assertEqual(item['guid'], '9a6955fc-11da-46b6-9903-439ebb288f2d')
-        self.assertEqual(item['firstcreated'].isoformat(), '2018-01-30T17:32:18.397000+01:00')
+        self.assertEqual(item['firstcreated'].isoformat(), '2018-01-30T16:32:18.397000+00:00')
+
+    def test_cest_timezone(self):
+        self.assertEqual(RitzauFeedParser()._publish_date_filter('2018-09-18T13:09:18.397').isoformat(),
+                         '2018-09-18T11:09:18.397000+00:00')


### PR DESCRIPTION
use Copenhagen tz for dates instead of just CET

SDNTB-513