### PR TITLE
Fix AttributeError when url is not in config. Remove redundant validation.

### DIFF
--- a/superdesk/io/feeding_services/http_base_service.py
+++ b/superdesk/io/feeding_services/http_base_service.py
@@ -134,24 +134,12 @@ class HTTPFeedingServiceBase(FeedingService):
                 Exception('{} are required.'.format(', '.join(required_keys)))
             )
 
-        url = self.config.get('url').strip()
-        if not url:
-            try:
-                url_field = next({f for f in self.fields if f['id'] == u'url'})
-            except StopIteration:
-                url_required = False
-            else:
-                url_required = url_field.get('required', False)
-            if url_required:
-                raise SuperdeskIngestError.notConfiguredError(
-                    Exception('URL is a required field.')
-                )
-        else:
-            # validate url
-            if not url.startswith('http'):
-                raise SuperdeskIngestError.notConfiguredError(
-                    Exception('URL must be a valid HTTP link.')
-                )
+        # validate url
+        url = self.config.get('url', '').strip()
+        if url and not url.startswith('http'):
+            raise SuperdeskIngestError.notConfiguredError(
+                Exception('URL must be a valid HTTP link.')
+            )
 
     def get_url(self, url=None, **kwargs):
         """Do an HTTP Get on URL


### PR DESCRIPTION
Hi @jerome-poisson ,
- this part was rising an error when `url` is not in config -> `url = self.config.get('url').strip()`
- I removed "required" url validation because we already have it -> https://github.com/ride90/superdesk-core/blob/d07c6970402a1b537d818870115551ba98e97a51/superdesk/io/feeding_services/http_base_service.py#L130