### PR TITLE
FIX: Associated media that was sent to another desk is not moved to desk output stage upon publishing the containing article. [SDESK-5709]

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -719,7 +719,6 @@ class BasePublishService(BaseService):
 
                 if associated_item.get('state') not in PUBLISH_STATES:
                     # This associated item has not been published before
-                    associated_item.get('task', {}).pop('stage', None)
                     remove_unwanted(associated_item)
 
                     # get the original associated item from archive

--- a/features/content_publish.feature
+++ b/features/content_publish.feature
@@ -2653,7 +2653,10 @@ Feature: Content Publishing
         "type": "text",
         "state": "published",
         "associations": {
-            "media--1": {"state": "published"}
+            "media--1": {
+              "state": "published",
+              "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}
+            }
         },
         "task":{"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}
       }
@@ -2667,7 +2670,6 @@ Feature: Content Publishing
           "task":{"desk": "#desks._id#"}
       }
       """
-      And we get null stage
       When we get "/published"
       Then we get list with 3 items
       """
@@ -2677,7 +2679,8 @@ Feature: Content Publishing
           "media--1": {
             "_id": "234",
             "type": "picture",
-            "state": "published"
+            "state": "published",
+            "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}
           },
           "related--1": {
             "_id": "text",


### PR DESCRIPTION
Reason:
The content update event refreshes the stages, but the push notification for the content update **(push_content_notification)** just send the stage for the article and not for the associated item because we just pop it out, and because of that, the content update event gets only the article stage and it refreshes only the article stage and not the associated item stage.