### PR TITLE
[EDITOR UTILS] Added classes to manipulate *draftjs* internal state w…

### DIFF
--- a/docs/editor.rst
+++ b/docs/editor.rst
@@ -1,0 +1,30 @@
+.. _editor:
+
+Editor
+======
+
+If you want to modify fields managed by the editor (e.g. ``headline`` or  ``body_html``),
+with a macro for instance, you need to use the EditorContent class which is an abstraction
+used to manipulate the content. This is needed because since Editor 3, the HTML is managed
+from internal representation of data. This page explains how to modify it.
+
+.. note::
+
+    with editor 2 you can directly modify ``body_html`` or ``headline`` fields
+
+
+Modifying an HTML content from backend
+--------------------------------------
+
+You first need to create an instance of editor_content.
+The following example show how to add an embedded code at the top of the body:
+
+.. code:: python
+
+   from superdesk.editor_utils import EditorContent
+
+   def some_method_getting_an_item(item):
+       body_editor = EditorContent.create(item, 'body_html')
+       body_editor.prepend('embed', '<p class="some_class">some embedded HTML to
+       prepend</p>')
+       body_editor.update_item()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@ works and can be developed further.
     schema
     content-types
     contentapi
+    editor
     auth_server
     extending
     authentication

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_requires = [
     'python-dateutil<2.8',
     'unidecode==0.04.21',
     'authlib>0.12,<0.13',
-
+    'draftjs-exporter[lxml]<2.2',
 ]
 
 package_data = {

--- a/superdesk/editor_utils.py
+++ b/superdesk/editor_utils.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+"""This module contains tools to manage content for Superdesk editor"""
+
+import re
+import logging
+import uuid
+from textwrap import dedent
+from collections.abc import MutableSequence
+from draftjs_exporter.html import HTML
+from draftjs_exporter.constants import ENTITY_TYPES, INLINE_STYLES
+from draftjs_exporter.defaults import STYLE_MAP
+from draftjs_exporter.dom import DOM
+
+
+logger = logging.getLogger(__name__)
+DUMMY_RE = re.compile(r"</?dummy_tag>")
+
+ANNOTATION = 'ANNOTATION'
+MEDIA = 'MEDIA'
+TABLE = 'TABLE'
+
+
+class Entity:
+    """Abstraction of a DraftJS entity"""
+
+    def __init__(self, ranges, data):
+        self.ranges = ranges
+        self.data = data
+
+    @property
+    def key(self):
+        return str(self.ranges['key'])
+
+    @property
+    def type(self):
+        return self.data['type']
+
+    @property
+    def is_mutable(self):
+        return self.data['mutability'] == 'MUTABLE'
+
+    @property
+    def content(self):
+        return self.data['data']
+
+    def __str__(self):
+        return str(self.data)
+
+    def __repr__(self):
+        return "{mutable}{type} entity (key: {key})".format(
+            mutable="mutable " if self.is_mutable else "",
+            type=self.type,
+            key=self.key,
+        )
+
+
+class EntitySequence(MutableSequence):
+
+    def __init__(self, editor, block):
+        self._ranges = block.data.setdefault('entityRanges', [])
+        self._mapping = editor.content_state.setdefault('entityMap', {})
+
+    def __getitem__(self, key):
+        ranges = self._ranges[key]
+        data = self._mapping[str(ranges['key'])]
+        return Entity(ranges, data)
+
+    def __setitem__(self, key, value):
+        if not isinstance(value, Entity):
+            raise TypeError("an Entity instance is expected")
+        self._ranges[key] = value.ranges
+        self._mapping[value.key] = value.data
+
+    def __delitem__(self, key):
+        entity_key = str(self._ranges[key]['key'])
+        del self._ranges[key]
+        del self._mapping[entity_key]
+
+    def __len__(self):
+        return len(self._ranges)
+
+    def insert(self, index, value):
+        if not isinstance(value, Entity):
+            raise TypeError("an Entity instance is expected")
+        self._ranges.insert(index, value.ranges)
+        self._mapping[value.key] = value.data
+
+
+class Block:
+    """Abstraction of DraftJS block"""
+
+    def __init__(self, editor, data=None):
+        if data is None:
+            data = {
+                "key": str(uuid.uuid4()),
+                "text": "",
+                "type": "unstyled",
+                "depth": 0,
+                "inlineStyleRanges": [],
+                "entityRanges": [],
+                "data": {},
+            }
+        self.data = data
+        self.entities = EntitySequence(editor, self)
+
+    @property
+    def depth(self):
+        return self.data['depth']
+
+    @property
+    def type(self):
+        return self.data['type']
+
+    @property
+    def text(self):
+        return self.data.get('text')
+
+    def __str__(self):
+        return self.text
+
+    def __repr__(self):
+        return "{type} block with text {text!r} and {len_entities} entities".format(
+            type=self.type, text=self.text, len_entities=len(self.entities))
+
+
+class EmbedBlock(Block):
+
+    def __init__(self, editor, html):
+        """
+        :param str html: raw HTML to embed
+        """
+        super().__init__(editor)
+        self.data.update({
+            "text": " ",
+            "type": "atomic",
+        })
+        entity_data = {
+            "type": "EMBED",
+            "mutability": "MUTABLE",
+            "data": {
+                "data": {
+                    "html": html,
+                }
+            },
+        }
+        entity = Entity(
+            ranges={"offset": 0, "length": 1, "key": editor.get_next_entity_key()},
+            data=entity_data,
+        )
+        self.entities.append(entity)
+
+
+class BlockSequence(MutableSequence):
+
+    def __init__(self, editor):
+        self.editor = editor
+        self._blocks = editor.content_state.setdefault('blocks', {})
+
+    def __getitem__(self, key):
+        return Block(self.editor, self._blocks[key])
+
+    def __setitem__(self, key, value):
+        if not isinstance(value, Block):
+            raise TypeError("a Block instance is expected")
+        self._blocks[key] = value.data
+
+    def __delitem__(self, key):
+        del self._blocks[key]
+
+    def __len__(self):
+        return len(self._blocks)
+
+    def insert(self, index, value):
+        if not isinstance(value, Block):
+            raise TypeError("a Block instance is expected")
+        self._blocks.insert(index, value.data)
+
+
+class EditorContent:
+    """Base class to manage content from editors"""
+
+    def __init__(self):
+        raise RuntimeError("This class must not be instantiated directly, use create()")
+
+    @staticmethod
+    def create(item, field):
+        """Factory for EditorContent"""
+        if 'fields_meta' in item:
+            return Editor3Content(item, field)
+        else:
+            raise NotImplementedError("This is not an editor 3 item, EditorContent doesn't manage this")
+
+
+class DraftJSHTMLExporter:
+
+    def __init__(self, content_editor):
+        self.content_editor = content_editor
+        # XXX: we need one exporter per DraftJSHTMLExporter because
+        #      self.render_media needs to access "entityMap" from local
+        #      instance. If MEDIA rendering changes in the future, exporter
+        #      should be global for all DraftJSHTMLExporter instances
+        self.exporter = HTML({
+            'engine': DOM.LXML,
+            'style_map': dict(STYLE_MAP, **{
+                INLINE_STYLES.BOLD: 'b',
+                INLINE_STYLES.ITALIC: 'i',
+                INLINE_STYLES.FALLBACK: self.style_fallback,
+            }),
+            'entity_decorators': {
+                ENTITY_TYPES.LINK: self.render_link,
+                ENTITY_TYPES.HORIZONTAL_RULE: lambda props: DOM.create_element('hr'),
+                ENTITY_TYPES.EMBED: self.render_embed,
+                MEDIA: self.render_media,
+                ANNOTATION: self.render_annotation,
+                TABLE: self.render_table,
+            },
+        })
+
+    @property
+    def content_state(self):
+        return self.content_editor.content_state
+
+    def render(self):
+        blocks = self.content_state['blocks']
+        if blocks and blocks[0]['text'].strip() == '' or blocks[-1]['text'].strip() == '':
+            # first and last block may be empty due to client constraints, in this case
+            # we must discard them during rendering
+            content_state = self.content_state.copy()
+            content_state['blocks'] = blocks = blocks[:]
+            if blocks[0]['text'].strip() == '' and not blocks[0]['entityRanges']:
+                del blocks[0]
+            if blocks and blocks[-1]['text'].strip() == '' and not blocks[-1]['entityRanges']:
+                del blocks[-1]
+            html = self.exporter.render(content_state)
+        else:
+            html = self.exporter.render(self.content_state)
+        # see render_media for details
+        return DUMMY_RE.sub('', html)
+
+    def render_annotation(self, props):
+        return props['children']
+
+    def render_media(self, props):
+        media_props = props['media']
+        media_type = media_props.get('type', 'picture')
+        rendition = media_props['renditions'].get('original') or media_props['renditions']['viewImage']
+        alt_text = media_props.get('alt_text') or ''
+        desc = media_props.get('description_text')
+        if media_type == 'picture':
+            embed_type = "Image"
+            elt = DOM.create_element('img', {'src': rendition['href'],
+                                             'alt': alt_text}, props['children'])
+        elif media_type == 'video':
+            embed_type = "Video"
+            elt = DOM.create_element('video', {'control': 'control',
+                                               'src': rendition['href'],
+                                               'alt': alt_text,
+                                               'width': '100%',
+                                               'height': '100%'}, props['children'])
+        elif media_type == 'audio':
+            embed_type = "Audio"
+            elt = DOM.create_element('audio', {'control': 'control',
+                                               'src': rendition['href'],
+                                               'alt': alt_text,
+                                               'width': '100%',
+                                               'height': '100%'}, props['children'])
+        else:
+            logger.error("Invalid or not implemented media type: {media_type}".format(
+                media_type=media_type))
+            return None
+
+        content = DOM.render(elt)
+
+        if desc:
+            content += "<figcaption>{}</figcaption>".format(desc)
+
+        # we need to retrieve the key, there is not straightforward way to do it
+        # so we find the key in entityMap with a corresponding value
+        embed_key = next(
+            k for k, v in self.content_state['entityMap'].items()
+            if v['data']['media'] == props['media'])
+
+        # <dummy_tag> is needed for the comments, because a root node is necessary
+        # it will be removed during rendering.
+        embed = DOM.parse_html(dedent("""\
+            <dummy_tag><!-- EMBED START {embed_type} {{id: "editor_{key}"}} -->
+            <figure>{content}</figure>
+            <!-- EMBED END {embed_type} {{id: "editor_{key}"}} --></dummy_tag>""").format(
+            embed_type=embed_type,
+            key=embed_key,
+            content=content)
+        )
+
+        return embed
+
+    def render_link(self, props):
+        if 'url' in props:
+            attribs = {'href': props['url']}
+        else:
+            link_data = props.get('link', {})
+            if link_data.get('attachment'):
+                attribs = {'data-attachment': link_data['attachment']}
+            elif link_data.get('target'):
+                attribs = {'href': link_data['href'], 'target': link_data['target']}
+            else:
+                attribs = {'href': link_data['href']}
+
+        return DOM.create_element('a', attribs, props['children'])
+
+    def render_embed(self, props):
+        # FIXME: Qumu hack is not handled yet
+        div = DOM.create_element('div', {'class': 'embed-block'})
+        embedded_html = DOM.parse_html(props['data']['html'])
+        DOM.append_child(div, embedded_html)
+        description = props.get('description')
+        if description:
+            p = DOM.create_element('p', {'class': 'embed-block__description'}, description)
+            DOM.append_child(div, p)
+        return div
+
+    def render_table(self, props):
+        num_cols = props['data']['numCols']
+        num_rows = props['data']['numRows']
+        with_header = props['data'].get('withHeader', False)
+        cells = props['data']['cells']
+        table = DOM.create_element('table')
+        if with_header:
+            start_row = 1
+            thead = DOM.create_element('thead')
+            DOM.append_child(table, thead)
+            tr = DOM.create_element('tr')
+            DOM.append_child(thead, tr)
+            for col_idx in range(num_cols):
+                th = DOM.create_element('th')
+                DOM.append_child(tr, th)
+                try:
+                    content_state = cells[0][col_idx]
+                except IndexError:
+                    continue
+                content = DOM.parse_html(self.exporter.render(content_state))
+                if content.text or len(content):
+                    DOM.append_child(th, content)
+        else:
+            start_row = 0
+
+        if not with_header or num_rows > 1:
+            tbody = DOM.create_element('tbody')
+            DOM.append_child(table, tbody)
+
+        for row_idx in range(start_row, num_rows):
+            tr = DOM.create_element('tr')
+            DOM.append_child(tbody, tr)
+            for col_idx in range(num_cols):
+                td = DOM.create_element('td')
+                DOM.append_child(tr, td)
+                try:
+                    content_state = cells[row_idx][col_idx]
+                except IndexError:
+                    continue
+                content = DOM.parse_html(self.exporter.render(content_state))
+                if content.text or len(content):
+                    DOM.append_child(td, content)
+
+        return table
+
+    def style_fallback(self, props):
+        type_ = props['inline_style_range']['style']
+        # we need to use fallback for annotations, has they have suffixes, it's
+        # not only "ANNOTATION"
+        if type_.startswith('ANNOTATION'):
+            attribs = {"annotation-id": type_[11:]}
+            return DOM.create_element('span', attribs, props['children'])
+        else:
+            logger.error("No style renderer for {type_!r}".format(type_=type_))
+
+
+class Editor3Content(EditorContent):
+    """Handle content for Superdesk Editor 3, using Draft.js ContentState
+
+    see https://medium.com/@rajaraodv/how-draft-js-represents-rich-text-data-eeabb5f25cf2 for documentation
+    on ContentState.
+    """
+
+    editor_version = 3
+    HTML_EXPORTER = DraftJSHTMLExporter
+
+    def __init__(self, item, field='body_html'):
+        """
+        :param item: item containing Draft.js ContentState
+        :param field: field to manage, can be "body_html", "headline", etc.
+        """
+        self.item = item
+        self.field = field
+        data = item.get('fields_meta', {}).get(field, {})
+        if not data:
+            self.content_state = {}
+        else:
+            # if the field exist, draftjsState must exist too
+            self.content_state = data['draftjsState'][0]
+        self.blocks = BlockSequence(self)
+
+        self.html_exporter = DraftJSHTMLExporter(self)
+
+    @property
+    def html(self):
+        return self.html_exporter.render()
+
+    def get_next_entity_key(self):
+        """Return a non existing key for entityMap"""
+        return max((int(k) for k in self.content_state['entityMap'].keys()), default=-1) + 1
+
+    def update_item(self):
+        self.item[self.field] = self.html
+
+    def create_block(self, block_type, *args, **kwargs):
+        cls_name = "{}Block".format(block_type.capitalize())
+        cls = globals()[cls_name]
+        return cls(self, *args, **kwargs)
+
+    def prepend(self, block_type, *args, **kwargs):
+        """Shortcut to prepend a block from its type"""
+        block = self.create_block(block_type, *args, **kwargs)
+        self.prepend_block(block)
+        return block
+
+    def prepend_block(self, block):
+        # first block may be empty, this is a client constraint. In this case,
+        # we prepend our block after it
+        if self.blocks and not self.blocks[0].text.strip():
+            index = 1
+        else:
+            index = 0
+        self.blocks.insert(index, block)

--- a/tests/editor_utils_test.py
+++ b/tests/editor_utils_test.py
@@ -1,0 +1,1600 @@
+#!/usr/bin/env python3
+# This file is part of Superdesk.
+#
+# Copyright 2018 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+"""Unit tests for editor utils"""
+
+import uuid
+import json
+from superdesk.tests import TestCase
+from superdesk.editor_utils import Editor3Content
+
+
+class Editor3TestCase(TestCase):
+
+    def build_item(self, draftjs_data, field='body_html'):
+        return {
+            'fields_meta': {
+                field: {
+                    'draftjsState': [draftjs_data],
+                },
+            },
+        }
+
+    def blocks_with_text(self, data_list):
+        draftjs_data = {
+            "blocks": [],
+            "entityMap": {},
+        }
+        blocks = draftjs_data['blocks']
+        for item_data in data_list:
+            type_, depth, text = item_data
+            blocks.append({
+                "key": str(uuid.uuid4()),
+                "text": text,
+                "type": type_,
+                "depth": depth,
+                "inlineStyleRanges": [],
+                "entityRanges": [],
+                "data": {"MULTIPLE_HIGHLIGHTS": {}},
+            })
+        return draftjs_data
+
+    def create_table(self, cols, rows, cells, with_header=False):
+        cells_list = []
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "first_block",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "table_key",
+                    "text": " ",
+                    "type": "atomic",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+                    "data": {},
+                },
+                {
+                    "key": "last_block",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+            ],
+            "entityMap": {
+                "0": {
+                    "type": "TABLE",
+                    "mutability": "MUTABLE",
+                    "data": {
+                        "data": {
+                            "cells": cells_list,
+                            "numCols": cols,
+                            "numRows": rows,
+                            "withHeader": with_header,
+                        }
+                    }
+                }},
+        }
+
+        for cell_row in cells:
+            row = []
+            cells_list.append(row)
+            for cell in cell_row:
+                row.append({
+                    "blocks": [{
+                        "key": str(uuid.uuid4()),
+                        "text": cell,
+                        "type": "unstyled",
+                        "depth": 0,
+                        "inlineStyleRanges": [],
+                        "entityRanges": [],
+                        "data": {},
+                    }],
+                    "entityMap": {},
+                })
+
+        draftjs_data['blocks'][0]['data']['data'] = json.dumps(draftjs_data['entityMap']['0']['data']['data'])
+        return draftjs_data
+
+    def test_no_formatting(self):
+        """Check that a sentence without formatting can generate HTML"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": 'The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds".',
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                }
+            ],
+            "entityMap": {},
+        }
+        expected = '<p>The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds".</p>'
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_simple_inline_styles(self):
+        """Check that a sentence with simple inline styles can generate HTML"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": 'The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds".',
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [
+                        {"offset": 0, "length": 3, "style": "BOLD"},
+                        {"offset": 4, "length": 4, "style": "ITALIC"},
+                        {"offset": 9, "length": 2, "style": "UNDERLINE"},
+                        {"offset": 12, "length": 8, "style": "STRIKETHROUGH"},
+                        {"offset": 21, "length": 5, "style": "SUBSCRIPT"},
+                        {"offset": 27, "length": 4, "style": "SUPERSCRIPT"},
+                    ],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                }
+            ],
+            "entityMap": {},
+        }
+
+        expected = (
+            '<p><b>The</b> <i>name</i> <u>of</u> <s>Highlaws</s> <sub>comes</sub> <sup>from</sup> the Old English '
+            'hēah-hlāw, meaning "high mounds".</p>')
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_heading(self):
+        """Check that headlines are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": "The name of Highlaws comes from the Old English hēah-hlāw",
+                    "type": "header-one",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "32mrs",
+                    "text": ', meaning "high mounds". In the past,',
+                    "type": "header-two",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "d2ggv",
+                    "text": "variant spellings included Heelawes, Hielawes,",
+                    "type": "header-three",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "3eqv5",
+                    "text": "Highlows, Hielows, and Hylaws.",
+                    "type": "header-four",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "8lcpm",
+                    "text": "[2] The hamlet appears in a survey of Holm Cultram dating back",
+                    "type": "header-five",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "emuqc",
+                    "text": "to the year 1538, during the reign of Henry VIII.",
+                    "type": "header-six",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "90o9n",
+                    "text": "There were at least thirteen families resident in Highlaws at that time.[3] Abdastartus "
+                            "is a genus of lace bugs in the family Tingidae. There are about five described species in "
+                            "Abdastartus.",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {},
+        }
+
+        expected = (
+            '<h1>The name of Highlaws comes from the Old English hēah-hlāw</h1><h2>, meaning "high mounds". In the past'
+            ',</h2><h3>variant spellings included Heelawes, Hielawes,</h3><h4>Highlows, Hielows, and Hylaws.</h4><h5>['
+            '2] The hamlet appears in a survey of Holm Cultram dating back</h5><h6>to the year 1538, during the reign o'
+            'f Henry VIII.</h6><p>There were at least thirteen families resident in Highlaws at that time.[3] Abdastart'
+            'us is a genus of lace bugs in the family Tingidae. There are about five described species in Abdastartus.<'
+            '/p>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_blockquote(self):
+        """Check that blockqotes are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": 'The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds".',
+                    "type": "blockquote",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "2u79k",
+                    "text": "In the past, variant spellings included Heelawes, Hielawes, Highlows, Hielows, and "
+                            "Hylaws.",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {},
+        }
+
+        expected = (
+            '<blockquote>The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds".</blockquote>'
+            '<p>In the past, variant spellings included Heelawes, Hielawes, Highlows, Hielows, and Hylaws.</p>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_code_blocks(self):
+        """Check that code blocks are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": 'The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds".',
+                    "type": "code-block",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "2u79k",
+                    "text": "In the past, variant spellings included Heelawes, Hielawes, Highlows, Hielows, and "
+                            "Hylaws.",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {},
+        }
+
+        expected = (
+            '<pre><code>The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds".</code></pre><'
+            'p>In the past, variant spellings included Heelawes, Hielawes, Highlows, Hielows, and Hylaws.</p>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_links(self):
+        """Check that links are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": 'The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds".',
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [{"offset": 12, "length": 8, "key": 0}],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                }
+            ],
+            "entityMap": {
+                "0": {
+                    "type": "LINK",
+                    "mutability": "MUTABLE",
+                    "data": {"link": {"href": "https://en.wikipedia.org/wiki/Highlaws"}},
+                }
+            },
+        }
+
+        expected = (
+            '<p>The name of <a href="https://en.wikipedia.org/wiki/Highlaws">Highlaws</a> comes from the Old English hē'
+            'ah-hlāw, meaning "high mounds".</p>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_simple_table(self):
+        """Check that a simple table is converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "fhokc",
+                    "text": " ",
+                    "type": "atomic",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+                    "data": {
+                        "data": '{"cells":[[{"blocks":[{"key":"k8sb","text":"three","type":"unstyled","depth":0,"inline'
+                                'StyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}},{"blocks":[{"key":"a25i9'
+                                '","text":"column","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]'
+                                ',"data":{}}],"entityMap":{}},{"blocks":[{"key":"ej3lv","text":"table","type":"unstyled'
+                                '","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}],[{"b'
+                                'locks":[{"key":"f0qc0","text":"example","type":"unstyled","depth":0,"inlineStyleRanges'
+                                '":[],"entityRanges":[],"data":{}}],"entityMap":{}},{"blocks":[{"key":"50s2o","text":"r'
+                                'ight","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]'
+                                ',"entityMap":{}},{"blocks":[{"key":"escgd","text":"here","type":"unstyled","depth":0,"'
+                                'inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}]],"numRows":2,"num'
+                                'Cols":3,"withHeader":false}'
+                    },
+                },
+                {
+                    "key": "2u79k",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {
+                "0": {
+                    "type": "TABLE",
+                    "mutability": "MUTABLE",
+                    "data": {
+                        "data": {
+                            "cells": [
+                                [
+                                    {
+                                        "blocks": [
+                                            {
+                                                "key": "k8sb",
+                                                "text": "three",
+                                                "type": "unstyled",
+                                                "depth": 0,
+                                                "inlineStyleRanges": [],
+                                                "entityRanges": [],
+                                                "data": {},
+                                            }
+                                        ],
+                                        "entityMap": {},
+                                    },
+                                    {
+                                        "blocks": [
+                                            {
+                                                "key": "a25i9",
+                                                "text": "column",
+                                                "type": "unstyled",
+                                                "depth": 0,
+                                                "inlineStyleRanges": [],
+                                                "entityRanges": [],
+                                                "data": {},
+                                            }
+                                        ],
+                                        "entityMap": {},
+                                    },
+                                    {
+                                        "blocks": [
+                                            {
+                                                "key": "ej3lv",
+                                                "text": "table",
+                                                "type": "unstyled",
+                                                "depth": 0,
+                                                "inlineStyleRanges": [],
+                                                "entityRanges": [],
+                                                "data": {},
+                                            }
+                                        ],
+                                        "entityMap": {},
+                                    },
+                                ],
+                                [
+                                    {
+                                        "blocks": [
+                                            {
+                                                "key": "f0qc0",
+                                                "text": "example",
+                                                "type": "unstyled",
+                                                "depth": 0,
+                                                "inlineStyleRanges": [],
+                                                "entityRanges": [],
+                                                "data": {},
+                                            }
+                                        ],
+                                        "entityMap": {},
+                                    },
+                                    {
+                                        "blocks": [
+                                            {
+                                                "key": "50s2o",
+                                                "text": "right",
+                                                "type": "unstyled",
+                                                "depth": 0,
+                                                "inlineStyleRanges": [],
+                                                "entityRanges": [],
+                                                "data": {},
+                                            }
+                                        ],
+                                        "entityMap": {},
+                                    },
+                                    {
+                                        "blocks": [
+                                            {
+                                                "key": "escgd",
+                                                "text": "here",
+                                                "type": "unstyled",
+                                                "depth": 0,
+                                                "inlineStyleRanges": [],
+                                                "entityRanges": [],
+                                                "data": {},
+                                            }
+                                        ],
+                                        "entityMap": {},
+                                    },
+                                ],
+                            ],
+                            "numRows": 2,
+                            "numCols": 3,
+                            "withHeader": False,
+                        }
+                    },
+                }
+            },
+        }
+
+        expected = (
+            '<table><tbody><tr><td><p>three</p></td><td><p>column</p></td><td><p>table</p></td></tr><tr><td><p>example<'
+            '/p></td><td><p>right</p></td><td><p>here</p></td></tr></tbody></table>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_table_inline_styles(self):
+        """Check that tables with inline styles are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "fhokc",
+                    "text": " ",
+                    "type": "atomic",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+                    "data": {
+                        "data": '{"cells":[[{"blocks":[{"key":"k8sb","text":"three","type":"unstyled","depth":0,"inline'
+                                'StyleRanges":[{"offset":0,"length":5,"style":"BOLD"}],"entityRanges":[],"data":{}}],"e'
+                                'ntityMap":{}},{"blocks":[{"key":"a25i9","text":"column","type":"unstyled","depth":0,"i'
+                                'nlineStyleRanges":[{"offset":0,"length":6,"style":"ITALIC"}],"entityRanges":[],"data":'
+                                '{}}],"entityMap":{}},{"blocks":[{"key":"ej3lv","text":"table","type":"unstyled","depth'
+                                '":0,"inlineStyleRanges":[{"offset":0,"length":5,"style":"UNDERLINE"}],"entityRanges":['
+                                '],"data":{}}],"entityMap":{}}],[{"blocks":[{"key":"f0qc0","text":"example","type":"uns'
+                                'tyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":7,"style":"SUBSCRIPT"}],"en'
+                                'tityRanges":[],"data":{}}],"entityMap":{}},{"blocks":[{"key":"50s2o","text":"right","t'
+                                'ype":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":5,"style":"SUPERSC'
+                                'RIPT"}],"entityRanges":[],"data":{}}],"entityMap":{}},{"blocks":[{"key":"escgd","text"'
+                                ':"here","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":4,"style'
+                                '":"STRIKETHROUGH"}],"entityRanges":[],"data":{}}],"entityMap":{}}]],"numRows":2,"numCo'
+                                'ls":3,"withHeader":false}'
+                    },
+                },
+                {
+                    "key": "2u79k",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {
+                "0": {
+                    "type": "TABLE",
+                    "mutability": "MUTABLE",
+                    "data": {
+                        "data": {
+                            "cells": [
+                                [
+                                    {
+                                        "blocks": [
+                                            {
+                                                "key": "k8sb",
+                                                "text": "three",
+                                                "type": "unstyled",
+                                                "depth": 0,
+                                                "inlineStyleRanges": [
+                                                    {"offset": 0, "length": 5, "style": "BOLD"}
+                                                ],
+                                                "entityRanges": [],
+                                                "data": {},
+                                            }
+                                        ],
+                                        "entityMap": {},
+                                    },
+                                    {
+                                        "blocks": [
+                                            {
+                                                "key": "a25i9",
+                                                "text": "column",
+                                                "type": "unstyled",
+                                                "depth": 0,
+                                                "inlineStyleRanges": [
+                                                    {"offset": 0, "length": 6, "style": "ITALIC"}
+                                                ],
+                                                "entityRanges": [],
+                                                "data": {},
+                                            }
+                                        ],
+                                        "entityMap": {},
+                                    },
+                                    {
+                                        "blocks": [
+                                            {
+                                                "key": "ej3lv",
+                                                "text": "table",
+                                                "type": "unstyled",
+                                                "depth": 0,
+                                                "inlineStyleRanges": [
+                                                    {"offset": 0, "length": 5, "style": "UNDERLINE"}
+                                                ],
+                                                "entityRanges": [],
+                                                "data": {},
+                                            }
+                                        ],
+                                        "entityMap": {},
+                                    },
+                                ],
+                                [
+                                    {
+                                        "blocks": [
+                                            {
+                                                "key": "f0qc0",
+                                                "text": "example",
+                                                "type": "unstyled",
+                                                "depth": 0,
+                                                "inlineStyleRanges": [
+                                                    {"offset": 0, "length": 7, "style": "SUBSCRIPT"}
+                                                ],
+                                                "entityRanges": [],
+                                                "data": {},
+                                            }
+                                        ],
+                                        "entityMap": {},
+                                    },
+                                    {
+                                        "blocks": [
+                                            {
+                                                "key": "50s2o",
+                                                "text": "right",
+                                                "type": "unstyled",
+                                                "depth": 0,
+                                                "inlineStyleRanges": [
+                                                    {"offset": 0, "length": 5, "style": "SUPERSCRIPT"}
+                                                ],
+                                                "entityRanges": [],
+                                                "data": {},
+                                            }
+                                        ],
+                                        "entityMap": {},
+                                    },
+                                    {
+                                        "blocks": [
+                                            {
+                                                "key": "escgd",
+                                                "text": "here",
+                                                "type": "unstyled",
+                                                "depth": 0,
+                                                "inlineStyleRanges": [
+                                                    {"offset": 0, "length": 4, "style": "STRIKETHROUGH"}
+                                                ],
+                                                "entityRanges": [],
+                                                "data": {},
+                                            }
+                                        ],
+                                        "entityMap": {},
+                                    },
+                                ],
+                            ],
+                            "numRows": 2,
+                            "numCols": 3,
+                            "withHeader": False,
+                        }
+                    },
+                }
+            },
+        }
+
+        expected = (
+            '<table><tbody><tr><td><p><b>three</b></p></td><td><p><i>column</i></p></td><td><p><u>table</u></p></td></t'
+            'r><tr><td><p><sub>example</sub></p></td><td><p><sup>right</sup></p></td><td><p><s>here</s></p></td></tr></'
+            'tbody></table>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_table_none(self):
+        """Check that a table with None value in a cell is generated correctly"""
+
+        draftjs_data = self.create_table(
+            cols=3,
+            rows=2,
+            cells=[
+                ['a', None, 'c'],
+                ['d', 'e', 'f'],
+            ],
+        )
+
+        expected = (
+            '<table><tbody><tr><td><p>a</p></td><td></td><td><p>c</p></td></tr><tr><td><p>d</p></td><td><p>e</p></td><t'
+            'd><p>f</p></td></tr></tbody></table>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_table_single(self):
+        """Check that a table with a single row is generated correctly"""
+
+        draftjs_data = self.create_table(
+            cols=3,
+            rows=1,
+            cells=[
+                ['a', 'b', 'c'],
+            ],
+        )
+
+        expected = (
+            '<table><tbody><tr><td><p>a</p></td><td><p>b</p></td><td><p>c</p></td></tr></tbody></table>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_table_header(self):
+        """Check that a table with header is generated correctly"""
+
+        draftjs_data = self.create_table(
+            cols=3,
+            rows=3,
+            with_header=True,
+            cells=[
+                ['a', None, 'c'],
+                ['d', 'e', 'f'],
+                ['g', 'h', 'i'],
+            ],
+        )
+
+        expected = (
+            '<table><thead><tr><th><p>a</p></th><th></th><th><p>c</p></th></tr></thead><tbody><tr><td><p>d</p></td><td>'
+            '<p>e</p></td><td><p>f</p></td></tr><tr><td><p>g</p></td><td><p>h</p></td><td><p>i</p></td></tr></tbody></t'
+            'able>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_table_header_single_row(self):
+        """Check that a table with header and single row is generated correctly"""
+
+        draftjs_data = self.create_table(
+            cols=3,
+            rows=1,
+            with_header=True,
+            cells=[
+                ['a', 'b', 'c'],
+            ],
+        )
+
+        expected = (
+            '<table><thead><tr><th><p>a</p></th><th><p>b</p></th><th><p>c</p></th></tr></thead></table>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_table_empty(self):
+        """Check that an empty table is generated correctly"""
+
+        draftjs_data = self.create_table(
+            cols=3,
+            rows=2,
+            cells=[],
+        )
+
+        expected = (
+            '<table><tbody><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr></tbody></table>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_image(self):
+        """Check that images are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "fi1d",
+                    "text": " ",
+                    "type": "atomic",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+                    "data": {},
+                },
+                {
+                    "key": "60vvd",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {
+                "0": {
+                    "type": "MEDIA",
+                    "mutability": "MUTABLE",
+                    "data": {
+                        "media": {
+                            "flags": {
+                                "marked_for_not_publication": False,
+                                "marked_for_sms": False,
+                                "marked_archived_only": False,
+                                "marked_for_legal": False,
+                            },
+                            "language": "en",
+                            "_updated": "2019-03-28T17:26:54+0000",
+                            "description_text": "pin dec",
+                            "source": "Superdesk",
+                            "type": "picture",
+                            "priority": 6,
+                            "_current_version": 2,
+                            "versioncreated": "2019-03-28T17:26:54+0000",
+                            "task": {
+                                "stage": "5c374805149f116db6aae6ad",
+                                "user": "5acb79292e03ed5d2a84bbd6",
+                                "desk": "5c374805149f116db6aae6af",
+                            },
+                            "urgency": 3,
+                            "alt_text": "pin alt",
+                            "_created": "2019-03-28T17:26:53+0000",
+                            "genre": [{"name": "Article (news)", "qcode": "Article"}],
+                            "guid": "tag:localhost:5000:2019:9df37ab0-4d96-4f95-8da5-06b744ef8604",
+                            "renditions": {
+                                "baseImage": {
+                                    "width": 933,
+                                    "mimetype": "image/jpeg",
+                                    "href": "http://localhost:5000/api/upload-raw/5c9d03de149f116747b67317.jpg",
+                                    "media": "5c9d03de149f116747b67317",
+                                    "height": 1400,
+                                },
+                                "thumbnail": {
+                                    "width": 79,
+                                    "mimetype": "image/jpeg",
+                                    "href": "http://localhost:5000/api/upload-raw/5c9d03de149f116747b67319.jpg",
+                                    "media": "5c9d03de149f116747b67319",
+                                    "height": 120,
+                                },
+                                "viewImage": {
+                                    "width": 426,
+                                    "mimetype": "image/jpeg",
+                                    "href": "http://localhost:5000/api/upload-raw/5c9d03de149f116747b6731b.jpg",
+                                    "media": "5c9d03de149f116747b6731b",
+                                    "height": 640,
+                                },
+                                "original": {
+                                    "width": 3648,
+                                    "mimetype": "image/jpeg",
+                                    "href": "http://localhost:5000/api/upload-raw/5c9d03dd149f116747b6730f.jpg",
+                                    "media": "5c9d03dd149f116747b6730f",
+                                    "height": 5472,
+                                },
+                            },
+                            "state": "in_progress",
+                            "expiry": None,
+                            "byline": None,
+                            "headline": "A picture of pineapple",
+                            "_etag": "a2c443900319548148e9073b9c5cc4c76c9331c5",
+                            "_id": "urn:newsml:localhost:5000:2019-03-28T18:26:53.805271:f47e37fd-a6bd-4a5e-b91d-01b581"
+                                   "f04e8c",
+                            "_type": "archive",
+                            "_links": {
+                                "self": {
+                                    "title": "Archive",
+                                    "href": "archive/urn:newsml:localhost:5000:2019-03-28T18:26:53.805271:f47e37fd-a6bd"
+                                            "-4a5e-b91d-01b581f04e8c",
+                                }
+                            },
+                            "_latest_version": 2,
+                            "selected": False,
+                        }
+                    },
+                }
+            },
+        }
+
+        expected = (
+            '<!-- EMBED START Image {id: "editor_0"} -->\n'
+            '<figure><img alt="pin alt" src="http://localhost:5000/api/upload-raw/5c9d03dd149f116747b6730f.jpg">'
+            '<figcaption>pin dec</figcaption></figure>\n'
+            '<!-- EMBED END Image {id: "editor_0"} -->'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_image_without_alt_and_desc(self):
+        """Check that images without alt text and description are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "fi1d",
+                    "text": " ",
+                    "type": "atomic",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+                    "data": {},
+                },
+                {
+                    "key": "60vvd",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {
+                "0": {
+                    "type": "MEDIA",
+                    "mutability": "MUTABLE",
+                    "data": {
+                        "media": {
+                            "flags": {
+                                "marked_for_not_publication": False,
+                                "marked_for_sms": False,
+                                "marked_archived_only": False,
+                                "marked_for_legal": False,
+                            },
+                            "language": "en",
+                            "_updated": "2019-03-28T17:26:54+0000",
+                            "source": "Superdesk",
+                            "type": "picture",
+                            "priority": 6,
+                            "_current_version": 2,
+                            "versioncreated": "2019-03-28T17:26:54+0000",
+                            "task": {
+                                "stage": "5c374805149f116db6aae6ad",
+                                "user": "5acb79292e03ed5d2a84bbd6",
+                                "desk": "5c374805149f116db6aae6af",
+                            },
+                            "urgency": 3,
+                            "_created": "2019-03-28T17:26:53+0000",
+                            "genre": [{"name": "Article (news)", "qcode": "Article"}],
+                            "guid": "tag:localhost:5000:2019:9df37ab0-4d96-4f95-8da5-06b744ef8604",
+                            "renditions": {
+                                "baseImage": {
+                                    "width": 933,
+                                    "mimetype": "image/jpeg",
+                                    "href": "http://localhost:5000/api/upload-raw/5c9d03de149f116747b67317.jpg",
+                                    "media": "5c9d03de149f116747b67317",
+                                    "height": 1400,
+                                },
+                                "thumbnail": {
+                                    "width": 79,
+                                    "mimetype": "image/jpeg",
+                                    "href": "http://localhost:5000/api/upload-raw/5c9d03de149f116747b67319.jpg",
+                                    "media": "5c9d03de149f116747b67319",
+                                    "height": 120,
+                                },
+                                "viewImage": {
+                                    "width": 426,
+                                    "mimetype": "image/jpeg",
+                                    "href": "http://localhost:5000/api/upload-raw/5c9d03de149f116747b6731b.jpg",
+                                    "media": "5c9d03de149f116747b6731b",
+                                    "height": 640,
+                                },
+                                "original": {
+                                    "width": 3648,
+                                    "mimetype": "image/jpeg",
+                                    "href": "http://localhost:5000/api/upload-raw/5c9d03dd149f116747b6730f.jpg",
+                                    "media": "5c9d03dd149f116747b6730f",
+                                    "height": 5472,
+                                },
+                            },
+                            "state": "in_progress",
+                            "expiry": None,
+                            "byline": None,
+                            "headline": "A picture of pineapple",
+                            "_etag": "a2c443900319548148e9073b9c5cc4c76c9331c5",
+                            "_id": "urn:newsml:localhost:5000:2019-03-28T18:26:53.805271:f47e37fd-a6bd-4a5e-b91d-01b581"
+                                   "f04e8c",
+                            "_type": "archive",
+                            "_links": {
+                                "self": {
+                                    "title": "Archive",
+                                    "href": "archive/urn:newsml:localhost:5000:2019-03-28T18:26:53.805271:f47e37fd-a6bd"
+                                            "-4a5e-b91d-01b581f04e8c",
+                                }
+                            },
+                            "_latest_version": 2,
+                            "selected": False,
+                        }
+                    },
+                }
+            },
+        }
+
+        expected = (
+            '<!-- EMBED START Image {id: "editor_0"} -->\n'
+            '<figure><img alt="" src="http://localhost:5000/api/upload-raw/5c9d03dd149f116747b6730f.jpg">'
+            '</figure>\n'
+            '<!-- EMBED END Image {id: "editor_0"} -->'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_unordered_list(self):
+        """Check that unordered lists are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": "The name of",
+                    "type": "unordered-list-item",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "fgkp6",
+                    "text": "Highlaws comes",
+                    "type": "unordered-list-item",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "6g9h6",
+                    "text": "from the Old English",
+                    "type": "unordered-list-item",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "7v7b1",
+                    "text": "hēah-hlāw",
+                    "type": "unordered-list-item",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {},
+        }
+
+        expected = (
+            '<ul><li>The name of</li><li>Highlaws comes</li><li>from the Old English</li><li>hēah-hlāw</li></ul>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_ordered_list(self):
+        """Check that ordered lists are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": "The name of",
+                    "type": "ordered-list-item",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "fgkp6",
+                    "text": "Highlaws comes",
+                    "type": "ordered-list-item",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "6g9h6",
+                    "text": "from the Old English",
+                    "type": "ordered-list-item",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "7v7b1",
+                    "text": "hēah-hlāw",
+                    "type": "ordered-list-item",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {},
+        }
+
+        expected = (
+            '<ol><li>The name of</li><li>Highlaws comes</li><li>from the Old English</li><li>hēah-hlāw</li></ol>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_mixing_ordered_unordered_lists(self):
+        """Check that a mix of ordered and unordered lists are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": "The name of Highlaws comes from the Old English",
+                    "type": "ordered-list-item",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "6oe0d",
+                    "text": 'hēah-hlāw, meaning "high mounds". In the past, variant',
+                    "type": "unordered-list-item",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "aegg",
+                    "text": "spellings included Heelawes, Hielawes, Highlows,",
+                    "type": "ordered-list-item",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "a1qv7",
+                    "text": "Hielows, and Hylaws.",
+                    "type": "ordered-list-item",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {},
+        }
+
+        expected = (
+            '<ol><li>The name of Highlaws comes from the Old English</li></ol><ul><li>hēah-hlāw, meaning "high mounds".'
+            ' In the past, variant</li></ul><ol><li>spellings included Heelawes, Hielawes, Highlows,</li><li>Hielows, a'
+            'nd Hylaws.</li></ol>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_embed(self):
+        """Check that an embed is converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                },
+                {
+                    "key": "2s495",
+                    "text": " ",
+                    "type": "atomic",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+                    "data": {},
+                },
+                {
+                    "key": "egj1u",
+                    "text": "",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {
+                "0": {
+                    "type": "EMBED",
+                    "mutability": "MUTABLE",
+                    "data": {
+                        "data": {
+                            "url": "https://www.youtube.com/watch?v=G5-KJgVsoUM",
+                            "type": "video",
+                            "version": "1.0",
+                            "title": "Mother Mother - It's Alright",
+                            "author": "MotherMotherVEVO",
+                            "author_url": "https://www.youtube.com/channel/UCVzJrFuVWzf8mPiuV3o2_pQ",
+                            "provider_name": "YouTube",
+                            "description":
+                                "Music video by Mother Mother performing It's Alright. © 2019 Mother Mother Music Inc.,"
+                                ' under exclusive license to Universal Music Canada Inc.\\n\\nhttp://vevo.ly/V49vkg\n',
+
+                            "thumbnail_url": "https://i.ytimg.com/vi/G5-KJgVsoUM/maxresdefault.jpg",
+                            "thumbnail_width": 1280,
+                            "thumbnail_height": 720,
+                            "html":
+                                '<div><div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: '
+                                '56.2493%;"><iframe src="//cdn.iframe.ly/api/iframe?url=https%3A%2F%2Fwww.youtube.com%2'
+                                'Fwatch%3Fv%3DG5-KJgVsoUM&amp;key=87ca3314a9fa775b5c3a7726100694b0" style="border: 0; t'
+                                'op: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen scroll'
+                                'ing="no" allow="autoplay; encrypted-media"></iframe></div></div>',
+                            "cache_age": 86400,
+                        }
+                    },
+                }
+            },
+        }
+
+        expected = (
+            '<div class="embed-block"><div><div style="left: 0; width: 100%; height: 0; position: relative; padding-bot'
+            'tom: 56.2493%;"><iframe src="//cdn.iframe.ly/api/iframe?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DG5'
+            '-KJgVsoUM&amp;key=87ca3314a9fa775b5c3a7726100694b0" style="border: 0; top: 0; left: 0; width: 100%; height'
+            ': 100%; position: absolute;" allowfullscreen scrolling="no" allow="autoplay; encrypted-media"></iframe></d'
+            'iv></div></div>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_nested_inline_styles(self):
+        """Check that nested inline styles are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text":
+                        'The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds". In the past,'
+                        ' variant spellings included Heelawes, Hielawes, Highlows, Hielows, and Hylaws.',
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [
+                        {"offset": 4, "length": 43, "style": "BOLD"},
+                        {"offset": 21, "length": 5, "style": "UNDERLINE"},
+                        {"offset": 32, "length": 3, "style": "ITALIC"},
+                    ],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                }
+            ],
+            "entityMap": {},
+        }
+
+        expected = (
+            '<p>The <b>name of Highlaws </b><b><u>comes</u></b><b> from </b><b><i>the</i></b><b> Old English</b> hēah-h'
+            'lāw, meaning "high mounds". In the past, variant spellings included Heelawes, Hielawes, Highlows, Hielows,'
+            ' and Hylaws.</p>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_overlapping_inline(self):
+        """Check that overlapping inline styles are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text":
+                        'The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds". In the past,'
+                        ' variant spellings included Heelawes, Hielawes, Highlows, Hielows, and Hylaws.',
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [
+                        {"offset": 0, "length": 66, "style": "BOLD"},
+                        {"offset": 4, "length": 89, "style": "ITALIC"},
+                        {"offset": 27, "length": 142, "style": "UNDERLINE"},
+                        {"offset": 165, "length": 5, "style": "SUPERSCRIPT"},
+                    ],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                }
+            ],
+            "entityMap": {},
+        }
+
+        expected = (
+            '<p><b>The </b><b><i>name of Highlaws comes </i></b><b><i><u>from the Old English hēah-hlāw, meaning</u></i'
+            '></b><i><u> "high mounds". In the past</u></i><u>, variant spellings included Heelawes, Hielawes, Highlows'
+            ', Hielows, and </u><sup><u>Hyla</u></sup><sup>w</sup>s.</p>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_overlapping_inline_with_links(self):
+        """Check that overlapping inline styles with links are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text":
+                        'The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds". In the past,'
+                        ' variant spellings included Heelawes, Hielawes, Highlows, Hielows, and Hylaws.',
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [
+                        {"offset": 12, "length": 14, "style": "BOLD"},
+                        {"offset": 55, "length": 6, "style": "BOLD"},
+                        {"offset": 48, "length": 18, "style": "UNDERLINE"},
+                    ],
+                    "entityRanges": [
+                        {"offset": 21, "length": 10, "key": 0},
+                        {"offset": 36, "length": 21, "key": 1},
+                    ],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                }
+            ],
+            "entityMap": {
+                "0": {
+                    "type": "LINK",
+                    "mutability": "MUTABLE",
+                    "data": {"link": {"href": "https://en.wikipedia.org/wiki/Highlaws"}},
+                },
+                "1": {
+                    "type": "LINK",
+                    "mutability": "MUTABLE",
+                    "data": {"link": {"href": "https://en.wikipedia.org/wiki/Highlaws"}},
+                },
+            },
+        }
+
+        expected = (
+            '<p>The name of <b>Highlaws </b><a href="https://en.wikipedia.org/wiki/Highlaws"><b>comes</b> from</a> the '
+            '<a href="https://en.wikipedia.org/wiki/Highlaws">Old English <u>hēah-hl</u><b><u>āw</u></b></a><b><u>, me<'
+            '/u></b><u>aning</u> "high mounds". In the past, variant spellings included Heelawes, Hielawes, Highlows, H'
+            'ielows, and Hylaws.</p>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_attachment(self):
+        """Check that attachments are converted to HTML correctly"""
+
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": 'The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds".',
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [{"offset": 12, "length": 8, "key": 0}],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                }
+            ],
+            "entityMap": {
+                "0": {
+                    "type": "LINK",
+                    "mutability": "MUTABLE",
+                    "data": {"link": {"attachment": "5c9dd26d149f114c61d84db0"}},
+                }
+            },
+        }
+
+        expected = (
+            '<p>The name of <a data-attachment="5c9dd26d149f114c61d84db0">Highlaws</a> comes from the Old English hēah-'
+            'hlāw, meaning "high mounds".</p>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_lists(self):
+        """Check that lists are correctly generated"""
+
+        draftjs_data = self.blocks_with_text([
+            ['unordered-list-item', 0, '1'],
+            ['unordered-list-item', 0, '2'],
+            ['unordered-list-item', 1, '11'],
+            ['unordered-list-item', 1, '22'],
+            ['unordered-list-item', 1, '3'],
+            ['unordered-list-item', 2, '4'],
+            ['unordered-list-item', 2, '5'],
+            ['unordered-list-item', 3, '6'],
+            ['unordered-list-item', 3, '6.5'],
+            ['unordered-list-item', 2, 'x'],
+            ['unordered-list-item', 1, '7'],
+            ['unordered-list-item', 1, '33'],
+            ['unordered-list-item', 0, '8'],
+        ])
+
+        expected = (
+            '<ul><li>1</li><li>2<ul><li>11</li><li>22</li><li>3<ul><li>4</li><li>5<ul><li>6</li><li>6.5</li></ul></li><'
+            'li>x</li></ul></li><li>7</li><li>33</li></ul></li><li>8</li></ul>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_lists_ending_abruptly(self):
+        """Check that lists ending abruptly are correctly generated"""
+
+        draftjs_data = self.blocks_with_text([
+            ['unordered-list-item', 0, '1'],
+            ['unordered-list-item', 1, '2'],
+            ['unordered-list-item', 2, '3'],
+            ['unordered-list-item', 3, '4'],
+            ['unstyled', 0, 'abc'],
+        ])
+
+        expected = (
+            '<ul><li>1<ul><li>2<ul><li>3<ul><li>4</li></ul></li></ul></li></ul></li></ul><p>abc</p>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_annotation(self):
+        """Check that annotations are correctly generated"""
+
+        draftjs_data = {
+            "entityMap": {},
+            "blocks": [
+                {
+                    "inlineStyleRanges": [
+                        {"length": 5, "style": "ANNOTATION-1", "offset": 6},
+                        {"length": 5, "style": "ANNOTATION-2", "offset": 12},
+                    ],
+                    "data": {
+                        "MULTIPLE_HIGHLIGHTS": {
+                            "lastHighlightIds": {"ANNOTATION": 2},
+                            "highlightsData": {
+                                "ANNOTATION-1": {
+                                    "data": {
+                                        "email": "admin@admin.ro",
+                                        "date": "2018-03-30T14:57:53.172Z",
+                                        "msg":
+                                            '{"blocks":[{"key":"ejm11","text":"Annotation 1","type":"unstyled","depth":'
+                                            '0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}',
+                                        "author": "admin",
+                                        "annotationType": "regular",
+                                    },
+                                    "type": "ANNOTATION",
+                                },
+                                "ANNOTATION-2": {
+                                    "data": {
+                                        "email": "admin@admin.ro",
+                                        "date": "2018-03-30T14:58:20.876Z",
+                                        "msg":
+                                            '{"blocks":[{"key":"9i73f","text":"Annotation 2","type":"unstyled","depth":'
+                                            '0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"d3vb3","text'
+                                            '":"Line 2","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRange'
+                                            's":[],"data":{}}],"entityMap":{}}',
+                                        "author": "admin",
+                                        "annotationType": "regular",
+                                    },
+                                    "type": "ANNOTATION",
+                                },
+                            },
+                        },
+                    },
+                    "text": "lorem ipsum dolor",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "key": "2sso6",
+                    "entityRanges": [],
+                }
+            ],
+        }
+        expected = (
+            '<p>lorem <span annotation-id="1">ipsum</span> <span annotation-id="2">dolor</span></p>'
+        )
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_embed_prepend(self):
+        """Check that an embed block can be prepended"""
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "fcbn3",
+                    "text": 'The name of Highlaws comes from the Old English hēah-hlāw, meaning "high mounds".',
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {"MULTIPLE_HIGHLIGHTS": {}},
+                }
+            ],
+            "entityMap": {},
+        }
+        item = self.build_item(draftjs_data)
+        body_editor = Editor3Content(item)
+        embed_html = '<p class="some_class">some embedded HTML</p>'
+        body_editor.prepend('embed', embed_html)
+        body_editor.update_item()
+        expected = (
+            '<div class="embed-block"><p class="some_class">some embedded HTML</p></div><p>The name of Highlaws comes f'
+            'rom the Old English hēah-hlāw, meaning "high mounds".</p>'
+        )
+        self.assertEqual(item['body_html'], expected)


### PR DESCRIPTION
…ith `editor3`

This patch introduce `editor_utils` module which contains classes to
manipulate the internal state of editors, to be able to modify HTML in
fields like `body_html` or `headline` from backend.

The classes offer a common interface to modify the HTML, for now only
editor3 is supported, and the internal `fields_meta` is updated when
needed. Check /docs for details.

SDESK-4799