### PR TITLE
[ES UTILS] implements dates filters

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [flake8]
 max-line-length=120
 exclude=env,bin,lib,include,src,docs
-ignore=F811,D200,D202,D205,D400,D401,D100,D101,D102,D103,D104,D105,D107,W503
+ignore=F811,D200,D202,D205,D400,D401,D100,D101,D102,D103,D104,D105,D107,W503,W504,W605,F401,E261,F841
+# W504, W605, F401, E261 and F841 are temporarly ignored, due to recent changes in flake8

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ install_requires = [
     'chardet<4.0',
     'pymongo>=0.4,<4.0',
     'croniter<0.4',
-    'python-dateutil',
+    'python-dateutil<2.8',
 ]
 
 package_data = {

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ install_requires = [
     'chardet<4.0',
     'pymongo>=0.4,<4.0',
     'croniter<0.4',
+    'python-dateutil',
 ]
 
 package_data = {

--- a/superdesk/es_utils.py
+++ b/superdesk/es_utils.py
@@ -54,8 +54,8 @@ def get_index(repos=None):
         repos = REPOS
     indexes = {app.data.elastic.index}
     for repo in repos:
-        indexes.add(app.config['ELASTICSEARCH_INDEXES'].get(repo, app.data.elastic.index))
-    return ','.join(indexes)
+        indexes.add(app.config["ELASTICSEARCH_INDEXES"].get(repo, app.data.elastic.index))
+    return ",".join(indexes)
 
 
 def get_docs(query_result):
@@ -65,7 +65,7 @@ def get_docs(query_result):
     :return list: found documents
     """
     try:
-        docs = [h['_source'] for h in query_result['hits']['hits']]
+        docs = [h["_source"] for h in query_result["hits"]["hits"]]
     except KeyError:
         logger.warning(u"Can't retrieve doc from ES results: {data}".format(data=query_result))
         docs = []
@@ -79,83 +79,83 @@ def filter2query(filter_, user_id=None):
     :return dict: ElasticSearch query DSL usable with service.search method
     """
     # we'll delete key while we handle them, to check that all has been managed at the end
-    search_query = filter_['query'].copy()
+    search_query = filter_["query"].copy()
     query_must = []
     query_must_not = []
     post_filter = []
     post_filter_must_not = []
 
     # controlled vocabularies can be overriden in settings
-    search_cvs = app.config.get('search_cvs', SEARCH_CVS)
+    search_cvs = app.config.get("search_cvs", SEARCH_CVS)
 
     for cv in search_cvs:
-        if cv['id'] in search_query and cv['field'] != cv['id']:
-            terms = json.loads(search_query.pop(cv['id']))
-            query_must.append({"terms": {cv['field'] + ".qcode": terms}})
+        if cv["id"] in search_query and cv["field"] != cv["id"]:
+            terms = json.loads(search_query.pop(cv["id"]))
+            query_must.append({"terms": {cv["field"] + ".qcode": terms}})
 
     try:
-        query_string = search_query.pop('q')
+        query_string = search_query.pop("q")
     except KeyError:
         pass
     else:
         for cv in search_cvs:
-            if cv['field'] != cv['id']:
-                query_string.replace(cv['id'] + '.qcode:(', cv['field'] + 'q.code:(')
-        query_must.append(
-            {"query_string": {
-                "query": query_string,
-                "default_operator": "AND"}})
+            if cv["field"] != cv["id"]:
+                query_string.replace(cv["id"] + ".qcode:(", cv["field"] + "q.code:(")
+        query_must.append({"query_string": {"query": query_string, "default_operator": "AND"}})
 
     to_delete = []
     for key, value in search_query.items():
-        if key == 'from_desk':
-            desk = value.split('-')
+        if key == "from_desk":
+            desk = value.split("-")
             if len(desk) == 2:
-                if desk[1] == 'authoring':
-                    query_must.append({'term': {'task.last_authoring_desk': desk[0]}})
+                if desk[1] == "authoring":
+                    query_must.append({"term": {"task.last_authoring_desk": desk[0]}})
                 else:
-                    query_must.append({'term': {'task.last_production_desk': desk[0]}})
+                    query_must.append({"term": {"task.last_production_desk": desk[0]}})
             else:
                 logger.warning('unexpected "from_desk" value: {value}'.format(value=value))
-        elif key == 'to_desk':
-            desk = value.split('-')
+        elif key == "to_desk":
+            desk = value.split("-")
             if len(desk) == 2:
-                query_must.append({'term': {'task.desk': desk[0]}})
-                if 'from_desk' not in filter_['query']:
-                    if desk[1] == 'authoring':
-                        field = 'task.last_production_desk'
+                query_must.append({"term": {"task.desk": desk[0]}})
+                if "from_desk" not in filter_["query"]:
+                    if desk[1] == "authoring":
+                        field = "task.last_production_desk"
                     else:
-                        field = 'task.last_authoring_desk'
-                    query_must.append({'exists': {field: field}})
+                        field = "task.last_authoring_desk"
+                    query_must.append({"exists": {field: field}})
             else:
                 logger.warning('unexpected "from_desk" value: {value}'.format(value=value))
-        elif key == 'spike':
-            if value == 'include':
+        elif key == "spike":
+            if value == "include":
                 pass
-            elif value == 'only':
+            elif value == "only":
                 query_must.append({"term": {"state": "spiked"}})
             else:
                 query_must_not.append({"term": {"state": "spiked"}})
-        elif key == 'featuremedia' and value:
+        elif key == "featuremedia" and value:
             query_must.append({"exists": {"field": "associations.featuremedia"}})
-        elif key == 'subject':
+        elif key == "subject":
             terms = json.loads(value)
-            query_must.append({"bool": {
-                "should": [
-                    {"terms": {"subject.qcode": terms}},
-                    {"terms": {"subject.parent": terms}}],
-                "minimum_should_match": 1}})
-        elif key == 'company_codes':
+            query_must.append(
+                {
+                    "bool": {
+                        "should": [{"terms": {"subject.qcode": terms}}, {"terms": {"subject.parent": terms}}],
+                        "minimum_should_match": 1,
+                    }
+                }
+            )
+        elif key == "company_codes":
             terms = json.loads(value)
             query_must.append({"terms": {"company_codes.qcode": terms}})
-        elif key == 'marked_desks':
+        elif key == "marked_desks":
             terms = json.loads(value)
             query_must.append({"terms": {"marked_desks.desk_id": terms}})
-        elif key == 'ignoreKilled':
+        elif key == "ignoreKilled":
             query_must_not.append({"terms": {"state": ["killed", "recalled"]}})
-        elif key == 'onlyLastPublished':
+        elif key == "onlyLastPublished":
             query_must_not.append({"term": {"last_published_version": "false"}})
-        elif key == 'ignoreScheduled':
+        elif key == "ignoreScheduled":
             query_must_not.append({"term": {"state": "scheduled"}})
         else:
             continue
@@ -167,17 +167,17 @@ def filter2query(filter_, user_id=None):
     for key, field in POST_FILTER_MAP.items():
         value = search_query.pop(key, None)
         if value is not None:
-            post_filter.append({'terms': {field: json.loads(value)}})
+            post_filter.append({"terms": {field: json.loads(value)}})
         else:
-            value = search_query.pop('not' + key, None)
+            value = search_query.pop("not" + key, None)
             if value is not None:
-                post_filter_must_not.append({'terms': {field: json.loads(value)}})
+                post_filter_must_not.append({"terms": {field: json.loads(value)}})
 
     # used by AAP multimedia datalayer
-    credit_qcode = search_query.pop('creditqcode', None)
+    credit_qcode = search_query.pop("creditqcode", None)
     if credit_qcode is not None:
         values = json.loads(credit_qcode)
-        post_filter.append({'terms': {'credit': [v['value'] for v in values]}})
+        post_filter.append({"terms": {"credit": [v["value"] for v in values]}})
 
     # date filters
     tz = pytz.timezone(app.config["DEFAULT_TIMEZONE"])
@@ -225,33 +225,27 @@ def filter2query(filter_, user_id=None):
 
     # remove other users drafts
     if user_id is not None:
-        query_must.append({"bool": {
-            "should": [
-                {"bool": {
-                    "must": [
-                        {"term": {"state": "draft"}},
-                        {"term": {"original_creator": user_id}}]}},
-                {"bool": {
-                    "must_not": {"terms": {"state": ["draft"]}}}}]}})
+        query_must.append(
+            {
+                "bool": {
+                    "should": [
+                        {"bool": {"must": [{"term": {"state": "draft"}}, {"term": {"original_creator": user_id}}]}},
+                        {"bool": {"must_not": {"terms": {"state": ["draft"]}}}},
+                    ]
+                }
+            }
+        )
 
     # this is needed for archived collection
     query_must_not.append({"term": {"package_type": "takes"}})
 
-    query = {
-        "query": {
-            "bool": {
-                "must": query_must,
-                "must_not": query_must_not
-            }
-        }
-    }
+    query = {"query": {"bool": {"must": query_must, "must_not": query_must_not}}}
     if post_filter or post_filter_must_not:
-        query['post_filter'] = {"bool": {
-            "must": post_filter,
-            "must_not": post_filter_must_not}}
+        query["post_filter"] = {"bool": {"must": post_filter, "must_not": post_filter_must_not}}
 
     if search_query:
-        logger.warning("All query fields have not been used, remaining fields: {search_query}".format(
-            search_query=search_query))
+        logger.warning(
+            "All query fields have not been used, remaining fields: {search_query}".format(search_query=search_query)
+        )
 
     return query


### PR DESCRIPTION
Date filters are needed for saved searches report, this patch implements
it.
The date format can be specified in frontend (i.e. day first or month
first), but here we always keep day first, as the date is used for wire
format between client and backend, and we have no way to know which
format is used in client.

Also added `python-dateutil` to requirements : it is used in many
location in superdesk-core but was missing in `setup.py`.

SDESK-3425