### PR TITLE
Templates privilege cannot use desk templates for creating new article [SDANSA-441]

### DIFF
--- a/apps/templates/content_templates.py
+++ b/apps/templates/content_templates.py
@@ -197,16 +197,16 @@ class ContentTemplatesService(BaseService):
         privileges = active_user.get('active_privileges', {})
         if not lookup:
             lookup = {}
-        manage = req.args.get('manage')
-
-        if manage and not privileges.get('content_templates') and not privileges.get('personal_template'):
-            lookup.update({'$and': [{'is_public': False}, {'user': active_user.get('_id')}]})
-        elif manage and not privileges.get('content_templates') and privileges.get('personal_template'):
-            lookup.update({'$or': [{'is_public': False}, {'user': active_user.get('_id')}]})
-        elif (manage and privileges.get('content_templates')
-                and not privileges.get('personal_template')
-                or not manage and not privileges.get('personal_template')):
-            lookup.update({'$or': [{'is_public': True}, {'user': active_user.get('_id')}]})
+        if req and req.args and req.args.get('manage'):
+            if not privileges.get('content_templates') and not privileges.get('personal_template'):
+                lookup.update({'$and': [{'is_public': False}, {'user': active_user.get('_id')}]})
+            elif not privileges.get('content_templates') and privileges.get('personal_template'):
+                lookup.update({'$or': [{'is_public': False}, {'user': active_user.get('_id')}]})
+            elif (privileges.get('content_templates') and not privileges.get('personal_template')):
+                lookup.update({'$or': [{'is_public': True}, {'user': active_user.get('_id')}]})
+        else:
+            if not privileges.get('personal_template'):
+                lookup.update({'$or': [{'is_public': True}, {'user': active_user.get('_id')}]})
         results = super().get(req, lookup)
 
         return results

--- a/apps/templates/content_templates.py
+++ b/apps/templates/content_templates.py
@@ -197,13 +197,16 @@ class ContentTemplatesService(BaseService):
         privileges = active_user.get('active_privileges', {})
         if not lookup:
             lookup = {}
-        if not privileges.get('content_templates') and not privileges.get('personal_template'):
-            lookup.update({'$and': [{'is_public': False}, {'user': active_user.get('_id')}]})
-        elif not privileges.get('content_templates') and privileges.get('personal_template'):
-            lookup.update({'$or': [{'is_public': False}, {'user': active_user.get('_id')}]})
-        elif privileges.get('content_templates') and not privileges.get('personal_template'):
-            lookup.update({'$or': [{'is_public': True}, {'user': active_user.get('_id')}]})
+        manage = req.args.get('manage')
 
+        if manage and not privileges.get('content_templates') and not privileges.get('personal_template'):
+            lookup.update({'$and': [{'is_public': False}, {'user': active_user.get('_id')}]})
+        elif manage and not privileges.get('content_templates') and privileges.get('personal_template'):
+            lookup.update({'$or': [{'is_public': False}, {'user': active_user.get('_id')}]})
+        elif (manage and privileges.get('content_templates')
+                and not privileges.get('personal_template')
+                or not manage and not privileges.get('personal_template')):
+            lookup.update({'$or': [{'is_public': True}, {'user': active_user.get('_id')}]})
         results = super().get(req, lookup)
 
         return results


### PR DESCRIPTION
when we hit `/content_templates` API and If a user doesn't have any privileges then all templates in the database collection should be returned except private templates of others when that privilege is not present.