### PR TITLE
SDESK-4947 Do not publish locked associated items during correction.

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -544,14 +544,16 @@ class BasePublishService(BaseService):
                 if doc.get('lock_user'):
                     if original_item['lock_user'] != doc['lock_user']:
                         validation_errors.extend([
-                            '{}: packaged item is locked by another user'.format(
-                                doc.get('headline', doc['_id'])
+                            '{}: {}'.format(
+                                doc.get('headline', doc['_id']),
+                                _('packaged item is locked by another user')
                             )
                         ])
                     elif original_item['lock_user'] == doc['lock_user']:
                         validation_errors.extend([
-                            '{}: packaged item is locked by you. Unlock it and try again'.format(
-                                doc.get('headline', doc['_id'])
+                            '{}: {}'.format(
+                                doc.get('headline', doc['_id']),
+                                _('packaged item is locked by you. Unlock it and try again')
                             )
                         ])
 

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -488,7 +488,7 @@ class BasePublishService(BaseService):
             updates = {}
 
         # merge associations
-        associations = original_item.get(ASSOCIATIONS, {})
+        associations = deepcopy(original_item.get(ASSOCIATIONS, {}))
         associations.update(updates.get(ASSOCIATIONS, {}))
 
         items = [value for value in associations.values()]

--- a/features/publish_embedded.feature
+++ b/features/publish_embedded.feature
@@ -198,7 +198,7 @@ Feature: Publish embedded items feature
 
         When we patch "archive/#archive._id#"
         """
-        {"slugline": "bike"}
+        {"slugline": "bike", "pubstatus" : "usable"}
         """
         Then we get OK response
 
@@ -207,6 +207,8 @@ Feature: Publish embedded items feature
         {"headline": "foo", "associations": {
             "embedded1": {
                 "_id": "#archive._id#",
+                "slugline": "bike",
+                "pubstatus" : "usable",
                 "type": "picture",
                 "headline": "test",
                 "alt_text": "alt_text",
@@ -281,7 +283,7 @@ Feature: Publish embedded items feature
 
         When we patch "archive/#archive._id#"
         """
-        {"slugline": "bike"}
+        {"slugline": "bike", "pubstatus" : "usable"}
         """
         Then we get OK response
 
@@ -291,6 +293,8 @@ Feature: Publish embedded items feature
             "embedded1": {
                 "_id": "#archive._id#",
                 "type": "picture",
+                "slugline": "bike",
+                "pubstatus" : "usable",
                 "headline": "test",
                 "alt_text": "alt_text",
                 "description_text": "description_text",
@@ -375,6 +379,7 @@ Feature: Publish embedded items feature
                 "embedded1": {
                     "_id": "#archive._id#",
                     "type": "picture",
+                    "pubstatus" : "usable",
                     "headline": "test",
                     "alt_text": "alt_text",
                     "description_text": "description_text",
@@ -393,7 +398,7 @@ Feature: Publish embedded items feature
 
         When we patch "archive/#archive._id#"
         """
-        {"slugline": "bike"}
+        {"slugline": "bike", "pubstatus" : "usable"}
         """
         Then we get OK response
 
@@ -404,6 +409,8 @@ Feature: Publish embedded items feature
                 "_id": "#archive._id#",
                 "type": "picture",
                 "headline": "test",
+                "slugline": "bike",
+                "pubstatus" : "usable",
                 "alt_text": "alt_text",
                 "description_text": "description_text",
                 "state": "in_progress"}}}


### PR DESCRIPTION
SDESK-4947
- don't validate _if an associated item is locked_ during publishing if PUBLISH_ASSOCIATED_ITEMS is false
- use associations from `original_item` merged with`updates` during `_validate_associated_items` 