### PR TITLE
add index for archive versions doc id

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -168,7 +168,10 @@ class ArchiveVersionsResource(Resource):
     resource_methods = []
     internal_resource = True
     privileges = {'PATCH': 'archive'}
-    mongo_indexes = {'guid': ([('guid', 1)], {'background': True})}
+    mongo_indexes = {
+        'guid': ([('guid', 1)], {'background': True}),
+        '_id_document_1': ([('_id_document', 1)], {'background': True}),
+    }
 
 
 class ArchiveVersionsService(BaseService):


### PR DESCRIPTION
it's causing an error on pro instances:

```
Sort operation used more than the maximum 33554432 bytes of RAM. Add an index, or specify a smaller limit.
```