### PR TITLE
set default pagination to match limit

### DIFF
--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -89,7 +89,14 @@ BANDWIDTH_SAVER = False
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%S+0000'
 ELASTIC_DATE_FORMAT = '%Y-%m-%d'
 ELASTIC_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
+
 PAGINATION_LIMIT = 200
+
+#: keep default in sync with limit - so when client does not use pagination return all
+#:
+#: .. versionadded:: 1.33
+#:
+PAGINATION_DEFAULT = PAGINATION_LIMIT
 
 LOG_CONFIG_FILE = env('LOG_CONFIG_FILE', 'logging_config.yml')
 LOG_SERVER_ADDRESS = env('LOG_SERVER_ADDRESS', 'localhost')

--- a/tests/pagination_test.py
+++ b/tests/pagination_test.py
@@ -1,0 +1,18 @@
+
+from flask import json
+from superdesk.tests import TestCase, setup_auth_user
+
+
+class PaginationTestCase(TestCase):
+    headers = [('Content-Type', 'application/json')]
+
+    def test_default_pagination(self):
+        setup_auth_user(self)
+        self.app.data.insert('stages', [{'name': 'stage{}'.format(i)} for i in range(300)])
+
+        response = self.client.get('/api/stages', headers=self.headers)
+        self.assertEqual(200, response.status_code)
+
+        data = json.loads(response.get_data())
+        self.assertEqual(200, len(data['_items']))
+        self.assertEqual(300, data['_meta']['total'])


### PR DESCRIPTION
allowing client to fetch more items by default
without explicit pagination when it assumes it gets all.

SDBELGA-265