### PR TITLE
fix(templates): Template fields changed before post are reverted

### DIFF
--- a/apps/templates/content_templates.py
+++ b/apps/templates/content_templates.py
@@ -507,7 +507,11 @@ def render_content_template(item, template, update=False):
     def render_content_template_fields(data, dest=None, top=True):
         updates = {}
         for key, value in data.items():
-            if (top and key in TEMPLATE_DATA_IGNORE_FIELDS) or not value:
+            if (top and key in TEMPLATE_DATA_IGNORE_FIELDS) or not value or (item[key] and item[key] != value):
+                # Ignore template field if:
+                #   * Top level field is in TEMPLATE_DATA_IGNORE_FIELDS
+                #   * template value is not defined
+                #   * item field is defined and has changed from the template
                 continue
 
             if top and key == 'extra':

--- a/apps/templates/content_templates.py
+++ b/apps/templates/content_templates.py
@@ -508,7 +508,7 @@ def render_content_template(item, template, update=False):
     def render_content_template_fields(data, dest=None, top=True):
         updates = {}
         for key, value in data.items():
-            if (top and key in TEMPLATE_DATA_IGNORE_FIELDS) or not value or (item[key] and item[key] != value):
+            if (top and key in TEMPLATE_DATA_IGNORE_FIELDS) or not value or (item.get(key) and item[key] != value):
                 # Ignore template field if:
                 #   * Top level field is in TEMPLATE_DATA_IGNORE_FIELDS
                 #   * template value is not defined

--- a/apps/templates/content_templates.py
+++ b/apps/templates/content_templates.py
@@ -499,6 +499,7 @@ def render_content_template(item, template, update=False):
 
     :param dict item: item on which template is applied
     :param dict template: template
+    :param bool update: apply updates to item
     :return dict: updates to the item
     """
     kwargs = dict(item=item, user=get_user())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,21 @@
+from nose.plugins.attrib import attr
+
+
+def wip(f):
+    """Allows to run a single test using a @wip decorator
+
+    i.e.
+    from superdesk.tests import TestCase
+    from tests import wip
+
+
+    class TestWIP(TestCase):
+        @wip
+        def test_something(self):
+            self.assertEqual(1, 1)
+
+    then run with:
+    nosetests -a wip
+    """
+
+    return attr('wip')(f)

--- a/tests/templates/render_templates_test.py
+++ b/tests/templates/render_templates_test.py
@@ -10,7 +10,6 @@
 
 from superdesk.tests import TestCase
 from apps.templates.content_templates import get_item_from_template, render_content_template
-from tests import wip
 
 
 class RenderTemplateTestCase(TestCase):

--- a/tests/templates/render_templates_test.py
+++ b/tests/templates/render_templates_test.py
@@ -10,6 +10,7 @@
 
 from superdesk.tests import TestCase
 from apps.templates.content_templates import get_item_from_template, render_content_template
+from tests import wip
 
 
 class RenderTemplateTestCase(TestCase):
@@ -57,3 +58,23 @@ class RenderTemplateTestCase(TestCase):
 
         item = get_item_from_template(template)
         self.assertEqual('test it', item['headline'])
+
+    def test_skip_fields_when_they_differ_from_template(self):
+        template = {
+            '_id': 'foo',
+            'template_name': 'test',
+            'template_desks': ['sports'],
+            'data': {
+                'headline': 'toto template',
+                'body_html': 'this is a test template',
+                'urgency': 1, 'priority': 3,
+                'dateline': {},
+                'anpa_take_key': 'test',
+                'genre': [{'name': 'Analysis', 'qcode': 'Analysis'}]
+            }
+        }
+
+        before = get_item_from_template(template)
+        before['genre'] = [{'name': 'template_genre', 'qcode': 'template_genre'}]
+        after = render_content_template(before, template, update=True)
+        self.assertListEqual(after['genre'], before['genre'])


### PR DESCRIPTION
Field(s) are reverted if they're changed after creating metadata from template and before archive.post