### PR TITLE
Fix clear session

### DIFF
--- a/apps/auth/service.py
+++ b/apps/auth/service.py
@@ -78,7 +78,7 @@ class UserSessionClearService(BaseService):
         If there are any orphan session_preferences exist they get deleted as well
         """
         users_service = get_resource_service('users')
-        user_id = request.view_args['user_id']
+        user_id = request.view_args['user']
         user = users_service.find_one(req=None, _id=user_id)
         sessions = get_resource_service('auth').get(req=None, lookup={'user': user_id})
 

--- a/apps/auth/sessions.py
+++ b/apps/auth/sessions.py
@@ -28,8 +28,9 @@ class SessionsResource(Resource):
 
 class UserSessionClearResource(Resource):
     endpoint_name = 'clear_sessions'
-    url = 'users/<{0}:user_id>/sessions'.format(item_url)
-    datasource = {'source': 'users'}
+    url = 'users/<{0}:user>/sessions'.format(item_url)
+    datasource = {'source': 'auth'}
     resource_methods = ['DELETE']
+    item_methods = []
     resource_title = endpoint_name
     privileges = {'DELETE': 'users'}


### PR DESCRIPTION
It seems like breaking changes which were applied in eve 0.8 had broken clear_session feature.

```
Be aware that DELETE on sub-resource endpoint will now only delete the documents matching endpoint semantics. A delete operation on people/51f63e0838345b6dcd7eabff/invoices will delete all documents matching the followig query: {'contact_id': '51f63e0838345b6dcd7eabff'} (#1010).
```
P.S. It's not fully clear for me what these changes are, but they broke clear_session subresource endpoint.

In case of clear session subresource https://docs.python-eve.org/en/stable/features.html#sub-resource `'users/<{0}:user_id>/sessions'`, eve 0.8+ is looking into `users` collection with lookup `{"user_id": <id>}`, which returns empty list  https://github.com/pyeve/eve/blob/master/eve/methods/delete.py#L224

In our case it must be `users` collection with lookup `{"_id": <id>}`, but I was not able to change a URL definition to `'users/<{0}:_id>/sessions'`, because `_id` is reserved (under the hood eve builds URL for subresource, expecting session item detail endpoint to be: `'users/<{0}:user_id>/sessions'/<_id>` ).

To avoid changing URL pattern, I've decided to use `auth` collection with `user` lookup. I think it makes sense because at the end we want to delete a record from `auth` collection and not from the `user` .
