### PR TITLE
[BACKEND_META] Do not add PyPI href link if version is not semver

### DIFF
--- a/superdesk/backend_meta/backend_meta.py
+++ b/superdesk/backend_meta/backend_meta.py
@@ -123,7 +123,7 @@ class BackendMetaService(BaseService):
                 revision = rev_match.group("revision")
                 data["revision"] = revision
                 data["href"] = cls.get_commit_href(package, revision)
-            else:
+            elif version == semver:
                 data["href"] = PYPI_VERSION_HREF.format(
                     package=package,
                     version=semver,


### PR DESCRIPTION
It may happen that version is a dev version but we don't have the whole
hash, in this case it may look like `2.1.0.dev0`.
As we don't do pre-release on PyPI, a version which is not the semver
without suffix will lead a 404, thus this patch doesn't add an `href` when
this case arise.

SDESK-3632