### PR TITLE
make the default size of elastic query configurable

### DIFF
--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -88,6 +88,12 @@ BANDWIDTH_SAVER = False
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%S+0000'
 ELASTIC_DATE_FORMAT = '%Y-%m-%d'
 ELASTIC_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
+#: default size of elastic queries generated on server
+#: for saved search reports etc.
+#:
+#: .. versionadded:: 1.34
+#:
+ELASTIC_DEFAULT_SIZE = 10
 PAGINATION_LIMIT = 200
 
 MERGE_NESTED_DOCUMENTS = False

--- a/superdesk/es_utils.py
+++ b/superdesk/es_utils.py
@@ -15,7 +15,7 @@ import logging
 import json
 import pytz
 from datetime import datetime
-from superdesk import app
+from flask import current_app as app
 
 logger = logging.getLogger(__name__)
 
@@ -263,6 +263,7 @@ def filter2query(filter_, user_id=None):
         query["post_filter"] = {"bool": {"must": post_filter, "must_not": post_filter_must_not}}
 
     query["sort"] = {"versioncreated": "desc"}
+    query.setdefault('size', app.config['ELASTIC_DEFAULT_SIZE'])
 
     search_query.pop("repo", None)
 

--- a/tests/es_utils_test.py
+++ b/tests/es_utils_test.py
@@ -13,6 +13,7 @@ class ESUtilsTestCase(TestCase):
             },
             "post_filter": {"bool": {"must": [], "must_not": [{"terms": {"genre.name": ["Article (news)"]}}]}},
             "sort": {"versioncreated": "desc"},
+            "size": 10,
         }
 
         with self.app.app_context():
@@ -53,6 +54,7 @@ class ESUtilsTestCase(TestCase):
                 }
             },
             "sort": {"versioncreated": "desc"},
+            "size": 10,
         }
         with self.app.app_context():
             query = es_utils.filter2query(filter_)


### PR DESCRIPTION
we don't set size on saved searches as this can be changed
via ui, but then it's using 10 as a default and that might
not be enough for saved search report.