### PR TITLE
[FORMATTER][NINJS] Added `id` to authors

### DIFF
--- a/docs/superdesk-ninjs-schema.json
+++ b/docs/superdesk-ninjs-schema.json
@@ -407,6 +407,10 @@
 			"items": {
 				"type" : "object",
 				"properties" : {
+					"code" : {
+						"description" : "The qualified code of the author",
+						"type" : "string"
+					},
 					"name" : {
 						"description" : "The full name of the author",
 						"type" : "string"

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -469,6 +469,7 @@ class NINJSFormatter(Formatter):
             avatar_url = user.get('picture_url', author.get('avatar_url'))
 
             author = {
+                "code": str(user.get('_id', author.get('name', ''))),
                 "name": user.get('display_name', author.get('name', '')),
                 "role": author.get('role', ''),
                 "biography": user.get('biography', author.get('biography', ''))

--- a/tests/publish/ninjs_formatter_test.py
+++ b/tests/publish/ninjs_formatter_test.py
@@ -597,6 +597,7 @@ class NinjsFormatterTest(TestCase):
 
         expected = [
             {
+                "code": "test_id",
                 "name": "author 1",
                 "role": "writer",
                 "jobtitle": {"qcode": "writer_code", "name": "Writer"},
@@ -607,6 +608,7 @@ class NinjsFormatterTest(TestCase):
                 "avatar_url": "http://example.com",
             },
             {
+                "code": "test_id_2",
                 "name": "author 2",
                 "role": "photographer",
                 "jobtitle": {"qcode": "reporter_code", "name": "Reporter"},
@@ -642,8 +644,8 @@ class NinjsFormatterTest(TestCase):
             "type": "text",
             "priority": 5,
             "authors": [
-                {"name": "Writer", "role": "writer", "biography": ""},
-                {"name": "photographer", "role": "photographer", "biography": ""},
+                {"code": "Writer", "name": "Writer", "role": "writer", "biography": ""},
+                {"code": "photographer", "name": "photographer", "role": "photographer", "biography": ""},
             ],
         }
 


### PR DESCRIPTION
Author id was not available in ninjs output, making it hard to
impossible to distinguish authors with same name.

This patch introduce it and change ninjs schema accordingly.

SDFID-569