### PR TITLE
[SAVED SEARCHES] decode "filter" before actually updating the item

### DIFF
--- a/apps/saved_searches/saved_searches.py
+++ b/apps/saved_searches/saved_searches.py
@@ -227,11 +227,11 @@ class SavedSearchesService(BaseService):
         return super().get(req, lookup=None)
 
     def update(self, id, updates, original):
-        res = super().update(id, updates, original)
         try:
-            res['filter'] = decode_filter(res['filter'])
+            updates['filter'] = decode_filter(updates.get('filter', original["filter"]))
         except KeyError:
             logger.warning('"filter" key must be specified')
+        res = super().update(id, updates, original)
         return res
 
     def init_request(self, elastic_query):


### PR DESCRIPTION
"filter" was decoded after updating the item, to be returned decoded to
the client. But this was resulting in invalid ETAG. This patch changes
this behaviour by decoding "filter" before actually updating the item.

SDESK-3435