### PR TITLE
fix(parser): change log level from error to info

### DIFF
--- a/superdesk/io/feed_parsers/__init__.py
+++ b/superdesk/io/feed_parsers/__init__.py
@@ -114,7 +114,7 @@ class XMLFeedParser(FeedParser, metaclass=ABCMeta):
                                  "only default will be used ({})".format(self.__class__))
                 if 'xpath':
                     if '/' not in 'xpath':
-                        logger.error("default_attr can be used for simple child element ({})".format(self.__class__))
+                        logger.info("default_attr can be used for simple child element ({})".format(self.__class__))
                 else:
                     logger.error("xpath is needed when default_attr is used ({})".format(self.__class__))
             if 'callback' in value and 'list' in value:


### PR DESCRIPTION
when default_attr can be used. it is logged on sentry all the time.