### PR TITLE
fix(backend-meta): return none when superdesk rev is unknown

### DIFF
--- a/superdesk/backend_meta/backend_meta.py
+++ b/superdesk/backend_meta/backend_meta.py
@@ -110,7 +110,7 @@ class BackendMetaService(BaseService):
                     return rev_f.read()
             except (IOError, IndexError):
                 pass
-        return {}
+        return None
 
     def get_server_rev(self, package):
         if settings is not None:


### PR DESCRIPTION
SDESK-3632