### PR TITLE
[EDITOR UTILS] embed pre-processing + fixed HTML parsing:

### DIFF
--- a/docs/editor.rst
+++ b/docs/editor.rst
@@ -48,3 +48,15 @@ show how to add an embedded code at the top of the body::
        body_editor.prepend('embed', '<p class="some_class">some embedded HTML to
        prepend</p>')
        body_editor.update_item()
+
+Rendering customisation
+=======================
+
+Sometimes, you may want to modify the behavior of the renderer.
+
+embeds
+------
+
+Embeds can be modified before being rendered. For that, the ``EMBED_PRE_PROCESS`` setting
+can be used. It is an iterable linking to callable. Each callable will get the data dict
+where the ``html`` key contains the raw HTML, so it can modify it.

--- a/superdesk/etree.py
+++ b/superdesk/etree.py
@@ -14,6 +14,7 @@ from lxml.etree import ParseError  # noqa
 from lxml import html
 from superdesk import config
 
+
 # from https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements
 BLOCK_ELEMENTS = (
     "address",
@@ -114,8 +115,13 @@ def parse_html(html, content='xml', lf_on_block=False, space_on_elements=False):
         if root is None:
             root = etree.Element('div')
         else:
-            root = root.find('body')
-            root.tag = 'div'
+            div = etree.Element('div')
+            # we unwrap elements in <head> and <body>
+            # <script> can be used in embed, and the parser will move them to <head>
+            # so we need both <head> and <body>
+            for elt in root:
+                div.extend(elt)
+            root = div
     else:
         raise ValueError('invalid content: {}'.format(content))
     if lf_on_block:

--- a/superdesk/io/feed_parsers/ap_anpa.py
+++ b/superdesk/io/feed_parsers/ap_anpa.py
@@ -108,7 +108,7 @@ class AP_ANPAFeedParser(ANPAFeedParser):
             html = item.get('body_html')
             if html:
                 parsed = parse_html(html, content='html')
-                for par in parsed.xpath('/html/div/child::*'):
+                for par in parsed.xpath('/div/child::*'):
                     if not par.text:
                         continue
                     city, source, the_rest = par.text.partition(' (AP) _ ')
@@ -160,7 +160,7 @@ class AP_ANPAFeedParser(ANPAFeedParser):
             html = item.get('body_html')
             if html:
                 parsed = parse_html(html, content='html')
-                pars = parsed.xpath('/html/div/child::*')
+                pars = parsed.xpath('/div/child::*')
                 if pars and len(pars) > 0:
                     city, source, the_rest = pars[0].text.partition(' (AP) _ ')
                     if the_rest:


### PR DESCRIPTION
pre-processing of embed for customisation is now possible using
callables set in the new `EMBED_PRE_PROCESS` setting.

This patch also fix parsing of HTML, as part of the HTML could be lost
with DOM.parse_html + selecting only children (seen with QUMU embed).
As we use `lxml` as draftjs_exporter backend, we can use
`superdesk.etree.parse_html`.

SDESK-4939