### PR TITLE
fix item.extra mapping

### DIFF
--- a/features/extra.feature
+++ b/features/extra.feature
@@ -1,0 +1,15 @@
+Feature: item.extra storage
+
+    @auth
+    Scenario: It can store any data
+        When we post to "/archive"
+        """
+        {"type": "text", "version": 1, "extra": {"foo": "2019-12-17T10:37:00+0000"}}
+        """
+        Then we get OK response
+
+        When we post to "/archive"
+        """
+        {"type": "text", "version": 1, "extra": {"foo": ""}}
+        """
+        Then we get OK response

--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -588,9 +588,7 @@ metadata_schema = {
 
     'extra': {
         'type': 'dict',
-        'mapping': {
-            'type': 'object',
-        }
+        'mapping': not_enabled,
     },
 
     'attachments': {


### PR DESCRIPTION
disable it by default so there are no mapper exceptions
when storing date like fields and empty strings later