### PR TITLE
avoid overriding of published item _id via param

### DIFF
--- a/apps/publish/published_item.py
+++ b/apps/publish/published_item.py
@@ -23,7 +23,7 @@ from superdesk.utc import utcnow
 
 from bson.objectid import ObjectId
 from eve.utils import ParsedRequest, config
-from flask import current_app as app
+from flask import current_app as app, request
 
 from apps.archive.archive import SOURCE as ARCHIVE
 from apps.archive.common import handle_existing_data, item_schema
@@ -207,6 +207,10 @@ class PublishedItemService(BaseService):
                     "lock_session": archive_item.get("lock_session", None),
                     "archive_item": archive_item if archive_item else None,
                 }
+
+                if request and request.args.get("published_id") == "1":
+                    updates.pop(config.ID_FIELD)
+                    updates.pop("item_id")
 
                 item.update(updates)
                 handle_existing_data(item)

--- a/features/published.feature
+++ b/features/published.feature
@@ -8,15 +8,25 @@ Feature: Published Items Repo
 
     @auth
     Scenario: Get published items with published state
+        Given "archive"
+        """
+        [{"_id": "archive_id", "state": "published"}]
+        """
         Given "published"
         """
-        [{"_id": "tag:example.com,0000:newsml_BRE9A605", "state": "published"}]
+        [{"_id": "archive_id", "state": "published"}]
         """
         When we get "/published"
         Then we get existing resource
         """
-        {"_items": [{"_id": "tag:example.com,0000:newsml_BRE9A605", "state": "published"}]}
+        {"_items": [{"_id": "archive_id", "state": "published"}]}
         """
+        When we get "/published?published_id=1"
+        Then we get existing resource
+        """
+        {"_items": [{"_id": "__objectid__", "item_id": "archive_id", "state": "published"}]}
+        """
+
     @auth
     Scenario: Insert published items with non-published state
         When we post to "published"

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -168,6 +168,11 @@ def json_match(context_data, response_data, json_fields=None):
             if context_data[key] == "__empty__":
                 assert len(response_data[key]) == 0, "%s is not empty (%s)" % (key, response_data[key])
                 continue
+            if context_data[key] == "__objectid__":
+                assert ObjectId(response_data[key]), "{key} is not ObjectId ({value})".format(
+                    key=key, value=response_data[key]
+                )
+                continue
             response_field = response_data[key]
             if key in json_fields:
                 try:


### PR DESCRIPTION
when request is made with `?published_id=1` superdesk
won't override `_id` of published item with `_id` from
archive but will keep `_id` from published collection.