### PR TITLE
fix place parser for NITF

### DIFF
--- a/superdesk/io/feed_parsers/nitf.py
+++ b/superdesk/io/feed_parsers/nitf.py
@@ -226,10 +226,11 @@ class NITFFeedParser(XMLFeedParser):
     def get_places(self, docdata):
         places = []
         evloc = docdata.find('evloc')
-        if evloc is not None:
+        if evloc is not None and evloc.attrib.get('city') and evloc.attrib.get('iso-cc'):
             places.append({
                 'name': evloc.attrib.get('city'),
                 'code': evloc.attrib.get('iso-cc'),
+                'qcode': evloc.attrib.get('city'),
             })
         return places
 

--- a/tests/io/feed_parsers/nitf_tests.py
+++ b/tests/io/feed_parsers/nitf_tests.py
@@ -129,6 +129,7 @@ class IPTCExampleTestCase(NITFTestCase):
         self.assertEqual(1, len(places))
         self.assertEqual('Norfolk', places[0]['name'])
         self.assertEqual('US', places[0]['code'])
+        self.assertEqual('Norfolk', places[0]['qcode'])
 
     def test_expiry(self):
         self.assertEqual('2012-02-26T14:30:00+00:00', self.item.get('expiry').isoformat())
@@ -272,3 +273,11 @@ class HandleInvalidFieldsTestCase(NITFTestCase):
 
     def test_keywords(self):
         self.assertEqual(len(self.item.get('keywords')), 0)
+
+
+class NTBTestCase(NITFTestCase):
+
+    filename = 'nitf-ntb.xml'
+
+    def test_place(self):
+        self.assertEqual([], self.item.get('place'))

--- a/tests/io/fixtures/nitf-ntb.xml
+++ b/tests/io/fixtures/nitf-ntb.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<nitf baselang="nb-NO" version="-//IPTC//DTD NITF 3.6//EN">
+  <head>
+    <title>Faktisk.no: Nei, dette dokumentet beskriver ikke FNs Agenda 21 eller Agenda 2030 </title>
+    <meta name="timestamp" content="2020.09.07 14:45:26"/>
+    <meta name="ntb-dato" content="07.09.2020 14:45"/>
+    <meta name="NTBUtDato" content="07.09.2020"/>
+    <meta name="NTBStikkord" content="faktisk-faktasjekk"/>
+    <meta name="subject" content="faktisk-faktasjekk"/>
+    <meta name="NTBID" content="faktisk-d9cde75b-256e-4989-b6a3-b8ad27f43a5c"/>
+    <meta name="NTBDistribusjonsKode" content="ALL"/>
+    <meta name="NTBKanal" content="A"/>
+    <meta name="NTBIPTCSequence" content="417"/>
+    <meta name="NTBTjeneste" content="Nyhetstjenesten"/>
+    <meta name="filename" content="2020-09-07_14-45-26_Nyhetstjenesten_Innneriks_faktisk-helt-feil-a0G.xml"/>
+    <tobject tobject.type="Innenriks">
+      <tobject.property tobject.property.type="Faktasjekk"/>
+    </tobject>
+    <docdata>
+      <urgency ed-urg="5"/>
+      <date.issue norm="2020-09-07T14:45:26"/>
+      <doc-id id-string="faktisk-d9cde75b-256e-4989-b6a3-b8ad27f43a5c_47" regsrc="NTB"/>
+      <ed-msg info="Dette stoffet distribuerer NTB p&#229; vegne av Faktisk.no. Det er ikke anledning til &#229; endre innhold eller konklusjoner i faktasjekker fra Faktisk.no. Ved sp&#248;rsm&#229;l, ta kontakt med kontakt@faktisk.no."/>
+      <key-list key="faktisk-d9cde75b-256e-4989-b6a3-b8ad27f43a5c"/>
+      <du-key key="faktisk-d9cde75b-256e-4989-b6a3-b8ad27f43a5c" version="48"/>
+      <evloc state-prov="Norge" county-dist="Norge"/>
+    </docdata>
+    <pubdata date.publication="20200907T144527" item-length="0" unit-of-measure="character"/>
+  </head>
+  <body>
+    <body.head>
+      <hedline>
+        <hl1>Faktisk.no: Nei, dette dokumentet beskriver ikke FNs Agenda 21 eller Agenda 2030 </hl1>
+      </hedline>
+      <byline>Geir Molnes / Faktisk.no</byline>
+      <distributor>
+        <org>NTB</org>
+      </distributor>
+      <dateline>Oslo</dateline>
+    </body.head>
+    <body.content>
+      <p class="lead" lead="true">Nei, dette dokumentet beskriver ikke FNs Agenda 21 eller Agenda 2030</p>
+      <hl2>P&#229;stand</hl2>
+      <p quote-source="Facebook-innlegg">&#171;[Dette dokumentet beskriver] FNs Agenda 21 og Agenda 2030&#187;</p>
+      <p>Facebook-innlegg, 29.08.2020</p>
+      <p>Facebook-innlegg</p>
+      <hl2>Konklusjon: Faktisk helt feil</hl2>
+      <p summary="true">Det stemmer ikke at punktlisten i et dokument som har spredd seg p&#229; Facebook, har noe med FNs Agenda 21 eller Agenda 2030 &#229; gj&#248;re. Blant punktene er angivelige m&#229;l om &#229; opprette &#233;n global verdensregjering, og at FN &#248;nsker slutten p&#229; all privat eiendomsrett.&#10;S&#248;k i de reelle dokumentene som beskriver disse handlingsplanene for b&#230;rekraftig utvikling, viser at de inneholder helt andre ting enn det som er beskrevet i punktlisten. Punktene har ogs&#229; tidligere blitt avvist av en talsperson i FN.</p>
+      <hl2>Gjennomgang</hl2>
+      <p class="txt-ind">Det siste &#229;ret har ulike diskusjoner om FNs Agenda 21 f&#229;tt over 13 000 delinger, kommentarer og reaksjoner p&#229; Facebook, viser tall fra analyseverkt&#248;yet Crowdtangle. Samtlige av de mest delte innleggene diskuterer handlingsplanen med negativt fortegn, og er ofte sv&#230;rt f&#248;lelsesladde.</p>
+      <p class="txt-ind">Et eksempel p&#229; slike innlegg er et bilde av et dokument som angivelig skal vise m&#229;lene for FNs Agenda 21 og/eller Agenda 2030. Dokumentet inneholder en liste p&#229; 23 ulike punkter som skal stamme fra disse handlingsplanene. </p>
+      <p class="txt-ind">
+        BILDE: 
+        <a href="http://res.cloudinary.com/faktisk/image/upload/s--9bTiQh1t--/w_1200/grslmogu1j3l6vfenevp.jpg">Dette dokumentet skal angivelig vise m&#229;lene bak FNs Agenda 21 og Agenda 2030.</a>
+      </p>
+      <p/>
+      <p class="txt-ind">Blant punktene det hevdes at FN &#248;nsker &#229; oppn&#229; er f&#248;lgende (Faktisk.nos oversettelse):</p>
+      <ul>
+        <li>&#201;n global verdensregjering</li>
+        <li>&#201;n global sentralbank</li>
+        <li>Flere obligatoriske vaksiner</li>
+        <li>&#201;n global kontantl&#248;s valuta</li>
+        <li>Slutten p&#229; all privat eiendomsrett</li>
+        <li>Regjeringen skal oppdra befolkningens barn</li>
+        <li>Slutten p&#229; all privat transport, herunder mulighet for &#229; eie bil</li>
+      </ul>
+      <p class="txt-ind">I denne faktasjekken skal vi se n&#230;rmere p&#229; om dette faktisk er m&#229;lene for FNs Agenda 21 og Agenda 2030. For at dette skal v&#230;re riktig m&#229; samtlige av punktene i det avbildede dokumentet ha en kobling til minst &#233;n av disse handlingsplanene.</p>
+      <p class="txt-ind">Faktisk.no har tidligere omtalt ulike konspirasjoner rundt FNs b&#230;rekraftm&#229;l i denne artikkelen om FN-n&#229;len:</p>
+      <p>[ GRAFIKK/VIDEO MANGLER ]</p>
+      <hl2>Hva er Agenda 21 og Agenda 2030?</hl2>
+      <p class="txt-ind">
+        <a href="https://sustainabledevelopment.un.org/content/documents/Agenda21.pdf">FNs Agenda 21</a>
+         er en ikke-bindende handlingsplan for b&#230;rekraftig utvikling fra 1992. Blant punktene som trekkes frem er m&#229;l om &#229; bekjempe fattigdom, beskytte atmosf&#230;ren, beskyttelse av biologisk mangfold og &#229; s&#248;rge for trygg h&#229;ndtering av radioaktivt avfall.
+      </p>
+      <p class="txt-ind">
+        Handlingsplanen er tematisk beslektet med 
+        <a href="https://sustainabledevelopment.un.org/content/documents/21252030%20Agenda%20for%20Sustainable%20Development%20web.pdf">FNs Agenda 2030</a>
+         fra 2015, som ogs&#229; er kjent som FNs b&#230;rekraftsm&#229;l. Det &#229; utrydde alle former for fattigdom, utrydde sult, oppn&#229; likestilling mellom kj&#248;nnene, og &#229; minske globale &#248;konomiske forskjeller b&#229;de innad og mellom land, er blant de 
+        <a href="https://norad.no/om-bistand/dette-er-fns-barekraftsmal/">17 m&#229;lene</a>
+         som finnes i denne handlingsplanen.
+      </p>
+      <p class="txt-ind">
+        BILDE: 
+        <a href="http://res.cloudinary.com/faktisk/image/upload/s--obour8aD--/w_1200/r8mkjt7zimmrpqfmhk75.jpg">http://res.cloudinary.com/faktisk/image/upload/s--obour8aD--/w_1200/r8mkjt7zimmrpqfmhk75.jpg</a>
+      </p>
+      <p>Budskapet om FNs Agenda 21 og Agenda 2030 deles p&#229; sosiale medier. </p>
+      <hl2>Ingenting med saken &#229; gj&#248;re</hl2>
+      <p class="txt-ind">
+        Ved &#229; s&#248;ke gjennom dokumentene for Agenda 21 og Agenda 2030, kan du se at det ikke st&#229;r noe om verken obligatoriske vaksiner, &#233;n global kontantl&#248;s valuta, eller slutten p&#229; all privat transport. &#10;N&#229;r det gjelder punktet om &#233;n global sentralbank, st&#229;r det ingenting om dette i Agenda 2030, mens sentralbanker er omtalt &#233;n gang i Agenda 21, p&#229; 
+        <a href="https://sustainabledevelopment.un.org/content/documents/Agenda21.pdf#page=13">side 13</a>
+         (Faktisk.nos oversettelse):
+      </p>
+      <p class="txt-ind">
+        &#8211; 
+        De ovennevnte endringene i utviklingsland forutsetter en betydelig nasjonal innsats for kapasitetsbygging innen omr&#229;dene offentlig administrasjon, sentralbanker, skatteadministrasjon, spareinstitusjoner og finansmarkeder.
+      </p>
+      <p class="txt-ind">
+        Med andre ord ans&#229; FN det som en sentral nasjonal oppgave for utviklingsland &#229; bygge opp sine sentralbanker. Det er noe ganske annet enn &#229; g&#229; inn for &#233;n global sentralbank. Punktet m&#229; for &#248;vrig ikke forveksles med 
+        <a href="https://www.worldbank.org/">Verdensbanken</a>
+        , som ble opprettet i 1944, lenge f&#248;r b&#229;de Agenda 2030 og Agenda 21, og som heller ikke er en 
+        <a href="https://snl.no/sentralbank">sentralbank</a>
+        .
+      </p>
+      <hl2>&#8211; Velkjente konspirasjonsteorier</hl2>
+      <p class="txt-ind">Professor Asbj&#248;rn Dyrendal ved NTNU har forsket p&#229; og skrevet bok om konspirasjonsteorier. Han forteller at flere av punktene i dokumentet er velkjente konspirasjonsteorier, og at konspirasjonsteorier om FN lenge har v&#230;rt et kjent fenomen.</p>
+      <p class="txt-ind">&#8211; Dette er en del av en st&#248;rre familie nasjonsorienterte konspirasjonsteorier. Teorien om &#171;New world order&#187;, &#233;n verdensregjering og FN har lang fartstid i kristenfundamentalistiske profetikretser og i nasjonalpopulistiske kretser, og er spesielt popul&#230;r i USA, sier Dyrendal til Faktisk.no.</p>
+      <p class="txt-ind">
+        BILDE: 
+        <a href="http://res.cloudinary.com/faktisk/image/upload/s--MaME__GB--/w_1200/rsdtfbh20iorvdjkj7aq.jpg">Professor Asbj&#248;rn Dyrendal.</a>
+      </p>
+      <p>Foto: NTNU</p>
+      <p class="txt-ind">Selv om konspirasjonsteoriene ikke er nye, oppdateres innholdet til stadighet med en ny og tidsriktig vri, forteller professoren. Dette dokumentet inneholder for eksempel konspirasjonsteorier om b&#229;de 5G og et globalt sosialt kredittsystem.</p>
+      <p class="txt-ind">Teorien om at det finnes en ond plan om &#229; begrense jordens befolkning, den s&#229;kalte depopulasjonsteorien, var if&#248;lge Dyrendal veldig popul&#230;r for ti til 15 &#229;r siden. Konspirasjonsteorier om vaksiner beskriver han som en &#171;tilbakevendende vinner&#187;.</p>
+      <p class="txt-ind">Han synes det er interessant &#229; se at dokumentet ogs&#229; inneholder et punkt om borgerl&#248;nn (universal basic income), som i dokumentet kobles til en finansiell innstrammingspolitikk.</p>
+      <p class="txt-ind">&#10;&#8211; Dette budskapet skrur i en litt annen retning, og l&#229;ner fra mer venstreorienterte tema enn de h&#248;yreorienterte, som ellers dominerer.</p>
+      <hl2>Importeres til Norge fra USA</hl2>
+      <p class="txt-ind">Dyrendal mener det er lett &#229; kjenne igjen budskapet i dokumentet som konspirasjonsteorier, og trekker frem flere klassiske kjennetegn:</p>
+      <p class="txt-ind">&#8211; Mektige krefter planlegger onde gjerninger i skjul. Ingen du blir fortalt er sant. Det appelleres til frykt for angrep p&#229; sentrale verdier: Familie, nasjon og personlig frihet. &#171;Avsl&#248;ringene&#187; kommer fra mennesker uten tilgang til gode kilder, og strider mot det vi vet. </p>
+      <p class="txt-ind">Professoren forteller at selv om det ikke er noe hold i punktene, har de gjerne en slags kobling til noe som foreg&#229;r i virkeligheten. For eksempel er det riktig at det finnes et sosialt kredittsystem i Kina, men det er ingenting som tyder p&#229; at FN har et &#248;nske om, eller evne til, &#229; gjennomf&#248;re noe slikt for hele verden.</p>
+      <p class="txt-ind">&#10;&#8211; For at konspirasjonsteoriene skal fenge m&#229; de bygge p&#229; noe vi tar p&#229; alvor. Man appellerer gjerne til en frykt for at grunnleggende ting vil bli tatt fra oss.</p>
+      <p class="txt-ind">Selv om konspirasjonsteoriene i dette dokumentet har hatt st&#248;rre klangbunn i USA enn i Norge, sprer de seg ogs&#229; godt her til lands, if&#248;lge Dyrendal.</p>
+      <p class="txt-ind">&#10;&#8211; Det finnes ingen konspirasjonsteorier som oppst&#229;r i USA som ikke kommer til Norge. Nordmenn er stort sett gode til &#229; lese engelsk, og mange av de st&#248;rste konspirasjonsteoriene i Norge importeres derfra.&#160;</p>
+      <hl2>Avvises av talsperson og forsker</hl2>
+      <p class="txt-ind">
+        Den internasjonale faktasjekkredaksjonen AFP Fact Check har kommet frem til at innholdet i dokumentet 
+        <a href="https://factcheck.afp.com/hoax-circulates-about-united-nations-mission-goals">er rent oppspinn</a>
+        . Organisasjonen har v&#230;rt i kontakt med en ikke navngitt talsperson i FN som forteller at samtlige av punktene i dokumentet enten er helt feil, eller er s&#229; fordreide at de ikke har noen sannhetsverdi.
+      </p>
+      <p class="txt-ind">
+        AFP Fact Check har ogs&#229; v&#230;rt i kontakt med ekstremismeforsker Heidi Beirich, som leder 
+        <a href="https://internationalhatestudies.com/">International Network for Hate Studies</a>
+        . Hun forteller ogs&#229; at innholdet i dokumentet er falskt, og at det inneholder en rekke vanlige konspirasjonsteorier om Agenda 21.
+      </p>
+      <p class="txt-ind">
+        Les faktasjekken p&#229; 
+        <a href="https://www.faktisk.no/faktasjekker/a0G">Faktisk.no</a>
+      </p>
+      <hl2>Embed (stor):</hl2>
+      <p>&#60;div class=&#34;faktisk-embed&#34; id=&#34;faktisk-embed-factcheck-a0G-large&#34; data-type=&#34;factcheck&#34; data-id=&#34;a0G&#34; data-version=&#34;large&#34;&#62;&#60;/div&#62;&#60;script async defer src=&#34;https://www.faktisk.no/js/embed.js&#34;&#62;&#60;/script&#62;</p>
+      <hl2>Embed (medium):</hl2>
+      <p>&#60;div class=&#34;faktisk-embed&#34; id=&#34;faktisk-embed-factcheck-a0G-medium&#34; data-type=&#34;factcheck&#34; data-id=&#34;a0G&#34; data-version=&#34;medium&#34;&#62;&#60;/div&#62;&#60;script async defer src=&#34;https://www.faktisk.no/js/embed.js&#34;&#62;&#60;/script&#62;</p>
+      <hl2>Embed (liten):</hl2>
+      <p>&#60;div class=&#34;faktisk-embed&#34; id=&#34;faktisk-embed-factcheck-a0G-small&#34; data-type=&#34;factcheck&#34; data-id=&#34;a0G&#34; data-version=&#34;small&#34;&#62;&#60;/div&#62;&#60;script async defer src=&#34;https://www.faktisk.no/js/embed.js&#34;&#62;&#60;/script&#62;</p>
+      <media media-type="image">
+        <media-reference mime-type="image/jpeg" source="iJIJyyF0tiE"/>
+        <media-caption> Foto: NTB / Scanpix, montasje av Faktisk.no</media-caption>
+      </media>
+    </body.content>
+  </body>
+</nitf>


### PR DESCRIPTION
now it would generate `[{"name": None, "code": None}]` for files
with `evloc` element present without any matching attributes.

SDNTB-653