### PR TITLE
Update 00022_20200309-121947_archive.py

### DIFF
--- a/superdesk/data_updates/00022_20200309-121947_archive.py
+++ b/superdesk/data_updates/00022_20200309-121947_archive.py
@@ -21,15 +21,18 @@ class DataUpdate(DataUpdate):
     def forwards(self, mongodb_collection, mongodb_database):
         for resource in ('archive', 'published'):
             service = get_resource_service(resource)
-            for item in mongodb_database[resource].find({'associations': {'$exists': 'true', '$ne': {}}}):
+            for item in mongodb_database[resource].find({'associations': {'$exists': 'true', '$nin': [{}, None]}}):
                 update = False
                 associations = {}
-                for key, val in item['associations'].items():
-                    associations[key] = val
-                    if val and is_related_content(key) and val.get('order', None) is None:
-                        update = True
-                        order = int(key.split('--')[1])
-                        associations[key]['order'] = order
+                try:
+                    for key, val in item['associations'].items():
+                        associations[key] = val
+                        if val and is_related_content(key) and val.get('order', None) is None:
+                            update = True
+                            order = int(key.split('--')[1])
+                            associations[key]['order'] = order
+                except AttributeError:
+                    pass
                 if update:
                     try:
                         _id = ObjectId(item['_id'])


### PR DESCRIPTION
SDESK-5303
Supposed to fix:
```
ERROR:superdesk:'NoneType' object has no attribute 'items'
Traceback (most recent call last):
File "/opt/superdesk/env/lib/python3.5/site-packages/superdesk/_init.py", line 56, in __call_
res = self.run(*args, **kwargs)
File "/opt/superdesk/env/lib/python3.5/site-packages/superdesk/commands/data_updates.py", line 172, in run
module_scope.DataUpdate().apply('forwards')
File "/opt/superdesk/env/lib/python3.5/site-packages/superdesk/commands/data_updates.py", line 284, in apply
getattr(self, direction)(collection, db)
File "/opt/superdesk/env/lib/python3.5/site-packages/superdesk/data_updates/00022_20200309-121947_archive.py", line 27, in forwards
for key, val in item['associations'].items():
AttributeError: 'NoneType' object has no attribute 'items'
Sentry responded with an API error: RateLimited(None)
["'NoneType' object has no attribute 'items'", ' File "superdesk/__init__.py", line 56, in __call__', ' File "superdesk/commands/data_updates.py", line 172, in run', ' File "superdesk/commands/data_updates.py", line 284, in apply', ' File "/opt/superdesk/env/lib/python3.5/site-packages/superdesk/data_updates/00022_20200309-121947_archive.py", line 27, in forwards']
```