### PR TITLE
fix missing associations on save

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -111,7 +111,7 @@ def update_associations(doc):
 
     :param dict doc: update data
     """
-    if not doc.get('fields_meta', {}).get('body_html'):
+    if not doc.get('fields_meta', {}).get('body_html') or ASSOCIATIONS not in doc:
         return
     entityMap = doc['fields_meta']['body_html']['draftjsState'][0].get('entityMap', {})
     associations = doc.get(ASSOCIATIONS, {})
@@ -335,7 +335,7 @@ class ArchiveService(BaseService):
         if original[ITEM_TYPE] == CONTENT_TYPE.PICTURE:  # create crops
             self.cropService.create_multiple_crops(updates, original)
 
-        if ASSOCIATIONS not in updates or not updates.get(ASSOCIATIONS):
+        if not updates.get(ASSOCIATIONS):
             return
 
         body = updates.get("body_html", original.get("body_html", None))

--- a/features/archive.feature
+++ b/features/archive.feature
@@ -1121,7 +1121,7 @@ Feature: News Items Archive
     Scenario: body_html is generated from draftJS state
         Given "archive"
         """
-        [{"_id": "test_editor_gen_1", "guid": "test_editor_gen_1", "headline": "test"}]
+        [{"_id": "test_editor_gen_1", "guid": "test_editor_gen_1", "headline": "test", "associations": {"foo": {"type": "text"}}}]
         """
 
         When we patch given
@@ -1172,6 +1172,9 @@ Feature: News Items Archive
                         "entityMap": {}
                     }]
                 }
+            },
+            "associations": {
+                "foo": {"type": "text"}
             }
         }
         """


### PR DESCRIPTION
when there is no modification done to associations
but some editor3 field is updated it would set
associations to `{}` when populating embedded media.

SDCP-370