### PR TITLE
Don't store replaced associated item's metadata in the newly added as associated item. [SDESK-4764]

### DIFF
--- a/features/archive.feature
+++ b/features/archive.feature
@@ -1115,3 +1115,29 @@ Feature: News Items Archive
         """
         {"associations": {"foo--1": {"headline": "flower", "byline": "foo", "description_text": "flower desc"}}}
         """
+
+    @auth
+    Scenario: Don't store replaced association items metadata into newly added association item
+        Given "archive"
+        """
+        [{"_id": "item-1", "guid": "item-1", "type": "text", "headline": "test", "state": "in_progress", "_type": "archive"
+        }]
+        """
+        When we patch given
+        """
+        {"associations": {"foo--1": {"headline": "flower", "_id": "123", "byline": "foo", "description_text": "flower desc", "_type": "archive", "credit_line": "to myself", "alt_text": "flower"}}}
+        """
+        When we get "/archive/item-1"
+        Then we get existing resource
+        """
+        {"associations": {"foo--1": {"headline": "flower", "_id": "123", "byline": "foo", "description_text": "flower desc", "credit_line": "to myself", "alt_text": "flower"}}}
+        """
+        When we patch latest
+        """
+        {"associations": {"foo--1": {"headline": "rose", "_id": "125", "description_text": "rose desc", "_type": "externalsource"}}}
+        """
+        When we get "/archive/item-1"
+        Then we get existing resource
+        """
+        {"associations": {"foo--1": {"headline": "rose", "description_text": "rose desc", "byline": "__none__", "credit_line": "__none__", "alt_text": "__none__"}}}
+        """


### PR DESCRIPTION
https://dev.sourcefabric.org/browse/SDESK-4764