### PR TITLE
Ability to change schema(s) from the instance settings

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -643,3 +643,33 @@ will use it for place field searching.
 .. autodata:: ARCHIVE_AUTOCOMPLETE
 .. autodata:: ARCHIVE_AUTOCOMPLETE_DAYS
 .. autodata:: ARCHIVE_AUTOCOMPLETE_HOURS
+
+.. _settings.extending:
+
+Extend Superdesk
+-----------------
+
+Additional settings which are allowed to change some Superdesk defaults
+
+``SCHEMA_UPDATE``
+
+Default: ``None``
+
+Allows to update a default schema.
+
+Example::
+
+    SCHEMA_UPDATE = {
+        'archive': {
+            'extra': {
+                'type': 'dict',
+                'schema': {},
+                'mapping': {
+                    'type': 'object',
+                    'enabled': True
+                },
+                'allow_unknown': True,
+            }
+        }
+    }
+

--- a/superdesk/resource.py
+++ b/superdesk/resource.py
@@ -125,6 +125,12 @@ class Resource():
                 # used in app:initialize_data
                 endpoint_schema['mongo_indexes__init'] = self.mongo_indexes
 
+            if app.config.get('SCHEMA_UPDATE', {}).get(self.endpoint_name):
+                schema_updates = app.config['SCHEMA_UPDATE'][self.endpoint_name]
+                log.warning('Updating {} schema with custom data for fields: {}'.format(
+                    self.endpoint_name.upper(), ', '.join(schema_updates.keys())))
+                self.schema.update(schema_updates)
+
         self.endpoint_schema = endpoint_schema
 
         on_fetched_resource = getattr(app, 'on_fetched_resource_%s' % self.endpoint_name)


### PR DESCRIPTION
~~⚠️ This is not a finished PR, more like a POC (it works).~~

 The use case for Belga is the ability to search/order using fields from `archive.extra` in production API using elastic search. By default mapping for `extra` is not enabled, so it would be handy to have an ability to update a schema from the instance settings.

I've tested this approach and it works just fine, the only action needed is to reindex es.

Do I need to add some restrictions? Like not allowing new fields for example. Personally, I wouldn't add it because this config is set up by devs.

Usage example:

`settings.py`
```
...
SCHEMA_UPDATE = {
    'archive': {
        'extra': {
            'type': 'dict',
            'schema': {},
            'mapping': {
                'type': 'object',
                'enabled': True
            },
            'allow_unknown': True,
        }
    }
}
...
```
 