### PR TITLE
fix routing ingested items on every ingest update

### DIFF
--- a/apps/io/feeding_services/reuters.py
+++ b/apps/io/feeding_services/reuters.py
@@ -258,7 +258,7 @@ class ReutersHTTPFeedingService(HTTPFeedingService):
         result_items = []
         while items:
             item = items.pop()
-            self.add_timestamps(item)
+            self.localize_timestamps(item)
             try:
                 items.extend(self._fetch_items_in_package(item))
                 result_items.append(item)

--- a/superdesk/io/feeding_services/__init__.py
+++ b/superdesk/io/feeding_services/__init__.py
@@ -9,6 +9,8 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import logging
+import warnings
+
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
 
@@ -194,15 +196,14 @@ class FeedingService(metaclass=ABCMeta):
                                                                    updates, provider)
 
     def add_timestamps(self, item):
-        """
-        Adds firstcreated and versioncreated timestamps to item
+        warnings.warn('deprecated, use localize_timestamps', DeprecationWarning)
+        self.localize_timestamps(item)
 
-        :param item: object which can be saved to ingest collection
-        :type item: dict
-        """
-
-        item['firstcreated'] = utc.localize(item['firstcreated']) if item.get('firstcreated') else utcnow()
-        item['versioncreated'] = utc.localize(item['versioncreated']) if item.get('versioncreated') else utcnow()
+    def localize_timestamps(self, item):
+        """Make sure timestamps are in UTC."""
+        for timestamp in ('firstcreated', 'versioncreated'):
+            if item.get(timestamp):
+                item[timestamp] = utc.localize(item[timestamp])
 
     def log_item_error(self, err, item, provider):
         """TODO: put item into provider error basket."""

--- a/superdesk/io/feeding_services/rss.py
+++ b/superdesk/io/feeding_services/rss.py
@@ -181,7 +181,7 @@ class RSSFeedingService(HTTPFeedingServiceBase):
                 pass
 
             item = self._create_item(entry, field_aliases, provider.get('source', None))
-            self.add_timestamps(item)
+            self.localize_timestamps(item)
 
             # If the RSS entry references any images, create picture items from
             # them and create a package referencing them and the entry itself.

--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -82,6 +82,10 @@ metadata_schema = {
         'unique': True,
         'mapping': not_analyzed
     },
+    'uri': {
+        'type': 'string',
+        'mapping': not_analyzed,
+    },
     'unique_id': {
         'type': 'integer',
         'unique': True,

--- a/tests/feeding_services_test.py
+++ b/tests/feeding_services_test.py
@@ -1,3 +1,7 @@
+import pytz
+import warnings
+
+from datetime import datetime
 from unittest.mock import patch
 from superdesk.tests import TestCase
 from superdesk.io.feeding_services import FeedingService
@@ -19,3 +23,19 @@ class FeedingServiceParserTestCase(TestCase):
                         {'test_feeding': {'ninjs': True}}):
             with self.assertRaises(SuperdeskIngestError):
                 feeding_service.config_test({'feed_parser': 'foo', 'feeding_service': 'test_feeding'})
+
+    def test_add_timestamps_warning(self):
+        item = {}
+        feeding_service = TestFeedingService()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            feeding_service.add_timestamps(item)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+
+    def test_localize_timestamps(self):
+        item = {'firstcreated': datetime(2019, 10, 15, 10, 59, 0)}
+        self.assertIsNone(item['firstcreated'].tzinfo)
+        feeding_service = TestFeedingService()
+        feeding_service.localize_timestamps(item)
+        self.assertEqual(pytz.utc, item['firstcreated'].tzinfo)

--- a/tests/io/update_ingest_tests.py
+++ b/tests/io/update_ingest_tests.py
@@ -101,7 +101,7 @@ class GetProviderRoutingSchemeTestCase(TestCase):
 class ItemExpiryTestCase(TestCase):
 
     def test_expiry_no_dateinfo(self):
-        self.assertFalse(is_not_expired({}, None))
+        self.assertTrue(is_not_expired({}, None))
 
     def test_expiry_overflow(self):
         item = {'versioncreated': datetime.now()}
@@ -158,4 +158,11 @@ class UtilsTestCase(unittest.TestCase):
         self.assertFalse(is_new_version(
             {'subject': [{'name': 'foo', 'qcode': 'foo'}]},
             {'subject': [{'name': 'foo', 'qcode': 'foo'}]},
+        ))
+
+    def test_is_new_version_ignores_expiry(self):
+        yesterday = datetime.now() - timedelta(days=1)
+        self.assertFalse(is_new_version(
+            {'headline': 'foo', 'firstcreated': None, 'expiry': datetime.now()},
+            {'headline': 'foo', 'firstcreated': yesterday, 'expiry': yesterday},
         ))


### PR DESCRIPTION
when versioncreated is missing don't populate it with current time
in ingest so it's not used for new item checking.

it will be populated later when item is stored to ingest collection.

SDESK-4650