### PR TITLE
avoid validation errors for missing cvs

### DIFF
--- a/apps/validate/validate.py
+++ b/apps/validate/validate.py
@@ -202,6 +202,11 @@ class ValidateService(superdesk.Service):
                         schema['extra']['schema'].update({extra_field['_id']: get_validator_schema(rules)})
                         self._populate_extra(doc['validate'], extra_field['_id'])
                 content_type['schema'] = schema
+                try:
+                    # avoid errors when cv is removed and value is still there
+                    schema['subject']['schema']['schema']['scheme'].pop('allowed', None)
+                except KeyError:
+                    pass
                 return [content_type]
         lookup = {'act': doc['act'], 'type': doc[ITEM_TYPE]}
         if doc.get('embedded'):

--- a/features/validate.feature
+++ b/features/validate.feature
@@ -343,3 +343,48 @@ Feature: Validate
     """
     {"errors": "__empty__"}
     """
+
+  @auth
+  Scenario: Validate subject with subject scheme not in allowed
+  Given "content_types"
+    """
+    [{"_id": "test", "schema": {
+      "subject": {
+        "mandatory_in_list": {"scheme": {"01": "01", "destination": null}},
+        "type": "list",
+        "nullable": false,
+        "required": true,
+        "type": "list",
+        "schema": {
+          "type": "dict",
+          "schema": {
+            "scheme": {
+              "allowed": ["01"],
+              "nullable": true,
+              "required": true,
+              "type": "string"
+            }
+          }
+        }
+      }
+    }}]
+    """
+
+    When we post to "/validate"
+    """
+    {
+      "act": "publish", "type": "text",
+      "validate": {
+        "profile": "test",
+        "subject": [
+          {"name": "foo", "qcode": "foo", "scheme": null},
+          {"name": "01", "qcode": "01", "scheme": "01"},
+          {"name": "bar", "qcode": "bar", "scheme": "bar"}
+        ]
+      }
+    }
+    """
+    Then we get existing resource
+    """
+    {"errors": "__empty__"}
+    """


### PR DESCRIPTION
fix validation error when cv is removed from profile but some value
is set for it already in template or in article.

SDANSA-267