### PR TITLE
migration: Update usageterms schema_field on db

### DIFF
--- a/superdesk/data_updates/00024_20200909-142600_vocabularies.py
+++ b/superdesk/data_updates/00024_20200909-142600_vocabularies.py
@@ -23,4 +23,3 @@ class DataUpdate(DataUpdate):
 
     def backwards(self, mongodb_collection, mongodb_database):
         pass
-

--- a/superdesk/data_updates/00024_20200909-142600_vocabularies.py
+++ b/superdesk/data_updates/00024_20200909-142600_vocabularies.py
@@ -16,10 +16,10 @@ class DataUpdate(DataUpdate):
     resource = 'vocabularies'
 
     def forwards(self, mongodb_collection, mongodb_database):
-      for vocabulary in mongodb_collection.find({'_id': 'usageterms'}):
-        if 'schema_field' not in vocabulary:
-          mongodb_collection.update({'_id': vocabulary.get(config.ID_FIELD)},
-                                    {'$set': {'schema_field': 'usageterms'}})
+        for vocabulary in mongodb_collection.find({'_id': 'usageterms'}):
+            if 'schema_field' not in vocabulary:
+                mongodb_collection.update({'_id': vocabulary.get(config.ID_FIELD)},
+                                          {'$set': {'schema_field': 'usageterms'}})
 
     def backwards(self, mongodb_collection, mongodb_database):
         pass

--- a/superdesk/data_updates/00024_20200909-142600_vocabularies.py
+++ b/superdesk/data_updates/00024_20200909-142600_vocabularies.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : pablopunk
+# Creation: 2020-09-09 14:08
+
+from superdesk.commands.data_updates import DataUpdate
+from eve.utils import config
+
+
+class DataUpdate(DataUpdate):
+
+    resource = 'vocabularies'
+
+    def forwards(self, mongodb_collection, mongodb_database):
+      for vocabulary in mongodb_collection.find({'_id': 'usageterms'}):
+        if 'schema_field' not in vocabulary:
+          mongodb_collection.update({'_id': vocabulary.get(config.ID_FIELD)},
+                                    {'$set': {'schema_field': 'usageterms'}})
+
+    def backwards(self, mongodb_collection, mongodb_database):
+        pass
+


### PR DESCRIPTION
SDESK-5423

Since [this PR](https://github.com/superdesk/superdesk-core/pull/1729) the vocabulary `usageterms` has a `schema_field`, but some instances (like sd-master) don't have that in the database, so there are some errors related to that like SDESK-5423, that won't reproduce on newer instances but it does on sd-master.