### PR TITLE
[SDESK-4006] - state is missing on article to be published

### DIFF
--- a/features/ingest.feature
+++ b/features/ingest.feature
@@ -495,6 +495,7 @@ Feature: Fetch From Ingest
                  "state":"ingested",
                  "associations":{
                     "featuremedia":{
+                       "state": "ingested",
                        "renditions":{
                           "baseImage":{
                              "width":1400

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -531,6 +531,7 @@ def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=N
 
         # if the item has associated media
         for key, assoc in item.get('associations', {}).items():
+            set_default_state(assoc, CONTENT_STATE.INGESTED)
             if assoc.get('renditions'):
                 transfer_renditions(assoc['renditions'])
             # wire up the id of the associated feature media to the ingested one


### PR DESCRIPTION
- `state` was not set for associated item if the association has been ingested with ninjs format