### PR TITLE
fix binary image ingest

### DIFF
--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -541,7 +541,7 @@ def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=N
         rend = item.get('renditions', {})
         if rend:
             baseImageRend = rend.get('baseImage') or next(iter(rend.values()))
-            if baseImageRend:
+            if baseImageRend and not baseImageRend.get('media'):  # if there is media should be processed already
                 href = feeding_service.prepare_href(baseImageRend['href'], rend.get('mimetype'))
                 update_renditions(item, href, old_item)
 

--- a/superdesk/io/feed_parsers/image_iptc.py
+++ b/superdesk/io/feed_parsers/image_iptc.py
@@ -68,8 +68,8 @@ class ImageIPTCFeedParser(FileFeedParser):
         content_type = mimetypes.guess_type(image_path)[0]
         guid = utils.generate_guid(type=GUID_TAG)
         item = {'guid': guid,
+                'uri': guid,
                 config.VERSION: 1,
-                config.ID_FIELD: guid,
                 ITEM_TYPE: CONTENT_TYPE.PICTURE,
                 'mimetype': content_type,
                 'versioncreated': utcnow(),

--- a/tests/io/feed_parsers/image_iptc_test.py
+++ b/tests/io/feed_parsers/image_iptc_test.py
@@ -31,6 +31,7 @@ class ImageIPTCTestCase(BaseImageIPTCTestCase):
 
     def test_content(self):
         item = self.item
+        self.assertNotIn('_id', item)
         self.assertEqual(item['headline'], 'The Headline (ref2017.1)')
         self.assertEqual(item['byline'], 'Creator1 (ref2017.1)')
         self.assertEqual(item['slugline'], 'The Title (ref2017.1)')


### PR DESCRIPTION
- avoid populating `_id` which raises exception if same file is ingested again
- avoid generating renditions 2x