### PR TITLE
Required label for dateline field is missing for plain/text items. [SDESK-5313]

### DIFF
--- a/apps/validate/validate.py
+++ b/apps/validate/validate.py
@@ -376,11 +376,12 @@ class ValidateService(superdesk.Service):
         :param schema:
         :return:
         """
+
         if doc.get('flags', {}).get('marked_for_sms', False):
             doc['sms'] = doc.get('sms_message', '')
         else:
             # remove it from the valiadation it is not required
-            schema.pop('sms', None)
+            schema.pop('sms', None) if schema.get('sms') else schema.pop('sms_message', None)
 
     def _process_media_metadata(self, doc, schema):
         """Request media validation if associations is present


### PR DESCRIPTION
For plain/text items, we have the `sms_message` field not the `sms` field.