### PR TITLE
[INGEST][REGISTRY] SDESK-3582 Don't store feeding service instance in registry.

### DIFF
--- a/apps/io/update_ingest_tests.py
+++ b/apps/io/update_ingest_tests.py
@@ -20,7 +20,8 @@ from apps.io.tests import setup_providers, teardown_providers
 from superdesk import etree, get_resource_service
 from superdesk.celery_task_utils import mark_task_as_not_running, is_task_running
 from superdesk.errors import SuperdeskApiError, ProviderError
-from superdesk.io.registry import register_feeding_service, registered_feeding_services
+from superdesk.io import get_feeding_service
+from superdesk.io.registry import register_feeding_service
 from superdesk.io.commands.remove_expired_content import get_expired_items, RemoveExpiredContent
 from superdesk.io.feeding_services import FeedingService
 from superdesk.io.feeding_services.file_service import FileFeedingService
@@ -72,7 +73,7 @@ class UpdateIngestTest(TestCase):
         return get_resource_service('ingest_providers').find_one(name=provider_name, req=None)
 
     def _get_provider_service(self, provider):
-        return registered_feeding_services[provider['feeding_service']]()
+        return get_feeding_service(provider['feeding_service'])
 
     def test_ingest_items(self):
         provider, provider_service = self.setup_reuters_provider()

--- a/apps/io/update_ingest_tests.py
+++ b/apps/io/update_ingest_tests.py
@@ -72,8 +72,7 @@ class UpdateIngestTest(TestCase):
         return get_resource_service('ingest_providers').find_one(name=provider_name, req=None)
 
     def _get_provider_service(self, provider):
-        provider_service = registered_feeding_services[provider['feeding_service']]
-        return provider_service.__class__()
+        return registered_feeding_services[provider['feeding_service']]()
 
     def test_ingest_items(self):
         provider, provider_service = self.setup_reuters_provider()

--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -25,7 +25,6 @@ from superdesk.celery_app import init_celery
 from superdesk.datalayer import SuperdeskDataLayer  # noqa
 from superdesk.errors import SuperdeskError, SuperdeskApiError
 from superdesk.factory.sentry import SuperdeskSentry
-from superdesk.io import registered_feeding_services
 from superdesk.logging import configure_logging
 from superdesk.storage import AmazonMediaStorage, SuperdeskGridFSMediaStorage
 from superdesk.validator import SuperdeskValidator
@@ -168,10 +167,6 @@ def get_app(config=None, media_storage=None, config_object=None, init_elastic=No
 
     for name, jinja_filter in superdesk.JINJA_FILTERS.items():
         app.jinja_env.filters[name] = jinja_filter
-
-    # instantiate registered provider classes (leave non-classes intact)
-    for key, provider in registered_feeding_services.items():
-        registered_feeding_services[key] = provider() if isinstance(provider, type) else provider
 
     configure_logging(app.config['LOG_CONFIG_FILE'])
 

--- a/superdesk/io/__init__.py
+++ b/superdesk/io/__init__.py
@@ -20,6 +20,7 @@ from superdesk.io.registry import registered_feeding_services, allowed_feeding_s
 from superdesk.io.registry import feeding_service_errors, publish_errors  # noqa
 from superdesk.io.registry import FeedParserAllowedResource, FeedParserAllowedService
 from superdesk.io.registry import FeedingServiceAllowedResource, FeedingServiceAllowedService
+from superdesk.io.registry import get_feeding_service  # noqa
 
 from superdesk.io.commands.add_provider import AddProvider  # noqa
 from superdesk.io import importers  # noqa

--- a/superdesk/io/commands/remove_expired_content.py
+++ b/superdesk/io/commands/remove_expired_content.py
@@ -57,8 +57,8 @@ def remove_expired_data(provider):
     logger.info('Removing expired content for provider: %s' % provider.get('_id', 'Detached items'))
 
     try:
-        feeding_service = registered_feeding_services[provider['feeding_service']]
-        feeding_service = feeding_service.__class__()
+        feeding_service_class = registered_feeding_services[provider['feeding_service']]
+        feeding_service = feeding_service_class()
         ingest_collection = feeding_service.service if hasattr(feeding_service, 'service') else 'ingest'
     except KeyError:
         ingest_collection = 'ingest'

--- a/superdesk/io/commands/remove_expired_content.py
+++ b/superdesk/io/commands/remove_expired_content.py
@@ -15,7 +15,7 @@ from superdesk.notification import push_notification
 from apps.content import push_expired_notification
 from superdesk.errors import ProviderError
 from superdesk.lock import lock, unlock
-from superdesk.io.registry import registered_feeding_services
+from superdesk.io import get_feeding_service
 
 
 class RemoveExpiredContent(superdesk.Command):
@@ -57,8 +57,7 @@ def remove_expired_data(provider):
     logger.info('Removing expired content for provider: %s' % provider.get('_id', 'Detached items'))
 
     try:
-        feeding_service_class = registered_feeding_services[provider['feeding_service']]
-        feeding_service = feeding_service_class()
+        feeding_service = get_feeding_service(provider['feeding_service'])
         ingest_collection = feeding_service.service if hasattr(feeding_service, 'service') else 'ingest'
     except KeyError:
         ingest_collection = 'ingest'

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -20,6 +20,7 @@ from superdesk.activity import ACTIVITY_EVENT, notify_and_add_activity
 from superdesk.celery_app import celery
 from superdesk.celery_task_utils import get_lock_id
 from superdesk.errors import ProviderError
+from superdesk.io import get_feeding_service
 from superdesk.io.registry import registered_feeding_services, registered_feed_parsers
 from superdesk.io.iptc import subject_codes
 from superdesk.lock import lock, unlock
@@ -230,9 +231,7 @@ def update_provider(provider, rule_set=None, routing_scheme=None):
         return
 
     try:
-        feeding_service_class = registered_feeding_services[provider['feeding_service']]
-        feeding_service = feeding_service_class()
-
+        feeding_service = get_feeding_service(provider['feeding_service'])
         update = {LAST_UPDATED: utcnow()}
 
         for items in feeding_service.update(provider, update):

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -50,8 +50,8 @@ def is_service_and_parser_registered(provider):
     :return: True if both Feed Service and Feed Parser are registered. False otherwise.
     :rtype: bool
     """
-    return provider.get('feeding_service') in registered_feeding_services and provider.get(
-        'feed_parser') is None or provider.get('feed_parser') in registered_feed_parsers
+    return provider.get('feeding_service') in registered_feeding_services and \
+        provider.get('feed_parser') is None or provider.get('feed_parser') in registered_feed_parsers
 
 
 def is_scheduled(provider):
@@ -230,8 +230,8 @@ def update_provider(provider, rule_set=None, routing_scheme=None):
         return
 
     try:
-        feeding_service = registered_feeding_services[provider['feeding_service']]
-        feeding_service = feeding_service.__class__()
+        feeding_service_class = registered_feeding_services[provider['feeding_service']]
+        feeding_service = feeding_service_class()
 
         update = {LAST_UPDATED: utcnow()}
 

--- a/superdesk/io/ingest_provider_model.py
+++ b/superdesk/io/ingest_provider_model.py
@@ -18,7 +18,7 @@ from superdesk import get_resource_service
 from superdesk.activity import ACTIVITY_CREATE, ACTIVITY_EVENT, ACTIVITY_UPDATE, notify_and_add_activity, \
     ACTIVITY_DELETE
 from superdesk.errors import SuperdeskApiError
-from superdesk.io import allowed_feeding_services, allowed_feed_parsers, registered_feeding_services
+from superdesk.io import allowed_feeding_services, allowed_feed_parsers, get_feeding_service
 from superdesk.metadata.item import CONTENT_STATE, content_type
 from superdesk.notification import push_notification
 from superdesk.resource import Resource
@@ -281,7 +281,7 @@ class IngestProviderService(BaseService):
         provider.update(updates)
 
         try:
-            service = registered_feeding_services[provider['feeding_service']]()
+            service = get_feeding_service(provider['feeding_service'])
         except KeyError:
             return
         service.config_test(provider)

--- a/superdesk/io/ingest_provider_model.py
+++ b/superdesk/io/ingest_provider_model.py
@@ -281,7 +281,7 @@ class IngestProviderService(BaseService):
         provider.update(updates)
 
         try:
-            service = registered_feeding_services[provider['feeding_service']].__class__()
+            service = registered_feeding_services[provider['feeding_service']]()
         except KeyError:
             return
         service.config_test(provider)

--- a/superdesk/io/registry.py
+++ b/superdesk/io/registry.py
@@ -35,11 +35,13 @@ def register_feeding_service(service_class):
     """
 
     if service_class.NAME in registered_feeding_services:
-        raise AlreadyExistsError('Feeding Service: {} already registered by {}'
-                                 .format(service_class.NAME,
-                                         type(registered_feeding_services[service_class.NAME])))
+        raise AlreadyExistsError(
+            'Feeding Service: {} already registered by {}'.format(
+                service_class.NAME,
+                registered_feeding_services[service_class.NAME])
+        )
 
-    registered_feeding_services[service_class.NAME] = service_class()
+    registered_feeding_services[service_class.NAME] = service_class
     allowed_feeding_services.append(service_class.NAME)
 
     service_class.ERRORS.append(SuperdeskIngestError.parserNotFoundError().get_error_description())
@@ -130,14 +132,14 @@ class FeedingServiceAllowedService(Service):
 
     def get(self, req, lookup):
         def service(service_id):
-            registered = registered_feeding_services[service_id]
+            feeding_service_class = registered_feeding_services[service_id]
             restricted_parsers = list(restricted_feeding_service_parsers.get(service_id, {}).keys())
 
             return {
                 'feeding_service': service_id,
-                'label': getattr(registered, 'label', service_id),
-                'fields': getattr(registered, 'fields', []),
-                'field_groups': getattr(registered, 'field_groups', {}),
+                'label': getattr(feeding_service_class, 'label', service_id),
+                'fields': getattr(feeding_service_class, 'fields', []),
+                'field_groups': getattr(feeding_service_class, 'field_groups', {}),
                 'parser_restricted_values': restricted_parsers
             }
 

--- a/superdesk/io/registry.py
+++ b/superdesk/io/registry.py
@@ -59,6 +59,17 @@ def register_feeding_service_error(service_name, error):
     feeding_service_errors.get(service_name, {}).update(dict([error]))
 
 
+def get_feeding_service(service_name):
+    """
+    Create and return Feeding Service instance.
+    :param service_name: unique name to identify the Feeding Service class.
+    :return: Feeding Service instance.
+    :raise KeyError: there is no feeding service registered with this `service_name`.
+    """
+
+    return registered_feeding_services[service_name]()
+
+
 def register_feed_parser(parser_name, parser_class):
     """
     Registers the Feed Parser with the application.

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -583,8 +583,7 @@ def fetch_from_provider(context, provider_name, guid, routing_scheme=None, desk_
     else:
         rule_set = None
 
-    provider_service = registered_feeding_services[provider['feeding_service']]
-    provider_service = provider_service.__class__()
+    provider_service = registered_feeding_services[provider['feeding_service']]()
 
     if provider.get('name', '').lower() in ('aap', 'dpa', 'ninjs', 'email', 'ftp_ninjs'):
         if provider.get('name', '').lower() == 'ftp_ninjs':

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -45,7 +45,7 @@ from wooper.expect import (
 import superdesk
 from superdesk import tests
 from superdesk import default_user_preferences, get_resource_service, utc, etree
-from superdesk.io import registered_feeding_services
+from superdesk.io import get_feeding_service
 from superdesk.io.commands import update_ingest
 from superdesk.io.commands.update_ingest import LAST_ITEM_UPDATE
 from superdesk.io.feeding_services import ftp
@@ -583,7 +583,7 @@ def fetch_from_provider(context, provider_name, guid, routing_scheme=None, desk_
     else:
         rule_set = None
 
-    provider_service = registered_feeding_services[provider['feeding_service']]()
+    provider_service = get_feeding_service(provider['feeding_service'])
 
     if provider.get('name', '').lower() in ('aap', 'dpa', 'ninjs', 'email', 'ftp_ninjs'):
         if provider.get('name', '').lower() == 'ftp_ninjs':


### PR DESCRIPTION
There is no sense to store feeding service instance in **registered_feeding_services** https://github.com/superdesk/superdesk-core/blob/master/superdesk/io/registry.py#L42, would be enough to store just class.
BTW. We create a new feeding service instance all the time during update_provider task https://github.com/superdesk/superdesk-core/blob/master/superdesk/io/commands/update_ingest.py#L234

⚠️ This PR should not brake any instances (I hope 🤞). Please, check if custom instances use **registered_feeding_services** somehow. For example **ntb** does not. 

⚠️ ⚠️ Planning component requires PR, because **registered_feeding_services** used in tests.