### PR TITLE
[INTERNAL DESTINATION] fixed duplication of packages

### DIFF
--- a/superdesk/internal_destinations.py
+++ b/superdesk/internal_destinations.py
@@ -89,7 +89,7 @@ def handle_item_published(sender, item, **extra):
                     continue
 
         extra_fields = [PUBLISH_SCHEDULE, SCHEDULE_SETTINGS]
-        next_id = archive_service.duplicate_content(new_item, state='routed', extra_fields=extra_fields)
+        next_id = archive_service.duplicate_item(new_item, state='routed', extra_fields=extra_fields)
         next_item = archive_service.find_one(req=None, _id=next_id)
         item_routed.send(sender, item=next_item)
 


### PR DESCRIPTION
while a package was going through internal destination, it was sent to
`duplicate_content` which is also duplicating items of the packages, but
those items were already published individually before.

This patch fixes it by calling directly `duplicate_item` which is not
duplicating items of the package.

fixes SDESK-5371