### PR TITLE
SPELLCHECKERS] default spellchecker implementation + discard spelling…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [1.30] NOT RELEASED YET
 
+### Added
+
+- Add generic spellcheckers management
+- Add Grammalecte French spellchecker support
+- Add Leuven University Dutch spellchecker support
+- Add basic generic spellchecker
+
 ### Fixed
 
 - Fix subject required validation failing in some cases

--- a/docs/spellchecking.rst
+++ b/docs/spellchecking.rst
@@ -6,12 +6,31 @@ Spellchecking
 Superdesk can support several spellcheckers. They are implemented as backend plugin and
 used by the client.
 
+Getting list of spellcheckers
+-----------------------------
+To retrieve list of registered spellcheckers, a GET request must be done on ``spellcheckers_list`` endpoint.
+
+Checking a text
+---------------
+
+A text can be checked using ``spellchecker`` endpoint.
+
+.. autoclass:: superdesk.text_checkers.spellcheckers.SpellcheckerService
+
+Getting suggestions
+-------------------
+
+Getting suggestions for a word is done in a similar way as checking a text, on the same
+``spellchecker`` endpoint, but with the additional ``"suggestions": true`` key.
+
 Spellchecker plugin
 -------------------
 
-So far, Superdesk support the following spellcheckers:
+So far, Superdesk supports the following spellcheckers:
 
 
 .. autoclass:: superdesk.text_checkers.spellcheckers.grammalecte.Grammalecte
 
 .. autoclass:: superdesk.text_checkers.spellcheckers.leuven_dutch.LeuvenDutch
+
+.. autoclass:: superdesk.text_checkers.spellcheckers.default.Default

--- a/superdesk/text_checkers/spellcheckers/__init__.py
+++ b/superdesk/text_checkers/spellcheckers/__init__.py
@@ -22,6 +22,12 @@ logger = logging.getLogger(__name__)
 # can be set to False if importSpellcheckers need to be called manually
 # (e.g. in unit tests)
 AUTO_IMPORT = True
+# default spellchecker is the basic one, using internal dictionary
+SPELLCHECKER_DEFAULT = "default"
+CAP_SPELLING = "spelling"
+CAP_GRAMMAR = "grammar"
+# any language is supported
+LANG_ANY = "*"
 
 
 class SpellcheckerResource(Resource):
@@ -34,9 +40,18 @@ class SpellcheckerResource(Resource):
             'type': 'string',
             'required': True,
         },
+        'language': {
+            'type': 'string',
+            'nullable': True,
+        },
         'suggestions': {
             'type': 'boolean',
             'default': False,
+        },
+        # if True, spelling errors which are in internal dictionary will be ignored
+        'use_internal_dict': {
+            'type': 'boolean',
+            'default': True,
         },
     }
     internal_resource = False
@@ -45,22 +60,85 @@ class SpellcheckerResource(Resource):
 
 
 class SpellcheckerService(BaseService):
+    r"""Service managing spellchecking and suggestions.
+
+    When doing a POST request on this service, the following keys can be used (keys with a \* are required):
+
+
+    =================   ===========
+    key                 explanation
+    =================   ===========
+    spellchecker \*     name of the spellchecker
+    text \*             text to check or word for suggestions
+    language            language to use (for spellcheckers handling several ones)
+    suggestions         false (default) to check a text, else will get suggestions
+    use_internal_dict   true (default) to remove spellings mistakes from words in personal dictionary
+    =================   ===========
+
+    e.g. to check a French text while removing words from personal dictionary (grammar mistakes are here on purpose):
+
+    .. sourcecode:: json
+
+        {
+            "spellchecker": "grammalecte",
+            "text": "Il nous reste à vérifié votre maquette."
+        }
+
+    Here is an example payload for suggestions:
+
+    .. sourcecode:: json
+
+        {
+            "spellchecker": "grammalecte",
+            "suggestions": true,
+            "text": "fote"
+        }
+
+    """
+
+    def remove_errors_in_dict(self, spellchecker, language, check_data):
+        """Remove spelling error which are in the internal dictionary
+
+        :param SpellcheckerBase: spellchecker used
+        :param str language: language specified by the client
+        :param dict check_data: data returned by spellchecker.check method (will be modified in place)
+        """
+        if spellchecker.name == SPELLCHECKER_DEFAULT:
+            # default spellchecker already works with internal dictionaries
+            return
+        errors = check_data['errors']
+        if not errors:
+            return
+        lang = spellchecker.get_language(language)
+        dictionaries_service = superdesk.get_resource_service('dictionaries')
+        model = dictionaries_service.get_model_for_lang(lang)
+        to_remove = []
+        for error in errors:
+            if error.get('type', 'spelling') != 'spelling':
+                continue
+            if error['text'].lower() in model:
+                to_remove.append(error)
+        for error in to_remove:
+            errors.remove(error)
 
     def create(self, docs, **kwargs):
         # we override create because we don't want anything stored in database
         doc = docs[0]
         sc_name = doc["spellchecker"]
+        language = doc.get('language')
         try:
             spellchecker = registered_spellcheckers[sc_name]
         except KeyError:
             raise SuperdeskApiError.notFoundError("{sc_name} spellchecker can't be found".format(sc_name=sc_name))
 
         if doc["suggestions"]:
-            check_data = spellchecker.suggest(doc['text'])
+            check_data = spellchecker.suggest(doc['text'], language)
             assert "suggestions" in check_data
         else:
-            check_data = spellchecker.check(doc['text'])
+            check_data = spellchecker.check(doc['text'], language)
             assert "errors" in check_data
+            if doc["use_internal_dict"]:
+                self.remove_errors_in_dict(spellchecker, language, check_data)
         docs[0].update(check_data)
         return [0]
 

--- a/superdesk/text_checkers/spellcheckers/default.py
+++ b/superdesk/text_checkers/spellcheckers/default.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013-2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import re
+import logging
+# from superdesk.errors import SuperdeskApiError
+import superdesk
+from superdesk.text_checkers.spellcheckers import SPELLCHECKER_DEFAULT, CAP_SPELLING, LANG_ANY
+from superdesk.text_checkers.spellcheckers.base import SpellcheckerBase
+from superdesk.errors import SuperdeskApiError
+
+
+logger = logging.getLogger(__name__)
+
+
+class Default(SpellcheckerBase):
+    """Default spellchecker of Superdesk
+
+    This spellchecker works with internal dictionaries, in any language.
+    """
+
+    name = SPELLCHECKER_DEFAULT
+    label = "Superdesk default spellchecker"
+    capacities = [CAP_SPELLING]
+    languages = [LANG_ANY]
+
+    def check(self, text, language=None):
+        if language is None:
+            raise SuperdeskApiError.badRequestError("missing language for default spellchecker")
+        dictionaries_service = superdesk.get_resource_service('dictionaries')
+        model = dictionaries_service.get_model_for_lang(language)
+        err_list = []
+        check_data = {'errors': err_list}
+        for match in re.finditer(r'([^\d\W]+-?)+', text):
+            word = match.group().lower()
+            if word not in model:
+                ercorr_data = {
+                    'startOffset': match.start(),
+                    'text': match.group(),
+                    'type': 'spelling',
+                }
+                err_list.append(ercorr_data)
+        return check_data
+
+    def suggest(self, text, language=None):
+        if language is None:
+            raise SuperdeskApiError.badRequestError("missing language for default spellchecker")
+        spellcheck_service = superdesk.get_resource_service('spellcheck')
+        suggestions = spellcheck_service.suggest(text, language)
+        return {'suggestions': self.list2suggestions(suggestions)}

--- a/superdesk/text_checkers/spellcheckers/grammalecte.py
+++ b/superdesk/text_checkers/spellcheckers/grammalecte.py
@@ -18,6 +18,7 @@ from urllib.parse import urljoin
 import requests
 from os.path import abspath, expanduser
 from superdesk.errors import SuperdeskApiError
+from superdesk.text_checkers.spellcheckers import CAP_SPELLING, CAP_GRAMMAR
 from superdesk.text_checkers.spellcheckers.base import SpellcheckerBase
 
 logger = logging.getLogger(__name__)
@@ -69,7 +70,7 @@ class Grammalecte(SpellcheckerBase):
     """
 
     name = "grammalecte"
-    capacities = ("spelling", "grammar")
+    capacities = (CAP_SPELLING, CAP_GRAMMAR)
     languages = ['fr']
 
     def __init__(self, app):
@@ -204,7 +205,7 @@ class Grammalecte(SpellcheckerBase):
             raise SuperdeskApiError.internalError("Unexpected return code from Grammalecte")
         return self.grammalecte2superdesk(text, r.json())
 
-    def check(self, text):
+    def check(self, text, language=None):
         return self._check_cli(text) if self.use_cli else self._check_server(text)
 
     def _suggest_cli(self, text):
@@ -230,7 +231,7 @@ class Grammalecte(SpellcheckerBase):
         suggestions = r.json().get('suggestions', [])
         return {'suggestions': self.list2suggestions(suggestions)}
 
-    def suggest(self, text):
+    def suggest(self, text, language=None):
         return self._suggest_cli(text) if self.use_cli else self._suggest_server(text)
 
     def _available_cli(self):

--- a/superdesk/text_checkers/spellcheckers/leuven_dutch.py
+++ b/superdesk/text_checkers/spellcheckers/leuven_dutch.py
@@ -12,6 +12,7 @@ import os
 import logging
 import requests
 from superdesk.errors import SuperdeskApiError
+from superdesk.text_checkers.spellcheckers import CAP_SPELLING
 from superdesk.text_checkers.spellcheckers.base import SpellcheckerBase
 
 logger = logging.getLogger(__name__)
@@ -29,14 +30,14 @@ class LeuvenDutch(SpellcheckerBase):
 
     name = "leuven_dutch"
     label = "University of Leuven Dutch spellchecker"
-    capacities = ["spelling"]
+    capacities = [CAP_SPELLING]
     languages = ['nl']
 
     def __init__(self, app):
         super().__init__(app)
         self.api_key = self.config.get(OPT_API_KEY, os.environ.get(OPT_API_KEY))
 
-    def check(self, text):
+    def check(self, text, language=None):
         check_url = API_URL.format(method="spellingchecker")
         data = {
             "key": self.api_key,
@@ -64,14 +65,13 @@ class LeuvenDutch(SpellcheckerBase):
                 'startOffset': text_idx,
                 'text': mistake,
                 'type': "spelling",
-                'json': r.json(),
             }
             err_list.append(ercorr_data)
             text_idx += len(marked_part) - len_end_marker
 
         return check_data
 
-    def suggest(self, text):
+    def suggest(self, text, language=None):
         check_url = API_URL.format(method="suggesties")
         data = {
             "key": self.api_key,

--- a/tests/text_checkers/spellcheckers/default_test.py
+++ b/tests/text_checkers/spellcheckers/default_test.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013 - 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from functools import partial
+from unittest.mock import MagicMock, patch
+from flask import Flask
+from .utils import mock_dictionaries
+from superdesk.tests import TestCase
+from superdesk.text_checkers import spellcheckers
+from superdesk.text_checkers.spellcheckers import SPELLCHECKER_DEFAULT
+from superdesk.text_checkers.spellcheckers.base import registered_spellcheckers
+from superdesk.text_checkers.spellcheckers.default import Default
+from superdesk import get_resource_service
+
+spellcheckers.AUTO_IMPORT = False
+
+
+MODEL = {
+    "is": 1,
+    "there": 1,
+    "a": 1,
+    "spelling": 1,
+    "mistake": 1,
+    "number": 1,
+    "rendez-vous": 1,
+}
+
+
+def load_spellcheckers():
+    registered_spellcheckers.clear()
+    app = Flask(__name__)
+    spellcheckers.importSpellcheckers(app, spellcheckers.__name__)
+
+
+class DefaultSpellcheckerTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        load_spellcheckers()
+
+    def test_list(self):
+        """Check that Default spellchecker is listed by spellcheckers_list service"""
+        doc = {}
+        spellcheckers_list = get_resource_service('spellcheckers_list')
+        spellcheckers_list.on_fetched(doc)
+        for checker in doc['spellcheckers']:
+            if ((checker['name'] == SPELLCHECKER_DEFAULT
+                 and 'label' in checker
+                 and set(checker['capacities']) == set(Default.capacities)
+                 and checker['languages'] == ['*'])):
+                return
+        self.fail("Defaut spellchecker not found")
+
+    @patch('superdesk.get_resource_service', MagicMock(side_effect=partial(mock_dictionaries, model=MODEL)))
+    def test_checker(self):
+        """Check that spellchecking is working"""
+        doc = {
+            "spellchecker": "default",
+            # the number is to test that they are not seen as mistakes
+            # and the "rendez-vous" is to check that compound words work
+            "text": "Is therre a speling mitake? A number: 123456, a rendez-vous",
+            "suggestions": False,
+            "language": "en",
+            "use_internal_dict": False,
+        }
+        spellchecker = get_resource_service('spellchecker')
+        spellchecker.create([doc])
+
+        self.assertEqual(doc['errors'], [
+            {'startOffset': 3, 'text': 'therre', 'type': 'spelling'},
+            {'startOffset': 12, 'text': 'speling', 'type': 'spelling'},
+            {'startOffset': 20, 'text': 'mitake', 'type': 'spelling'}])
+
+    @patch('superdesk.get_resource_service', MagicMock(side_effect=partial(mock_dictionaries, model=MODEL)))
+    def test_suggest(self):
+        """Check that spelling suggestions are working"""
+
+        doc = {
+            "spellchecker": "default",
+            "text": "mitake",
+            "suggestions": True,
+            "language": "en",
+        }
+        spellchecker = get_resource_service('spellchecker')
+        spellchecker.create([doc])
+
+        self.assertEqual(doc, {
+            'language': 'en',
+            'spellchecker': 'default',
+            'suggestions': [{'text': 'mistake'}],
+            'text': 'mitake'})

--- a/tests/text_checkers/spellcheckers/grammalecte_test.py
+++ b/tests/text_checkers/spellcheckers/grammalecte_test.py
@@ -67,6 +67,7 @@ class GrammalecteTestCase(TestCase):
             "spellchecker": "grammalecte",
             "text": "Il nous reste à vérifié votre maquette.",
             "suggestions": False,
+            "use_internal_dict": False,
         }
         spellchecker = get_resource_service('spellchecker')
         check_url = urljoin(TEST_URL, PATH_CHECK)
@@ -103,21 +104,20 @@ class GrammalecteTestCase(TestCase):
         )
         spellchecker.create([doc])
 
-        self.assertEqual(doc, {
-            'errors': [{'startOffset': 14,
-                         'suggestions': [{'text': 'a'}],
-                         'text': 'à',
-                         'message': 'Confusion probable : “à” est une préposition. '
-                                    'Pour le verbe “avoir”, écrivez “a”.',
-                         'type': 'grammar'},
-                        {'startOffset': 16,
-                         'suggestions': [{'text': 'vérifier'}],
-                         'text': 'vérifié',
-                         'message': 'Le verbe devrait être à l’infinitif.',
-                         'type': 'grammar'}],
-            'spellchecker': 'grammalecte',
-            'suggestions': False,
-            'text': 'Il nous reste à vérifié votre maquette.'})
+        expected = [{
+            'startOffset': 14,
+            'suggestions': [{'text': 'a'}],
+            'text': 'à',
+            'message': 'Confusion probable : “à” est une préposition. '
+                       'Pour le verbe “avoir”, écrivez “a”.',
+            'type': 'grammar'},
+            {'startOffset': 16,
+             'suggestions': [{'text': 'vérifier'}],
+             'text': 'vérifié',
+             'message': 'Le verbe devrait être à l’infinitif.',
+             'type': 'grammar'}]
+
+        self.assertEqual(doc['errors'], expected)
 
     @responses.activate
     def test_checker_paragraphs(self):
@@ -126,6 +126,7 @@ class GrammalecteTestCase(TestCase):
             "spellchecker": "grammalecte",
             "text": "Il nous reste à vérifié votre maquette.\n\nIl nous reste à vérifié votre maquette.",
             "suggestions": False,
+            "use_internal_dict": False,
         }
         spellchecker = get_resource_service('spellchecker')
         check_url = urljoin(TEST_URL, PATH_CHECK)
@@ -189,35 +190,31 @@ class GrammalecteTestCase(TestCase):
             })
         spellchecker.create([doc])
 
-        self.assertEqual(doc, {
-            'errors': [{'message': 'Confusion probable : “à” est une préposition. Pour le '
-                                   'verbe “avoir”, écrivez “a”.',
-                        'startOffset': 14,
-                        'suggestions': [{'text': 'a'}],
-                        'text': 'à',
-                        'type': 'grammar'},
-                       {'message': 'Le verbe devrait être à l’infinitif.',
-                        'startOffset': 16,
-                        'suggestions': [{'text': 'vérifier'}],
-                        'text': 'vérifié',
-                        'type': 'grammar'},
-                       {'message': 'Confusion probable : “à” est une préposition. Pour le '
-                                   'verbe “avoir”, écrivez “a”.',
-                        'startOffset': 55,
-                        'suggestions': [{'text': 'a'}],
-                        'text': 'à',
-                        'type': 'grammar'},
-                       {'message': 'Le verbe devrait être à l’infinitif.',
-                        'startOffset': 57,
-                        'suggestions': [{'text': 'vérifier'}],
-                        'text': 'vérifié',
-                        'type': 'grammar'}],
-            'spellchecker': 'grammalecte',
-            'suggestions': False,
-            'text': 'Il nous reste à vérifié votre maquette.\n'
-                    '\n'
-                    'Il nous reste à vérifié votre maquette.'}
-        )
+        expected = [{
+            'message': 'Confusion probable : “à” est une préposition. Pour le '
+                       'verbe “avoir”, écrivez “a”.',
+            'startOffset': 14,
+            'suggestions': [{'text': 'a'}],
+            'text': 'à',
+            'type': 'grammar'},
+            {'message': 'Le verbe devrait être à l’infinitif.',
+             'startOffset': 16,
+             'suggestions': [{'text': 'vérifier'}],
+             'text': 'vérifié',
+             'type': 'grammar'},
+            {'message': 'Confusion probable : “à” est une préposition. Pour le '
+                        'verbe “avoir”, écrivez “a”.',
+             'startOffset': 55,
+             'suggestions': [{'text': 'a'}],
+             'text': 'à',
+             'type': 'grammar'},
+            {'message': 'Le verbe devrait être à l’infinitif.',
+             'startOffset': 57,
+             'suggestions': [{'text': 'vérifier'}],
+             'text': 'vérifié',
+             'type': 'grammar'}]
+
+        self.assertEqual(doc['errors'], expected)
 
     @responses.activate
     def test_suggest(self):
@@ -226,7 +223,7 @@ class GrammalecteTestCase(TestCase):
         doc = {
             "spellchecker": "grammalecte",
             "text": "fote",
-            "suggestions": True
+            "suggestions": True,
         }
         spellchecker = get_resource_service('spellchecker')
         check_url = urljoin(TEST_URL, PATH_SUGGEST)

--- a/tests/text_checkers/spellcheckers/utils.py
+++ b/tests/text_checkers/spellcheckers/utils.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013 - 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+"""This module contains common tools for spellchecker tests"""
+
+from unittest.mock import MagicMock
+from superdesk import get_resource_service
+
+
+def mock_dictionaries(service, model):
+    """A side effect to return a mocked dictionaries service
+
+    other services are returned normally
+    """
+    if service == 'dictionaries':
+        fake_service = MagicMock()
+        fake_service.get_model_for_lang.return_value = model
+        return fake_service
+    else:
+        return get_resource_service(service)


### PR DESCRIPTION
… mistakes

Default spellchecker is a basic spellchecker working with personal
dictionaries.

Spelling mistakes for words in personal dictionary are discarded by
default (this is controlled by the new `use_internal_dict` key while
checking a text).

Also improved spellcheckers documentation.

SDBELGA-132