### PR TITLE
[FEED PARSED][RENDITION][NINJS] fixed ninjs associations's version cr…

### DIFF
--- a/superdesk/io/feed_parsers/ninjs.py
+++ b/superdesk/io/feed_parsers/ninjs.py
@@ -97,6 +97,10 @@ class NINJSFeedParser(FeedParser):
                 if child_ninjs.get('type') == 'picture' and child_ninjs.get('body_text'):
                     child_ninjs['alt_text'] = child_ninjs.get('body_text')
             item['associations'] = deepcopy(ninjs.get('associations'))
+            # we don't want strings for versioncreated
+            for metadata in item['associations'].values():
+                if metadata.get('versioncreated'):
+                    metadata['versioncreated'] = self.datetime(metadata['versioncreated'])
 
         if ninjs.get('renditions', {}).get('baseImage'):
             item['renditions'] = {'baseImage': {'href': ninjs.get('renditions', {}).get('original', {}).get('href')}}

--- a/superdesk/media/renditions.py
+++ b/superdesk/media/renditions.py
@@ -58,9 +58,16 @@ def generate_renditions(original, media_id, inserted, file_type, content_type,
 
     # remove crop if original is small
     custom_renditions = get_renditions_spec(without_internal_renditions=True)
+    # we only want to remove rendition from rendition_config if they are custom ones
     for rendition, crop in custom_renditions.items():
+        if rendition not in rendition_config:
+            continue
         if not can_generate_custom_crop_from_original(width, height, crop):
-            rendition_config.pop(rendition, None)
+            if rendition in config.RENDITIONS['picture']:
+                logger.info('image is too small for rendition "{rendition}", but it is an internal one, '
+                            'so we keep it'.format(rendition=rendition))
+            else:
+                del rendition_config[rendition]
 
     ext = content_type.split('/')[1].lower()
     if ext in ('JPG', 'jpg'):


### PR DESCRIPTION
…eated + don't skip internal renditions

When ingesting a ninjs file, associations metadata a deep copied,
resulting in troubles with `versioncreated` which needs to be a datetime,
not a string. This patch fixes this by converting `versioncreated` after
the copy.

Furthermore, internal rendition were skipped if those 2 conditions were
met:
1) source image is too small for a rendition
2) a custom crop with the same name as internal rendition exists

This patch fixes it by not discarding a rendition if it is an internal
one.

fix SDESK-3614