### PR TITLE
publish associated items only if those were not published

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -592,6 +592,14 @@ class BasePublishService(BaseService):
                         raise SuperdeskApiError.badRequestError(
                             _('Associated item "{}" does not exist in the system'.format(associations_key)))
 
+                    if original_associated_item.get('state') in PUBLISH_STATES:
+                        # item was published already
+                        original[ASSOCIATIONS][associations_key].update({
+                            'state': original_associated_item['state'],
+                            'operation': original_associated_item.get('operation', self.publish_type),
+                        })
+                        continue
+
                     get_resource_service('archive_publish').patch(id=associated_item.pop(config.ID_FIELD),
                                                                   updates=associated_item)
                     associated_item['state'] = self.published_state


### PR DESCRIPTION
when publishing item with associations which were published
after assigning it would try to publish those again and
validation would fail is you can not publish published content.

only happening when `PUBLISH_ASSOCIATED_ITEMS` is on.