### PR TITLE
[FEEDING SERVICES][FTP] Don't move file on failed ingestion before ba…

### DIFF
--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -645,7 +645,7 @@ FTP_INGEST_FILES_LIST_LIMIT = 100
 #:
 #: .. versionadded:: 1.32.2
 #:
-FILE_INGEST_OLD_CONTENT_MINUTES = 10
+INGEST_OLD_CONTENT_MINUTES = 10
 
 #: default timeout for email connections
 EMAIL_TIMEOUT = 10

--- a/superdesk/io/feeding_services/file_service.py
+++ b/superdesk/io/feeding_services/file_service.py
@@ -11,21 +11,18 @@
 import logging
 import os
 import shutil
-from datetime import timedelta, datetime
-
+from datetime import datetime
 from lxml import etree
 from flask import current_app as app
 from superdesk.errors import IngestFileError, ParserError, ProviderError
 from superdesk.io.registry import register_feeding_service
 from superdesk.io.feed_parsers import XMLFeedParser
-from superdesk.io.feeding_services import FeedingService
+from superdesk.io.feeding_services import FeedingService, OLD_CONTENT_MINUTES
 from superdesk.notification import push_notification
-from superdesk.utc import utc, utcnow
+from superdesk.utc import utc
 from superdesk.utils import get_sorted_files, FileSortAttributes
 
 logger = logging.getLogger(__name__)
-
-OLD_CONTENT_MINUTES = 'FILE_INGEST_OLD_CONTENT_MINUTES'
 
 
 class FileFeedingService(FeedingService):
@@ -61,6 +58,16 @@ class FileFeedingService(FeedingService):
             raise IngestFileError.isNotDirError()
 
     def _update(self, provider, update):
+        # check if deprecated FILE_INGEST_OLD_CONTENT_MINUTES setting is still used
+        if "FILE_INGEST_OLD_CONTENT_MINUTES" in app.config:
+            deprecated_cont_min = app.config["FILE_INGEST_OLD_CONTENT_MINUTES"]
+            cont_min = app.config[OLD_CONTENT_MINUTES]
+            if deprecated_cont_min != cont_min:
+                logger.warning(
+                    "'FILE_INGEST_OLD_CONTENT_MINUTES' is deprecated, please update settings.py to use {new_name!r}"
+                    .format(new_name=OLD_CONTENT_MINUTES))
+                app.config[OLD_CONTENT_MINUTES] = deprecated_cont_min
+
         self.provider = provider
         self.path = provider.get('config', {}).get('path', None)
 
@@ -149,25 +156,6 @@ class FileFeedingService(FeedingService):
             raise IngestFileError.fileMoveError(ex, provider)
         finally:
             os.remove(os.path.join(file_path, filename))
-
-    def is_latest_content(self, last_updated, provider_last_updated=None):
-        """
-        Parse file only if it's not older than provider last update -10m
-        """
-
-        if not provider_last_updated:
-            provider_last_updated = utcnow() - timedelta(days=7)
-
-        return provider_last_updated - timedelta(minutes=app.config[OLD_CONTENT_MINUTES]) < last_updated
-
-    def is_old_content(self, last_updated):
-        """Test if file is old so it wouldn't probably work in is_latest_content next time.
-
-        Such files can be moved to `_ERROR` folder, it wouldn't be ingested anymore.
-
-        :param last_updated: file last updated datetime
-        """
-        return last_updated < utcnow() - timedelta(minutes=app.config[OLD_CONTENT_MINUTES])
 
     def get_last_updated(self, file_path):
         """Get last updated time for file.

--- a/superdesk/io/feeding_services/ftp.py
+++ b/superdesk/io/feeding_services/ftp.py
@@ -121,8 +121,13 @@ class FTPFeedingService(FeedingService):
             else:
                 raise IngestFtpError.ftpError(ex, provider)
 
-    def _move(self, ftp, src, dest):
+    def _move(self, ftp, src, dest, file_modify, failed):
         """Move distant file
+
+        file won't be moved if it is failed and last modification was made
+        recently enough (i.e. before config's INGEST_OLD_CONTENT_MINUTES is
+        expired). In other words, if a file fails, it will be tried again until
+        INGEST_OLD_CONTENT_MINUTES delay expires.
 
         :param ftp: FTP instance to use
         :type ftp: ftplib.FTP
@@ -130,7 +135,16 @@ class FTPFeedingService(FeedingService):
         :type src: str
         :param dest: dest path of the file to move
         :type dest: str
+        :param file_modify: date of last file modification
+        :type file_modify: datetime
+        :param failed: True if something when wrong during ingestion
+        :type failed: bool
         """
+        if failed and not self.is_old_content(file_modify):
+            logger.warning(
+                "{src!r} ingestion failed, but we are in the backstop delay, it will be "
+                "tried again next time".format(src=src))
+            return
         try:
             ftp.rename(src, dest)
         except ftplib.all_errors as e:
@@ -270,7 +284,6 @@ class FTPFeedingService(FeedingService):
                 self._log_msg("Connected to FTP server. Exec time: {:.4f} secs.".format(
                     self._timer.stop('ftp_connect')
                 ))
-                items = []
                 files_to_process = []
                 files = self._sort_files(self._list_files(ftp, provider))
 
@@ -320,13 +333,17 @@ class FTPFeedingService(FeedingService):
 
                         if do_move:
                             move_dest_file_path = os.path.join(move_path if not failed else move_path_error, filename)
-                            self._move(ftp, filename, move_dest_file_path)
+                            self._move(
+                                ftp, filename, move_dest_file_path, file_modify,
+                                failed=failed)
                     except Exception as e:
                         logger.error("Error while parsing {filename}: {msg}".format(filename=filename, msg=e))
 
                         if do_move:
                             move_dest_file_path_error = os.path.join(move_path_error, filename)
-                            self._move(ftp, filename, move_dest_file_path_error)
+                            self._move(
+                                ftp, filename, move_dest_file_path_error, file_modify,
+                                failed=True)
 
                 self._log_msg(
                     "Processing finished. Exec time: {:.4f} secs.".format(self._timer.stop('start_processing'))


### PR DESCRIPTION
…ckstop delay

If a file can't be ingested with FTP, it will be tried again until
`INGEST_OLD_CONTENT_MINUTES` delay expires. The last modification date
is used to check when backstop delay. The behaviour is the same as for
file feeding service.

The `FILE_INGEST_OLD_CONTENT_MINUTES` setting has been renamed to
`INGEST_OLD_CONTENT_MINUTES` has it is now used both for `file` and
`ftp` feeding services (and maybe others in the future).

SDESK-4834