### PR TITLE
Checking if user is a member of destination desk when moving content

### DIFF
--- a/apps/duplication/archive_move.py
+++ b/apps/duplication/archive_move.py
@@ -57,7 +57,7 @@ class MoveResource(Resource):
     resource_methods = ['POST']
     item_methods = []
 
-    privileges = {'POST': 'move'}
+    privileges = {'POST': 'archive'}
 
 
 class MoveService(BaseService):
@@ -181,5 +181,5 @@ class MoveService(BaseService):
 superdesk.workflow_action(
     name='submit_to_desk',
     include_states=['draft', 'fetched', 'routed', 'submitted', 'in_progress', 'published', 'scheduled'],
-    privileges=['archive', 'move']
+    privileges=['archive']
 )


### PR DESCRIPTION
- move privilege is removed to be required to move content
- if user has move privilege she can move content to any desk
- if user has no move privilege she can move content to only those desks she's a member of