### PR TITLE
avoid editor3 rendering error on missing style implementation

### DIFF
--- a/superdesk/editor_utils.py
+++ b/superdesk/editor_utils.py
@@ -494,9 +494,9 @@ class DraftJSHTMLExporter:
             return DOM.create_element("span", attribs, props["children"])
         if type_.startswith("COMMENT"):
             # nothing to render for comments
-            pass
-        else:
-            logger.error("No style renderer for {type_!r}".format(type_=type_))
+            return
+        logger.info("No style renderer for {type_!r}".format(type_=type_))
+        return props["children"]
 
 
 class Editor3Content(EditorContent):

--- a/tests/editor_utils_test.py
+++ b/tests/editor_utils_test.py
@@ -176,6 +176,7 @@ class Editor3TestCase(unittest.TestCase):
                         {"offset": 12, "length": 8, "style": "STRIKETHROUGH"},
                         {"offset": 21, "length": 5, "style": "SUBSCRIPT"},
                         {"offset": 27, "length": 4, "style": "SUPERSCRIPT"},
+                        {"offset": 32, "length": 1, "style": "LIMIT_CHARACTERS_OVERFLOW"},
                     ],
                     "entityRanges": [],
                     "data": {"MULTIPLE_HIGHLIGHTS": {}},


### PR DESCRIPTION
client could introduce new inline styles which should not be
rendered in the output (like error highlighting), so handle
that without raising an error