### PR TITLE
[SAVED SEARCHES] improved robustness:

### DIFF
--- a/superdesk/es_utils.py
+++ b/superdesk/es_utils.py
@@ -167,7 +167,13 @@ def filter2query(filter_, user_id=None):
     for key, field in POST_FILTER_MAP.items():
         value = search_query.pop(key, None)
         if value is not None:
-            post_filter.append({"terms": {field: json.loads(value)}})
+            try:
+                post_filter.append({"terms": {field: json.loads(value)}})
+            except TypeError as e:
+                logger.error('Invalid data received for post filter "{key}": {e}\ndata: {value}'.format(
+                    key=key, e=e, value=value))
+                # the value is probably not JSON encoded as expected, we try directly the value
+                post_filter.append({"terms": {field: value}})
         else:
             value = search_query.pop("not" + key, None)
             if value is not None:


### PR DESCRIPTION
When a report was failing, all following ones were skipped. This is
fixed by this PR: an error message is show for the failing report, but
other are not skipped anymore.

Bad data were found in search filters (data were not JSON encoded as
expected), this is worked around in this patch and error is logged when
this happen (as a reminder to fix the issue).

SDESK-3527