### PR TITLE
Add action type to macros.

### DIFF
--- a/apps/macros/macros.py
+++ b/apps/macros/macros.py
@@ -112,4 +112,8 @@ class MacrosResource(superdesk.Resource):
             'type': 'string',
             'readonly': True,
         },
+        'action_type': {
+            'type': 'string',
+            'readonly': True,
+        },
     }


### PR DESCRIPTION
We need `action_type` because at the time of the routing scheme, we check for the `action_type` and filter out the macros.