### PR TITLE
[SDESK-5890] Support timeouts for HTTP Push transmitter

### DIFF
--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -661,7 +661,7 @@ ENABLE_PROFILING = False
 FTP_TIMEOUT = 300
 
 #: default timeout when publishing using the `http_push` transmitter
-HTTP_PUSH_TIMEOUT = 30
+HTTP_PUSH_TIMEOUT = int(env("HTTP_PUSH_TIMEOUT", 30))
 
 #: default amount of files which can processed during one iteration of ftp ingest
 FTP_INGEST_FILES_LIST_LIMIT = 100

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -661,7 +661,7 @@ ENABLE_PROFILING = False
 FTP_TIMEOUT = 300
 
 #: default timeout when publishing using the `http_push` transmitter
-HTTP_PUSH_TIMEOUT = int(env("HTTP_PUSH_TIMEOUT", 30))
+HTTP_PUSH_TIMEOUT = (5, 30)
 
 #: default amount of files which can processed during one iteration of ftp ingest
 FTP_INGEST_FILES_LIST_LIMIT = 100

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -660,6 +660,9 @@ ENABLE_PROFILING = False
 #: default timeout for ftp connections
 FTP_TIMEOUT = 300
 
+#: default timeout when publishing using the `http_push` transmitter
+HTTP_PUSH_TIMEOUT = 30
+
 #: default amount of files which can processed during one iteration of ftp ingest
 FTP_INGEST_FILES_LIST_LIMIT = 100
 

--- a/superdesk/publish/transmitters/http_push.py
+++ b/superdesk/publish/transmitters/http_push.py
@@ -194,7 +194,7 @@ class HTTPPushService(PublishService):
         return response.status_code == requests.codes.ok  # @UndefinedVariable
 
     def _get_timeout(self):
-        return app.config.get('HTTP_PUSH_TIMEOUT', 30)
+        return app.config.get("HTTP_PUSH_TIMEOUT", 30)
 
     def _get_headers(self, data, destination, current_headers):
         secret_token = self._get_secret_token(destination)

--- a/superdesk/publish/transmitters/http_push.py
+++ b/superdesk/publish/transmitters/http_push.py
@@ -92,7 +92,7 @@ class HTTPPushService(PublishService):
     def _push_item(self, destination, data):
         resource_url = self._get_resource_url(destination)
         headers = self._get_headers(data, destination, self.headers)
-        response = requests.post(resource_url, data=data, headers=headers)
+        response = requests.post(resource_url, data=data, headers=headers, timeout=self._get_timeout())
 
         # need to rethrow exception as a superdesk exception for now for notifiers.
         try:
@@ -166,7 +166,7 @@ class HTTPPushService(PublishService):
         prepped.prepare_body(data, files)
         headers = self._get_headers(prepped.body, destination, prepped.headers)
         prepped.prepare_headers(headers)
-        response = s.send(prepped)
+        response = s.send(prepped, timeout=self._get_timeout())
         if response.status_code not in (200, 201):
             self._raise_publish_error(
                 response.status_code,
@@ -186,12 +186,15 @@ class HTTPPushService(PublishService):
         @return: bool
         """
         assets_url = self._get_assets_url(destination, media_id)
-        response = requests.get(assets_url)
+        response = requests.get(assets_url, timeout=self._get_timeout())
         if response.status_code not in (requests.codes.ok, requests.codes.not_found):  # @UndefinedVariable
             self._raise_publish_error(
                 response.status_code, Exception("Error querying the assets service %s" % assets_url), destination
             )
         return response.status_code == requests.codes.ok  # @UndefinedVariable
+
+    def _get_timeout(self):
+        return app.config.get('HTTP_PUSH_TIMEOUT', 30)
 
     def _get_headers(self, data, destination, current_headers):
         secret_token = self._get_secret_token(destination)

--- a/superdesk/publish/transmitters/http_push.py
+++ b/superdesk/publish/transmitters/http_push.py
@@ -194,7 +194,7 @@ class HTTPPushService(PublishService):
         return response.status_code == requests.codes.ok  # @UndefinedVariable
 
     def _get_timeout(self):
-        return app.config.get("HTTP_PUSH_TIMEOUT", 30)
+        return app.config.get("HTTP_PUSH_TIMEOUT", (5, 30))
 
     def _get_headers(self, data, destination, current_headers):
         secret_token = self._get_secret_token(destination)

--- a/tests/publish/transmitters/http_push_transmitter_tests.py
+++ b/tests/publish/transmitters/http_push_transmitter_tests.py
@@ -227,7 +227,7 @@ class HTTPPushServiceTestCase(unittest.TestCase):
         ]
 
         for media in images:
-            get_mock.assert_any_call("http://example.com/%s" % media, timeout=30)
+            get_mock.assert_any_call("http://example.com/%s" % media, timeout=(5, 30))
 
     @mock.patch("superdesk.publish.transmitters.http_push.app")
     @mock.patch("superdesk.publish.transmitters.http_push.requests.Session.send", return_value=CreatedResponse)
@@ -248,8 +248,8 @@ class HTTPPushServiceTestCase(unittest.TestCase):
         service._copy_published_media_files(item, dest)
 
         app_mock.media.get.assert_called_with("media-id", resource="attachments")
-        get_mock.assert_called_with("http://example.com/media-id", timeout=30)
-        send_mock.assert_called_once_with(mock.ANY, timeout=30)
+        get_mock.assert_called_with("http://example.com/media-id", timeout=(5, 30))
+        send_mock.assert_called_once_with(mock.ANY, timeout=(5, 30))
         request = send_mock.call_args[0][0]
         self.assertEqual("http://example.com/", request.url)
         self.assertEqual("POST", request.method)
@@ -269,8 +269,8 @@ class HTTPPushServiceTestCase(unittest.TestCase):
         dest = {"config": {"assets_url": "http://example.com", "secret_token": "foo"}}
         service = HTTPPushService()
         service._transmit_media(media, dest)
-        get_mock.assert_called_with("http://example.com/media-id", timeout=30)
-        send_mock.assert_called_once_with(mock.ANY, timeout=30)
+        get_mock.assert_called_with("http://example.com/media-id", timeout=(5, 30))
+        send_mock.assert_called_once_with(mock.ANY, timeout=(5, 30))
         request = send_mock.call_args[0][0]
         self.assertEqual("http://example.com/", request.url)
         self.assertIn(b"content", request.body)


### PR DESCRIPTION
@petrjasek This is to be back-ported to v1.32+