### PR TITLE
[INGEST] fix ingestion crash on unknown subject qcode:

### DIFF
--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -356,11 +356,19 @@ def process_iptc_codes(item, provider):
             if 'qcode' in subject and len(subject['qcode']) == 8 and subject['qcode'].isdigit():
                 top_qcode = subject['qcode'][:2] + '000000'
                 if not iptc_already_exists(top_qcode):
-                    item['subject'].append({'qcode': top_qcode, 'name': subject_codes[top_qcode]})
+                    try:
+                        item['subject'].append({'qcode': top_qcode, 'name': subject_codes[top_qcode]})
+                    except KeyError:
+                        logger.warning("missing qcode in subject_codes: {qcode}".format(qcode=top_qcode))
+                        continue
 
                 mid_qcode = subject['qcode'][:5] + '000'
                 if not iptc_already_exists(mid_qcode):
-                    item['subject'].append({'qcode': mid_qcode, 'name': subject_codes[mid_qcode]})
+                    try:
+                        item['subject'].append({'qcode': mid_qcode, 'name': subject_codes[mid_qcode]})
+                    except KeyError:
+                        logger.warning("missing qcode in subject_codes: {qcode}".format(qcode=mid_qcode))
+                        continue
     except Exception as ex:
         raise ProviderError.iptcError(ex, provider)
 

--- a/tests/io/update_ingest_tests.py
+++ b/tests/io/update_ingest_tests.py
@@ -9,11 +9,13 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
-from unittest import mock, TestCase
+from unittest import mock
 from unittest.mock import MagicMock
+from superdesk.tests import TestCase
 from datetime import datetime, timedelta
+from copy import deepcopy
 
-from superdesk.io.commands.update_ingest import is_not_expired
+from superdesk.io.commands.update_ingest import is_not_expired, process_iptc_codes
 
 
 class FakeSuperdesk():
@@ -103,3 +105,19 @@ class ItemExpiryTestCase(TestCase):
         item = {'versioncreated': datetime.now()}
         delta = timedelta(minutes=999999999999)
         self.assertTrue(is_not_expired(item, delta))
+
+
+class IPTCCodesTestCase(TestCase):
+
+    def test_unknown_iptc(self):
+        """Test if an unknown IPTC code is not causing a crash"""
+        item = {
+            "guid": "urn:newsml:localhost:2019-02-07T12:00:00.030513:369c16e0-d6b7-40e1-8838-9c5f6a61626c",
+            "subject": [{"name": "system", "qcode": "99009000"}],
+        }
+        # item should not be modified
+        expected = deepcopy(item)
+
+        with self.app.app_context():
+            process_iptc_codes(item, {})
+        self.assertEqual(item, expected)


### PR DESCRIPTION
ingestion was failing (after parsing) when an unknown qcode was found.
This patch fixes it by ignoring unknown qcodes

SDESK-3804