### PR TITLE
Fixed: Cannot deschedule scheduled articles. (SDESK-4129)

### DIFF
--- a/apps/publish/enqueue/__init__.py
+++ b/apps/publish/enqueue/__init__.py
@@ -11,6 +11,7 @@
 import cProfile
 import logging
 import superdesk
+import superdesk.signals as signals
 from flask import current_app as app
 
 from superdesk import get_resource_service
@@ -138,6 +139,9 @@ class EnqueueContent(superdesk.Command):
                 # send a notification to the clients
                 push_content_notification(
                     [{'_id': str(published_item['item_id']), 'task': published_item.get('task', None)}])
+                #  apply internal destinations
+                signals.item_published.send(self,
+                                            item=archive_service.find_one(req=None, _id=published_item['item_id']))
 
             published_service.patch(published_item_id, published_update)
             # queue the item for publishing

--- a/features/internal_destinations.feature
+++ b/features/internal_destinations.feature
@@ -673,3 +673,71 @@ Feature: Internal Destinations
             ]
         }
         """
+
+    @auth
+    Scenario: Create items for destinations on publish and keep the state same as original item's state.
+        When we post to "archive" with success
+        """
+        [{
+            "guid": "123",
+            "type": "text",
+            "headline": "Take-1 headline",
+            "abstract": "Take-1 abstract",
+            "task": {
+                "user": "#CONTEXT_USER_ID#",
+                "desk": "#origin_desk#",
+                "stage": "#origin_stage#"
+            },
+            "body_html": "Body $10",
+            "state": "submitted",
+            "slugline": "Take-1 slugline",
+            "urgency": "4",
+            "pubstatus": "usable",
+            "subject":[{"qcode": "17004000", "name": "Statistics"}],
+            "anpa_category": [{"qcode": "A", "name": "Sport"}],
+            "anpa_take_key": "Take",
+            "publish_schedule": "2099-05-19T10:15:00",
+            "schedule_settings": {
+                "time_zone": "Europe/London",
+                "utc_publish_schedule": "2099-05-19T10:15:00+0000"
+            }
+        }]
+        """
+        Given "internal_destinations"
+        """
+        [{"name": "copy", "is_active": true,  "desk": "#destination_desk#", "macro": "Internal_Destination_Auto_Publish"}]
+        """
+        When we publish "#archive._id#" with "publish" type and "published" state
+        """
+        {
+            "publish_schedule": "2099-05-19T10:15:00",
+            "schedule_settings": {
+                "time_zone": "Europe/London",
+                "utc_publish_schedule": "2099-05-19T10:15:00+0000"
+            }
+        }
+        """
+        Then we get OK response
+        When we get "/published?where=%7B%22processed_from%22%3A%22123%22%7D"
+        Then we get list with 1 items
+        """
+        {
+            "_items": [{
+            "processed_from": "123",
+            "format": "HTML",
+            "operation": "publish",
+            "family_id": "123",
+            "state": "scheduled",
+            "publish_schedule": "2099-05-19T10:15:00+0000",
+            "pubstatus": "usable",
+            "schedule_settings": {
+                "time_zone": "Europe/London",
+                "utc_embargo": null,
+                "utc_publish_schedule": "2099-05-19T10:15:00+0000"
+            }
+            }]
+        }
+        """
+        When we get "/published"
+        Then we get list with 2 items
+

--- a/features/internal_destinations.feature
+++ b/features/internal_destinations.feature
@@ -707,7 +707,7 @@ Feature: Internal Destinations
         """
         [{"name": "copy", "is_active": true,  "desk": "#destination_desk#", "macro": "Internal_Destination_Auto_Publish"}]
         """
-        When we publish "#archive._id#" with "publish" type and "published" state
+        When we publish "#archive._id#" with "publish" type and "scheduled" state
         """
         {
             "publish_schedule": "2099-05-19T10:15:00",
@@ -740,4 +740,54 @@ Feature: Internal Destinations
         """
         When we get "/published"
         Then we get list with 2 items
+
+    @auth
+    Scenario: Delay item creation for destinations on publish if the send_after_schedule is enabled for internal destinations
+        When we post to "archive" with success
+        """
+        [{
+            "guid": "123",
+            "type": "text",
+            "headline": "Take-1 headline",
+            "abstract": "Take-1 abstract",
+            "task": {
+                "user": "#CONTEXT_USER_ID#",
+                "desk": "#origin_desk#",
+                "stage": "#origin_stage#"
+            },
+            "body_html": "Body $10",
+            "state": "submitted",
+            "slugline": "Take-1 slugline",
+            "urgency": "4",
+            "pubstatus": "usable",
+            "subject":[{"qcode": "17004000", "name": "Statistics"}],
+            "anpa_category": [{"qcode": "A", "name": "Sport"}],
+            "anpa_take_key": "Take",
+            "publish_schedule": "2099-05-19T10:15:00",
+            "schedule_settings": {
+                "time_zone": "Europe/London",
+                "utc_publish_schedule": "2099-05-19T10:15:00+0000"
+            }
+        }]
+        """
+        Given "internal_destinations"
+        """
+        [{"name": "copy", "is_active": true,  "desk": "#destination_desk#", "macro": "Internal_Destination_Auto_Publish",
+        "send_after_schedule": true}]
+        """
+        When we publish "#archive._id#" with "publish" type and "scheduled" state
+        """
+        {
+            "publish_schedule": "2099-05-19T10:15:00",
+            "schedule_settings": {
+                "time_zone": "Europe/London",
+                "utc_publish_schedule": "2099-05-19T10:15:00+0000"
+            }
+        }
+        """
+        Then we get OK response
+        When we get "/published?where=%7B%22processed_from%22%3A%22123%22%7D"
+        Then we get list with 0 items
+        When we get "/published"
+        Then we get list with 1 items
 


### PR DESCRIPTION
New item created from internal destinations, is always set to published state as we were not sending `schedule_settings` and `publish_schdule` fields in `updates`. So, irrespective of what is the state of the original item, a newly created item is always set to be published. But now the state of new item will be the same as the original item. 