### PR TITLE
fix firstpublished according to scheduled

### DIFF
--- a/apps/publish/content/publish.py
+++ b/apps/publish/content/publish.py
@@ -42,6 +42,9 @@ class ArchivePublishService(BasePublishService):
                 raise SuperdeskApiError.badRequestError(_("Empty package cannot be published!"))
 
     def on_update(self, updates, original):
+        updates[ITEM_OPERATION] = self.item_operation
+        super().on_update(updates, original)
+
         if not original.get('firstpublished'):
             if updates.get(SCHEDULE_SETTINGS) and updates[SCHEDULE_SETTINGS].get('utc_publish_schedule'):
                 updates['firstpublished'] = updates[SCHEDULE_SETTINGS]['utc_publish_schedule']
@@ -53,8 +56,6 @@ class ArchivePublishService(BasePublishService):
             updates['previous_marked_user'] = original['marked_for_user']
             updates['marked_for_user'] = None
 
-        updates[ITEM_OPERATION] = self.item_operation
-        super().on_update(updates, original)
         set_sign_off(updates, original)
         update_word_count(updates)
 

--- a/features/content_publish.feature
+++ b/features/content_publish.feature
@@ -709,7 +709,6 @@ Feature: Content Publishing
       """
       [{"guid": "123", "headline": "test", "_current_version": 1, "state": "fetched",
         "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
-        "publish_schedule":"#DATE+2#",
         "subject":[{"qcode": "17004000", "name": "Statistics"}],
         "slugline": "test",
         "body_html": "Test Document body"}]
@@ -735,7 +734,7 @@ Feature: Content Publishing
       Then we get OK response
       And we get existing resource
       """
-      {"_current_version": 2, "state": "scheduled", "operation": "publish"}
+      {"_current_version": 2, "state": "scheduled", "operation": "publish", "firstpublished": "__future__"}
       """
       And we get expiry for schedule and embargo content 60 minutes after "#archive_publish.publish_schedule#"
       When we get "/published"

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -158,6 +158,9 @@ def json_match(context_data, response_data, json_fields=None):
             if context_data[key] == "__now__":
                 assert_is_now(response_data[key], key)
                 continue
+            if context_data[key] == "__future__":
+                assert arrow.get(response_data[key]) > arrow.get(), '{} should be in future'.format(key)
+                continue
             if context_data[key] == "__empty__":
                 assert len(response_data[key]) == 0, '%s is not empty (%s)' % (key, response_data[key])
                 continue


### PR DESCRIPTION
scheduled utc is only populated after `super().on_update` runs,
clients send it using timezone.

SDESK-5677