### PR TITLE
[SDESK-3995] - Updates to associated items were not reflected in correction

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -102,7 +102,7 @@ class BasePublishService(BaseService):
     package_service = PackageService()
 
     def on_update(self, updates, original):
-        self._publish_associated_items(original)
+        self._refresh_associated_items(original)
         self._validate(original, updates)
         self._set_updates(original, updates, updates.get(config.LAST_UPDATED, utcnow()))
         convert_task_attributes_to_objectId(updates)  # ???
@@ -157,11 +157,12 @@ class BasePublishService(BaseService):
                 self._publish_package_items(original, updates)
                 self._update_archive(original, updates, should_insert_into_versions=auto_publish)
             else:
-                self._publish_associated_items(original, updates, publish=True)
+                self._publish_associated_items(original, updates)
                 updated = deepcopy(original)
                 updated.update(deepcopy(updates))
 
-                self._publish_associated_items(updated, updates)  # updates got lost with update
+                if updates.get(ASSOCIATIONS):
+                    self._refresh_associated_items(updated)  # updates got lost with update
 
                 self._update_archive(original, updates, should_insert_into_versions=auto_publish)
                 self.update_published_collection(published_item_id=original[config.ID_FIELD], updated=updated)
@@ -514,48 +515,82 @@ class BasePublishService(BaseService):
             # countdown=3 is for elasticsearch to be refreshed with archive and published changes
             import_into_legal_archive.apply_async(countdown=3, kwargs=kwargs)  # @UndefinedVariable
 
-    def _publish_associated_items(self, original, updates={}, publish=False):
-        """Refresh and publish associated items before publishing. The publishing is done if the setting
-        PUBLISH_ASSOCIATED_ITEMS was true.
-
-        Any further updates made to basic metadata done after item was associated will be carried on and
-        used when validating those items.
+    def _refresh_associated_items(self, original):
+        """Refreshes associated items with the latest version. Any further updates made to basic metadata done after
+        item was associated will be carried on and used when validating those items.
         """
-        publish_service = None
-        if config.PUBLISH_ASSOCIATED_ITEMS and publish_services.get(self.publish_type):
-            publish_service = get_resource_service(publish_services[self.publish_type])
-
         associations = original.get(ASSOCIATIONS) or {}
-        for associations_key, item in associations.items():
+        for _, item in associations.items():
             if type(item) == dict and item.get(config.ID_FIELD):
                 keys = [key for key in DEFAULT_SCHEMA.keys() if key not in PRESERVED_FIELDS]
 
                 if app.settings.get('COPY_METADATA_FROM_PARENT') and item.get(ITEM_TYPE) in MEDIA_TYPES:
-                    original_item = original
+                    updates = original
                     keys = FIELDS_TO_COPY_FOR_ASSOCIATED_ITEM
                 else:
-                    original_item = super().find_one(req=None, _id=item[config.ID_FIELD]) or {}
+                    updates = super().find_one(req=None, _id=item[config.ID_FIELD]) or {}
 
-                update_item_data(item, original_item, keys)
-                remove_unwanted(item)
+                try:
+                    is_db_item_bigger_ver = updates['_current_version'] > item['_current_version']
+                except KeyError:
+                    update_item_data(item, updates, keys)
+                else:
+                    # if copying from parent the don't keep the existing
+                    # otherwise check the value is_db_item_bigger_ver
+                    keep_existing = not app.settings.get('COPY_METADATA_FROM_PARENT') and not is_db_item_bigger_ver
+                    update_item_data(item, updates, keys, keep_existing=keep_existing)
 
-                if publish_service and publish and item['type'] in MEDIA_TYPES:
-                    if item.get('task', {}).get('stage', None):
-                        del item['task']['stage']
-                    if item['state'] not in PUBLISH_STATES:
-                        get_resource_service('archive_publish').patch(id=item.pop(config.ID_FIELD), updates=item)
-                    else:
-                        publish_service.patch(id=item.pop(config.ID_FIELD), updates=item)
-                    item['state'] = self.published_state
+    def _publish_associated_items(self, original, updates={}):
+        """If there any updates to associated item and if setting:PUBLISH_ASSOCIATED_ITEMS is true
+        then publish the associated item
+        """
+        if not publish_services.get(self.publish_type):
+            # publish type not supported
+            return
+
+        publish_service = get_resource_service(publish_services.get(self.publish_type))
+
+        if not updates.get(ASSOCIATIONS) and not original.get(ASSOCIATIONS):
+            # there's nothing to update
+            return
+
+        associations = original.get(ASSOCIATIONS) or {}
+        for associations_key, associated_item in associations.items():
+            if type(associated_item) == dict and associated_item.get(config.ID_FIELD):
+
+                if not config.PUBLISH_ASSOCIATED_ITEMS or not publish_service:
+                    # Not allowed to publish
                     original[ASSOCIATIONS][associations_key]['state'] = self.published_state
                     original[ASSOCIATIONS][associations_key]['operation'] = self.publish_type
-                    if ASSOCIATIONS not in updates:
-                        updates[ASSOCIATIONS] = original[ASSOCIATIONS]
-                    updates[ASSOCIATIONS][associations_key] = original[ASSOCIATIONS][associations_key]
-                elif publish:
-                    # Publishing an item with an association set the state and operation of the embedded association
-                    original[ASSOCIATIONS][associations_key]['state'] = self.published_state
-                    original[ASSOCIATIONS][associations_key]['operation'] = self.publish_type
+                    continue
+
+                if associated_item['state'] not in PUBLISH_STATES:
+                    # This associated item has not been published before
+                    associated_item.get('task', {}).pop('stage', None)
+                    remove_unwanted(associated_item)
+                    get_resource_service('archive_publish').patch(id=associated_item.pop(config.ID_FIELD),
+                                                                  updates=associated_item)
+                    associated_item['state'] = self.published_state
+                    associated_item['operation'] = self.publish_type
+                    updates[ASSOCIATIONS] = updates.get(ASSOCIATIONS, {})
+                    updates[ASSOCIATIONS][associations_key] = associated_item
+                else:
+                    # Check if there are updates to associated item
+                    association_updates = updates.get(ASSOCIATIONS, {}).get(associations_key)
+
+                    if not association_updates:
+                        # there is no update for this item but still patching the associated item
+                        associated_item.get('task', {}).pop('stage', None)
+                        remove_unwanted(associated_item)
+                        publish_service.patch(id=associated_item.pop(config.ID_FIELD), updates=associated_item)
+                        continue
+
+                    if association_updates['state'] not in PUBLISH_STATES:
+                        # There's an update to the published associated item
+                        remove_unwanted(association_updates)
+                        publish_service.patch(id=association_updates.pop(config.ID_FIELD), updates=association_updates)
+
+        self._refresh_associated_items(original)
 
     def _mark_media_item_as_used(self, updates, original):
         if ASSOCIATIONS not in updates or not updates.get(ASSOCIATIONS):

--- a/features/content_expire_published.feature
+++ b/features/content_expire_published.feature
@@ -59,7 +59,7 @@ Feature: Content Expiry Published Items
                 }
             }
         }
-    
+
     ]
     """
     When we post to "/products" with success

--- a/features/content_publish.feature
+++ b/features/content_publish.feature
@@ -2607,6 +2607,152 @@ Feature: Content Publishing
       And we get null stage
 
     @auth
+    Scenario: Correct associated items updates the fields
+      Given "vocabularies"
+      """
+      [{
+          "_id": "media1", "field_type": "media",
+          "display_name": "Media 1", "type": "manageable",
+          "service": {"all": 1}, "items": [],
+          "field_options": {"allowed_types": {"picture": true}},
+          "schema": {"parent": {}, "name": {}, "qcode": {}}
+      }, {
+      	"_id": "crop_sizes",
+      	"unique_field": "name",
+      	"items": [
+      		{"is_active": true, "name": "original", "width": 800, "height": 600}
+      	]
+      }
+      ]
+      """
+      And "content_types"
+      """
+      [{
+          "_id": "profile1", "label": "Profile 1",
+          "is_used": true, "enabled": true, "priority": 0, "editor": {},
+          "schema": {"media1": {"required": true, "nullable": false, "enabled": true, "type": "media"}}
+      }]
+      """
+      And "validators"
+      """
+      [
+          {"_id": "publish_text", "act": "publish", "type": "text", "schema":{}},
+          {"_id": "correct_text", "act": "correct", "type": "text", "schema":{}},
+          {
+            "_id": "publish_picture",
+            "act": "publish",
+            "type": "picture",
+            "schema": {
+                "renditions": {
+                    "type": "dict",
+                    "required": true,
+                    "schema": {"original": {"type": "dict", "required": true}}
+                }
+            }
+        },
+        {
+            "_id": "correct_picture",
+            "act": "correct",
+            "type": "picture",
+            "schema": {
+                "renditions": {
+                    "type": "dict",
+                    "required": false,
+                    "schema": {"original": {"type": "dict", "required": true}}
+                }
+            }
+        }
+      ]
+      """
+      And "desks"
+      """
+      [{"name": "Sports"}]
+      """
+      When we post to "/products" with success
+      """
+      {
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
+      }
+      """
+      And we post to "/subscribers" with success
+      """
+      {
+        "name":"Channel 3","media_type":"media", "subscriber_type": "digital", "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
+        "products": ["#products._id#"],
+        "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}]
+      }
+      """
+      And we post to "archive" with success
+      """
+      [
+          {
+               "guid": "234", "type": "picture", "slugline": "234", "headline": "234", "state": "in_progress",
+               "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
+               "renditions": {
+                  "original": {"CropLeft": 0, "CropRight": 800, "CropTop": 0, "CropBottom": 600}
+               }
+          },
+          {
+              "guid": "123", "type": "text", "headline": "test", "state": "in_progress",
+            "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
+            "subject":[{"qcode": "17004000", "name": "Statistics"}], "body_html": "Test Document body",
+            "associations": {
+                "featuremedia": {
+                    "_id": "234",
+                    "guid": "234",
+                    "type": "picture",
+                    "slugline": "234",
+                    "headline": "234",
+                    "byline": "xyz",
+                    "alt_text": "alt_text",
+                    "description_text": "description_text",
+                    "state": "in_progress",
+                    "renditions": {
+                        "original": {"CropLeft": 0, "CropRight": 800, "CropTop": 0, "CropBottom": 600}
+                     },
+                    "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"}
+                }
+            }
+           }
+      ]
+      """
+      And we publish "123" with "publish" type and "published" state
+      Then we get OK response
+      And we get existing resource
+      """
+      {
+        "_current_version": 2,
+        "type": "text",
+        "state": "published",
+        "associations": {
+            "featuremedia": {"state": "published"}
+        },
+        "task":{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}
+      }
+      """
+      When we publish "123" with "correct" type and "corrected" state
+      """
+      {
+        "associations": {
+            "featuremedia": {
+                "byline": "foo",
+                "alt_text": "alt_text",
+                "description_text": "description_text",
+                "headline": "234",
+                "renditions": {
+                      "original": {"CropLeft": 0, "CropRight": 800, "CropTop": 0, "CropBottom": 600}
+                   }
+                }
+            }
+      }
+      """
+      Then we get OK response
+      And we get existing resource
+      """
+      {"_current_version": 3, "state": "corrected", "associations": {"featuremedia": {"byline": "foo"}}}
+      """
+
+    @auth
     Scenario: Publish with success when associated item contains _type field
       Given the "validators"
       """


### PR DESCRIPTION
- When a story with a featured image is corrected with the byline of the image, it was not reflected on the correction