### PR TITLE
fix delete on publish queue with more items

### DIFF
--- a/superdesk/publish/publish_queue.py
+++ b/superdesk/publish/publish_queue.py
@@ -156,7 +156,7 @@ class PublishQueueService(BaseService):
     def delete(self, lookup):
         # as encoded item is added manually to storage
         # we also need to remove it manually on delete
-        cur = self.get_from_mongo(req=None, lookup=lookup)
+        cur = self.get_from_mongo(req=None, lookup=lookup).sort("_id", 1)
         for doc in cur:
             try:
                 encoded_item_id = doc['encoded_item_id']

--- a/tests/publish/get_queue_items_tests.py
+++ b/tests/publish/get_queue_items_tests.py
@@ -12,6 +12,7 @@ from bson import ObjectId
 from unittest import mock
 from unittest.mock import MagicMock
 from datetime import timedelta
+from collections import UserList
 
 from superdesk.tests import TestCase
 from superdesk.utc import utcnow
@@ -133,6 +134,9 @@ class QueueItemsTestCase(TestCase):
         fake_storage_delete = fake_storage.delete
         service = publish_queue.PublishQueueService(backend=MagicMock())
         service.get_from_mongo = MagicMock()
-        service.get_from_mongo.return_value = [{'_id': "4567", 'encoded_item_id': 'TEST ID'}]
+        cursor = UserList([{'_id': "4567", 'encoded_item_id': 'TEST ID'}])
+        cursor.sort = MagicMock()
+        cursor.sort.return_value = cursor
+        service.get_from_mongo.return_value = cursor
         service.delete({'_id': "4567"})
         assert fake_storage_delete.call_args == mock.call('TEST ID')


### PR DESCRIPTION
there is operation failure on sort when using default sort,
so make use of `_id` field for sorting when deleting.

SDCP-417