### PR TITLE
[DESKS] new endpoint to get overview

### DIFF
--- a/apps/desks.py
+++ b/apps/desks.py
@@ -11,13 +11,14 @@ import json
 import itertools
 
 import superdesk
-from flask import current_app as app
+from flask import current_app as app, request
 
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError
 from superdesk.resource import Resource
 from superdesk import config
 from superdesk.utils import SuperdeskBaseEnum
+from superdesk.timer import timer
 from bson.objectid import ObjectId
 from superdesk.services import BaseService
 from superdesk.notification import push_notification
@@ -135,6 +136,9 @@ def init_app(app):
     endpoint_name = 'sluglines'
     service = SluglineDeskService(endpoint_name, backend=superdesk.get_backend())
     SluglineDesksResource(endpoint_name, app=app, service=service)
+    endpoint_name = 'stages_overview'
+    service = StagesOverviewService(endpoint_name, backend=superdesk.get_backend())
+    StagesOverviewResource(endpoint_name, app=app, service=service)
 
 
 superdesk.privilege(name='desks', label='Desk Management', description='User can manage desks.')
@@ -545,6 +549,43 @@ class SluglineDeskService(BaseService):
                 else:
                     return (True, [])
         return (False, older_sluglines)
+
+
+class StagesOverviewResource(Resource):
+    url = r'desks/<regex("([a-f0-9]{24})|all"):desk_id>/stages_overview'
+    resource_title = "desk_stages_overview"
+    resource_methods = ['GET']
+
+
+class StagesOverviewService(BaseService):
+    """Aggregate count of items per stage"""
+
+    def on_fetched(self, doc):
+        desk_id = request.view_args['desk_id']
+        if desk_id == 'all':
+            agg_query = {}
+        else:
+            agg_query = {
+                "filter": {
+                    "term": {"task.desk": desk_id}
+                }
+            }
+
+        agg_query['aggs'] = {
+            "stages": {
+                "terms": {
+                    "field": "task.stage"
+                }
+            }
+        }
+
+        with timer("stages overview aggregation {desk_id!r}".format(desk_id=desk_id)):
+            response = app.data.elastic.search(agg_query, "archive", params={"size": 0})
+
+        doc["_items"] = [
+            {'count': b['doc_count'], 'stage': b['key']}
+            for b in response.hits['aggregations']['stages']['buckets']
+        ]
 
 
 def remove_profile_from_desks(item):

--- a/features/desks.feature
+++ b/features/desks.feature
@@ -410,3 +410,66 @@ Feature: Desks
         """
         {"slugline": "x", "headline": "sports", "anpa_category": [{"qcode": "sport"}]}
         """
+
+    @auth
+    @notification
+    Scenario: Retrieve number of items with desk stages overview
+        Given we have "desks" with "SPORTS_DESK_ID" and success
+        """
+        [{"name": "Sports", "desk_type": "authoring"}]
+        """
+        And we have "desks" with "POLITICS_DESK_ID" and success
+        """
+        [{"name": "Politics", "desk_type": "authoring"}]
+        """
+        Given "archive"
+         """
+         [
+         {"_id":"1","slugline": "slugline1", "state": "draft",
+         "task": {"desk": "#SPORTS_DESK_ID#", "stage": "#desks.working_stage#"}, "headline": "one", "family_id": 1},
+         {"_id":"2","slugline": "slugline2", "state": "draft",
+         "task": {"desk": "#SPORTS_DESK_ID#", "stage": "#desks.working_stage#"}, "place": null, "headline": "two",
+         "family_id": 2},
+         {"_id":"3","slugline": "slugline3", "last_published_version": "True", "state": "published",
+         "task": {"desk": "#SPORTS_DESK_ID#", "stage": "#desks.incoming_stage#"}, "place": null, "headline": "three",
+         "family_id": 2},
+         {"_id":"4","slugline": "slugline4", "last_published_version": "True", "state": "published",
+         "task": {"desk": "#POLITICS_DESK_ID#", "stage": "#desks.incoming_stage#"}, "place": null, "headline": "four",
+         "family_id": 2},
+         {"_id":"5","slugline": "slugline5", "state": "draft",
+         "task": {"desk": "#POLITICS_DESK_ID#", "stage": "#desks.incoming_stage#"}, "place": null, "headline": "five",
+         "family_id": 2}
+         ]
+         """
+        When we get "/desks/#SPORTS_DESK_ID#/stages_overview"
+        Then we get existing resource
+        """
+            {
+                "_items": [
+                    {
+                        "stage": "#desks.incoming_stage#",
+                        "count": 1
+                    },
+                    {
+                        "stage": "#desks.working_stage#",
+                        "count": 2
+                    }
+                ]
+            }
+        """
+        When we get "/desks/all/stages_overview"
+        Then we get existing resource
+        """
+            {
+                "_items": [
+                    {
+                        "stage": "#desks.incoming_stage#",
+                        "count": 3
+                    },
+                    {
+                        "stage": "#desks.working_stage#",
+                        "count": 2
+                    }
+                ]
+            }
+        """


### PR DESCRIPTION
by checking `desks/DESK_ID/stages_overview`, a count of items per stage can be
retrieved.
If `all` is used for `DESK_ID`, the a count of items for all desks is
retrieved.

SDESK-5208