### PR TITLE
use _id for sorting when deleting items

### DIFF
--- a/features/publish_queue.feature
+++ b/features/publish_queue.feature
@@ -430,13 +430,15 @@ Feature: Publish Queue
   Scenario: publish queue us returned in correct order
     Given "publish_queue"
     """
-    [{"_id":4, "_created":"2016-05-30T10:00:00+00:00", "subscriber_id": 4, "published_seq_num": 2},
-    {"_id":3, "_created":"2016-05-30T10:00:00+00:00", "subscriber_id": 4, "published_seq_num": 3},
-    {"_id":2, "_created":"2016-05-30T10:00:00+00:00", "subscriber_id": 3, "published_seq_num": 1},
-    {"_id":1, "_created":"2016-05-30T10:00:00+00:00", "subscriber_id": 2, "published_seq_num": 1}]
+    [
+      {"_created":"2016-05-30T13:00:00+00:00", "subscriber_id": 4, "published_seq_num": 2},
+      {"_created":"2016-05-30T12:00:00+00:00", "subscriber_id": 4, "published_seq_num": 3},
+      {"_created":"2016-05-30T11:00:00+00:00", "subscriber_id": 3, "published_seq_num": 1},
+      {"_created":"2016-05-30T10:00:00+00:00", "subscriber_id": 2, "published_seq_num": 1}
+    ]
     """
     When we get "/publish_queue"
-    Then we get list ordered by _id with 4 items
+    Then we get list ordered by _created with 4 items
 
   @auth
   Scenario: Expire published queue items

--- a/superdesk/eve_backend.py
+++ b/superdesk/eve_backend.py
@@ -338,7 +338,7 @@ class EveBackend():
         :param lookup: User mongo query syntax. example 1. ``{'_id':123}``, 2. ``{'item_id': {'$in': [123, 234]}}``
         :returns: Returns list of ids which were removed.
         """
-        docs = list(self.get_from_mongo(endpoint_name, lookup=lookup, req=ParsedRequest()))
+        docs = list(self.get_from_mongo(endpoint_name, lookup=lookup, req=ParsedRequest()).sort("_id", 1))
         removed_ids = self.delete_docs(endpoint_name, docs)
         if len(docs) and not len(removed_ids):
             logger.warn("No documents for %s resource were deleted using lookup %s", endpoint_name, lookup)

--- a/superdesk/publish/publish_queue.py
+++ b/superdesk/publish/publish_queue.py
@@ -120,7 +120,7 @@ class PublishQueueResource(Resource):
     }
 
     etag_ignore_fields = ['moved_to_legal']
-    datasource: Dict[str, Any] = {'default_sort': [('_created', -1), ('subscriber_id', 1), ('published_seq_num', -1)]}
+    datasource: Dict[str, Any] = {'default_sort': [('_id', -1), ('subscriber_id', 1), ('published_seq_num', -1)]}
     privileges = {'POST': 'publish_queue', 'PATCH': 'publish_queue'}
 
 


### PR DESCRIPTION
and use `_id` for default sort in publish queue to avoid mongo OperationFailure

SDCP-417