### PR TITLE
[PUBLICATION][UNPUBLISH] Unpublishing an item is now possible in package

### DIFF
--- a/apps/publish/content/kill.py
+++ b/apps/publish/content/kill.py
@@ -28,8 +28,16 @@ from apps.archive.common import ITEM_OPERATION, ARCHIVE, insert_into_versions, g
 from itertools import chain
 from apps.publish.published_item import PUBLISHED, LAST_PUBLISHED_VERSION
 from flask_babel import _
+from enum import Enum
 
 logger = logging.getLogger(__name__)
+# what to do when the item is in a package
+PACKAGE_WORKFLOW = Enum('PACKAGE_WORKFLOW', (
+    # raise an exception, the VALIDATE_ERROR_MESSAGE will be used
+    'RAISE',
+    # ignore, the action can be done on items in a package
+    'IGNORE',
+))
 
 
 class KillPublishResource(BasePublishResource):
@@ -41,6 +49,7 @@ class KillPublishService(BasePublishService):
     publish_type = 'kill'
     published_state = 'killed'
     item_operation = ITEM_KILL
+    package_workflow = PACKAGE_WORKFLOW.RAISE
     VALIDATE_ERROR_MESSAGE = _(
         'This item is in a package. It needs to be removed before the item can be killed'
     )
@@ -49,14 +58,18 @@ class KillPublishService(BasePublishService):
         super().__init__(datasource=datasource, backend=backend)
 
     def on_update(self, updates, original):
-        # check if we are trying to kill and item that is contained in package
+        # check if we are trying to kill an item that is contained in package
         # and the package itself is not killed.
 
         packages = self.package_service.get_packages(original[config.ID_FIELD])
-        if packages and packages.count() > 0:
-            for package in packages:
-                if package[ITEM_STATE] not in {CONTENT_STATE.KILLED, CONTENT_STATE.RECALLED, CONTENT_STATE.UNPUBLISHED}:
-                    raise SuperdeskApiError.badRequestError(message=self.VALIDATE_ERROR_MESSAGE)
+        if self.package_workflow == PACKAGE_WORKFLOW.RAISE:
+            if packages and packages.count() > 0:
+                for package in packages:
+                    if package[ITEM_STATE] not in {
+                            CONTENT_STATE.KILLED, CONTENT_STATE.RECALLED, CONTENT_STATE.UNPUBLISHED}:
+                        raise SuperdeskApiError.badRequestError(message=self.VALIDATE_ERROR_MESSAGE)
+        elif self.package_workflow not in PACKAGE_WORKFLOW:
+            raise ValueError("Invalid package workflow")
 
         updates['pubstatus'] = PUB_STATUS.CANCELED
         updates['versioncreated'] = utcnow()

--- a/apps/publish/content/unpublish.py
+++ b/apps/publish/content/unpublish.py
@@ -1,8 +1,8 @@
 
 from flask_babel import _
 
-from .common import BasePublishResource, ITEM_UNPUBLISH, CONTENT_STATE, PUB_STATUS, ITEM_KILL
-from .kill import KillPublishService
+from .common import BasePublishResource, ITEM_UNPUBLISH, CONTENT_STATE, ITEM_KILL
+from .kill import KillPublishService, PACKAGE_WORKFLOW
 
 
 class UnpublishResource(BasePublishResource):
@@ -15,6 +15,7 @@ class UnpublishService(KillPublishService):
     publish_type = ITEM_KILL
     item_operation = ITEM_UNPUBLISH
     published_state = CONTENT_STATE.UNPUBLISHED
+    package_workflow = PACKAGE_WORKFLOW.IGNORE
     VALIDATE_ERROR_MESSAGE = _(
         'This item is in a package. It needs to be removed before the item can be unpublished.'
     )

--- a/features/unpublish.feature
+++ b/features/unpublish.feature
@@ -65,3 +65,151 @@ Feature: Unpublish content
 
       When we publish "#archive._id#" with "publish" type and "published" state
       Then we get OK response
+
+    @auth
+    Scenario: Unpublish an item that is in a published package
+      Given empty "archive"
+      Given "desks"
+          """
+          [{"name": "test_desk1", "members":[{"user":"#CONTEXT_USER_ID#"}]}]
+          """
+      And the "validators"
+          """
+          [{"_id": "publish_composite", "act": "publish", "type": "composite", "schema":{}},
+          {"_id": "publish_text", "act": "publish", "type": "text", "schema":{}},
+          {"_id": "publish_picture", "act": "publish", "type": "picture", "schema":{}}]
+          """
+      When we post to "archive" with success
+          """
+          [{
+              "headline" : "WA:Navy steps in with WA asylum-seeker boat",
+              "guid" : "tag:localhost:2015:515b895a-b336-48b2-a506-5ffaf561b916",
+              "state" : "submitted",
+              "type" : "text",
+              "body_html": "item content",
+              "task": {
+                  "user": "#CONTEXT_USER_ID#",
+                  "status": "todo",
+                  "stage": "#desks.incoming_stage#",
+                  "desk": "#desks._id#"
+              }
+          }]
+          """
+      When we post to "archive" with success
+        """
+        [{
+              "original_source" : "AAP Image/AAP",
+              "description_text" : "A test picture",
+              "state" : "submitted",
+              "headline" : "ABC SHOP CLOSURES",
+              "byline" : "PAUL MILLER",
+              "source" : "AAP Image",
+              "mimetype" : "image/jpeg",
+              "type" : "picture",
+              "pubstatus" : "usable",
+              "task": {
+                  "user": "#CONTEXT_USER_ID#",
+                  "status": "todo",
+                  "stage": "#desks.incoming_stage#",
+                  "desk": "#desks._id#"
+              },
+              "guid" : "urn:newsml:localhost:2015-07-24T15:04:29.589984:af3bef9a-5002-492b-a15a-8b460e69b164",
+              "renditions" : {
+                  "baseImage" : {
+                      "height" : 1400,
+                      "media" : "55b078b31d41c8e974d17ecf",
+                      "href" : "http://localhost:5000/api/upload/55b078b31d41c8e974d17ecf/raw?_schema=http",
+                      "mimetype" : "image/jpeg",
+                      "width" : 933
+                  }
+              },
+              "slugline" : "ABC SHOP CLOSURES"
+        }]
+        """
+      When we post to "archive" with success
+          """
+          [{
+              "groups": [
+              {
+                  "id": "root",
+                  "refs": [
+                      {
+                          "idRef": "main"
+                      },
+                      {
+                          "idRef": "sidebars"
+                      }
+                  ],
+                  "role": "grpRole:NEP"
+              },
+              {
+                  "id": "main",
+                  "refs": [
+                      {
+                          "renditions": {},
+                          "slugline": "Boat",
+                          "guid": "tag:localhost:2015:515b895a-b336-48b2-a506-5ffaf561b916",
+                          "headline": "WA:Navy steps in with WA asylum-seeker boat",
+                          "location": "archive",
+                          "type": "text",
+                          "itemClass": "icls:text",
+                          "residRef": "tag:localhost:2015:515b895a-b336-48b2-a506-5ffaf561b916"
+                      }
+                  ],
+                  "role": "grpRole:main"
+              },
+              {
+                  "id": "sidebars",
+                  "refs": [
+                      {
+                          "renditions": {
+                              "baseImage": {
+                                  "width": 933,
+                                  "height": 1400,
+                                  "href": "http://localhost:5000/api/upload/55b078b31d41c8e974d17ecf/raw?_schema=http",
+                                  "mimetype": "image/jpeg",
+                                  "media": "55b078b31d41c8e974d17ecf"
+                              }
+                          },
+                          "slugline": "ABC SHOP CLOSURES",
+                          "type": "picture",
+                          "guid": "urn:newsml:localhost:2015-07-24T15:04:29.589984:af3bef9a-5002-492b-a15a-8b460e69b164",
+                          "headline": "ABC SHOP CLOSURES",
+                          "location": "archive",
+                          "itemClass": "icls:picture",
+                          "residRef": "urn:newsml:localhost:2015-07-24T15:04:29.589984:af3bef9a-5002-492b-a15a-8b460e69b164"
+                      }
+                  ],
+                  "role": "grpRole:sidebars"
+              }
+          ],
+              "task": {
+                  "user": "#CONTEXT_USER_ID#",
+                  "status": "todo",
+                  "stage": "#desks.incoming_stage#",
+                  "desk": "#desks._id#"
+              },
+              "guid" : "compositeitem",
+              "headline" : "WA:Navy steps in with WA asylum-seeker boat",
+              "state" : "submitted",
+              "type" : "composite"
+          }]
+          """
+      When we post to "/products" with success
+      """
+      {
+        "name":"prod-1","codes":"abc,xyz", "product_type": "both"
+      }
+      """
+      And we post to "/subscribers" with success
+          """
+          {
+          "name":"Channel 3","media_type":"media", "subscriber_type": "digital", "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
+          "products": ["#products._id#"],
+          "destinations":[{"name":"Test","format": "ninjs", "delivery_type":"PublicArchive","config":{"recipients":"test@test.com"}}]
+          }
+          """
+      And we publish "compositeitem" with "publish" type and "published" state
+      Then we get OK response
+      When we publish "tag:localhost:2015:515b895a-b336-48b2-a506-5ffaf561b916" with "unpublish" type and "unpublished" state
+      Then we get OK response


### PR DESCRIPTION
This patch add a package_workflow attribute in KillPublishResource: if
set to PACKAGE_WORKFLOW.RAISE, it will have the usual behaviour of
raising and exception if we try to unpublish an item in a package; if it
is set to the new PACKAGE_WORKFLOW.IGNORE, the action will be possible.

SDFID-582