### PR TITLE
FIX: language is reset in metadata section of the template when making changes in parent content profile. [SDCP-265]

### DIFF
--- a/apps/content_types/content_types.py
+++ b/apps/content_types/content_types.py
@@ -180,6 +180,8 @@ class ContentTypesService(superdesk.Service):
         Finds the templates that are referencing the given
         content profile an clears the disabled fields
         """
+
+        # these are the only fields of templates that don't depend on the schema.
         template_metadata_fields = ['language', 'usageterms']
 
         templates = list(superdesk.get_resource_service('content_templates').

--- a/apps/content_types/content_types.py
+++ b/apps/content_types/content_types.py
@@ -188,7 +188,7 @@ class ContentTypesService(superdesk.Service):
             schema = updates.get('schema', {})
             processed = False
             for field, params in schema.items():
-                if not params or not params.get('enabled', True):
+                if (not params or not params.get('enabled', True)) and not data.get(field):
                     data.pop(field, None)
                     processed = True
             if processed:

--- a/apps/content_types/content_types.py
+++ b/apps/content_types/content_types.py
@@ -180,6 +180,8 @@ class ContentTypesService(superdesk.Service):
         Finds the templates that are referencing the given
         content profile an clears the disabled fields
         """
+        template_metadata_fields = ['language', 'usageterms']
+
         templates = list(superdesk.get_resource_service('content_templates').
                          get_templates_by_profile_id(original.get('_id')))
 
@@ -188,7 +190,7 @@ class ContentTypesService(superdesk.Service):
             schema = updates.get('schema', {})
             processed = False
             for field, params in schema.items():
-                if (not params or not params.get('enabled', True)) and not data.get(field):
+                if (not params or not params.get('enabled', True)) and field not in template_metadata_fields:
                     data.pop(field, None)
                     processed = True
             if processed:

--- a/features/content_profile.feature
+++ b/features/content_profile.feature
@@ -1834,3 +1834,68 @@ Feature: Content Profile
         """
         {"_status": "ERR", "_issues": {"item_type": "Only 1 instance is allowed."}}
         """
+
+    @auth
+    Scenario: Updating the content profile doesn't change template metadata
+        Given "content_types"
+        """
+        [{"_id": "foo", "label": "Foo", "schema": {
+            "headline": {
+                "maxlength" : 64,
+                "type" : "string",
+                "required" : false,
+                "nullable" : true
+            },
+            "slugline" : {
+                "type" : "string",
+                "nullable" : true,
+                "maxlength" : 24,
+                "required" : false
+            },
+            "place": {"default": [{"name": "Prague"}]}
+        }}]
+        """
+        And "content_templates"
+        """
+        [{
+            "template_name": "foo",
+            "data": {
+                "slugline": "Testing the slugline",
+                "headline": "Testing the headline",
+                "profile": "foo",
+                "language": "fr"
+            }
+        }]
+        """
+        When we patch "content_types/foo"
+        """
+        {"schema": {
+            "headline": null,
+            "slugline" : {
+                "type" : "string",
+                "nullable" : true,
+                "maxlength" : 24,
+                "required" : false
+            },
+            "language": null,
+            "place": {"default": [{"name": "Prague"}]}
+        }}
+        """
+        Then we get updated response
+        """
+        {"updated_by": "#CONTEXT_USER_ID#"}
+        """
+        When we get "content_templates"
+        Then we get list with 1 items
+        """
+        {"_items": [{
+            "template_name": "foo",
+            "data": {
+                "slugline": "Testing the slugline",
+                "profile": "foo",
+                "language": "fr"
+            }
+          }]
+        }
+        """
+        And there is no "headline" in data


### PR DESCRIPTION
We keep updating the template with the new schema without checking if there is any metadata value present before.