### PR TITLE
[SDESK-3329] Publish queue should allow item_id to any resource type

### DIFF
--- a/superdesk/publish/publish_queue.py
+++ b/superdesk/publish/publish_queue.py
@@ -35,7 +35,7 @@ class QueueState(SuperdeskBaseEnum):
 
 class PublishQueueResource(Resource):
     schema = {
-        'item_id': Resource.rel('archive', type='string'),
+        'item_id': {'type': 'string', 'required': True},
         'item_version': {'type': 'integer', 'nullable': False},
 
         'formatted_item': {'type': 'string', 'nullable': False},
@@ -67,13 +67,15 @@ class PublishQueueResource(Resource):
             'type': 'string'
         },
         'unique_name': {
-            'type': 'string'
+            'type': 'string',
+            'nullable': True
         },
         'content_type': {
             'type': 'string'
         },
         'headline': {
-            'type': 'string'
+            'type': 'string',
+            'nullable': True
         },
 
         'transmit_started_at': {


### PR DESCRIPTION
This allows Events or Planning items to be resent from the client.