### PR TITLE
avoid double elastic update during locking

### DIFF
--- a/apps/item_lock/components/item_lock.py
+++ b/apps/item_lock/components/item_lock.py
@@ -81,14 +81,15 @@ class ItemLock(BaseComponent):
                 if action:
                     updates[LOCK_ACTION] = action
 
-                item_model.update(item_filter, updates)
-
-                if item.get(TASK):
-                    item[TASK]['user'] = user_id
+                updates[TASK] = item.get(TASK)
+                if updates.get(TASK):
+                    updates[TASK]['user'] = user_id
                 else:
-                    item[TASK] = {'user': user_id}
+                    updates[TASK] = {'user': user_id}
 
-                superdesk.get_resource_service('tasks').assign_user(item[config.ID_FIELD], item[TASK])
+                # tasks service will update the user
+                superdesk.get_resource_service('tasks').assign_user(item[config.ID_FIELD], updates)
+
                 item = item_model.find_one(item_filter)
                 self.app.on_item_locked(item, user_id)
                 push_notification('item:lock',

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -296,8 +296,8 @@ class TasksService(BaseService):
     def on_deleted(self, doc):
         push_notification(self.datasource, deleted=1)
 
-    def assign_user(self, item_id, user):
-        return self.patch(item_id, {'task': user})
+    def assign_user(self, item_id, updates):
+        return self.patch(item_id, updates)
 
     def _stage_changed(self, updates, original):
         new_stage_id = str(updates.get('task', {}).get('stage', ''))


### PR DESCRIPTION
I've noticed when checking elastic apm that locking was updating elastic 2x which is unnecessary