### PR TITLE
[FEED PARSER][WORDPRESS WXR] fixed versioncreated + improvments

### DIFF
--- a/superdesk/storage/desk_media_storage.py
+++ b/superdesk/storage/desk_media_storage.py
@@ -37,11 +37,11 @@ class SuperdeskGridFSMediaStorage(GridFSMediaStorage):
             media_file = None
         if media_file and media_file.metadata:
             for k, v in media_file.metadata.items():
-                try:
-                    if isinstance(v, str):
+                if isinstance(v, str):
+                    try:
                         media_file.metadata[k] = json.loads(v)
-                except ValueError:
-                    logger.exception('Failed to load metadata for file: %s with key: %s and value: %s', _id, k, v)
+                    except ValueError:
+                        logger.info('Non JSON metadata for file: %s with key: %s and value: %s', _id, k, v)
         return media_file
 
     def url_for_media(self, media_id, content_type=None):

--- a/tests/io/feed_parsers/wordpress_wxr_test.py
+++ b/tests/io/feed_parsers/wordpress_wxr_test.py
@@ -84,8 +84,8 @@ class WPWXRTestCase(TestCase):
     def test_guid(self):
         self.assertEqual(self.articles[0]['guid'], 'http://sdnewtester.org/?p=216')
 
-    def test_versioncreated(self):
-        self.assertEqual(self.articles[0]['versioncreated'],
+    def test_firstpublished(self):
+        self.assertEqual(self.articles[0]['firstpublished'],
                          datetime.datetime(2013, 7, 29, 16, 3, 54, tzinfo=datetime.timezone.utc))
 
     def test_author(self):


### PR DESCRIPTION
Publication date was used as versioncreated, resulting in items
published for long time being filtered out. This patch fixes this by
using current time for version created and putting publication date in
firstpublished.

In addition protocol relative URLs are now handled.

While storing media in GridFS, and a non JSON value is found in, log
message is an info and not an exception anymore, because the case is not
an error (values can be simple strings).

Fixes SDESK-3685