### PR TITLE
[ERRORS]Avoid RuntimeError when SuperdeskValidationError is thrown ou…

### DIFF
--- a/superdesk/errors.py
+++ b/superdesk/errors.py
@@ -733,20 +733,26 @@ class SuperdeskValidationError(HTTPException):
         Exception.__init__(self)
         self.errors = errors
         self.fields = fields
-        self.response = send_response(
-            None, (
-                {
-                    app.config['STATUS']: app.config['STATUS_ERR'],
-                    app.config['ISSUES']: {
-                        'validator exception': str([self.errors]),  # BC
-                        'fields': self.fields,
+        try:
+            self.response = send_response(
+                None, (
+                    {
+                        app.config['STATUS']: app.config['STATUS_ERR'],
+                        app.config['ISSUES']: {
+                            'validator exception': str([self.errors]),  # BC
+                            'fields': self.fields,
+                        },
                     },
-                },
-                None,
-                None,
-                400,
+                    None,
+                    None,
+                    400,
+                )
             )
-        )
+        except RuntimeError as e:
+            # the exception is run outside of request context
+            # it may be the case with CLI commands
+            # we log the error to not loose the initial error
+            logger.warning(e)
 
     def __str__(self):
         return 'Validation Error: {}'.format(str(self.errors))


### PR DESCRIPTION
…tside of request context

SuperdeskValidationError was assuming that the exception was raised in a
Flask request context, but this is not necessary the case (e.g. it can
be raised with a CLI command), and this result in a RuntimeError masking
the initial one.

This patch avoid it by catching the RuntimeError and showing a simple
warning, thus the initial SuperdeskValidationError will still be raised
normally.

SDFID-589