### PR TITLE
[FEED PARSER][NINJS] fixed "original_source"

### DIFF
--- a/superdesk/io/feed_parsers/ninjs.py
+++ b/superdesk/io/feed_parsers/ninjs.py
@@ -33,7 +33,7 @@ class NINJSFeedParser(FeedParser):
     direct_copy_properties = ('usageterms', 'language', 'headline', 'copyrightnotice',
                               'urgency', 'pubstatus', 'mimetype', 'copyrightholder', 'ednote',
                               'body_text', 'body_html', 'slugline', 'keywords',
-                              'source', 'extra', 'byline', 'description_text', 'profile')
+                              'extra', 'byline', 'description_text', 'profile')
 
     items = []
 
@@ -69,6 +69,9 @@ class NINJSFeedParser(FeedParser):
         for copy_property in self.direct_copy_properties:
             if ninjs.get(copy_property) is not None:
                 item[copy_property] = ninjs[copy_property]
+
+        if ninjs.get('source'):
+            item['original_source'] = ninjs['source']
 
         if ninjs.get('priority'):
             item['priority'] = int(ninjs['priority'])

--- a/tests/io/feed_parsers/ninjs_test.py
+++ b/tests/io/feed_parsers/ninjs_test.py
@@ -40,6 +40,8 @@ class SimpleTestCase(NINJSTestCase):
             'avatar_url': 'http://example.com',
             'biography': 'bio',
         })
+        self.assertNotIn("source", self.items[0])
+        self.assertEqual(self.items[0]['original_source'], "AAP")
 
 
 class AssociatedTestCase(NINJSTestCase):


### PR DESCRIPTION
"source" from ingested items were wrongly copied to "source" when it
needs to be copied to "original_source". This patch fixes it

SDESK-3928