### PR TITLE
SDESK-4147 Fix multiple object creation. Make definition_text field read only.

### DIFF
--- a/apps/concept_items/resource.py
+++ b/apps/concept_items/resource.py
@@ -25,11 +25,12 @@ class ConceptItemsResource(Resource):
             'required': True,
             'empty': False
         },
-        'group_id': Resource.rel(
-            resource='concept_items',
-            required=False,
-            embeddable=False
-        ),
+        'group_id': {
+            'type': 'string',
+            'required': False,
+            'empty': False,
+            'readonly': False
+        },
         'definition_text': {
             'type': 'string',
             'required': False,

--- a/apps/concept_items/resource.py
+++ b/apps/concept_items/resource.py
@@ -33,11 +33,12 @@ class ConceptItemsResource(Resource):
         'definition_text': {
             'type': 'string',
             'required': False,
-            'empty': False
+            'empty': False,
+            'readonly': True
         },
         'definition_html': {
             'type': 'string',
-            'required': False,
+            'required': True,
             'empty': False
         },
         'language': {

--- a/apps/concept_items/service.py
+++ b/apps/concept_items/service.py
@@ -30,14 +30,12 @@ class ConceptItemsService(BaseService):
 
     def on_create(self, docs):
         for doc in docs:
-            self._validate_definition(doc)
             self._validate_properties(doc)
             self._validate_language(doc)
             self._setup_created_by(doc)
             self._fill_definition_text(doc)
 
     def on_replace(self, doc, original):
-        self._validate_definition(doc, original)
         self._validate_properties(doc)
         self._validate_language(doc)
         self._setup_created_by(doc, original)
@@ -58,8 +56,7 @@ class ConceptItemsService(BaseService):
         if 'language' in updates:
             self._validate_language(updates)
 
-        if 'definition_text' in updates or 'definition_html' in updates:
-            self._validate_definition(updates, original)
+        if 'definition_html' in updates:
             self._fill_definition_text(updates)
 
         self._setup_updated_by(updates)
@@ -87,20 +84,8 @@ class ConceptItemsService(BaseService):
                 payload={"language": "unallowed value '{}'".format(doc['language'])}
             )
 
-    def _validate_definition(self, doc, original=None):
-        if not original:
-            # at least one definition_* field is required
-            if 'definition_text' not in doc and 'definition_html' not in doc:
-                raise SuperdeskApiError.badRequestError(
-                    message="Request is not valid",
-                    payload={"definition_text": "'definition_text' or 'definition_html' were not provided, "
-                                                "at least one parameter is required."}
-                )
-
     def _fill_definition_text(self, doc):
-        # fill definition_text if it was not provided
-        if 'definition_html' in doc and 'definition_text' not in doc:
-            doc['definition_text'] = get_text(doc['definition_html'], content='html', lf_on_block=True).strip()
+        doc['definition_text'] = get_text(doc['definition_html'], content='html', lf_on_block=True).strip()
 
     def _validate_properties(self, doc):
         getattr(

--- a/features/concept_items.feature
+++ b/features/concept_items.feature
@@ -34,7 +34,7 @@ Feature: Concept items
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
             "language": "en",
-            "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
         Then we get response code 201
@@ -54,6 +54,7 @@ Feature: Concept items
                     ],
                     "language": "en",
                     "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien.",
+                    "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien.",
                     "_updated": "__any_value__",
                     "_created": "__any_value__",
                     "created_by": "#CONTEXT_USER_ID#",
@@ -96,7 +97,7 @@ Feature: Concept items
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
             "language": "en",
-            "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
         Then we get response code 400
@@ -154,7 +155,7 @@ Feature: Concept items
             "language": "de",
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
-            "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
         Then we get error 400
@@ -197,9 +198,14 @@ Feature: Concept items
         """
         {
             "_status": "ERR",
-            "_message": "Request is not valid",
             "_issues": {
-                "definition_text": "'definition_text' or 'definition_html' were not provided, at least one parameter is required."
+                "definition_html": {
+                    "required": 1
+                }
+            },
+            "_error": {
+                "code": 400,
+                "message": "Insertion failure: 1 document(s) contain(s) error(s)"
             }
         }
         """
@@ -321,7 +327,7 @@ Feature: Concept items
             "cpnat_type": "cpnat:person",
             "labels": ["book", "tolkien"],
             "language": "en",
-            "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
         Then we get error 400
@@ -367,7 +373,7 @@ Feature: Concept items
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
             "language": "en",
-            "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien.",
+            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien.",
             "properties": {
                 "name": "Some name"
             }
@@ -418,7 +424,7 @@ Feature: Concept items
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
             "language": "en",
-            "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
         Then we get error 400
@@ -436,7 +442,7 @@ Feature: Concept items
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
             "language": "en",
-            "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
         Then we get response code 201
@@ -455,6 +461,7 @@ Feature: Concept items
                         "tolkien"
                     ],
                     "language": "en",
+                    "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien.",
                     "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien.",
                     "_updated": "__any_value__",
                     "_created": "__any_value__",
@@ -472,7 +479,7 @@ Feature: Concept items
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
             "language": "en",
-            "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
         Then we get response code 409
@@ -484,7 +491,7 @@ Feature: Concept items
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
             "language": "es",
-            "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
         Then we get response code 201
@@ -524,7 +531,7 @@ Feature: Concept items
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
             "language": "en",
-            "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
         Then we get response code 201
@@ -543,6 +550,7 @@ Feature: Concept items
             "group_id": "#concept_items._id#",
             "cpnat_type": "cpnat:abstract",
             "created_by": "#CONTEXT_USER_ID#",
+            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien.",
             "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien.",
             "labels": [
                 "book",
@@ -581,7 +589,7 @@ Feature: Concept items
             "labels": ["book", "tolkien"],
             "group_id": "#concept_items._id#",
             "language": "es",
-            "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
         When we patch "/concept_items/#concept_items._id#"
@@ -624,7 +632,7 @@ Feature: Concept items
                 "cpnat_type": "cpnat:abstract",
                 "labels": ["book", "tolkien"],
                 "language": "en",
-                "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+                "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
             }
             """
             Then we get response code 201
@@ -636,7 +644,7 @@ Feature: Concept items
                 "group_id": "#concept_items._id#",
                 "labels": ["book", "tolkien", "fantasy"],
                 "language": "es",
-                "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+                "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
             }
             """
             Then we get updated response
@@ -649,6 +657,7 @@ Feature: Concept items
                 "group_id": "#concept_items._id#",
                 "cpnat_type": "cpnat:abstract",
                 "created_by": "#CONTEXT_USER_ID#",
+                "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien.",
                 "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien.",
                 "labels": [
                     "book",
@@ -695,7 +704,7 @@ Feature: Concept items
                 "cpnat_type": "cpnat:abstract",
                 "labels": ["book", "tolkien"],
                 "language": "en",
-                "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
+                "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
             }
             """
             Then we get response code 201
@@ -773,8 +782,7 @@ Feature: Concept items
                 "group_id": "#concept_items._id#",
                 "labels": ["book", "tolkien", "fantasy"],
                 "language": "es",
-                "definition_html": "<p><b>The Hobbit</b> is a <span>children's <i>fantasy</i></span> novel by English author J. R. R. Tolkien.</p>",
-                "definition_text": "Star wars"
+                "definition_html": "<p><b>The Hobbit</b> is a <span>children's <i>fantasy</i></span> novel by English author J. R. R. Tolkien.</p>"
             }
             """
             Then we get updated response
@@ -788,7 +796,7 @@ Feature: Concept items
                 "cpnat_type": "cpnat:abstract",
                 "created_by": "#CONTEXT_USER_ID#",
                 "definition_html": "<p><b>The Hobbit</b> is a <span>children's <i>fantasy</i></span> novel by English author J. R. R. Tolkien.</p>",
-                "definition_text": "Star wars",
+                "definition_text": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien.",
                 "labels": [
                     "book",
                     "tolkien",

--- a/features/concept_items.feature
+++ b/features/concept_items.feature
@@ -45,7 +45,7 @@ Feature: Concept items
             "_items": [
                 {
                     "_id": "#concept_items._id#",
-                    "group_id": "#concept_items._id#",
+                    "group_id": "#concept_items.group_id#",
                     "name": "Hobbit",
                     "cpnat_type": "cpnat:abstract",
                     "labels": [
@@ -70,7 +70,7 @@ Feature: Concept items
         """
         {
             "_id": "#concept_items._id#",
-            "group_id": "#concept_items._id#",
+            "group_id": "__any_value__",
             "name": "Hobbit",
             "cpnat_type": "cpnat:abstract",
             "labels": [
@@ -390,7 +390,7 @@ Feature: Concept items
 
     @auth
     @app_init
-    Scenario: Create a concept item: code in payload
+    Scenario: Create a concept item: group_id in payload
         Given "vocabularies"
         """
         [{
@@ -427,24 +427,6 @@ Feature: Concept items
             "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
-        Then we get error 400
-        """
-        {
-            "_issues": {
-                "group_id": "value '5c62d77efe985ea36958fa3e' must exist in resource 'concept_items', field '_id'."
-            }
-        }
-        """
-        When we post to "/concept_items"
-        """
-        {
-            "name": "Hobbit",
-            "cpnat_type": "cpnat:abstract",
-            "labels": ["book", "tolkien"],
-            "language": "en",
-            "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
-        }
-        """
         Then we get response code 201
         When we get "/concept_items"
         Then we get existing resource
@@ -452,8 +434,7 @@ Feature: Concept items
         {
             "_items": [
                 {
-                    "_id": "#concept_items._id#",
-                    "group_id": "#concept_items._id#",
+                    "group_id": "5c62d77efe985ea36958fa3e",
                     "name": "Hobbit",
                     "cpnat_type": "cpnat:abstract",
                     "labels": [
@@ -471,11 +452,12 @@ Feature: Concept items
             ]
         }
         """
+        When we get "/concept_items"
         When we post to "/concept_items"
         """
         {
             "name": "Hobbit",
-            "group_id": "#concept_items._id#",
+            "group_id": "5c62d77efe985ea36958fa3e",
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
             "language": "en",
@@ -487,7 +469,7 @@ Feature: Concept items
         """
         {
             "name": "Hobbit",
-            "group_id": "#concept_items._id#",
+            "group_id": "b615a998-544b-4c3f-b063-9ceccdd7c1dc",
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
             "language": "es",
@@ -531,6 +513,7 @@ Feature: Concept items
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
             "language": "en",
+            "group_id": "5c94ebcdfe985e1c9fc26d52",
             "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
@@ -547,7 +530,7 @@ Feature: Concept items
             "_status": "OK",
             "_type": "concept_items",
             "_updated": "__any_value__",
-            "group_id": "#concept_items._id#",
+            "group_id": "#concept_items.group_id#",
             "cpnat_type": "cpnat:abstract",
             "created_by": "#CONTEXT_USER_ID#",
             "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien.",
@@ -587,11 +570,12 @@ Feature: Concept items
             "name": "Hobbit",
             "cpnat_type": "cpnat:abstract",
             "labels": ["book", "tolkien"],
-            "group_id": "#concept_items._id#",
+            "group_id": "5c94ebcdfe985e1c9fc26d52",
             "language": "es",
             "definition_html": "The Hobbit is a children's fantasy novel by English author J. R. R. Tolkien."
         }
         """
+        When we get "/concept_items"
         When we patch "/concept_items/#concept_items._id#"
         """
         {"language": "en"}
@@ -756,7 +740,7 @@ Feature: Concept items
                 "_items": [
                     {
                         "_id": "#concept_items._id#",
-                        "group_id": "#concept_items._id#",
+                        "group_id": "__any_value__",
                         "name": "Hobbit",
                         "cpnat_type": "cpnat:abstract",
                         "labels": [


### PR DESCRIPTION
1) I've marked `definition_text` field as read only. Before it was possible to set up it explicitly, now if `definition_text` is in payload error will be raised.
2) Multiple object creation was fixed. Issue was in group_id & language mongo index. 

NOTE: Since feature not in production, there is no migration.