### PR TITLE
improve signals for archive update/move

### DIFF
--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -26,6 +26,9 @@ Core Signals
 .. autodata:: item_update
     :annotation:
 
+.. autodata:: item_updated
+    :annotation:
+
 .. autodata:: item_publish
     :annotation:
 
@@ -33,6 +36,9 @@ Core Signals
     :annotation:
 
 .. autodata:: item_fetched
+    :annotation:
+
+.. autodata:: item_move
     :annotation:
 
 .. autodata:: item_moved

--- a/superdesk/signals.py
+++ b/superdesk/signals.py
@@ -13,7 +13,9 @@ __all__ = [
     'item_publish',
     'item_published',
     'item_update',
+    'item_updated',
     'item_fetched',
+    'item_move',
     'item_moved',
     'item_routed',
 ]
@@ -51,6 +53,15 @@ item_published = signals.signal('item:published')
 #: :param original: original item version
 item_update = signals.signal('item:update')
 
+#: Sent after new version is saved.
+#:
+#: .. versionadded:: 1.33
+#:
+#: :param sender: ArchiveService
+#: :param item: updated item
+#: :param original: original item version
+item_updated = signals.signal('item:updated')
+
 #: Sent after item is fetched.
 #:
 #: .. versionadded:: 1.29
@@ -59,6 +70,15 @@ item_update = signals.signal('item:update')
 #: :param item: fetched item in production
 #: :param ingest_item: item in ingest
 item_fetched = signals.signal('item:fetched')
+
+#: Sent before item is moved to different desk/stage.
+#:
+#: .. versionadded:: 1.33
+#:
+#: :param sender: MoveService
+#: :param item: item after moving
+#: :param original: item before moving
+item_move = signals.signal('item:move')
 
 #: Sent after item is moved to different desk/stage.
 #:


### PR DESCRIPTION
- make sure `item_update/item_updated` is always called
- add `item_move` signal before item is moved to new place
- make sure mark for user notification is always sent

SDBELGA-314