### PR TITLE
Correcting an author profile fails when uploading a photo. [SDFID-603]

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -670,11 +670,11 @@ class BasePublishService(BaseService):
                 continue
 
             if type(associated_item) == dict and associated_item.get(config.ID_FIELD):
-
                 if not config.PUBLISH_ASSOCIATED_ITEMS or not publish_service:
-                    # Not allowed to publish
-                    original[ASSOCIATIONS][associations_key]['state'] = self.published_state
-                    original[ASSOCIATIONS][associations_key]['operation'] = self.publish_type
+                    if original.get(ASSOCIATIONS, {}).get(associations_key):
+                        # Not allowed to publish
+                        original[ASSOCIATIONS][associations_key]['state'] = self.published_state
+                        original[ASSOCIATIONS][associations_key]['operation'] = self.publish_type
                     continue
 
                 # if item is not fetchable, only mark it as published

--- a/features/content_publish.feature
+++ b/features/content_publish.feature
@@ -4090,3 +4090,137 @@ Feature: Content Publishing
             }
         }
         """
+
+    @auth
+    Scenario: Send correction with adding a featuremedia
+      Given config update
+      """
+      { "PUBLISH_ASSOCIATED_ITEMS": false}
+      """
+      And "vocabularies"
+      """
+      [{
+        "_id": "crop_sizes",
+        "unique_field": "name",
+        "items": [
+          {"is_active": true, "name": "original", "width": 800, "height": 600}
+        ]
+      }
+      ]
+      """
+      And "validators"
+      """
+      [
+          {"_id": "publish_text", "act": "publish", "type": "text", "schema":{}},
+          {"_id": "correct_text", "act": "correct", "type": "text", "schema":{}},
+          {"_id": "publish_picture", "act": "publish", "type": "picture", "schema": {}},
+          {"_id": "correct_picture", "act": "correct", "type": "picture", "schema": {}}
+      ]
+      """
+      And "desks"
+      """
+      [{"name": "Sports"}]
+      """
+      And "archive"
+      """
+      [
+          {
+            "guid": "123",
+            "type": "text",
+            "headline": "test",
+            "state": "in_progress",
+            "task": {
+              "desk": "#desks._id#",
+              "stage": "#desks.incoming_stage#",
+              "user": "#CONTEXT_USER_ID#"
+              },
+            "subject":
+              [
+                {"qcode": "17004000",
+                "name": "Statistics"}
+              ],
+            "body_html": "Test Document body",
+            "_current_version": 1
+          },
+          {
+              "guid": "234",
+              "type": "picture",
+              "slugline": "234",
+              "headline": "234",
+              "state": "in_progress",
+              "task": {
+                "desk": "#desks._id#",
+                "stage": "#desks.incoming_stage#",
+                "user": "#CONTEXT_USER_ID#"
+              },
+              "renditions": {
+                  "original": {"CropLeft": 0, "CropRight": 800, "CropTop": 0, "CropBottom": 600}
+              },
+              "_current_version": 1
+          }
+      ]
+      """
+      When we post to "/products" with success
+      """
+      {
+          "name":"prod-1","codes":"abc,xyz", "product_type": "both"
+      }
+      """
+      And we post to "/subscribers" with success
+      """
+      {
+        "name":"Channel 3","media_type":"media", "subscriber_type": "digital", "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
+        "products": ["#products._id#"],
+        "destinations":[{"name":"Test","format": "nitf", "delivery_type":"email","config":{"recipients":"test@test.com"}}]
+      }
+      """
+      When we publish "123" with "publish" type and "published" state
+      Then we get OK response
+      And we get existing resource
+      """
+      {
+        "_current_version": 2,
+        "type": "text",
+        "state": "published",
+        "task":{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}
+      }
+      """
+      When we publish "123" with "correct" type and "corrected" state
+      """
+      {
+        "associations": {
+          "featuremedia": {
+              "_id": "234",
+              "guid": "234",
+              "byline": "foo",
+              "alt_text": "alt_text",
+              "description_text": "description_text",
+              "headline": "234",
+              "renditions": {
+                    "original": {"CropLeft": 0, "CropRight": 800, "CropTop": 0, "CropBottom": 600}
+                  }
+              }
+          }
+      }
+      """
+      Then we get OK response
+      And we get existing resource
+      """
+      {
+        "_current_version": 3,
+        "state": "corrected",
+        "associations": {
+            "featuremedia": {
+              "_id": "234",
+              "guid": "234",
+              "byline": "foo",
+              "alt_text": "alt_text",
+              "description_text": "description_text",
+              "headline": "234",
+              "renditions": {
+                    "original": {"CropLeft": 0, "CropRight": 800, "CropTop": 0, "CropBottom": 600}
+                  }
+              }
+          }
+      }
+      """


### PR DESCRIPTION
The issue was `association` was missing in the published item object if there isn't any associated item. So, on correction, it checks for `association` key in the original item while trying to change state and since it was missing we were getting the error.

I have introduced an extra check for that purpose now, so it won't throw any error if the `association` is missing.