### PR TITLE
[BACKEND_META] better version handling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 120
-exclude = env,bin,lib,include,src,docs,dist,build,node_modules
+extend-exclude = env,bin,lib,include,src,docs,dist,build,node_modules
 ignore = F811,D200,D202,D205,D400,D401,D100,D101,D102,D103,D104,D105,D107,W503,W504,W605,F401,E261,F841,
          B010,B009,B007,B305,B011
 # W504, W605, F401, E261 and F841 are temporarly ignored, due to recent changes in flake8

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ install_requires = [
     'regex==2020.7.14',
     'flask-oidc-ex==0.5.5',
     'vine==1.3.0',
+    # to be replaced by stdlib version when we use Python 3.8+
+    'importlib_metadata<3.2',
 ]
 
 package_data = {
@@ -91,6 +93,8 @@ setup(
     packages=find_packages(exclude=['tests', 'features']),
     package_data=package_data,
     include_package_data=True,
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     install_requires=install_requires,
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/superdesk/backend_meta/backend_meta.py
+++ b/superdesk/backend_meta/backend_meta.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8; -*-
-#
 # This file is part of Superdesk.
 #
 # Copyright 2013, 2014 Sourcefabric z.u. and contributors.
@@ -9,73 +7,31 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
-from superdesk.resource import Resource
-from superdesk.services import BaseService
 import os.path
 import re
 import json
+from pathlib import Path
+from superdesk.resource import Resource
+from superdesk.services import BaseService
+from superdesk import config
 try:
     import settings
 except ImportError:
     # settings doesn't exist during tests
     settings = None
 import logging
+from importlib_metadata import version as pkg_version, PackageNotFoundError
+
 
 logger = logging.getLogger(__name__)
 
-GITHUB_TAG_HREF = 'https://github.com/superdesk/%s/releases/tag/v%s'
-GITHUB_COMMIT_HREF = 'https://github.com/superdesk/%s/commit/%s'
-GITHUB_BRANCH_HREF = 'https://github.com/superdesk/%s/tree/%s'
+GITHUB_TAG_HREF = 'https://github.com/superdesk/{repo}/releases/tag/v{version}'
+GITHUB_COMMIT_HREF = 'https://github.com/superdesk/{package}/commit/{revision}'
+GITHUB_BRANCH_HREF = 'https://github.com/superdesk/{package}/tree/{branch}'
+PYPI_VERSION_HREF = 'https://pypi.org/project/{package}/{version}/'
+NPM_VERSION_HREF = 'https://www.npmjs.com/package/{package}/v/{version}'
 
-
-def get_client_ref(version, package, repo=None):
-    if not repo:
-        repo = package
-    try:
-        commit = version.split('#')[1]
-        try:
-            int(commit, 16)
-            template = GITHUB_COMMIT_HREF
-        except ValueError:
-            template = GITHUB_BRANCH_HREF
-        return {
-            'name': repo,
-            'href': template % (repo, commit),
-            'version': commit,
-        }
-    except IndexError:
-        pass
-    return {
-        'name': repo,
-        'href': GITHUB_TAG_HREF % (repo, version),
-        'version': version,
-    }
-
-
-def get_server_ref(req, package):
-    try:
-        version = re.search(r'%s==([0-9.]+)' % package, req, re.IGNORECASE).group(1)
-        return {
-            'name': package,
-            'href': GITHUB_TAG_HREF % (package, version),
-            'version': version,
-        }
-    except AttributeError:
-        pass
-    try:
-        commit = re.search(r'%s.git@([-.a-z0-9]+)#' % package, req, re.IGNORECASE).group(1)  # branch or commit
-        try:
-            int(commit, 16)
-            template = GITHUB_COMMIT_HREF
-        except ValueError:
-            template = GITHUB_BRANCH_HREF
-        return {
-            'name': package,
-            'href': template % (package, commit),
-            'version': commit,
-        }
-    except AttributeError:
-        pass
+RE_REV = re.compile(r"\+g(?P<revision>[a-f0-9]+)(\.[0-9]+)?")
 
 
 class BackendMetaResource(Resource):
@@ -85,65 +41,151 @@ class BackendMetaResource(Resource):
 class BackendMetaService(BaseService):
     """Service givin metadata on backend itself"""
 
-    def find_dir(self, name):
+    @staticmethod
+    def find_dir(name):
         # depending of the installation (local git or docker)
         # a dir can be in the same path as settings or in the parent
         # this method try both and return None if dir is not found
         if settings is None:
             return
-        current_path = settings.__file__
+        current_path = Path(settings.__file__)
         for i in range(2):
-            current_path = os.path.dirname(current_path)
-            tested_dir = os.path.join(current_path, name)
-            if os.path.isdir(tested_dir):
+            current_path = current_path.parent
+            tested_dir = current_path / name
+            if tested_dir.is_dir():
                 return tested_dir
 
-    def get_superdesk_rev(self):
-        git_dir = self.find_dir('.git')
+    @staticmethod
+    def get_commit_href(package, revision):
+        try:
+            repo_override = config.REPO_OVERRIDE
+        except AttributeError:
+            # config may not be initialised (during tests or beginning of the session)
+            repo_override = {}
+        return GITHUB_COMMIT_HREF.format(
+            package=repo_override.get(package, package),
+            revision=revision
+        )
+
+    @classmethod
+    def get_superdesk_version(cls):
+        git_dir = cls.find_dir('.git')
         if git_dir is not None:
-            head_path = os.path.join(git_dir, 'HEAD')
+            head_path = git_dir / 'HEAD'
             try:
-                with open(head_path) as f:
+                with head_path.open() as f:
                     head = f.read()
                 ref_path = head.split()[1]
                 with open(os.path.join(git_dir, ref_path)) as rev_f:
-                    return rev_f.read()
+                    revision = rev_f.read()
+                return {
+                    "name": "superdesk",
+                    # we don't have semver for Superdesk itself (only for core)
+                    "version": revision,
+                    "revision": revision,
+                    "href": cls.get_commit_href("superdesk", revision),
+                }
             except (IOError, IndexError):
                 pass
         return None
 
-    def get_server_rev(self, package):
-        if settings is not None:
-            # we get superdesk-core revision from requirements.txt
-            requirements_path = os.path.join(os.path.dirname(settings.__file__), 'requirements.txt')
-            try:
-                with open(requirements_path) as f:
-                    req = f.read()
-                    return get_server_ref(req, package)
-            except IOError:
-                pass
-        return None
+    @classmethod
+    def get_package_version(cls, package):
+        try:
+            version = pkg_version(package)
+        except PackageNotFoundError:
+            pass
+        except Exception as e:
+            logger.error(f"Can't retrieve package version: {e}")
+            return None
+        else:
+            semver = '.'.join(version.split('.', 3)[:3])
+            data = {
+                "name": package,
+                "version": version,
+                "semver": semver,
+            }
+            rev_match = RE_REV.search(version)
+            if rev_match is not None:
+                revision = rev_match.group("revision")
+                data["revision"] = revision
+                data["href"] = cls.get_commit_href(package, revision)
+            else:
+                data["href"] = PYPI_VERSION_HREF.format(
+                    package=package,
+                    version=semver,
+                )
+            return data
 
-    def get_client_rev(self, package, repo=None):
-        # we get superdesk-client-core revision from package.json
+    def complete_nodemod_ref(self, data, package, repo=None):
+        if not repo:
+            repo = package
+        try:
+            version = data['version']
+        except KeyError:
+            return
+        try:
+            commit = version.split('#')[1]
+        except IndexError:
+            if 'href' not in data:
+                data['href'] = GITHUB_TAG_HREF.format(repo=repo, version=version)
+        else:
+            if 'href' not in data:
+                try:
+                    int(version, 16)
+                    data['href'] = GITHUB_COMMIT_HREF.format(package=repo, revision=commit)
+                except ValueError:
+                    data['href'] = GITHUB_BRANCH_HREF.format(package=repo, branch=commit)
+
+    def get_nodemod_version(self, package, repo=None):
+        # we get superdesk-client-core version and revision from package.json and package-lock.json
         client_dir = self.find_dir('client')
         if client_dir is not None:
-            pkg_path = os.path.join(client_dir, 'package.json')
+            data = {
+                "name": repo or package,
+            }
+            pkg_path = client_dir / 'package.json'
             try:
-                with open(pkg_path) as f:
+                with pkg_path.open() as f:
                     pkg = json.load(f)
-                version = pkg['dependencies'][package]
-                return get_client_ref(version, package, repo)
+                data['version'] = pkg['dependencies'][package]
             except (IOError, KeyError):
                 pass
+            pkg_lock_path = client_dir / 'package-lock.json'
+            try:
+                with pkg_lock_path.open() as f:
+                    pkg_lock = json.load(f)
+                pkg_ver = pkg_lock['dependencies'][package]['version']
+                if pkg_ver.startswith('github:'):
+                    __, data['revision'] = pkg_ver[8:].split('#')
+                    data['version'] = data['revision']
+                    data['href'] = self.get_commit_href(repo or package, data['revision'])
+                else:
+                    data['version'] = data['semver'] = pkg_ver
+                    data['href'] = NPM_VERSION_HREF.format(package=package, version=pkg_ver)
+            except (IOError, KeyError):
+                self.complete_nodemod_ref(data, package, repo)
+
+            if len(data) == 1:
+                # if we have only the module name, we don't want to display it
+                return None
+            return data
+
         return None
 
     def on_fetched(self, doc):
-        doc['meta_rev'] = self.get_superdesk_rev()
         doc['modules'] = [mod for mod in [
-            self.get_server_rev('superdesk-core'),
-            self.get_client_rev('superdesk-core', repo='superdesk-client-core'),
-            self.get_server_rev('superdesk-planning'),
-            self.get_server_rev('superdesk-analytics'),
-            self.get_client_rev('superdesk-publisher'),
+            self.get_superdesk_version(),
+            self.get_package_version('superdesk-core'),
+            self.get_nodemod_version('superdesk-core', repo='superdesk-client-core'),
+            self.get_package_version('superdesk-planning'),
+            self.get_package_version('superdesk-analytics'),
+            self.get_nodemod_version('superdesk-publisher'),
         ] if mod is not None]
+
+
+# it may be useful to have the version of installed package in backend logs
+for package in ('superdesk-core', 'superdesk-planning', 'superdesk-analytics', 'superdesk-published'):
+    v_data = BackendMetaService.get_package_version(package)
+    if v_data is not None:
+        logger.info(f"version of {package!r}: {v_data['version']}")

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -114,6 +114,9 @@ server_url = urlparse(SERVER_URL)
 SERVER_DOMAIN = server_url.netloc or 'localhost'
 URL_PREFIX = env('URL_PREFIX', server_url.path.lstrip('/')) or ''
 
+# map package name => github repo name, to be filled when a custom version of a package is used
+REPO_OVERRIDE = {}
+
 JSON_SORT_KEYS = False
 VALIDATION_ERROR_STATUS = 400
 VALIDATION_ERROR_AS_LIST = True

--- a/tests/backend_meta_test.py
+++ b/tests/backend_meta_test.py
@@ -1,43 +1,68 @@
 
 import unittest
+from unittest.mock import patch
+from pathlib import Path
 
-from superdesk.backend_meta.backend_meta import get_client_ref, get_server_ref
+from superdesk.backend_meta import backend_meta
 
 
 class BackendMetaTestCase(unittest.TestCase):
 
-    def test_client_ref_commit(self):
-        ref = get_client_ref('superdesk-client-core#b5d555fd', 'superdesk-core', 'superdesk-client-core')
-        self.assertEqual('superdesk-client-core', ref['name'])
-        self.assertEqual('b5d555fd', ref['version'])
-        self.assertEqual('https://github.com/superdesk/superdesk-client-core/commit/b5d555fd', ref['href'])
+    @patch.object(backend_meta, "config", object)
+    def test_get_commit_href(self):
+        href = backend_meta.BackendMetaService.get_commit_href("superdesk", "xyz")
+        self.assertEqual(href, "https://github.com/superdesk/superdesk/commit/xyz")
 
-    def test_client_ref_branch(self):
-        ref = get_client_ref('superdesk-client-core#master', 'superdesk-core', 'superdesk-client-core')
-        self.assertEqual('master', ref['version'])
-        self.assertEqual('https://github.com/superdesk/superdesk-client-core/tree/master', ref['href'])
+    @patch.object(backend_meta.config, "REPO_OVERRIDE", {"superdesk": "superdesk-test"}, create=True)
+    def test_get_commit_href_override(self):
+        href = backend_meta.BackendMetaService.get_commit_href("superdesk", "xyz")
+        self.assertEqual(href, "https://github.com/superdesk/superdesk-test/commit/xyz")
 
-    def test_client_ref_tag(self):
-        ref = get_client_ref('1.27.0', 'superdesk-core', 'superdesk-client-core')
-        self.assertEqual('1.27.0', ref['version'])
-        self.assertEqual('https://github.com/superdesk/superdesk-client-core/releases/tag/v1.27.0', ref['href'])
+    @patch.object(backend_meta, "pkg_version")
+    def test_get_package_version_dev(self, pkg_version):
+        pkg_version.return_value = "2.0.123.dev123+g01abcde"
+        version_data = backend_meta.BackendMetaService.get_package_version("superdesk-core")
+        self.assertEqual(version_data, {
+            "name": "superdesk-core",
+            "version": "2.0.123.dev123+g01abcde",
+            "semver": "2.0.123",
+            "revision": "01abcde",
+            "href": "https://github.com/superdesk/superdesk-core/commit/01abcde",
+        })
 
-    def test_server_ref_branch(self):
-        ref = get_server_ref(
-            '-e git+git://github.com/superdesk/superdesk-core.git@master#egg=Superdesk-Core',
-            'superdesk-core')
-        self.assertEqual('superdesk-core', ref['name'])
-        self.assertEqual('master', ref['version'])
-        self.assertEqual('https://github.com/superdesk/superdesk-core/tree/master', ref['href'])
+    @patch.object(backend_meta, "pkg_version")
+    def test_get_package_version_stable(self, pkg_version):
+        pkg_version.return_value = "2.0.123"
+        version_data = backend_meta.BackendMetaService.get_package_version("superdesk-core")
+        self.assertEqual(version_data, {
+            "name": "superdesk-core",
+            "version": "2.0.123",
+            "semver": "2.0.123",
+            "href": "https://pypi.org/project/superdesk-core/2.0.123/",
+        })
 
-    def test_server_ref_commit(self):
-        ref = get_server_ref(
-            '-e git+git://github.com/superdesk/superdesk-core.git@aaaaa#egg=Superdesk-Core',
-            'superdesk-core')
-        self.assertEqual('aaaaa', ref['version'])
-        self.assertEqual('https://github.com/superdesk/superdesk-core/commit/aaaaa', ref['href'])
+    @patch.object(backend_meta.BackendMetaService, "find_dir")
+    def test_get_nodemod_version_rev(self, find_dir):
+        fixtures_path = Path(__file__).parent / "fixtures" / "backend_meta" / "dev"
+        find_dir.return_value = fixtures_path
+        backend_meta_service = backend_meta.BackendMetaService()
+        version_data = backend_meta_service.get_nodemod_version("superdesk-core", repo="superdesk-client-core")
+        self.assertEqual(version_data, {
+            "name": "superdesk-client-core",
+            "version": "141474f6643473dee1c6794989e9b231daf13465",
+            "revision": "141474f6643473dee1c6794989e9b231daf13465",
+            "href": "https://github.com/superdesk/superdesk-client-core/commit/141474f6643473dee1c6794989e9b231daf13465"
+        })
 
-    def test_server_ref_tag(self):
-        ref = get_server_ref('Superdesk-Core==1.26', 'superdesk-core')
-        self.assertEqual('1.26', ref['version'])
-        self.assertEqual('https://github.com/superdesk/superdesk-core/releases/tag/v1.26', ref['href'])
+    @patch.object(backend_meta.BackendMetaService, "find_dir")
+    def test_get_nodemod_version_stable(self, find_dir):
+        fixtures_path = Path(__file__).parent / "fixtures" / "backend_meta" / "stable"
+        find_dir.return_value = fixtures_path
+        backend_meta_service = backend_meta.BackendMetaService()
+        version_data = backend_meta_service.get_nodemod_version("superdesk-core", repo="superdesk-client-core")
+        self.assertEqual(version_data, {
+            "name": "superdesk-client-core",
+            "version": "2.1.0",
+            "semver": "2.1.0",
+            "href": "https://www.npmjs.com/package/superdesk-core/v/2.1.0"
+        })

--- a/tests/fixtures/backend_meta/dev/package-lock.json
+++ b/tests/fixtures/backend_meta/dev/package-lock.json
@@ -1,0 +1,11 @@
+{
+    "name": "superdesk",
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "superdesk-core": {
+            "version": "github:superdesk/superdesk-client-core#141474f6643473dee1c6794989e9b231daf13465",
+            "from": "github:superdesk/superdesk-client-core#master"
+        }
+    }
+}

--- a/tests/fixtures/backend_meta/dev/package.json
+++ b/tests/fixtures/backend_meta/dev/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "superdesk",
+    "license": "AGPL-3.0",
+    "dependencies": {
+        "superdesk-core": "superdesk/superdesk-client-core#master"
+    }
+}

--- a/tests/fixtures/backend_meta/stable/package-lock.json
+++ b/tests/fixtures/backend_meta/stable/package-lock.json
@@ -1,0 +1,11 @@
+{
+    "name": "superdesk",
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "superdesk-core": {
+            "version": "2.1.0",
+            "from": "2.1.0"
+        }
+    }
+}

--- a/tests/fixtures/backend_meta/stable/package.json
+++ b/tests/fixtures/backend_meta/stable/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "superdesk",
+    "license": "AGPL-3.0",
+    "dependencies": {
+        "superdesk-core": "2.1.0"
+    }
+}


### PR DESCRIPTION
- `importlib_metadata` is now used to get version from git repository
- when a version is stable, the PyPi URL is used instead of Github
- `package-lock.json` is used for node modules to retrieve Github
  revision when available, otherwise real semver
- when a version is stable, npmjs URL is used instead of Github
- revision of installed backend packages are logged, this can help debugging
- repository can be overriden, this is useful for custom superdesk
  versions.

SDESK-3632