### PR TITLE
[SDBELGA-324] Handle empty document on ingest

### DIFF
--- a/superdesk/io/feeding_services/file_service.py
+++ b/superdesk/io/feeding_services/file_service.py
@@ -85,6 +85,9 @@ class FileFeedingService(FeedingService):
                     last_updated = self.get_last_updated(file_path)
 
                     if self.is_latest_content(last_updated, provider.get('last_updated')):
+                        if self.is_empty(file_path):
+                            logger.info('Ignoring empty file {}'.format(filename))
+                            continue
                         if isinstance(registered_parser, XMLFeedParser):
                             with open(file_path, 'rb') as f:
                                 xml = etree.parse(f)
@@ -156,6 +159,11 @@ class FileFeedingService(FeedingService):
             raise IngestFileError.fileMoveError(ex, provider)
         finally:
             os.remove(os.path.join(file_path, filename))
+
+    def is_empty(self, file_path):
+        """Test if given file is empty, return True if file does not exist
+        """
+        return not (os.path.isfile(file_path) and os.path.getsize(file_path) > 0)
 
     def get_last_updated(self, file_path):
         """Get last updated time for file.

--- a/superdesk/io/feeding_services/file_service.py
+++ b/superdesk/io/feeding_services/file_service.py
@@ -161,7 +161,7 @@ class FileFeedingService(FeedingService):
             os.remove(os.path.join(file_path, filename))
 
     def is_empty(self, file_path):
-        """Test if given file is empty, return True if file does not exist
+        """Test if given file path is empty, return True if a file is empty
         """
         return not (os.path.isfile(file_path) and os.path.getsize(file_path) > 0)
 

--- a/superdesk/io/feeding_services/ftp.py
+++ b/superdesk/io/feeding_services/ftp.py
@@ -197,6 +197,11 @@ class FTPFeedingService(FeedingService):
         _, ext = os.path.splitext(filename)
         return ext.lower() in allowed_ext
 
+    def _is_empty(self, file_path):
+        """Test if given file is empty, return True if file does not exist
+        """
+        return not (os.path.isfile(file_path) and os.path.getsize(file_path) > 0)
+
     def _list_files(self, ftp, provider):
         self._timer.start('ftp_list')
         try:
@@ -296,6 +301,11 @@ class FTPFeedingService(FeedingService):
                     # filter by extension
                     if not self._is_allowed(filename, allowed_ext):
                         logger.info('ignoring file {filename} because of file extension'.format(filename=filename))
+                        continue
+
+                    file_path = os.path.join(config.get('dest_path', '/'), filename)
+                    if self._is_empty(file_path):
+                        logger.info('ignoring empty file {filename}'.format(filename=filename))
                         continue
 
                     # filter by modify datetime

--- a/superdesk/io/feeding_services/ftp.py
+++ b/superdesk/io/feeding_services/ftp.py
@@ -198,7 +198,7 @@ class FTPFeedingService(FeedingService):
         return ext.lower() in allowed_ext
 
     def _is_empty(self, file_path):
-        """Test if given file is empty, return True if file does not exist
+        """Test if given file path is empty, return True if a file is empty
         """
         return not (os.path.isfile(file_path) and os.path.getsize(file_path) > 0)
 

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -549,8 +549,10 @@ def run_update_ingest_ftp(*args):
         ftp_list_files_mock.return_value = (('ninjs1.json', '20181111123456'),
                                             ('ninjs2.json', '20181111123456'),
                                             ('ninjs3.json', '20181111123456'))
-        with mock.patch.object(ftp.FTPFeedingService, '_retrieve_and_parse') as retrieve_and_parse_mock:
+        with mock.patch.object(ftp.FTPFeedingService, '_retrieve_and_parse') as retrieve_and_parse_mock, \
+                mock.patch.object(ftp.FTPFeedingService, '_is_empty') as empty_file_mock:
             retrieve_and_parse_mock.side_effect = retrieve_and_parse_side_effect
+            empty_file_mock.return_value = False
             # run command
             update_ingest.UpdateIngest().run()
 

--- a/tests/io/feeding_services/ftp_tests.py
+++ b/tests/io/feeding_services/ftp_tests.py
@@ -170,6 +170,7 @@ class FTPTestCase(TestCase):
         """
         provider = copy.deepcopy(PROVIDER)
         service = ftp.FTPFeedingService()
+        service._is_empty = mock.MagicMock(return_value=False)
         ingest_items(service.update(provider, {}))
 
         mock_ftp = ftp_connect.return_value.__enter__.return_value
@@ -193,6 +194,7 @@ class FTPTestCase(TestCase):
         provider = copy.deepcopy(PROVIDER)
         provider['config']['ftp_move_path'] = ""
         service = ftp.FTPFeedingService()
+        service._is_empty = mock.MagicMock(return_value=False)
         ingest_items(service.update(provider, {}))
         mock_ftp = ftp_connect.return_value.__enter__.return_value
 
@@ -212,6 +214,7 @@ class FTPTestCase(TestCase):
         provider = copy.deepcopy(PROVIDER)
         provider['config']['ftp_move_path'] = ""
         service = ftp.FTPFeedingService()
+        service._is_empty = mock.MagicMock(return_value=False)
         ingest_items(service.update(provider, {}), False)
         mock_ftp = ftp_connect.return_value.__enter__.return_value
 
@@ -244,6 +247,7 @@ class FTPTestCase(TestCase):
         """Check that failing file is not moved if it's more recent thant INGEST_OLD_CONTENT_MINUTES"""
         provider = copy.deepcopy(PROVIDER)
         service = ftp.FTPFeedingService()
+        service._is_empty = mock.MagicMock(return_value=False)
         ingest_items(service.update(provider, {}))
         mock_ftp = ftp_connect.return_value.__enter__.return_value
 
@@ -265,6 +269,7 @@ class FTPTestCase(TestCase):
         """
         provider = copy.deepcopy(PROVIDER)
         service = ftp.FTPFeedingService()
+        service._is_empty = mock.MagicMock(return_value=False)
         ingest_items(service.update(provider, {}))
         mock_ftp = ftp_connect.return_value.__enter__.return_value
 
@@ -286,6 +291,7 @@ class FTPTestCase(TestCase):
         provider = copy.deepcopy(PROVIDER)
         provider['config']['move_path_error'] = ""
         service = ftp.FTPFeedingService()
+        service._is_empty = mock.MagicMock(return_value=False)
         ingest_items(service.update(provider, {}))
         mock_ftp = ftp_connect.return_value.__enter__.return_value
 
@@ -322,6 +328,7 @@ class FTPTestCase(TestCase):
         provider = copy.deepcopy(PROVIDER)
         provider['config']['move'] = False
         service = ftp.FTPFeedingService()
+        service._is_empty = mock.MagicMock(return_value=False)
         mock_ftp = ftp_connect.return_value.__enter__.return_value
 
         ingest_items(service.update(provider, update))
@@ -388,6 +395,7 @@ class FTPTestCase(TestCase):
         retrieve_and_parse, ftp_connect = mocks
         provider = copy.deepcopy(PROVIDER)
         service = ftp.FTPFeedingService()
+        service._is_empty = mock.MagicMock(return_value=False)
         mock_ftp = ftp_connect.return_value.__enter__.return_value
 
         ingest_items(service.update(provider, update))


### PR DESCRIPTION
From Karel
> ...Document is empty... error
this happens from time to time when a file is not saved on the server while the ingest is trying to process it. When it fails, ingest will retry and the file gets ingested in the end.

It also raises error when ingest file is empty, so we think you could use this to reproduce the error. The error is on file service but we think we should handle ftp service as well.

SDBELGA-324