### PR TITLE
FIX: Associated media that was sent to another desk is not moved to desk output stage upon publishing the containing article. [SDESK-5709]

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -737,7 +737,7 @@ class BasePublishService(BaseService):
                         })
                         continue
 
-                    if orig_associated_item.get('task', {}).get('stage'):
+                    if orig_associated_item.get('task', {}).get('stage') and associated_item.get('task'):
                         associated_item['task'].update({
                             'stage': orig_associated_item.get('task', {}).get('stage')
                         })

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -737,6 +737,7 @@ class BasePublishService(BaseService):
                         })
                         continue
 
+                    # if the original associated item stage is present, it should be updated in the association item.
                     if orig_associated_item.get('task', {}).get('stage') and associated_item.get('task'):
                         associated_item['task'].update({
                             'stage': orig_associated_item.get('task', {}).get('stage')

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -737,6 +737,11 @@ class BasePublishService(BaseService):
                         })
                         continue
 
+                    if orig_associated_item.get('task', {}).get('stage'):
+                        associated_item['task'].update({
+                            'stage': orig_associated_item.get('task', {}).get('stage')
+                        })
+
                     # update _updated, otherwise it's stored as string.
                     # fixes SDESK-5043
                     associated_item['_updated'] = utcnow()


### PR DESCRIPTION
If the associated item is sent to another stage, the stage should update everywhere.