### PR TITLE
[SDESK-3317] Allowing null value for from and to time in routing schedule.

### DIFF
--- a/apps/rules/routing_rules.py
+++ b/apps/rules/routing_rules.py
@@ -135,10 +135,12 @@ class RoutingRuleSchemeResource(Resource):
                                 'type': 'list'
                             },
                             'hour_of_day_from': {
-                                'type': 'string'
+                                'type': 'string',
+                                'nullable': True,
                             },
                             'hour_of_day_to': {
-                                'type': 'string'
+                                'type': 'string',
+                                'nullable': True,
                             },
                             'time_zone': {
                                 'type': 'string',
@@ -402,6 +404,8 @@ class RoutingRuleSchemeService(BaseService):
                 hour_of_day_to = schedule.get('hour_of_day_to')
                 if hour_of_day_to:
                     to_time = set_time(now_tz_schedule, hour_of_day_to)
+                    if hour_of_day_to[-2:] == '00':
+                        to_time = to_time + delta_minute
                 else:
                     to_time = set_time(now_tz_schedule, '23:59:59') + delta_minute
 

--- a/apps/rules/routing_rules_tests.py
+++ b/apps/rules/routing_rules_tests.py
@@ -304,3 +304,43 @@ class GetScheduledRoutingRulesMethodTestCase(RoutingRuleSchemeServiceTest):
         result = self.instance._get_scheduled_routing_rules(rules, now)
 
         self.assertEqual(result, rules)
+
+    def test_schedule_routing_rules_at_end_time(self):
+        rules = [{
+            'name': 'rule_berlin',
+            'schedule': {
+                'day_of_week': ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'],
+                'hour_of_day_from': '00:00:00',
+                'hour_of_day_to': '23:55:00',
+                'time_zone': 'UTC',
+            }
+        }]
+        # before end time
+        now = datetime(2015, 9, 15, 23, 54, 59, 999999)  # Tuesday
+        result = self.instance._get_scheduled_routing_rules(rules, now)
+        self.assertEqual(result, rules)
+
+        # one second after end time
+        now = datetime(2015, 9, 15, 23, 55, 1, 999999)  # Tuesday
+        result = self.instance._get_scheduled_routing_rules(rules, now)
+        self.assertEqual(result, rules)
+
+        # after end time
+        now = datetime(2015, 9, 15, 23, 55, 59, 999999)  # Tuesday
+        result = self.instance._get_scheduled_routing_rules(rules, now)
+        self.assertEqual(result, rules)
+
+        # one second after end time
+        now = datetime(2015, 9, 15, 23, 56, 0, 999999)  # Tuesday
+        result = self.instance._get_scheduled_routing_rules(rules, now)
+        self.assertEqual(result, [])
+
+        # one second after end time
+        now = datetime(2015, 9, 15, 23, 56, 1)  # Tuesday
+        result = self.instance._get_scheduled_routing_rules(rules, now)
+        self.assertEqual(result, [])
+
+        # after end time
+        now = datetime(2015, 9, 15, 23, 59, 59, 999999)  # Tuesday
+        result = self.instance._get_scheduled_routing_rules(rules, now)
+        self.assertEqual(result, [])

--- a/features/routing_rules.feature
+++ b/features/routing_rules.feature
@@ -535,6 +535,30 @@ Feature: Routing Scheme and Routing Rules
       ]
       """
       Then we get response code 201
+      When we post to "/routing_schemes"
+      """
+      [
+        {
+          "name": "routing rule scheme 2",
+          "rules": [
+            {
+              "name": "Sports Rule",
+              "filter": "#FILTER_ID#",
+              "actions": {
+                "fetch": [{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}]
+              },
+              "schedule": {
+                "day_of_week": ["FRI", "TUE"],
+                "hour_of_day_from": null,
+                "hour_of_day_to": null,
+                "time_zone": "Europe/Rome"
+              }
+            }
+          ]
+        }
+      ]
+      """
+      Then we get response code 201
 
     @auth
     Scenario: A user with no privilege to "routing schemes" can't create a Routing Scheme


### PR DESCRIPTION
- Allow null values for routing schedule
- If end time is set then the logic did not include the minute i.e. if 10:15 is set as end time then it does not route the item at 10:15:01. The end time should be inclusive.  