### PR TITLE
[VALIDATION] fix subject required error when custom vocabulary is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Superdesk Server Changelog
 
+## [1.30] NOT RELEASED YET
+
+### Fixed
+
+- Fix subject required validation failing in some cases
+
 ## [1.28] 2018-01-18
 
 ### Added

--- a/apps/validate/tests.py
+++ b/apps/validate/tests.py
@@ -108,6 +108,20 @@ class ValidateMandatoryInListTest(TestCase):
 
         self.assertEqual(errors, [['SUBJECT is a required field']])
 
+    def test_validate_required_subject_with_cv(self):
+        """Test that subject required error is raised as expected when a custom vocabulary is used"""
+        self.app.data.insert('content_types', [
+            {'_id': 'foo', 'schema': {'subject': {'type': 'list', 'required': True}}}
+        ])
+
+        service = ValidateService()
+        errors = service.create([
+            {'act': 'test', 'type': 'test', 'validate': {'profile': 'foo', 'subject': [
+                {'qcode': 'test', 'name': 'test', 'scheme': 'custom_cv'}]}}
+        ])
+
+        self.assertEqual(errors, [['SUBJECT is a required field']])
+
     def test_validate_required_none_list(self):
         self.app.data.insert('content_types', [{
             '_id': 'foo',

--- a/apps/validate/validate.py
+++ b/apps/validate/validate.py
@@ -104,9 +104,16 @@ class SchemaValidator(Validator):
     def _validate_empty(self, empty, field, value):
         """Original validates only strings, adding a list check."""
         super()._validate_empty(empty, field, value)
-        if isinstance(value, list) and not value:
+        if field == "subject":
+            # for subject, we have to ignore all data with scheme
+            # as they are used for custom values
+            filtered = [v for v in value if not v.get('scheme')]
+            if not filtered:
+                self._error(field, REQUIRED_FIELD)
+
+        elif isinstance(value, list) and not value:
             self._error(field, REQUIRED_FIELD)
-        if isinstance(value, str) and value == '<p></p>':  # default value for editor3
+        elif isinstance(value, str) and value == '<p></p>':  # default value for editor3
             self._error(field, REQUIRED_FIELD)
 
     def _validate_enabled(self, *args):


### PR DESCRIPTION
custom vocabularies are put in "subject" which was causing trouble during
validation (if not subject was used but custom vocabularies was,
"required" constraint was passing when it should not).

fix SDESK-4150