### PR TITLE
Handle lazy strings when json encoding

### DIFF
--- a/superdesk/json_utils.py
+++ b/superdesk/json_utils.py
@@ -9,12 +9,15 @@ from bson.errors import InvalidId
 from eve.utils import str_to_date
 from eve.io.mongo import MongoJSONEncoder
 from eve_elastic import ElasticJSONSerializer
-
+from flask_babel import LazyString
 
 class SuperdeskJSONEncoder(MongoJSONEncoder, ElasticJSONSerializer):
     """Custom JSON encoder for elastic that can handle `bson.ObjectId`s."""
 
-    pass
+    def default(self, obj):
+        if isinstance(obj, LazyString):
+            return str(obj)
+        return super().default(obj)
 
 
 def try_cast(v):


### PR DESCRIPTION
Fix for Newsroom it now uses lazy string types, required for https://github.com/superdesk/newsroom/pull/1130