### PR TITLE
[CONTENT TYPES] fixed subject made mandatory in schema when not prese…

### DIFF
--- a/apps/content_types/content_types.py
+++ b/apps/content_types/content_types.py
@@ -375,6 +375,13 @@ def prepare_for_save_content_type(original, updates):
     clean_editor(editor)
     init_schema_for_custom_fields(schema, fields_map)
     compose_subject_schema(schema, fields_map)
+    if not editor.get("subject"):
+        # subject must not be mandatory if not present in editor
+        # Note that it can still be used for custom vocabularies
+        try:
+            schema["subject"]["required"] = False
+        except (TypeError, KeyError):
+            pass
     init_editor_required(editor, schema)
     rename_schema_for_custom_fields(schema, fields_map)
 


### PR DESCRIPTION
…nt in editor

If some custom vocabularies were present in `content_types` and `subject` was
not set in the editor, it was made mandatory anyway in the `schema`,
resulting in validation errors.

This patch fixes this

SDESK-3745