### PR TITLE
Add date shortcuts to customize buttons

### DIFF
--- a/superdesk/vocabularies/vocabularies.py
+++ b/superdesk/vocabularies/vocabularies.py
@@ -116,6 +116,18 @@ class VocabulariesResource(Resource):
         'preffered_items': {
             'type': 'boolean',
         },
+        'date_shortcuts': {
+            'type': 'list',
+            'nullable': True,
+            'schema': {
+                'type': 'dict',
+                'schema': {
+                    'value': {'type': 'integer', 'required': True},
+                    'term': {'type': 'string', 'required': True},
+                    'label': {'type': 'string', 'required': True},
+                }
+            }
+        },
     }
 
     soft_delete = True


### PR DESCRIPTION
SDFID-503

Each custom date field will have three customizable buttons providing
for each button the following parameters:

  - value: for example 2
  - term: for example 'days'
  - label: for example 'In two days'