### PR TITLE
[ARCHIVE][FETCHING] add destination desk and stage ids to macros kwargs

### DIFF
--- a/apps/duplication/archive_fetch.py
+++ b/apps/duplication/archive_fetch.py
@@ -78,7 +78,12 @@ class FetchService(BaseService):
                 raise InvalidStateTransitionError()
 
             if doc.get('macro'):  # there is a macro so transform it
-                ingest_doc = get_resource_service('macros').execute_macro(ingest_doc, doc.get('macro'))
+                ingest_doc = get_resource_service('macros').execute_macro(
+                    ingest_doc,
+                    doc.get('macro'),
+                    dest_desk_id=desk_id,
+                    dest_stage_id=stage_id,
+                )
 
             archived = utcnow()
             ingest_service.patch(id_of_item_to_be_fetched, {'archived': archived})

--- a/apps/macros/macros.py
+++ b/apps/macros/macros.py
@@ -57,9 +57,9 @@ class MacrosService(superdesk.Service):
     def get_macro_by_name(self, macro_name):
         return macros.find(macro_name)
 
-    def execute_macro(self, doc, macro_name):
+    def execute_macro(self, doc, macro_name, **kwargs):
         macro = self.get_macro_by_name(macro_name)
-        return macro['callback'](doc)
+        return macro['callback'](doc, **kwargs)
 
     def get_macros(self, include_backend):
         if include_backend:

--- a/superdesk/internal_destinations.py
+++ b/superdesk/internal_destinations.py
@@ -73,7 +73,11 @@ def handle_item_published(sender, item, **extra):
         if dest.get('macro'):
             macro = macros_service.get_macro_by_name(dest['macro'])
             try:
-                macro['callback'](new_item)
+                macro['callback'](
+                    new_item,
+                    dest_desk_id=dest.get('desk'),
+                    dest_stage_id=dest.get('stage'),
+                )
             except StopDuplication:
                 continue
 


### PR DESCRIPTION
Macros had no way to know where an item is fetched or routed, this
patches fixes this by specifying `dest_desk_id` and `dest_stage_id` as
macros keyword arguments.

needed for SDBELGA-142 and SDBELGA-143