### PR TITLE
add production resource

### DIFF
--- a/apps/archive/__init__.py
+++ b/apps/archive/__init__.py
@@ -32,6 +32,7 @@ from apps.common.models.utils import register_model
 from apps.item_lock.models.item import ItemModel
 from apps.common.models.io.eve_proxy import EveProxy
 from .archive_rewrite import ArchiveRewriteResource, ArchiveRewriteService
+from .production import ProductionResource, ProductionService
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,10 @@ def init_app(app):
     endpoint_name = 'archive_related'
     service = ArchiveRelatedService(endpoint_name, backend=superdesk.get_backend())
     ArchiveRelatedResource(endpoint_name, app=app, service=service)
+
+    endpoint_name = 'production'
+    service = ProductionService(endpoint_name, backend=superdesk.get_backend())
+    ProductionResource(endpoint_name, app=app, service=service)
 
     from apps.item_autosave.components.item_autosave import ItemAutosave
     from apps.item_autosave.models.item_autosave import ItemAutosaveModel

--- a/apps/archive/production.py
+++ b/apps/archive/production.py
@@ -1,0 +1,26 @@
+
+from superdesk.resource import build_custom_hateoas
+from .archive import ArchiveResource, ArchiveService
+from .common import CUSTOM_HATEOAS
+
+
+class ProductionResource(ArchiveResource):
+    datasource = ArchiveResource.datasource.copy()
+    datasource.update({
+        'source': 'archive',
+        'elastic_filter': {'bool': {
+            'must_not': {'term': {'version': 0}}
+        }},
+    })
+
+    resource_methods = ['GET']
+    item_methods = []
+
+
+class ProductionService(ArchiveService):
+
+    def get(self, req, lookup):
+        docs = super().get(req, lookup)
+        for doc in docs:
+            build_custom_hateoas(CUSTOM_HATEOAS, doc)
+        return docs

--- a/features/production.feature
+++ b/features/production.feature
@@ -1,0 +1,36 @@
+Feature: News Items Production
+
+    @auth
+    Scenario: Can display all items no matter what's the status
+        When we post to "archive"
+        """
+        [
+            {"guid": "in_progress", "version": 1, "state": "in_progress"},
+            {"guid": "published", "version": 1, "state": "published"}
+        ]
+        """
+        And we get "/production"
+        Then we get list with 2 items
+        """
+        {
+            "_items": [
+                {
+                    "guid": "in_progress",
+                    "_links": {"self": {"title": "Archive", "href": "/archive/in_progress"}}
+                },
+                {
+                    "guid": "published"
+                }
+            ]
+        }
+        """
+
+    Scenario: Keep it readonly for now
+        When we post to "published"
+        """
+        [
+            {"guid": "in_progress", "version": 1, "state": "in_progress"},
+            {"guid": "published", "version": 1, "state": "published"}
+        ]
+        """
+        Then we get error 401


### PR DESCRIPTION
it's alias for archive, without filtering out published content.

for now it's readonly, eventually we could use it when looking
for content no matter its status.

SDESK-4687