### PR TITLE
[SEARCH] fix `html_field_analyzer` case handling

### DIFF
--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -185,6 +185,7 @@ ELASTICSEARCH_SETTINGS = {
                 },
                 "html_field_analyzer": {
                     "type": "custom",
+                    "filter": ["lowercase"],
                     "tokenizer": "standard",
                     "char_filter": ["html_strip_filter"],
                 },

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -200,6 +200,7 @@ CONTENTAPI_ELASTICSEARCH_SETTINGS = {
             "analyzer": {
                 "html_field_analyzer": {
                     "type": "custom",
+                    "filter": ["lowercase"],
                     "tokenizer": "standard",
                     "char_filter": ["html_strip_filter"],
                 }


### PR DESCRIPTION
Custom `html_field_analyzer` was not using `lowercase` filter, so case
was kept. As a result, words with uppercase in them could not be found
with the search API.

SDCP-423