### PR TITLE
fix(rss): use last item updated time for test if there is an update

### DIFF
--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -238,7 +238,12 @@ def update_provider(provider, rule_set=None, routing_scheme=None):
         for items in feeding_service.update(provider, update):
             ingest_items(items, provider, feeding_service, rule_set, routing_scheme)
             if items:
-                update[LAST_ITEM_UPDATE] = utcnow()
+                last_item_update = max(
+                    [item['versioncreated'] for item in items if item.get('versioncreated')],
+                    default=utcnow()
+                )
+                if not update.get(LAST_ITEM_UPDATE) or update[LAST_ITEM_UPDATE] < last_item_update:
+                    update[LAST_ITEM_UPDATE] = last_item_update
 
         # Some Feeding Services update the collection and by this time the _etag might have been changed.
         # So it's necessary to fetch it once again. Otherwise, OriginalChangedError is raised.

--- a/superdesk/io/feeding_services/rss.py
+++ b/superdesk/io/feeding_services/rss.py
@@ -22,6 +22,7 @@ from superdesk.io.feeding_services import FeedingService
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE, GUID_TAG
 from superdesk.utils import merge_dicts
 from superdesk.metadata.utils import generate_guid, generate_tag, generate_tag_from_url
+from superdesk.io.commands.update_ingest import LAST_ITEM_UPDATE
 
 from urllib.parse import quote as urlquote, urlsplit, urlunsplit
 
@@ -182,7 +183,7 @@ class RSSFeedingService(FeedingService):
         # so that it will be recognized as "not up to date".
         # Also convert it to a naive datetime object (removing tzinfo is fine,
         # because it is in UTC anyway)
-        t_provider_updated = provider.get('last_updated', utcfromtimestamp(0))
+        t_provider_updated = provider.get(LAST_ITEM_UPDATE, utcfromtimestamp(0))
         t_provider_updated = t_provider_updated.replace(tzinfo=None)
 
         new_items = []

--- a/tests/io/feeding_services/rss_test.py
+++ b/tests/io/feeding_services/rss_test.py
@@ -15,6 +15,7 @@ from unittest import mock
 from unittest.mock import call, MagicMock
 
 from superdesk.tests import TestCase
+from superdesk.io.commands.update_ingest import LAST_ITEM_UPDATE
 
 feed_parse = MagicMock()
 requests_get = MagicMock()
@@ -212,7 +213,7 @@ class UpdateMethodTestCase(RssIngestServiceTest):
         self.instance._create_item.return_value = item
 
         returned = self.instance._update(
-            {'last_updated': datetime(2015, 2, 25, 15, 0, 0)}, {}
+            {LAST_ITEM_UPDATE: datetime(2015, 2, 25, 15, 0, 0)}, {}
         )
 
         self.assertEqual(len(returned), 1)


### PR DESCRIPTION
rss could be caches so items that were not available in previous run
can show up later with updated time earlier than last ingest run.
such updated items would be ignored by ingest, so rather check using
last item updated timestamp.

SDESK-3426