### PR TITLE
[METADATA] Fixed data type for custom date fields

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -22,7 +22,7 @@ from .common import remove_unwanted, update_state, set_item_expiry, remove_media
     handle_existing_data, item_schema, validate_schedule, is_item_in_package, update_schedule_settings, \
     ITEM_OPERATION, ITEM_RESTORE, ITEM_CREATE, ITEM_UPDATE, ITEM_DUPLICATE, ITEM_DUPLICATED_FROM, \
     ITEM_DESCHEDULE, ARCHIVE as SOURCE, LAST_PRODUCTION_DESK, LAST_AUTHORING_DESK, ITEM_FETCH, \
-    convert_task_attributes_to_objectId, BROADCAST_GENRE, set_dateline, get_subject
+    convert_task_attributes_to_objectId, BROADCAST_GENRE, set_dateline, get_subject, transtype_metadata
 from superdesk.media.crop import CropService
 from flask import current_app as app, json
 from superdesk import get_resource_service
@@ -252,6 +252,7 @@ class ArchiveService(BaseService):
             self._add_desk_metadata(doc, {})
 
             convert_task_attributes_to_objectId(doc)
+            transtype_metadata(doc)
 
     def on_created(self, docs):
         packages = [doc for doc in docs if doc[ITEM_TYPE] == CONTENT_TYPE.COMPOSITE]
@@ -514,6 +515,7 @@ class ArchiveService(BaseService):
             new_doc[ITEM_STATE] = state
 
         convert_task_attributes_to_objectId(new_doc)
+        transtype_metadata(new_doc)
         get_model(ItemModel).create([new_doc])
         self._duplicate_versions(original_doc['_id'], new_doc)
         self._duplicate_history(original_doc['_id'], new_doc)
@@ -870,6 +872,7 @@ class ArchiveService(BaseService):
         """
 
         convert_task_attributes_to_objectId(updates)
+        transtype_metadata(updates, original)
 
         updates[ITEM_OPERATION] = ITEM_UPDATE
         updates.setdefault('original_creator', original.get('original_creator'))

--- a/apps/archive/archive_test.py
+++ b/apps/archive/archive_test.py
@@ -25,7 +25,7 @@ from apps.archive.common import (
     validate_schedule, remove_media_files,
     format_dateline_to_locmmmddsrc, convert_task_attributes_to_objectId,
     is_genre, BROADCAST_GENRE, get_default_source, set_default_source,
-    get_utc_schedule, get_dateline_city
+    get_utc_schedule, get_dateline_city, transtype_metadata
 )
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError
@@ -448,6 +448,31 @@ class ArchiveTestCase(TestCase):
         self.assertEqual(doc['task']['stage'], 'test')
         self.assertEqual(doc['task']['last_authoring_desk'], 3245)
         self.assertIsNone(doc['task']['last_production_desk'])
+
+    def test_if_metadata_are_transtyped(self):
+        """Check that date metadata in extra are transtyped correctly"""
+        content_type = {
+            "_id": "type_1",
+            "label": "test_type",
+            "editor": {"test_date_field": {"order": 1, "section": "header"}},
+            "schema": {
+                "test_date_field": {
+                    "type": "date",
+                    "required": False,
+                    "enabled": True,
+                    "nullable": True,
+                }
+            },
+        }
+        self.app.data.insert('content_types', [content_type])
+        doc = {
+            "_id": "transtype_1",
+            "profile": "type_1",
+            "extra": {"test_date_field": "2019-11-06T00:00:00+0000"},
+        }
+
+        transtype_metadata(doc)
+        self.assertIsInstance(doc['extra']['test_date_field'], datetime)
 
     def test_if_no_source_defined_on_desk(self):
         desk = {'name': 'sports'}

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -39,8 +39,7 @@ from apps.archive.archive import ArchiveResource, SOURCE as ARCHIVE
 from apps.archive.common import get_user, insert_into_versions, item_operations, \
     FIELDS_TO_COPY_FOR_ASSOCIATED_ITEM, remove_unwanted
 from apps.archive.common import validate_schedule, ITEM_OPERATION, update_schedule_settings, \
-    convert_task_attributes_to_objectId, \
-    get_expiry, get_utc_schedule, get_expiry_date
+    convert_task_attributes_to_objectId, get_expiry, get_utc_schedule, get_expiry_date, transtype_metadata
 from apps.common.components.utils import get_component
 from apps.item_autosave.components.item_autosave import ItemAutosave
 from apps.legal_archive.commands import import_into_legal_archive
@@ -110,6 +109,7 @@ class BasePublishService(BaseService):
         self._validate(original, updates)
         self._set_updates(original, updates, updates.get(config.LAST_UPDATED, utcnow()))
         convert_task_attributes_to_objectId(updates)  # ???
+        transtype_metadata(updates, original)
         self._process_publish_updates(original, updates)
         self._mark_media_item_as_used(updates, original)
 

--- a/apps/validate/validate.py
+++ b/apps/validate/validate.py
@@ -80,10 +80,11 @@ class SchemaValidator(Validator):
         pass
 
     def _validate_type_date(self, field, value):
-        try:
-            datetime.strptime(value or '', '%Y-%m-%dT%H:%M:%S+%f')
-        except ValueError:
-            self._error(field, DATE_FIELD)
+        if not isinstance(value, datetime):
+            try:
+                datetime.strptime(value or '', '%Y-%m-%dT%H:%M:%S+%f')
+            except ValueError:
+                self._error(field, DATE_FIELD)
 
     def _validate_type_picture(self, field, value):
         """Allow type picture in schema."""

--- a/superdesk/data_updates/00020_20191106-180807_archive.py
+++ b/superdesk/data_updates/00020_20191106-180807_archive.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : Jérôme
+# Creation: 2019-11-06 18:08
+
+from superdesk.commands.data_updates import DataUpdate
+from superdesk import get_resource_service
+from apps.archive.common import transtype_metadata
+from datetime import datetime
+
+
+class DataUpdate(DataUpdate):
+
+    resource = 'archive'
+
+    def forwards(self, mongodb_collection, mongodb_database):
+        vocabularies_service = get_resource_service('vocabularies')
+        cursor = vocabularies_service.find({"field_type": "date"})
+        if cursor.count() == 0:
+            print('No field with "date" type, there is nothing to do')
+        else:
+            for resource in ['archive', 'archive_autosave', 'published']:
+
+                collection = mongodb_database[resource]
+
+                for item in collection.find({'extra': {'$exists': True, '$ne': {}}}):
+                    transtype_metadata(item)
+                    print(collection.update({'_id': item['_id']}, {
+                        '$set': {
+                            'extra': item['extra']
+                        },
+                    }))
+
+    def backwards(self, mongodb_collection, mongodb_database):
+        vocabularies_service = get_resource_service('vocabularies')
+        cursor = vocabularies_service.find({"field_type": "date"})
+        if cursor.count() == 0:
+            print('No field with "date" type, there is nothing to do')
+        else:
+            for resource in ['archive', 'archive_autosave', 'published']:
+
+                collection = mongodb_database[resource]
+
+                for item in collection.find({'extra': {'$exists': True, '$ne': {}}}):
+                    extra = item['extra']
+                    for key, value in extra.items():
+                        if isinstance(value, datetime):
+                            extra[key] = value.isoformat()
+
+                    print(collection.update({'_id': item['_id']}, {
+                        '$set': {
+                            'extra': extra
+                        },
+                    }))


### PR DESCRIPTION
This patch fixes types for fields in extra (which is used for custom fields) when a date
is expected. So far, custom date fields were stored as plain text, which is causing
trouble when anything related to date is needed (like a comparison).

This patch also provides test + a data migration script to fix types of items already in
database. The data migration script provides the downgrade part, to avoid problems if
anything is going wrong.

fixes SDESK-4795