### PR TITLE
[SEARCH REPORTS][ES_UTILS] handle ingest_provider

### DIFF
--- a/apps/saved_searches/__init__.py
+++ b/apps/saved_searches/__init__.py
@@ -93,9 +93,9 @@ def send_report_email(user_id, search, docs):
 
 def publish_report(user_id, search_data):
     """Create report for a search and send it by email"""
-    query = es_utils.filter2query(json.loads(search_data['filter']), user_id=user_id)
+    repos, query = es_utils.filter2query(json.loads(search_data['filter']), user_id=user_id)
     found = superdesk.app.data.elastic.es.search(
-        body=query, index=es_utils.get_index())
+        body=query, index=es_utils.get_index(repos))
     docs = es_utils.get_docs(found)
     send_report_email(user_id, search_data, docs)
 

--- a/superdesk/es_utils.py
+++ b/superdesk/es_utils.py
@@ -179,6 +179,11 @@ def filter2query(filter_, user_id=None):
             if value is not None:
                 post_filter_must_not.append({"terms": {field: json.loads(value)}})
 
+    # ingest provider
+    ingest_provider = search_query.pop("ingest_provider", None)
+    if ingest_provider is not None:
+        post_filter.append({"term": {"ingest_provider": ingest_provider}})
+
     # used by AAP multimedia datalayer
     credit_qcode = search_query.pop("creditqcode", None)
     if credit_qcode is not None:
@@ -249,9 +254,15 @@ def filter2query(filter_, user_id=None):
     if post_filter or post_filter_must_not:
         query["post_filter"] = {"bool": {"must": post_filter, "must_not": post_filter_must_not}}
 
+    repo = search_query.pop("repo", None)
+    repos = repo.split(',') if repo is not None else None
+
+    if "params" in search_query and (search_query['params'] is None or not json.loads(search_query['params'])):
+        del search_query['params']
+
     if search_query:
         logger.warning(
             "All query fields have not been used, remaining fields: {search_query}".format(search_query=search_query)
         )
 
-    return query
+    return repos, query

--- a/tests/es_utils_test.py
+++ b/tests/es_utils_test.py
@@ -15,7 +15,7 @@ class ESUtilsTestCase(TestCase):
         }
 
         with self.app.app_context():
-            query = es_utils.filter2query(filter_)
+            __, query = es_utils.filter2query(filter_)
         self.assertEqual(query, expected)
 
     def test_filter2query_date(self):
@@ -53,5 +53,23 @@ class ESUtilsTestCase(TestCase):
             },
         }
         with self.app.app_context():
-            query = es_utils.filter2query(filter_)
+            __, query = es_utils.filter2query(filter_)
         self.assertEqual(query, expected)
+
+    def test_filter2query_ingest_provider(self):
+        """Check that ingest provider is handler correctly"""
+        filter_ = {
+            "query": {
+                "repo": "ingest",
+                "ingest_provider": "5c505c8f0d6f137d69cebc99",
+                "spike": "exclude",
+                "params": "{}",
+            }
+        }
+
+        expected = {'bool': {'must': [{'term': {'ingest_provider': '5c505c8f0d6f137d69cebc99'}}], 'must_not': []}}
+
+        with self.app.app_context():
+            __, query = es_utils.filter2query(filter_)
+
+        self.assertEqual(query['post_filter'], expected)


### PR DESCRIPTION
`ingest_provider` is now handled in filter2query and `repos` are
returned so they can be used to retrieve index to query.

SDESK-4014