### PR TITLE
[FEEDING SERVICES]Allows to restrict a feeding service to no parser, …

### DIFF
--- a/superdesk/celery_app.py
+++ b/superdesk/celery_app.py
@@ -34,7 +34,7 @@ TaskBase = celery.Task
 
 def try_cast(v):
     # False and 0 are getting converted to datetime by arrow
-    if v is None or isinstance(v, bool) or v is 0:
+    if v is None or isinstance(v, bool) or v == 0:
         return v
 
     try:

--- a/superdesk/io/feeding_services/rss.py
+++ b/superdesk/io/feeding_services/rss.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 from datetime import datetime
 
 from superdesk.errors import IngestApiError, ParserError
-from superdesk.io.registry import register_feeding_service
+from superdesk.io.registry import register_feeding_service, register_feeding_service_parser
 from superdesk.io.feeding_services.http_base_service import HTTPFeedingServiceBase
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE, GUID_TAG
 from superdesk.utils import merge_dicts
@@ -44,7 +44,7 @@ class RSSFeedingService(HTTPFeedingServiceBase):
               IngestApiError.apiGeneralError().get_error_description(),
               ParserError.parseMessageError().get_error_description()]
 
-    label = 'RSS'
+    label = 'RSS/Atom'
 
     fields = [
         {
@@ -398,3 +398,4 @@ class RSSFeedingService(HTTPFeedingServiceBase):
 
 
 register_feeding_service(RSSFeedingService)
+register_feeding_service_parser(RSSFeedingService.NAME, None)

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -345,7 +345,7 @@ class NINJSFormatter(Formatter):
         # get the actual article's renditions
         actual_renditions = article.get('renditions', {})
         # renditions list that we want to publish
-        if article['type'] is 'picture':
+        if article['type'] == 'picture':
             renditions_to_publish = ['original'] + list(get_renditions_spec(without_internal_renditions=True).keys())
             # filter renditions and keep only the ones we want to publish
             actual_renditions = {name: actual_renditions[name] for name in renditions_to_publish

--- a/tests/data_updates_test.py
+++ b/tests/data_updates_test.py
@@ -39,11 +39,11 @@ class DataUpdatesTestCase(TestCase):
             patcher.start()
 
     def test_data_update_generation(self):
-        assert len(get_data_updates_files()) is 0, get_data_updates_files()
+        assert len(get_data_updates_files()) == 0, get_data_updates_files()
         GenerateUpdate().run(resource_name='RESOURCE_NAME')
-        assert len(get_data_updates_files()) is 1, get_data_updates_files()
+        assert len(get_data_updates_files()) == 1, get_data_updates_files()
         GenerateUpdate().run(resource_name='RESOURNCE_NAME')
-        assert len(get_data_updates_files()) is 2, get_data_updates_files()
+        assert len(get_data_updates_files()) == 2, get_data_updates_files()
 
     def test_data_update_generation_create_updates_dir(self):
         updates_dir = DEFAULT_DATA_UPDATE_DIR_NAME
@@ -59,7 +59,7 @@ class DataUpdatesTestCase(TestCase):
     def test_dry_data_update(self):
         superdesk.commands.data_updates.DEFAULT_DATA_UPDATE_FW_IMPLEMENTATION = '''
             count = mongodb_collection.find({}).count()
-            assert count is 0, count
+            assert count == 0, count
         '''
         self.assertEqual(self.number_of_data_updates_applied(), 0)
         GenerateUpdate().run(resource_name='data_updates')
@@ -81,26 +81,26 @@ class DataUpdatesTestCase(TestCase):
         # create migrations
         for index in range(40):
             superdesk.commands.data_updates.DEFAULT_DATA_UPDATE_FW_IMPLEMENTATION = '''
-            assert(mongodb_collection)
+            assert mongodb_collection
             count = mongodb_collection.find({}).count()
-            assert count is %d, count
-            assert(mongodb_database)
+            assert count == %d, count
+            assert mongodb_database
             ''' % (index)
             superdesk.commands.data_updates.DEFAULT_DATA_UPDATE_BW_IMPLEMENTATION = '''
-            assert(mongodb_collection)
+            assert mongodb_collection
             count = mongodb_collection.find({}).count()
-            assert count is %d, count
-            assert(mongodb_database)
+            assert count == %d, count
+            assert mongodb_database
             ''' % (index + 1)
             GenerateUpdate().run(resource_name='data_updates')
-        assert(self.number_of_data_updates_applied() is 0)
+        assert self.number_of_data_updates_applied() == 0
         thirdieth_update = get_data_updates_files(True)[29]
         Upgrade().run(data_update_id=thirdieth_update)
-        assert(self.number_of_data_updates_applied() is 30)
+        assert self.number_of_data_updates_applied() == 30
         Upgrade().run()
-        assert(self.number_of_data_updates_applied() is 40)
+        assert self.number_of_data_updates_applied() == 40
         Downgrade().run()
-        assert(self.number_of_data_updates_applied() is 39)
+        assert self.number_of_data_updates_applied() == 39
         Downgrade().run(data_update_id=thirdieth_update)
-        assert(self.number_of_data_updates_applied() is 29)
+        assert self.number_of_data_updates_applied() == 29
         Upgrade().run()


### PR DESCRIPTION
…and do it in RSS

While it was possible to restrict a feeding services to one or more
parsers, if was not possible to restrict it to no parser at all.
RSS feeding service do the parsing itself, so no parser should be used
with it.
This patch modify the restriction mechanism to allow restriction to no
parser at all by using None instead of a feed parser name while using
register_feeding_service_parser.

Also changed the label to "RSS/Atom" because the RSS feeding service can
handle both.

SDESK-3846