### PR TITLE
Production API app.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.python-version
 /.project
 /.pydevproject
 *.pyc

--- a/content_api/app/__init__.py
+++ b/content_api/app/__init__.py
@@ -23,42 +23,14 @@ import flask
 import importlib
 
 from eve import Eve
-from eve.render import send_response
 from eve.io.mongo.mongo import MongoJSONEncoder
 
 from content_api.tokens import SubscriberTokenAuth
 from superdesk.datalayer import SuperdeskDataLayer
-from superdesk.errors import SuperdeskError, SuperdeskApiError
 from superdesk.storage import SuperdeskGridFSMediaStorage
 from superdesk.validator import SuperdeskValidator
+from superdesk.factory.app import set_error_handlers
 from superdesk.factory.sentry import SuperdeskSentry
-
-
-def _set_error_handlers(app):
-    """Set error handlers for the given application object.
-
-    Each error handler receives a :py:class:`superdesk.errors.SuperdeskError`
-    instance as a parameter and returns a tuple containing an error message
-    that is sent to the client and the HTTP status code.
-
-    :param app: an instance of `Eve <http://python-eve.org/>`_ application
-    """
-
-    # TODO: contains the same bug as the client_error_handler of the main
-    # superdesk app, fix it when the latter gets resolved (or, perhaps,
-    # replace it with a new 500 error handler tailored for the public API app)
-    @app.errorhandler(SuperdeskError)
-    def client_error_handler(error):
-        error_dict = error.to_dict()
-        error_dict.update(internal_error=error.status_code)
-        status_code = error.status_code or 422
-        return send_response(None, (error_dict, None, None, status_code))
-
-    @app.errorhandler(500)
-    def server_error_handler(error):
-        """Log server errors."""
-        return_error = SuperdeskApiError.internalError(error)
-        return client_error_handler(return_error)
 
 
 def get_app(config=None):
@@ -103,7 +75,7 @@ def get_app(config=None):
         validator=SuperdeskValidator
     )
 
-    _set_error_handlers(app)
+    set_error_handlers(app)
 
     for module_name in app.config.get('CONTENTAPI_INSTALLED_APPS', []):
         app_module = importlib.import_module(module_name)

--- a/prod_api/__init__.py
+++ b/prod_api/__init__.py
@@ -2,11 +2,8 @@
 #
 # This file is part of Superdesk.
 #
-# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+# Copyright 2019 Sourcefabric z.u. and contributors.
 #
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
-
-
-from flask import current_app as app

--- a/prod_api/__init__.py
+++ b/prod_api/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+
+from flask import current_app as app

--- a/prod_api/app/__init__.py
+++ b/prod_api/app/__init__.py
@@ -44,7 +44,7 @@ def get_app(config=None):
     app_config.from_object('prod_api.app.settings')
 
     # https://docs.python-eve.org/en/stable/config.html#domain-configuration
-    app_config.update({'DOMAIN': {}})
+    app_config.update({'DOMAIN': {'upload': {}}})
 
     # override from instance settings module, but only things defined in default config
     try:

--- a/prod_api/app/__init__.py
+++ b/prod_api/app/__init__.py
@@ -9,7 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 """
-A module that provides the Superdesk produciton API application object and runs
+A module that provides the Superdesk production API application object and runs
 the Superdesk production API.
 
 The API is built using the `Eve framework <http://python-eve.org/>`_ and is

--- a/prod_api/app/__init__.py
+++ b/prod_api/app/__init__.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+"""
+A module that provides the Superdesk produciton API application object and runs
+the Superdesk production API.
+
+The API is built using the `Eve framework <http://python-eve.org/>`_ and is
+thus essentially just a normal `Flask <http://flask.pocoo.org/>`_ application.
+"""
+
+import os
+import flask
+import importlib
+
+from eve import Eve
+from eve.io.mongo.mongo import MongoJSONEncoder
+
+from superdesk.datalayer import SuperdeskDataLayer
+from superdesk.storage import SuperdeskGridFSMediaStorage
+from superdesk.validator import SuperdeskValidator
+from superdesk.factory.app import set_error_handlers
+from superdesk.factory.sentry import SuperdeskSentry
+
+
+def get_app(config=None):
+    """
+    App factory.
+
+    :param dict config: configuration that can override config
+        from `settings.py`
+    :return: a new SuperdeskEve app instance
+    """
+
+    app_config = flask.Config('.')
+
+    # default config
+    app_config.from_object('prod_api.app.settings')
+
+    # https://docs.python-eve.org/en/stable/config.html#domain-configuration
+    app_config.update({'DOMAIN': {}})
+
+    # override from instance settings module, but only things defined in default config
+    try:
+        import settings as server_settings
+        for key in dir(server_settings):
+            if key.isupper() and key in app_config:
+                app_config[key] = getattr(server_settings, key)
+    except ImportError:
+        pass
+
+    if config:
+        app_config.update(config)
+
+    # media storage
+    media_storage = SuperdeskGridFSMediaStorage
+    if app_config.get('AMAZON_CONTAINER_NAME'):
+        from superdesk.storage import AmazonMediaStorage
+        media_storage = AmazonMediaStorage
+
+    app = Eve(
+        settings=app_config,
+        data=SuperdeskDataLayer,
+        media=media_storage,
+        json_encoder=MongoJSONEncoder,
+        validator=SuperdeskValidator
+    )
+
+    set_error_handlers(app)
+
+    for module_name in app.config.get('PRODAPI_INSTALLED_APPS', []):
+        app_module = importlib.import_module(module_name)
+        try:
+            app_module.init_app(app)
+        except AttributeError:
+            pass
+
+    app.sentry = SuperdeskSentry(app)
+
+    return app
+
+
+if __name__ == '__main__':
+    host = '0.0.0.0'
+    port = int(os.environ.get('PORT', '5500'))
+    app = get_app()
+    app.run(host=host, port=port, debug=True, use_reloader=True)

--- a/prod_api/app/__init__.py
+++ b/prod_api/app/__init__.py
@@ -78,9 +78,11 @@ def get_app(config=None):
     for module_name in app.config.get('PRODAPI_INSTALLED_APPS', []):
         app_module = importlib.import_module(module_name)
         try:
-            app_module.init_app(app)
+            init_app = app_module.init_app
         except AttributeError:
             pass
+        else:
+            init_app(app)
 
     app.sentry = SuperdeskSentry(app)
 

--- a/prod_api/app/__init__.py
+++ b/prod_api/app/__init__.py
@@ -2,11 +2,12 @@
 #
 # This file is part of Superdesk.
 #
-# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+# Copyright 2019 Sourcefabric z.u. and contributors.
 #
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
+
 """
 A module that provides the Superdesk produciton API application object and runs
 the Superdesk production API.

--- a/prod_api/app/settings.py
+++ b/prod_api/app/settings.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Superdesk.
 #
-# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+# Copyright 2019 Sourcefabric z.u. and contributors.
 #
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or

--- a/prod_api/app/settings.py
+++ b/prod_api/app/settings.py
@@ -35,6 +35,7 @@ PRODAPI_INSTALLED_APPS = (
     'prod_api.items',
     'prod_api.assets',
     'prod_api.desks',
+    'prod_api.planning',
 )
 
 # NOTE: no trailing slash for the PRODAPI_URL setting!

--- a/prod_api/app/settings.py
+++ b/prod_api/app/settings.py
@@ -34,6 +34,7 @@ SECRET_KEY = env('PRODAPI_SECRET_KEY', '')
 PRODAPI_INSTALLED_APPS = (
     'prod_api.items',
     'prod_api.assets',
+    'prod_api.desks',
 )
 
 # NOTE: no trailing slash for the PRODAPI_URL setting!

--- a/prod_api/app/settings.py
+++ b/prod_api/app/settings.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+"""
+A module containing configuration of the Superdesk's production API.
+
+The meaning of configuration options is described in the Eve framework
+`documentation <http://python-eve.org/config.html#global-configuration>`_.
+"""
+
+from superdesk.default_settings import env, urlparse
+
+from superdesk.default_settings import (  # noqa
+    MONGO_URI,
+    AMAZON_ACCESS_KEY_ID,
+    AMAZON_SECRET_ACCESS_KEY,
+    AMAZON_REGION,
+    AMAZON_CONTAINER_NAME,
+    AMAZON_S3_SUBFOLDER,
+    AMAZON_OBJECT_ACL
+)
+
+SECRET_KEY = env('PRODAPI_SECRET_KEY', '')
+
+PRODAPI_INSTALLED_APPS = []
+
+PRODAPI_DOMAIN = {}
+
+# NOTE: no trailing slash for the PRODAPI_URL setting!
+PRODAPI_URL = env('PRODAPI_URL', 'http://localhost:5500')
+MEDIA_PREFIX = env('MEDIA_PREFIX', '%s/assets' % PRODAPI_URL.rstrip('/'))
+URL_PREFIX = env('PRODAPI_URL_PREFIX', 'api')
+API_VERSION = 'v1'
+
+# date formats
+DATE_FORMAT = '%Y-%m-%dT%H:%M:%S+0000'
+ELASTIC_DATE_FORMAT = '%Y-%m-%d'

--- a/prod_api/app/settings.py
+++ b/prod_api/app/settings.py
@@ -18,6 +18,7 @@ The meaning of configuration options is described in the Eve framework
 from superdesk.default_settings import env, urlparse
 
 from superdesk.default_settings import (  # noqa
+    MONGO_URI,
     ELASTICSEARCH_INDEX,
     ELASTICSEARCH_URL,
     AMAZON_ACCESS_KEY_ID,
@@ -32,15 +33,14 @@ SECRET_KEY = env('PRODAPI_SECRET_KEY', '')
 
 PRODAPI_INSTALLED_APPS = (
     'prod_api.items',
+    'prod_api.assets',
 )
-
-PRODAPI_DOMAIN = {}
 
 # NOTE: no trailing slash for the PRODAPI_URL setting!
 PRODAPI_URL = env('PRODAPI_URL', 'http://localhost:5500')
-MEDIA_PREFIX = env('MEDIA_PREFIX', '%s/assets' % PRODAPI_URL.rstrip('/'))
 URL_PREFIX = env('PRODAPI_URL_PREFIX', 'api')
 API_VERSION = 'v1'
+MEDIA_PREFIX = env('MEDIA_PREFIX', '{}/{}/{}/assets'.format(PRODAPI_URL.rstrip('/'), URL_PREFIX, API_VERSION))
 
 # date formats
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%S+0000'

--- a/prod_api/app/settings.py
+++ b/prod_api/app/settings.py
@@ -18,6 +18,8 @@ The meaning of configuration options is described in the Eve framework
 from superdesk.default_settings import env, urlparse
 
 from superdesk.default_settings import (  # noqa
+    DEBUG,
+    SUPERDESK_TESTING,
     MONGO_URI,
     ELASTICSEARCH_INDEX,
     ELASTICSEARCH_URL,
@@ -26,7 +28,7 @@ from superdesk.default_settings import (  # noqa
     AMAZON_REGION,
     AMAZON_CONTAINER_NAME,
     AMAZON_S3_SUBFOLDER,
-    AMAZON_OBJECT_ACL
+    AMAZON_OBJECT_ACL,
 )
 
 SECRET_KEY = env('PRODAPI_SECRET_KEY', '')

--- a/prod_api/app/settings.py
+++ b/prod_api/app/settings.py
@@ -18,7 +18,8 @@ The meaning of configuration options is described in the Eve framework
 from superdesk.default_settings import env, urlparse
 
 from superdesk.default_settings import (  # noqa
-    MONGO_URI,
+    ELASTICSEARCH_INDEX,
+    ELASTICSEARCH_URL,
     AMAZON_ACCESS_KEY_ID,
     AMAZON_SECRET_ACCESS_KEY,
     AMAZON_REGION,
@@ -29,7 +30,9 @@ from superdesk.default_settings import (  # noqa
 
 SECRET_KEY = env('PRODAPI_SECRET_KEY', '')
 
-PRODAPI_INSTALLED_APPS = []
+PRODAPI_INSTALLED_APPS = (
+    'prod_api.items',
+)
 
 PRODAPI_DOMAIN = {}
 

--- a/prod_api/app/settings.py
+++ b/prod_api/app/settings.py
@@ -37,6 +37,7 @@ PRODAPI_INSTALLED_APPS = (
     'prod_api.desks',
     'prod_api.planning',
     'prod_api.contacts',
+    'prod_api.users',
 )
 
 # NOTE: no trailing slash for the PRODAPI_URL setting!

--- a/prod_api/app/settings.py
+++ b/prod_api/app/settings.py
@@ -36,6 +36,7 @@ PRODAPI_INSTALLED_APPS = (
     'prod_api.assets',
     'prod_api.desks',
     'prod_api.planning',
+    'prod_api.contacts',
 )
 
 # NOTE: no trailing slash for the PRODAPI_URL setting!

--- a/prod_api/assets/__init__.py
+++ b/prod_api/assets/__init__.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
 import superdesk
 from superdesk.upload import get_upload_as_data_uri
 from flask import current_app as app

--- a/prod_api/assets/__init__.py
+++ b/prod_api/assets/__init__.py
@@ -1,0 +1,23 @@
+import superdesk
+from superdesk.upload import get_upload_as_data_uri
+from flask import current_app as app
+
+
+bp = superdesk.Blueprint('assets', __name__)
+
+
+@bp.route('/assets/<path:media_id>', methods=['GET'])
+def prod_get_upload_as_data_uri(media_id):
+    return get_upload_as_data_uri(media_id)
+
+
+def upload_url(media_id, view=prod_get_upload_as_data_uri):
+    return '{}/{}'.format(
+        app.config.get('MEDIA_PREFIX').rstrip('/'),
+        media_id
+    )
+
+
+def init_app(app):
+    superdesk.blueprint(bp, app)
+    app.upload_url = upload_url

--- a/prod_api/contacts/__init__.py
+++ b/prod_api/contacts/__init__.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Superdesk.
 #
-# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+# Copyright 2019 Sourcefabric z.u. and contributors.
 #
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or

--- a/prod_api/contacts/__init__.py
+++ b/prod_api/contacts/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import superdesk
+from .service import ContactsService
+from .resource import ContactsResource
+
+
+def init_app(app):
+    """Initialize the `contacts` API endpoint.
+
+    :param app: the API application object
+    :type app: `Eve`
+    """
+    service = ContactsService(datasource='contacts', backend=superdesk.get_backend())
+    ContactsResource(endpoint_name='contacts', app=app, service=service)

--- a/prod_api/contacts/resource.py
+++ b/prod_api/contacts/resource.py
@@ -1,0 +1,17 @@
+from superdesk.resource import Resource
+from superdesk.metadata.utils import item_url
+
+
+class ContactsResource(Resource):
+    url = 'contacts'
+    item_url = item_url
+    item_methods = ['GET']
+    resource_methods = ['GET']
+    datasource = {
+        'source': 'contacts',
+        'search_backend': 'elastic',
+        'default_sort': [('last_name', 1)],
+        'projection': {
+            'fields_meta': 0
+        },
+    }

--- a/prod_api/contacts/resource.py
+++ b/prod_api/contacts/resource.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
 from superdesk.resource import Resource
 from superdesk.metadata.utils import item_url
 

--- a/prod_api/contacts/service.py
+++ b/prod_api/contacts/service.py
@@ -1,0 +1,11 @@
+from ..service import ProdApiService
+
+
+class ContactsService(ProdApiService):
+    excluded_fields = {
+        '_etag',
+        '_type',
+        '_updated',
+        '_created',
+        '_links'
+    }

--- a/prod_api/contacts/service.py
+++ b/prod_api/contacts/service.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
 from ..service import ProdApiService
 
 

--- a/prod_api/desks/__init__.py
+++ b/prod_api/desks/__init__.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Superdesk.
 #
-# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+# Copyright 2019 Sourcefabric z.u. and contributors.
 #
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or

--- a/prod_api/desks/__init__.py
+++ b/prod_api/desks/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import superdesk
+from .service import DesksService
+from .resource import DesksResource
+
+
+def init_app(app):
+    """Initialize the `desks` API endpoint.
+
+    :param app: the API application object
+    :type app: `Eve`
+    """
+    service = DesksService(datasource='desks', backend=superdesk.get_backend())
+    DesksResource(endpoint_name='desks', app=app, service=service)

--- a/prod_api/desks/resource.py
+++ b/prod_api/desks/resource.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
 from superdesk.resource import Resource
 from superdesk.metadata.utils import item_url
 

--- a/prod_api/desks/resource.py
+++ b/prod_api/desks/resource.py
@@ -21,7 +21,7 @@ class DesksResource(Resource):
         'source': 'desks',
         'default_sort': [('name', 1)],
         'projection': {
-            # NOTE: since schema is not definted here, setting up a projection explicitly is required,
+            # NOTE: since schema is not defined here, setting up a projection explicitly is required,
             # otherwise default `eve` fields (projection) will be applied e.q. `{'_id': 1}`
             # and it will cut off all required data.
             # https://github.com/pyeve/eve/blob/afd573d9254a9a23393f35760e9c515300909ccd/eve/io/base.py#L420

--- a/prod_api/desks/resource.py
+++ b/prod_api/desks/resource.py
@@ -1,0 +1,20 @@
+from superdesk.resource import Resource
+from superdesk.metadata.utils import item_url
+
+
+class DesksResource(Resource):
+    url = 'desks'
+    item_url = item_url
+    item_methods = ['GET']
+    resource_methods = ['GET']
+    datasource = {
+        'source': 'desks',
+        'default_sort': [('name', 1)],
+        'projection': {
+            # NOTE: since schema is not definted here, setting up a projection explicitly is required,
+            # otherwise default `eve` fields (projection) will be applied e.q. `{'_id': 1}`
+            # and it will cut off all required data.
+            # https://github.com/pyeve/eve/blob/afd573d9254a9a23393f35760e9c515300909ccd/eve/io/base.py#L420
+            'fields_meta': 0
+        },
+    }

--- a/prod_api/desks/resource.py
+++ b/prod_api/desks/resource.py
@@ -15,6 +15,6 @@ class DesksResource(Resource):
             # otherwise default `eve` fields (projection) will be applied e.q. `{'_id': 1}`
             # and it will cut off all required data.
             # https://github.com/pyeve/eve/blob/afd573d9254a9a23393f35760e9c515300909ccd/eve/io/base.py#L420
-            'fields_meta': 0
+            'desk_metadata': 0
         },
     }

--- a/prod_api/desks/service.py
+++ b/prod_api/desks/service.py
@@ -2,10 +2,11 @@ from ..service import ProdApiService
 
 
 class DesksService(ProdApiService):
-    excluded_fields = {
-        'default_content_template',
-        'working_stage',
-        'incoming_stage',
-        'desk_metadata',
-        'content_expiry',
-    } | ProdApiService.excluded_fields
+    excluded_fields = \
+        {
+            'default_content_template',
+            'working_stage',
+            'incoming_stage',
+            'desk_metadata',
+            'content_expiry',
+        } | ProdApiService.excluded_fields

--- a/prod_api/desks/service.py
+++ b/prod_api/desks/service.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
 from ..service import ProdApiService
 
 

--- a/prod_api/desks/service.py
+++ b/prod_api/desks/service.py
@@ -1,0 +1,11 @@
+from ..service import ProdApiService
+
+
+class DesksService(ProdApiService):
+    excluded_fields = {
+        'default_content_template',
+        'working_stage',
+        'incoming_stage',
+        'desk_metadata',
+        'content_expiry',
+    } | ProdApiService.excluded_fields

--- a/prod_api/items/__init__.py
+++ b/prod_api/items/__init__.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Superdesk.
 #
-# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+# Copyright 2019 Sourcefabric z.u. and contributors.
 #
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or

--- a/prod_api/items/__init__.py
+++ b/prod_api/items/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import superdesk
+from .service import ItemsService
+from .resource import ItemsResource
+
+
+def init_app(app):
+    """Initialize the `items` API endpoint.
+
+    :param app: the API application object
+    :type app: `Eve`
+    """
+    service = ItemsService(datasource='archive', backend=superdesk.get_backend())
+    ItemsResource(endpoint_name='archive', app=app, service=service)

--- a/prod_api/items/resource.py
+++ b/prod_api/items/resource.py
@@ -10,5 +10,12 @@ class ItemsResource(Resource):
     datasource = {
         'source': 'archive',
         'search_backend': 'elastic',
-        'default_sort': [('_updated', -1)]
+        'default_sort': [('_updated', -1)],
+        'projection': {
+            # NOTE: since schema is not definted here, setting up a projection explicitly is required,
+            # otherwise default `eve` fields (projection) will be applied e.q. `{'_id': 1}`
+            # and it will cut off all required data.
+            # https://github.com/pyeve/eve/blob/afd573d9254a9a23393f35760e9c515300909ccd/eve/io/base.py#L420
+            'fields_meta': 0
+        },
     }

--- a/prod_api/items/resource.py
+++ b/prod_api/items/resource.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
 from superdesk.resource import Resource
 from superdesk.metadata.utils import item_url
 

--- a/prod_api/items/resource.py
+++ b/prod_api/items/resource.py
@@ -22,7 +22,7 @@ class ItemsResource(Resource):
         'search_backend': 'elastic',
         'default_sort': [('_updated', -1)],
         'projection': {
-            # NOTE: since schema is not definted here, setting up a projection explicitly is required,
+            # NOTE: since schema is not defined here, setting up a projection explicitly is required,
             # otherwise default `eve` fields (projection) will be applied e.q. `{'_id': 1}`
             # and it will cut off all required data.
             # https://github.com/pyeve/eve/blob/afd573d9254a9a23393f35760e9c515300909ccd/eve/io/base.py#L420

--- a/prod_api/items/resource.py
+++ b/prod_api/items/resource.py
@@ -10,8 +10,5 @@ class ItemsResource(Resource):
     datasource = {
         'source': 'archive',
         'search_backend': 'elastic',
-        'default_sort': [('_updated', -1)],
-        # 'projection': {
-        #     '_etag': 0,
-        # }
+        'default_sort': [('_updated', -1)]
     }

--- a/prod_api/items/resource.py
+++ b/prod_api/items/resource.py
@@ -1,0 +1,17 @@
+from superdesk.resource import Resource
+from superdesk.metadata.utils import item_url
+
+
+class ItemsResource(Resource):
+    url = 'items'
+    item_url = item_url
+    item_methods = ['GET']
+    resource_methods = ['GET']
+    datasource = {
+        'source': 'archive',
+        'search_backend': 'elastic',
+        'default_sort': [('_updated', -1)],
+        # 'projection': {
+        #     '_etag': 0,
+        # }
+    }

--- a/prod_api/items/service.py
+++ b/prod_api/items/service.py
@@ -1,0 +1,5 @@
+import superdesk
+
+
+class ItemsService(superdesk.Service):
+    pass

--- a/prod_api/items/service.py
+++ b/prod_api/items/service.py
@@ -2,4 +2,14 @@ from ..service import ProdApiService
 
 
 class ItemsService(ProdApiService):
-    pass
+    excluded_fields = \
+        {
+            'fields_meta',
+            'unique_id',
+            'family_id',
+            'event_id',
+            'lock_session',
+            'lock_action',
+            'lock_time',
+            'lock_user',
+        } | ProdApiService.excluded_fields

--- a/prod_api/items/service.py
+++ b/prod_api/items/service.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
 from ..service import ProdApiService
 
 

--- a/prod_api/items/service.py
+++ b/prod_api/items/service.py
@@ -1,5 +1,5 @@
-import superdesk
+from ..service import ProdApiService
 
 
-class ItemsService(superdesk.Service):
+class ItemsService(ProdApiService):
     pass

--- a/prod_api/items/service.py
+++ b/prod_api/items/service.py
@@ -4,6 +4,7 @@ from ..service import ProdApiService
 class ItemsService(ProdApiService):
     excluded_fields = \
         {
+            '_id',
             'fields_meta',
             'unique_id',
             'family_id',

--- a/prod_api/planning/__init__.py
+++ b/prod_api/planning/__init__.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Superdesk.
 #
-# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+# Copyright 2019 Sourcefabric z.u. and contributors.
 #
 # For the full copyright and license information, please see the
 # AUTHORS and LICENSE files distributed with this source code, or

--- a/prod_api/planning/__init__.py
+++ b/prod_api/planning/__init__.py
@@ -9,8 +9,8 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import superdesk
-from .services import PlanningService
-from .resources import PlanningResource
+from .services import PlanningService, EventsService
+from .resources import PlanningResource, EventsResource
 
 
 def init_app(app):
@@ -19,5 +19,8 @@ def init_app(app):
     :param app: the API application object
     :type app: `Eve`
     """
-    service = PlanningService(datasource='planning', backend=superdesk.get_backend())
-    PlanningResource(endpoint_name='planning', app=app, service=service)
+    planning_service = PlanningService(datasource='planning', backend=superdesk.get_backend())
+    PlanningResource(endpoint_name='planning', app=app, service=planning_service)
+
+    events_service = EventsService(datasource='events', backend=superdesk.get_backend())
+    EventsResource(endpoint_name='events', app=app, service=events_service)

--- a/prod_api/planning/__init__.py
+++ b/prod_api/planning/__init__.py
@@ -9,12 +9,12 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import superdesk
-from .services import PlanningService, EventsService
-from .resources import PlanningResource, EventsResource
+from .services import PlanningService, EventsService, AssignmentsService
+from .resources import PlanningResource, EventsResource, AssignmentsResource
 
 
 def init_app(app):
-    """Initialize the `planning` API endpoint.
+    """Initialize the `planning`, `events` and `assignments` API endpoint.
 
     :param app: the API application object
     :type app: `Eve`
@@ -24,3 +24,6 @@ def init_app(app):
 
     events_service = EventsService(datasource='events', backend=superdesk.get_backend())
     EventsResource(endpoint_name='events', app=app, service=events_service)
+
+    assignments_service = AssignmentsService(datasource='assignments', backend=superdesk.get_backend())
+    AssignmentsResource(endpoint_name='assignments', app=app, service=assignments_service)

--- a/prod_api/planning/__init__.py
+++ b/prod_api/planning/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import superdesk
+from .services import PlanningService
+from .resources import PlanningResource
+
+
+def init_app(app):
+    """Initialize the `planning` API endpoint.
+
+    :param app: the API application object
+    :type app: `Eve`
+    """
+    service = PlanningService(datasource='planning', backend=superdesk.get_backend())
+    PlanningResource(endpoint_name='planning', app=app, service=service)

--- a/prod_api/planning/resources.py
+++ b/prod_api/planning/resources.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
 from superdesk.resource import Resource
 from superdesk.metadata.utils import item_url
 

--- a/prod_api/planning/resources.py
+++ b/prod_api/planning/resources.py
@@ -1,0 +1,17 @@
+from superdesk.resource import Resource
+from superdesk.metadata.utils import item_url
+
+
+class PlanningResource(Resource):
+    url = 'planning'
+    item_url = item_url
+    item_methods = ['GET']
+    resource_methods = ['GET']
+    datasource = {
+        'source': 'planning',
+        'search_backend': 'elastic',
+        'default_sort': [('_updated', -1)],
+        'projection': {
+            'fields_meta': 0
+        },
+    }

--- a/prod_api/planning/resources.py
+++ b/prod_api/planning/resources.py
@@ -30,3 +30,18 @@ class EventsResource(Resource):
             'fields_meta': 0
         },
     }
+
+
+class AssignmentsResource(Resource):
+    url = 'assignments'
+    item_url = item_url
+    item_methods = ['GET']
+    resource_methods = ['GET']
+    datasource = {
+        'source': 'assignments',
+        'search_backend': 'elastic',
+        'default_sort': [('_updated', -1)],
+        'projection': {
+            'fields_meta': 0
+        },
+    }

--- a/prod_api/planning/resources.py
+++ b/prod_api/planning/resources.py
@@ -15,3 +15,18 @@ class PlanningResource(Resource):
             'fields_meta': 0
         },
     }
+
+
+class EventsResource(Resource):
+    url = 'events'
+    item_url = item_url
+    item_methods = ['GET']
+    resource_methods = ['GET']
+    datasource = {
+        'source': 'events',
+        'search_backend': 'elastic',
+        'default_sort': [('dates.start', 1)],
+        'projection': {
+            'fields_meta': 0
+        },
+    }

--- a/prod_api/planning/services.py
+++ b/prod_api/planning/services.py
@@ -1,0 +1,12 @@
+from ..service import ProdApiService
+
+
+class PlanningService(ProdApiService):
+    excluded_fields = \
+        {
+            'item_class',
+            'flags',
+            'lock_user',
+            'lock_time',
+            'lock_session',
+        } | ProdApiService.excluded_fields

--- a/prod_api/planning/services.py
+++ b/prod_api/planning/services.py
@@ -10,3 +10,13 @@ class PlanningService(ProdApiService):
             'lock_time',
             'lock_session',
         } | ProdApiService.excluded_fields
+
+
+class EventsService(ProdApiService):
+    excluded_fields = \
+        {
+            'lock_action',
+            'lock_user',
+            'lock_time',
+            'lock_session',
+        } | ProdApiService.excluded_fields

--- a/prod_api/planning/services.py
+++ b/prod_api/planning/services.py
@@ -4,6 +4,7 @@ from ..service import ProdApiService
 class PlanningService(ProdApiService):
     excluded_fields = \
         {
+            '_id',
             'item_class',
             'flags',
             'lock_user',
@@ -15,6 +16,7 @@ class PlanningService(ProdApiService):
 class EventsService(ProdApiService):
     excluded_fields = \
         {
+            '_id',
             'lock_action',
             'lock_user',
             'lock_time',
@@ -22,14 +24,10 @@ class EventsService(ProdApiService):
         } | ProdApiService.excluded_fields
 
 
-assignments_excluded_fields = \
-    {
-        'lock_action',
-        'lock_user',
-        'lock_time',
-    } | ProdApiService.excluded_fields
-assignments_excluded_fields.remove('_id')
-
-
 class AssignmentsService(ProdApiService):
-    excluded_fields = assignments_excluded_fields
+    excluded_fields = \
+        {
+            'lock_action',
+            'lock_user',
+            'lock_time',
+        } | ProdApiService.excluded_fields

--- a/prod_api/planning/services.py
+++ b/prod_api/planning/services.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
 from ..service import ProdApiService
 
 

--- a/prod_api/planning/services.py
+++ b/prod_api/planning/services.py
@@ -20,3 +20,16 @@ class EventsService(ProdApiService):
             'lock_time',
             'lock_session',
         } | ProdApiService.excluded_fields
+
+
+assignments_excluded_fields = \
+    {
+        'lock_action',
+        'lock_user',
+        'lock_time',
+    } | ProdApiService.excluded_fields
+assignments_excluded_fields.remove('_id')
+
+
+class AssignmentsService(ProdApiService):
+    excluded_fields = assignments_excluded_fields

--- a/prod_api/service.py
+++ b/prod_api/service.py
@@ -1,0 +1,46 @@
+import superdesk
+
+
+class ProdApiService(superdesk.Service):
+    """
+    Base service for production api services
+    """
+
+    excluded_fields = {
+        '_id',
+        '_etag',
+        '_type',
+        '_updated',
+        '_created',
+        '_current_version',
+        'fields_meta'
+    }
+
+    def on_fetched(self, result):
+        """
+        Event handler when a collection of items is retrieved from database.
+        Post-process a fetched items.
+        :param dict result: dictionary contaning the list of fetched items and
+         some metadata, e.g. pagination info.
+        """
+
+        for doc in result['_items']:
+            self._process_fetched_object(doc)
+
+    def on_fetched_item(self, doc):
+        """
+        Event handler when a single item is retrieved from a database.
+        Post-process a fetched item.
+        :param dict docs: fetched items from a database.
+        """
+        self._process_fetched_object(doc)
+
+    def _process_fetched_object(self, doc):
+        """
+        Does some processing on the document fetched from database.
+        :param dict document: MongoDB document to process
+        """
+
+        # remove keys from a response
+        for key in self.excluded_fields:
+            doc.pop(key, None)

--- a/prod_api/service.py
+++ b/prod_api/service.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
 import superdesk
 from flask import current_app as app
 

--- a/prod_api/service.py
+++ b/prod_api/service.py
@@ -8,13 +8,13 @@ class ProdApiService(superdesk.Service):
     """
 
     excluded_fields = {
+        '_id',
         '_etag',
         '_type',
         '_updated',
         '_created',
         '_current_version',
         '_links',
-        'fields_meta',
     }
 
     def on_fetched(self, result):

--- a/prod_api/service.py
+++ b/prod_api/service.py
@@ -8,7 +8,6 @@ class ProdApiService(superdesk.Service):
     """
 
     excluded_fields = {
-        '_id',
         '_etag',
         '_type',
         '_updated',

--- a/prod_api/tests/__init__.py
+++ b/prod_api/tests/__init__.py
@@ -1,0 +1,21 @@
+from superdesk.tests import TestCase as _TestCase
+
+from prod_api.app import get_app
+
+
+class TestCase(_TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        test_config = {
+            'DEBUG': self.app.config['DEBUG'],
+            'TESTING': self.app.config['TESTING'],
+            'SUPERDESK_TESTING': self.app.config['SUPERDESK_TESTING'],
+            'MONGO_CONNECT': self.app.config['MONGO_CONNECT'],
+            'MONGO_MAX_POOL_SIZE': self.app.config['MONGO_MAX_POOL_SIZE'],
+            'MONGO_URI': self.app.config['MONGO_URI'],
+            'ELASTICSEARCH_INDEX': self.app.config['ELASTICSEARCH_INDEX'],
+        }
+
+        self.prodapi = get_app(test_config)

--- a/prod_api/tests/__init__.py
+++ b/prod_api/tests/__init__.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
 from superdesk.tests import TestCase as _TestCase
 
 from prod_api.app import get_app

--- a/prod_api/users/__init__.py
+++ b/prod_api/users/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import superdesk
+from .service import UsersService
+from .resource import UsersResource
+
+
+def init_app(app):
+    """Initialize the `users` API endpoint.
+
+    :param app: the API application object
+    :type app: `Eve`
+    """
+    service = UsersService(datasource='users', backend=superdesk.get_backend())
+    UsersResource(endpoint_name='users', app=app, service=service)

--- a/prod_api/users/resource.py
+++ b/prod_api/users/resource.py
@@ -1,0 +1,16 @@
+from superdesk.resource import Resource
+from superdesk.metadata.utils import item_url
+
+
+class UsersResource(Resource):
+    url = 'users'
+    item_url = item_url
+    item_methods = ['GET']
+    resource_methods = ['GET']
+    datasource = {
+        'source': 'users',
+        'default_sort': [('username', 1)],
+        'projection': {
+            'user_preferences': 0
+        },
+    }

--- a/prod_api/users/service.py
+++ b/prod_api/users/service.py
@@ -1,0 +1,5 @@
+from ..service import ProdApiService
+
+
+class UsersService(ProdApiService):
+    pass

--- a/prod_api/wsgi.py
+++ b/prod_api/wsgi.py
@@ -1,0 +1,3 @@
+from .app import get_app
+
+application = get_app()

--- a/prod_api/wsgi.py
+++ b/prod_api/wsgi.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
 from .app import get_app
 
 application = get_app()

--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -35,6 +35,35 @@ from superdesk.validator import SuperdeskValidator
 SUPERDESK_PATH = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
 
+def set_error_handlers(app):
+    """Set error handlers for the given application object.
+
+    Each error handler receives a :py:class:`superdesk.errors.SuperdeskError`
+    instance as a parameter and returns a tuple containing an error message
+    that is sent to the client and the HTTP status code.
+
+    :param app: an instance of `Eve <http://python-eve.org/>`_ application
+    """
+
+    @app.errorhandler(SuperdeskError)
+    def client_error_handler(error):
+        error_dict = error.to_dict()
+        error_dict.update(internal_error=error.status_code)
+        status_code = error.status_code or 422
+        return send_response(None, (error_dict, None, None, status_code))
+
+    @app.errorhandler(403)
+    def server_forbidden_handler(error):
+        return send_response(None, ({'code': 403, 'error': error.response}, None, None, 403))
+
+    @app.errorhandler(500)
+    def server_error_handler(error):
+        """Log server errors."""
+        return_error = SuperdeskApiError.internalError(error)
+        return client_error_handler(return_error)
+
+
+
 class SuperdeskEve(eve.Eve):
 
     def __getattr__(self, name):
@@ -137,23 +166,7 @@ def get_app(config=None, media_storage=None, config_object=None, init_elastic=No
 
         return user_language
 
-    @app.errorhandler(SuperdeskError)
-    def client_error_handler(error):
-        """Return json error response.
-
-        :param error: an instance of :attr:`superdesk.SuperdeskError` class
-        """
-        return send_response(None, (error.to_dict(), None, None, error.status_code))
-
-    @app.errorhandler(403)
-    def server_forbidden_handler(error):
-        return send_response(None, ({'code': 403, 'error': error.response}, None, None, 403))
-
-    @app.errorhandler(500)
-    def server_error_handler(error):
-        """Log server errors."""
-        return_error = SuperdeskApiError.internalError(error)
-        return client_error_handler(return_error)
+    set_error_handlers(app)
 
     @app.after_request
     def after_request(response):

--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -63,7 +63,6 @@ def set_error_handlers(app):
         return client_error_handler(return_error)
 
 
-
 class SuperdeskEve(eve.Eve):
 
     def __getattr__(self, name):


### PR DESCRIPTION
SDBELGA-169
SDBELGA-168

- [x] prod api app structure
- [x] versioning
- [x] serve assets
- [x] items endpoint
- [x] desks endpoint
- [x] planning related endpoints
    * [x] events endpoint
    * [x] planning endpoint
    * [x] assignments endpoint
- [x] contacts endpoint
- [x] users endpoint

@petrjasek @jerome-poisson for now prod api app does not have any auth, this is something we can implement later. I did not cover all this read only endpoints with tests, will do it after we integrate auth, now there is not much to test :) The same with a documentation, I'll add docs on later stages.

P.S. Regarding versioning, for now it's just a `v1` in the url, I think it's fine for now. IMO there is no sense to care now about a flexible structure inside prod_api app to cover possible future api versions (v1, v2, v3 subfolders etc). V2 might be a graphql or something else in a different app, so I think no sense to deal with it now.