### PR TITLE
[SDESK-4869] (1.32) Allow display_name to be formatted on ldap authentication

### DIFF
--- a/apps/ldap/ldap.py
+++ b/apps/ldap/ldap.py
@@ -178,6 +178,11 @@ class ADAuthService(AuthService):
 
         user = superdesk.get_resource_service('users').find_one(req=None, **query)
 
+        if app.settings.get('LDAP_SET_DISPLAY_NAME', False) and 'display_name' in user_data \
+                and all(f in user_data for f in app.settings.get('LDAP_SET_DISPLAY_NAME_FIELDS', [])):
+            user_data['display_name'] = app.settings.get('LDAP_SET_DISPLAY_NAME_FORMAT', '').format(
+                *[user_data.get(f) for f in app.settings.get('LDAP_SET_DISPLAY_NAME_FIELDS', [])])
+
         if not user:
             add_default_values(user_data, profile_to_import,
                                user_type=None if 'user_type' not in user_data else user_data['user_type'])

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -370,6 +370,13 @@ LDAP_USER_ATTRIBUTES = json.loads(env('LDAP_USER_ATTRIBUTES',
                                       '"displayName": "display_name", "mail": "email", '
                                       '"ipPhone": "phone"}'))
 
+#: Enable the ability for the display name of the user to be overridden with Superdesk user attributes
+LDAP_SET_DISPLAY_NAME = strtobool(env('LDAP_SET_DISPLAY_NAME', 'False'))
+#: List of Superdesk user attributes passed to the format method
+LDAP_SET_DISPLAY_NAME_FIELDS = json.loads(env('LDAP_SET_DISPLAY_NAME_FIELDS', '["first_name", "last_name"]'))
+#: Format for the user display name
+LDAP_SET_DISPLAY_NAME_FORMAT = env('LDAP_SET_DISPLAY_NAME_FORMAT', '{} {}')
+
 if LDAP_SERVER:
     CORE_APPS.append('apps.ldap')
 else:


### PR DESCRIPTION
* Cherry-picked from v1.33 (https://github.com/superdesk/superdesk-core/pull/1782)