### PR TITLE
Fix: No attachments are delivered when using Attachments widget only. [SDESK-4827]

### DIFF
--- a/apps/content_types/content_types.py
+++ b/apps/content_types/content_types.py
@@ -493,6 +493,9 @@ def apply_schema(item):
 
     :param item: item to apply schema to
     """
+    # fields that can be added to article without being added to CP eg: using widgets
+    allowed_keys = ['attachments']
+
     if item.get('type') == 'event':
         return item.copy()
     try:
@@ -500,7 +503,7 @@ def apply_schema(item):
         schema = profile['schema']
     except Exception:
         schema = DEFAULT_SCHEMA
-    return {key: val for key, val in item.items() if is_enabled(key, schema)}
+    return {key: val for key, val in item.items() if is_enabled(key, schema) or key in allowed_keys}
 
 
 def remove_profile_from_templates(item):


### PR DESCRIPTION
If the attachments are not enabled in the CP and added from the attachment widget it gets filtered out before being sent as output.