### PR TITLE
[CI] Install dependencies before CodeQL intialisation

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,6 @@ jobs:
     - name: Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get upgrade -y
         sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,6 +32,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - name: Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get upgrade -y
+        sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1


### PR DESCRIPTION
CodeQL auto python setup was failing, this patch install missing
dependencies before doing it.

SDESK-6148