### PR TITLE
fix manage subscription random error

### DIFF
--- a/apps/saved_searches/__init__.py
+++ b/apps/saved_searches/__init__.py
@@ -158,7 +158,7 @@ def report():
 
             if do_update:
                 updates = {'subscribers': search['subscribers']}
-                saved_searches.update(search['_id'], updates, search)
+                saved_searches.system_update(search['_id'], updates, search)
     except Exception as e:
         logger.error("Can't report saved searches: {reason}".format(reason=e))
     finally:

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -318,7 +318,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     'saved_searches:report': {
         'task': 'apps.saved_searches.report',
-        'schedule': timedelta(minutes=1)
+        'schedule': crontab(minute=0),
     },
 }
 


### PR DESCRIPTION
it would change etag every minute some changes were made
via celery task. this should be avoided now via system_update.
also run celery task only once per hour, there is no way to
configure it to get report more often anyhow.

SDESK-4555