### PR TITLE
[MACROS] expose `replace_type` (#2159)

### DIFF
--- a/apps/macros/macros.py
+++ b/apps/macros/macros.py
@@ -121,6 +121,10 @@ class MacrosResource(superdesk.Resource):
             "type": "string",
             "readonly": True,
         },
+        "replace_type": {
+            "type": "string",
+            "readonly": True,
+        },
         "group": {
             "type": "string",
             "readonly": True,


### PR DESCRIPTION
`replace_type` was not exposed by the API, as a result the client could
not apply the item update correctly.

fix SDBELGA-460