### PR TITLE
keep guid and _id the same for media items

### DIFF
--- a/apps/archive/archive_media.py
+++ b/apps/archive/archive_media.py
@@ -93,7 +93,7 @@ class ArchiveMediaService:
 
         update_dates_for(doc)
         generate_unique_id_and_name(doc)
-        doc["guid"] = generate_guid(type=GUID_TAG)
+        doc.setdefault("guid", generate_guid(type=GUID_TAG))
         doc.setdefault(config.ID_FIELD, doc["guid"])
         doc[config.VERSION] = 1
         set_item_expiry({}, doc)

--- a/features/archive.feature
+++ b/features/archive.feature
@@ -354,7 +354,7 @@ Feature: News Items Archive
         When we upload a file "bike.jpg" to "archive"
         Then we get new resource
         """
-        {"guid": "__any_value__", "firstcreated": "__any_value__", "versioncreated": "__any_value__", "state": "in_progress"}
+        {"guid": "#archive._id#", "firstcreated": "__any_value__", "versioncreated": "__any_value__", "state": "in_progress"}
         """
         When we patch latest
         """


### PR DESCRIPTION
as we do for text items

SDANSA-486