### PR TITLE
fix babel get locale selector

### DIFF
--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -163,12 +163,12 @@ def get_app(config=None, media_storage=None, config_object=None, init_elastic=No
         user_language = user.get('language', app.config.get('DEFAULT_LANGUAGE', 'en'))
         try:
             # Attempt to load the local using Babel.parse_local
-            parse_locale(user_language)
+            parse_locale(user_language.replace('-', '_'))
         except ValueError:
             # If Babel fails to recognise the locale, then use the default language
             user_language = app.config.get('DEFAULT_LANGUAGE', 'en')
 
-        return user_language
+        return user_language.replace('-', '_')
 
     set_error_handlers(app)
 


### PR DESCRIPTION
babel expects format like en_US not en-US as we do