### PR TITLE
disable MERGE_NESTED_DOCUMENTS

### DIFF
--- a/apps/content_types/content_types.py
+++ b/apps/content_types/content_types.py
@@ -108,6 +108,8 @@ class ContentTypesResource(superdesk.Resource):
         'default_sort': [('priority', -1)],
     }
 
+    merge_nested_documents = True
+
 
 class ContentTypesService(superdesk.Service):
     def _set_updated_by(self, doc):

--- a/apps/preferences.py
+++ b/apps/preferences.py
@@ -93,6 +93,7 @@ class PreferencesResource(Resource):
     allow_unknown = True
     resource_methods = []
     item_methods = ['GET', 'PATCH']
+    merge_nested_documents = True
 
     superdesk.register_default_user_preference('feature:preview', {
         'type': 'bool',

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -95,6 +95,7 @@ class BasePublishResource(ArchiveResource):
         self.item_methods = ['PATCH']
 
         self.privileges = {'PATCH': publish_type}
+
         super().__init__(endpoint_name, app=app, service=service)
 
 

--- a/apps/templates/content_templates.py
+++ b/apps/templates/content_templates.py
@@ -186,6 +186,8 @@ class ContentTemplatesResource(Resource):
                   'PATCH': CONTENT_TEMPLATE_PRIVILEGE,
                   'DELETE': CONTENT_TEMPLATE_PRIVILEGE}
 
+    merge_nested_documents = True
+
 
 class ContentTemplatesService(BaseService):
 

--- a/features/internal_destinations.feature
+++ b/features/internal_destinations.feature
@@ -732,7 +732,6 @@ Feature: Internal Destinations
             "pubstatus": "usable",
             "schedule_settings": {
                 "time_zone": "Europe/London",
-                "utc_embargo": null,
                 "utc_publish_schedule": "2099-05-19T10:15:00+0000"
             }
             }]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 LONG_DESCRIPTION = "Superdesk Server Core"
 
 install_requires = [
-    'eve>=1.1,<1.2',
+    'eve==1.1.1',
     'eve-elastic==2.5.0',
     'flask>=1.1,<1.2',
     'flask-oauthlib>=0.9.3,<0.10',

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -88,8 +88,9 @@ BANDWIDTH_SAVER = False
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%S+0000'
 ELASTIC_DATE_FORMAT = '%Y-%m-%d'
 ELASTIC_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
-
 PAGINATION_LIMIT = 200
+
+MERGE_NESTED_DOCUMENTS = False
 
 #: keep default in sync with limit - so when client does not use pagination return all
 #:

--- a/superdesk/resource.py
+++ b/superdesk/resource.py
@@ -68,6 +68,7 @@ class Resource():
     query_objectid_as_string = None
     soft_delete = None
     hateoas = None
+    merge_nested_documents = None
 
     def __init__(self, endpoint_name, app, service, endpoint_schema=None):
         self.endpoint_name = endpoint_name
@@ -118,6 +119,8 @@ class Resource():
                 endpoint_schema.update({'soft_delete': self.soft_delete})
             if self.hateoas is not None:
                 endpoint_schema.update({'hateoas': self.hateoas})
+            if self.merge_nested_documents is not None:
+                endpoint_schema.update({'merge_nested_documents': self.merge_nested_documents})
             if self.mongo_indexes:
                 # used in app:initialize_data
                 endpoint_schema['mongo_indexes__init'] = self.mongo_indexes


### PR DESCRIPTION
due to bug in eve it's enabled on archive publish resources where the versioning
doesn't work without it properly yet.

it's also enabled on few other resources where tests were failing (preferences/content_types)

SDESK-4764