### PR TITLE
Update PAPI to work with latest Eve.

### DIFF
--- a/prod_api/desks/resource.py
+++ b/prod_api/desks/resource.py
@@ -18,16 +18,10 @@ class DesksResource(Resource):
     item_url = item_url
     item_methods = ['GET']
     resource_methods = ['GET']
+    allow_unknown = True
     datasource = {
         'source': 'desks',
-        'default_sort': [('name', 1)],
-        'projection': {
-            # NOTE: since schema is not defined here, setting up a projection explicitly is required,
-            # otherwise default `eve` fields (projection) will be applied e.q. `{'_id': 1}`
-            # and it will cut off all required data.
-            # https://github.com/pyeve/eve/blob/afd573d9254a9a23393f35760e9c515300909ccd/eve/io/base.py#L420
-            'desk_metadata': 0
-        },
+        'default_sort': [('name', 1)]
     }
     privileges = {
         'GET': Scope.DESKS_READ.name

--- a/prod_api/planning/resources.py
+++ b/prod_api/planning/resources.py
@@ -18,13 +18,11 @@ class PlanningResource(Resource):
     item_url = item_url
     item_methods = ['GET']
     resource_methods = ['GET']
+    allow_unknown = True
     datasource = {
         'source': 'planning',
         'search_backend': 'elastic',
-        'default_sort': [('_updated', -1)],
-        'projection': {
-            'fields_meta': 0
-        },
+        'default_sort': [('_updated', -1)]
     }
     privileges = {
         'GET': Scope.PLANNING_READ.name
@@ -36,13 +34,11 @@ class EventsResource(Resource):
     item_url = item_url
     item_methods = ['GET']
     resource_methods = ['GET']
+    allow_unknown = True
     datasource = {
         'source': 'events',
         'search_backend': 'elastic',
-        'default_sort': [('_updated', -1)],
-        'projection': {
-            'fields_meta': 0
-        },
+        'default_sort': [('_updated', -1)]
     }
     privileges = {
         'GET': Scope.EVENTS_READ.name
@@ -54,13 +50,11 @@ class AssignmentsResource(Resource):
     item_url = item_url
     item_methods = ['GET']
     resource_methods = ['GET']
+    allow_unknown = True
     datasource = {
         'source': 'assignments',
         'search_backend': 'elastic',
-        'default_sort': [('_updated', -1)],
-        'projection': {
-            'fields_meta': 0
-        },
+        'default_sort': [('_updated', -1)]
     }
     privileges = {
         'GET': Scope.ASSIGNMENTS_READ.name
@@ -72,16 +66,10 @@ class EventsHistoryResource(Resource):
     item_url = item_url
     item_methods = ['GET']
     resource_methods = ['GET']
+    allow_unknown = True
     datasource = {
         'source': 'events_history',
-        'default_sort': [('_updated', -1)],
-        'projection': {
-            # NOTE: since schema is not defined here, setting up a projection explicitly is required,
-            # otherwise default `eve` fields (projection) will be applied e.q. `{'_id': 1}`
-            # and it will cut off all required data.
-            # https://github.com/pyeve/eve/blob/afd573d9254a9a23393f35760e9c515300909ccd/eve/io/base.py#L420
-            '_etag': 0
-        },
+        'default_sort': [('_updated', -1)]
     }
     privileges = {
         'GET': Scope.EVENTS_READ.name
@@ -93,16 +81,10 @@ class EventsFilesResource(Resource):
     item_url = item_url
     item_methods = ['GET']
     resource_methods = ['GET']
+    allow_unknown = True
     datasource = {
         'source': 'events_files',
-        'default_sort': [('_updated', -1)],
-        'projection': {
-            # NOTE: since schema is not defined here, setting up a projection explicitly is required,
-            # otherwise default `eve` fields (projection) will be applied e.q. `{'_id': 1}`
-            # and it will cut off all required data.
-            # https://github.com/pyeve/eve/blob/afd573d9254a9a23393f35760e9c515300909ccd/eve/io/base.py#L420
-            '_etag': 0
-        },
+        'default_sort': [('_updated', -1)]
     }
     privileges = {
         'GET': Scope.EVENTS_READ.name

--- a/prod_api/service.py
+++ b/prod_api/service.py
@@ -29,6 +29,7 @@ class ProdApiService(superdesk.Service):
         '_created',
         '_current_version',
         '_links',
+        'fields_meta',
     }
 
     def on_fetched(self, result):

--- a/prod_api/users/resource.py
+++ b/prod_api/users/resource.py
@@ -8,12 +8,10 @@ class UsersResource(Resource):
     item_url = item_url
     item_methods = ['GET']
     resource_methods = ['GET']
+    allow_unknown = True
     datasource = {
         'source': 'users',
-        'default_sort': [('username', 1)],
-        'projection': {
-            'user_preferences': 0
-        },
+        'default_sort': [('username', 1)]
     }
     privileges = {
         'GET': Scope.USERS_READ.name

--- a/prod_api/users/service.py
+++ b/prod_api/users/service.py
@@ -2,4 +2,9 @@ from ..service import ProdApiService
 
 
 class UsersService(ProdApiService):
-    pass
+    excluded_fields = \
+        {
+            'user_preferences',
+            'session_preferences',
+            'password',
+        } | ProdApiService.excluded_fields


### PR DESCRIPTION
After Eve update [this hack](https://github.com/superdesk/superdesk-core/blob/develop/prod_api/planning/resources.py#L79) does not work anymore, so only `_id` is returned for resources where a projection is not defined explicitly (eg items).
To make it work I've set [allow_unknown](https://github.com/pyeve/eve/blob/master/docs/validation.rst#allowing-the-unknown) to True for resources without explicit projection. Since our API is read-only it should not be an issue.
Unwanted data is removed from the response using [ProdApiService. excluded_fields] (https://github.com/superdesk/superdesk-core/blob/develop/prod_api/service.py#L25)

I've also removed  `'session_preferences', 'password'` (hash) from `user` response.