### PR TITLE
[FEEDING SERVICE][GMAIL]Set email on log-in + log-out button

### DIFF
--- a/superdesk/auth/oauth.py
+++ b/superdesk/auth/oauth.py
@@ -182,19 +182,14 @@ def configure_google(app, extra_scopes: Optional[List[str]] = None, refresh: boo
                         '"security/Third-party apps with account access") then try to log-in again'
                     )
 
-
             # token_id is actually the provider id
             ingest_providers_service = superdesk.get_resource_service("ingest_providers")
             provider = ingest_providers_service.find_one(req=None, _id=token_id)
             if provider is None:
-                logger.warning(
-                    f"No provider is corresponding to the id used with the token {token_id!r}"
-                )
+                logger.warning(f"No provider is corresponding to the id used with the token {token_id!r}")
             else:
                 ingest_providers_service.update(
-                    provider[config.ID_FIELD],
-                    updates={"config.email": user["email"]},
-                    original=provider
+                    provider[config.ID_FIELD], updates={"config.email": user["email"]}, original=provider
                 )
 
             return render_template(TEMPLATE, data={})
@@ -203,7 +198,7 @@ def configure_google(app, extra_scopes: Optional[List[str]] = None, refresh: boo
             return auth_user(user["email"], {"needs_activation": False})
 
     @bp.route("/logout/google/<url_id>")
-    def google_logout(url_id: str = None):
+    def google_logout(url_id: str):
         """Revoke token
 
         :param url_id: used to identify the token
@@ -214,7 +209,7 @@ def configure_google(app, extra_scopes: Optional[List[str]] = None, refresh: boo
     superdesk.blueprint(bp, app)
 
 
-def _get_token_and_sesion(token_id: str) -> Tuple[dict, dict]:
+def _get_token_and_sesion(token_id: str) -> Tuple[dict, OAuth2Session]:
     oauth2_token_service = superdesk.get_resource_service("oauth2_token")
     token = oauth2_token_service.find_one(req=None, _id=token_id)
     if token is None:
@@ -246,9 +241,5 @@ def revoke_google_token(token_id: str) -> None:
     ingest_providers_service = superdesk.get_resource_service("ingest_providers")
     provider = ingest_providers_service.find_one(req=None, _id=token_id)
     if provider is not None:
-        ingest_providers_service.update(
-            provider[config.ID_FIELD],
-            updates={"config.email": None},
-            original=provider
-        )
+        ingest_providers_service.update(provider[config.ID_FIELD], updates={"config.email": None}, original=provider)
     logger.info(f"OAUTH token {token_id!r} has been revoked")

--- a/superdesk/auth/oauth.py
+++ b/superdesk/auth/oauth.py
@@ -36,6 +36,7 @@ from authlib.integrations.requests_client import OAuth2Session
 from authlib.oauth2.rfc6749.wrappers import OAuth2Token
 from superdesk.resource import Resource
 from superdesk.services import BaseService
+from superdesk.errors import SuperdeskApiError
 
 from superdesk.auth import auth_user, TEMPLATE
 
@@ -219,7 +220,7 @@ def _get_token_and_sesion(token_id: ObjectId) -> Tuple[dict, OAuth2Session]:
     oauth2_token_service = superdesk.get_resource_service("oauth2_token")
     token = oauth2_token_service.find_one(req=None, _id=token_id)
     if token is None:
-        raise ValueError("unknown token id: {_id}".format(_id=token_id))
+        raise SuperdeskApiError.notFoundError(f"unknown token id: {token_id}")
     if not token["refresh_token"]:
         raise ValueError("missing refresh token for token {_id}".format(_id=token["_id"]))
     session = OAuth2Session(

--- a/superdesk/io/feeding_services/__init__.py
+++ b/superdesk/io/feeding_services/__init__.py
@@ -46,11 +46,9 @@ class FeedingService(metaclass=ABCMeta):
                 - required: if true the field is required
                 - errors: dictionary of with key being the error code and value the error description
                 - required_expression: if the evaluation of the expression is true the field is required
-                    on validation. Field values can be referred by enclosing the field identifier in
-                    accolades: {field_id}
+                    on validation.
                 - readonly: if true, the field is not editable
                 - show_expression: if the evaluation of this JavaScript expression is true the field is displayed.
-                    Field values can be referred by enclosing the field identifier in accolades: {field_id}
                 - default_value: value to use
             Type specific properties:
                 properties with a ``*`` are mandatory

--- a/superdesk/io/feeding_services/__init__.py
+++ b/superdesk/io/feeding_services/__init__.py
@@ -49,7 +49,7 @@ class FeedingService(metaclass=ABCMeta):
                     on validation. Field values can be referred by enclosing the field identifier in
                     accolades: {field_id}
                 - readonly: if true, the field is not editable
-                - show_expression: if the evaluation of the expression is true the field is displayed.
+                - show_expression: if the evaluation of this JavaScript expression is true the field is displayed.
                     Field values can be referred by enclosing the field identifier in accolades: {field_id}
                 - default_value: value to use
             Type specific properties:

--- a/superdesk/io/feeding_services/ftp.py
+++ b/superdesk/io/feeding_services/ftp.py
@@ -90,7 +90,7 @@ class FTPFeedingService(FeedingService):
             "label": "Move ingested items to",
             "placeholder": "FTP Server Path, keep empty to use default path",
             "required": False,
-            "show_expression": "{move}",
+            "show_expression": "provider.config.move === true",
         },
         {
             "id": "move_path_error",
@@ -98,7 +98,7 @@ class FTPFeedingService(FeedingService):
             "label": "Move *NOT* ingested items (i.e. on error) to",
             "placeholder": "FTP Server Path, keep empty to use default path",
             "required": False,
-            "show_expression": "{move}",
+            "show_expression": "provider.config.move === true",
         },
     ]
 

--- a/superdesk/io/feeding_services/gmail.py
+++ b/superdesk/io/feeding_services/gmail.py
@@ -7,6 +7,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import imaplib
+from bson import ObjectId
 from os.path import join
 import time
 import logging
@@ -83,7 +84,7 @@ class GMailFeedingService(EmailFeedingService):
 
     def authenticate(self, provider: dict, config: dict) -> imaplib.IMAP4_SSL:
         oauth2_token_service = superdesk.get_resource_service("oauth2_token")
-        token = oauth2_token_service.find_one(req=None, _id=provider["_id"])
+        token = oauth2_token_service.find_one(req=None, _id=ObjectId(provider["_id"]))
         if token is None:
             raise IngestEmailError.notConfiguredError(ValueError(l_("You need to log in first")), provider=provider)
         imap = imaplib.IMAP4_SSL("imap.gmail.com")

--- a/superdesk/io/feeding_services/gmail.py
+++ b/superdesk/io/feeding_services/gmail.py
@@ -37,24 +37,28 @@ class GMailFeedingService(EmailFeedingService):
 
     fields = [
         {
+            "id": "email",
+            "type": "text",
+            "label": l_("email"),
+            "readonly": True,
+            "show_expression": "provider.config['email'] != null",
+        },
+        {
             "id": "log_in_url",
             "type": "url_request",
             "label": l_("Log-in with GMail"),
-            "show_expression": "!provider.config['email']",
+
+            # provider._id != null              provider has to be saved before trying to log in
+            # provider.config['email'] == null  do not display log-in button if logged-in already
+            "show_expression": "provider._id != null && provider.config['email'] == null",
         },
         {
             "id": "log_out_url",
             "type": "url_request",
             "label": l_("Log-out"),
-            "show_expression": "provider.config['email']",
-        },
-        {
-            "id": "email",
-            "type": "text",
-            "label": l_("email"),
-            "readonly": True,
-            "placeholder": l_("This field will be automatically filled once you've logged using log-in button above"),
-            "show_expression": "{email}",
+
+            # provider.config['email'] != null  only display log-out button if already logged in
+            "show_expression": "provider.config['email'] != null",
         },
         {
             "id": "mailbox",

--- a/superdesk/io/feeding_services/gmail.py
+++ b/superdesk/io/feeding_services/gmail.py
@@ -47,7 +47,6 @@ class GMailFeedingService(EmailFeedingService):
             "id": "log_in_url",
             "type": "url_request",
             "label": l_("Log-in with GMail"),
-
             # provider._id != null              provider has to be saved before trying to log in
             # provider.config['email'] == null  do not display log-in button if logged-in already
             "show_expression": "provider._id != null && provider.config['email'] == null",
@@ -56,7 +55,6 @@ class GMailFeedingService(EmailFeedingService):
             "id": "log_out_url",
             "type": "url_request",
             "label": l_("Log-out"),
-
             # provider.config['email'] != null  only display log-out button if already logged in
             "show_expression": "provider.config['email'] != null",
         },

--- a/superdesk/io/feeding_services/http_base_service.py
+++ b/superdesk/io/feeding_services/http_base_service.py
@@ -95,16 +95,16 @@ class HTTPFeedingServiceBase(FeedingService):
             "type": "text",
             "label": "Username",
             "placeholder": "Username",
-            "required_expression": "{auth_required}",
-            "show_expression": "{auth_required}",
+            "required_expression": "provider.config.auth_required === true",
+            "show_expression": "provider.config.auth_required === true",
         },
         {
             "id": "password",
             "type": "password",
             "label": "Password",
             "placeholder": "Password",
-            "required_expression": "{auth_required}",
-            "show_expression": "{auth_required}",
+            "required_expression": "provider.config.auth_required === true",
+            "show_expression": "provider.config.auth_required === true",
         },
     ]
 


### PR DESCRIPTION
This patch needs a modification in client to save the provider before the
`Log-in with GMail` button can be used.

When user is successfully logged-in, the email address is set to the
corresponding feeding service.

The `Log-in with GMail` is now only shown if user is not already
logged-in (i.e. if we don't have an e-mail address set).

When user is logged-in, a `Log-out` button is shown instead, using it
will revoke the OAuth token, delete it from mongo and remove the email
from ingest provider configuration.

SDESK-5800