### PR TITLE
Include all schema items in default search projection + archive_item

### DIFF
--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -253,7 +253,7 @@ class SearchResource(superdesk.Resource):
     schema = get_schema(versioning=True)
     schema.update(published_item_fields)
     datasource = {
-        'projection': {field:1 for field in list(schema.keys()) + ['archive_item']}
+        'projection': {field: 1 for field in list(schema.keys()) + ['archive_item']}
     }
 
 

--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -252,6 +252,9 @@ class SearchResource(superdesk.Resource):
     item_url = item_url
     schema = get_schema(versioning=True)
     schema.update(published_item_fields)
+    datasource = {
+        'projection': {field:1 for field in list(schema.keys()) + ['archive_item']}
+    }
 
 
 def init_app(app):


### PR DESCRIPTION
Don't exclude `archive_item`s from the response payload.
The best option is to disable projection for a search resource, but it requires https://github.com/pyeve/eve/pull/1398 fix.