### PR TITLE
Replace thumbnail with viewImage for video editor

### DIFF
--- a/apps/video_edit/__init__.py
+++ b/apps/video_edit/__init__.py
@@ -38,10 +38,14 @@ class VideoEditService(superdesk.Service):
                     crop=capture.get('crop'),
                     rotate=capture.get('rotate')
                 )
-                renditions.setdefault('thumbnail', {}).update({
+                renditions.setdefault('viewImage', {}).update({
                     'href': project['thumbnails']['preview'].get('url'),
                     'mimetype': project['thumbnails']['preview'].get('mime_type', 'image/png'),
                 })
+
+                # clean up old thumbnails
+                renditions.pop('baseImage', None)
+                renditions.pop('thumbnail', None)
             # push task edit video to video server
             if 'edit' in doc:
                 edit = doc.pop('edit')
@@ -93,10 +97,12 @@ class VideoEditService(superdesk.Service):
         data = self.video_editor.upload_preview_thumbnail(project.get('_id'), file)
         document.update(original)
         renditions = document.get('renditions', {})
-        renditions.setdefault('thumbnail', {}).update({
+        renditions.setdefault('viewImage', {}).update({
             'href': data.get('url'),
             'mimetype': data.get('mimetype'),
         })
+        renditions.pop('baseImage', None)
+        renditions.pop('thumbnail', None)
         document.update({'renditions': renditions})
         return document
 

--- a/tests/video_edit/video_edit_test.py
+++ b/tests/video_edit/video_edit_test.py
@@ -162,7 +162,7 @@ class VideoEditTestCase(TestCase):
                                            'version': 1,
                                            'video_editor_id':
                                            'video_id'},
-                              'thumbnail': {
+                              'viewImage': {
                                  "mimetype": "image/png",
                                  "href": "http://localhost/projects/video_id/raw/thumbnails/preview"
                              }})
@@ -177,10 +177,10 @@ class VideoEditTestCase(TestCase):
             req = {'file': FileStorage(BytesIO(b'abcdef'), 'image.jpeg')}
             res = self.video_edit.on_replace(req, {'project': {'_id': 'video_id'}})
             self.assertEqual(
-                res['renditions']['thumbnail']['href'],
+                res['renditions']['viewImage']['href'],
                 'http://localhost/projects/video_id/raw/thumbnails/preview'
             )
-            self.assertEqual(res['renditions']['thumbnail']['mimetype'], 'image/jpeg')
+            self.assertEqual(res['renditions']['viewImage']['mimetype'], 'image/jpeg')
 
     def test_capture_timeline(self):
         with requests_mock.mock() as mock:


### PR DESCRIPTION
Update based on @tomaskikutis [comment](https://github.com/superdesk/superdesk-client-core/pull/3218#discussion_r482860659)
> you should replace it with renditions.viewImage in all places. thumbnail rendition is only for backwards-compatibility and will likely be dropped in the future.

- Replace `thumbnail` with `viewImage`
- Remove `thumbnail` and `baseImage` on `renditions` on thumbnail upload and capture