### PR TITLE
fix deschedule with empty associations

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -788,6 +788,8 @@ class ArchiveService(BaseService):
             associations = original.get(ASSOCIATIONS) or {}
             archive_service = get_resource_service("archive")
             for associations_key, associated_item in associations.items():
+                if not associated_item:
+                    continue
                 orig_associated_item = archive_service.find_one(req=None, _id=associated_item[config.ID_FIELD])
                 if orig_associated_item and orig_associated_item.get("state") == CONTENT_STATE.SCHEDULED:
                     # deschedule associated item itself

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -652,7 +652,9 @@ def validate_schedule(schedule):
             raise SuperdeskApiError.badRequestError(_("Schedule date is not recognized"))
         if not schedule.date() or schedule.date().year <= 1970:
             raise SuperdeskApiError.badRequestError(_("Schedule date is not recognized"))
-        if schedule < utcnow():
+        if (schedule.tzinfo and schedule < utcnow()) or (
+            not schedule.tzinfo and schedule < utcnow().replace(tzinfo=None)
+        ):
             raise SuperdeskApiError.badRequestError(_("Schedule cannot be earlier than now"))
 
 

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -650,11 +650,10 @@ class BasePublishService(BaseService):
                     CONTENT_STATE.RECALLED,
                     CONTENT_STATE.SPIKED,
                 }
-                or (doc_item_state == CONTENT_STATE.SCHEDULED and not main_publish_schedule)
+                or (doc_item_state == CONTENT_STATE.SCHEDULED and main_publish_schedule is None)
             ):
                 validation_errors.append(_("Item cannot contain associated {state} item.").format(state=doc_item_state))
-
-            if doc_item_state == CONTENT_STATE.SCHEDULED:
+            elif doc_item_state == CONTENT_STATE.SCHEDULED:
                 item_schedule = get_utc_schedule(orig, PUBLISH_SCHEDULE)
                 if main_publish_schedule < item_schedule:
                     validation_errors.append(_("Associated item is scheduled later than current item."))

--- a/features/content_publish.feature
+++ b/features/content_publish.feature
@@ -918,7 +918,8 @@ Feature: Content Publishing
         "publish_schedule": "#DATE+1#",
         "subject":[{"qcode": "17004000", "name": "Statistics"}],
         "slugline": "test",
-        "body_html": "Test Document body"}]
+        "body_html": "Test Document body",
+        "associations": {"editor_0": null}}]
       """
       When we post to "/products" with success
       """

--- a/superdesk/eve_backend.py
+++ b/superdesk/eve_backend.py
@@ -259,8 +259,13 @@ class EveBackend:
                 raise SuperdeskApiError.notFoundError()
             else:
                 # item is there, but no change was done - ok
-                logger.error(
-                    "Item : {} not updated in collection {}. " "Updates are : {}".format(id, endpoint_name, updates)
+                logger.warning(
+                    "Item was not updated in mongo.",
+                    extra=dict(
+                        id=id,
+                        resource=endpoint_name,
+                        updates=updates,
+                    ),
                 )
                 return updates
 


### PR DESCRIPTION
there can be associations set to `None` and
then descheduling would fail.

SDCP-419