### PR TITLE
Fix: Don't store replaced image's metadata in the newly uploaded image. [SDESK-4764]

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -156,6 +156,43 @@ def flush_renditions(updates, original):
                         updates[ASSOCIATIONS][key]['renditions'][old_rendition] = None
 
 
+def flush_previous_item_keys_from_associations(updates, original):
+    """Remove original association items keys from updated association item
+        if the association key is same and associated items _id is diffrent.
+    for ex:
+        1. Add an image to a articles body and save the article where let's say key is(association.edior_0)
+        2. Remove the associated image don't save artilce this time
+        3. And add a new media item wehere key is still (association.edior_0)
+        4. save the article and notice that new associated item contains all those keys from previous associated
+            items that were not present in this one.
+        Which is wrong, this function identifies those keys and sets them to None
+    :param dict updates: updates for the document
+    :param original: original is document
+    """
+    if not original.get(ASSOCIATIONS) or not updates.get(ASSOCIATIONS):
+        return
+
+    for key in [k for k in updates[ASSOCIATIONS] if k in original[ASSOCIATIONS]]:
+        if original[ASSOCIATIONS].get(key) and updates[ASSOCIATIONS].get(key) and (
+           updates[ASSOCIATIONS][key].get('_id') != original[ASSOCIATIONS][key].get('_id')):
+            # make sure associated item's "_id" are different in updates and original
+            for item_key in original[ASSOCIATIONS][key]:
+                present_in_updates = True
+                if item_key not in updates[ASSOCIATIONS][key]:
+                    present_in_updates = False
+                    updates[ASSOCIATIONS][key][item_key] = None
+
+                # handle the nested dict inside associations key
+                if isinstance(original[ASSOCIATIONS][key][item_key], dict):
+                    if not present_in_updates:
+                        updates[ASSOCIATIONS][key][item_key] = {}
+                    # handles situation like ex: original['associations']['foo']['extra'] = {'foo': 1}
+                    # and updates['associations']['foo']['extra'] = {'bar': 1}
+                    # output will be updates['associations']['foo']['extra'] = {'bar': 1, 'foo': None}
+                    for k in original[ASSOCIATIONS][key][item_key]:
+                        updates[ASSOCIATIONS][key][item_key][k] = None
+
+
 class ArchiveVersionsResource(Resource):
     schema = item_schema()
     extra_response_fields = extra_response_fields
@@ -313,6 +350,7 @@ class ArchiveService(BaseService):
         self._add_desk_metadata(updates, original)
         self._handle_media_updates(updates, original, user)
         flush_renditions(updates, original)
+        flush_previous_item_keys_from_associations(updates, original)
 
     def _handle_media_updates(self, updates, original, user):
         update_associations(updates)

--- a/features/archive.feature
+++ b/features/archive.feature
@@ -1116,3 +1116,29 @@ Feature: News Items Archive
         """
         {"associations": {"foo--1": {"headline": "flower", "byline": "foo", "description_text": "flower desc"}}}
         """
+
+    @auth
+    Scenario: Don't store replaced association items metadata into newly added association item
+        Given "archive"
+        """
+        [{"_id": "item-1", "guid": "item-1", "type": "text", "headline": "test", "state": "in_progress", "_type": "archive"
+        }]
+        """
+        When we patch given
+        """
+        {"associations": {"foo--1": {"headline": "flower", "_id": "123", "byline": "foo", "description_text": "flower desc", "_type": "archive", "credit_line": "to myself", "alt_text": "flower", "extra": {"foo": 1}}}}
+        """
+        When we get "/archive/item-1"
+        Then we get existing resource
+        """
+        {"associations": {"foo--1": {"headline": "flower", "_id": "123", "byline": "foo", "description_text": "flower desc", "credit_line": "to myself", "alt_text": "flower", "extra": {"foo": 1}}}}
+        """
+        When we patch latest
+        """
+        {"associations": {"foo--1": {"headline": "rose", "_id": "125", "description_text": "rose desc", "_type": "externalsource", "extra": {"bar": 1}}}}
+        """
+        When we get "/archive/item-1"
+        Then we get existing resource
+        """
+        {"associations": {"foo--1": {"headline": "rose", "description_text": "rose desc", "byline": "__none__", "credit_line": "__none__", "alt_text": "__none__", "extra": {"foo": "__none__", "bar": 1}}}}
+        """


### PR DESCRIPTION
sets all extra keys value to None