### PR TITLE
avoid settings default values based on content profile

### DIFF
--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -794,19 +794,12 @@ def transtype_metadata(doc, original=None):
 def copy_metadata_from_profile(doc):
     """Set the default values defined on document profile.
 
+    .. deprecated:: 2.2
+        We use templates to handle default values, so ignore profile defaults for now.
+
     :param doc
     """
     defaults = {}
-    profile = doc.get("profile", None)
-    if profile:
-        content_type = superdesk.get_resource_service("content_types").find_one(req=None, _id=profile)
-        if content_type:
-            defaults = {
-                name: field.get("default", None)
-                for (name, field) in content_type.get("schema", {}).items()
-                if field and field.get("default", None)
-            }
-
     defaults.setdefault("priority", config.DEFAULT_PRIORITY_VALUE_FOR_MANUAL_ARTICLES)
     defaults.setdefault("urgency", config.DEFAULT_URGENCY_VALUE_FOR_MANUAL_ARTICLES)
     defaults.setdefault("genre", config.DEFAULT_GENRE_VALUE_FOR_MANUAL_ARTICLES)

--- a/features/archive.feature
+++ b/features/archive.feature
@@ -672,34 +672,6 @@ Feature: News Items Archive
          {"guid": "123", "source": "FOO", "dateline": {"source": "FOO"}}
          """
 
-      @auth
-      Scenario: Create content item based on a content type with default values
-         Given "content_types"
-          """
-          [{"_id": "snap", "schema": {"headline": {"default": "default_headline"}, "priority": {"default": 10}}}]
-          """
-         When we post to "/archive"
-          """
-           [{  "type":"text", "guid": "123",  "profile": "snap" }]
-          """
-         When we get "archive/123"
-         Then we get OK response
-         Then we get existing resource
-         """
-         {"guid": "123", "headline": "default_headline", "priority": 10}
-         """
-
-         When we post to "/archive"
-          """
-           [{  "type":"text", "headline": "test1", "guid": "456",  "priority": 3, "profile": "snap" }]
-          """
-         When we get "archive/456"
-         Then we get OK response
-         Then we get existing resource
-         """
-         {"guid": "456", "headline": "test1", "priority": 3}
-         """
-
     @auth
     Scenario: Hide version 0 items from lists
         When we post to "/archive"

--- a/features/content_profile.feature
+++ b/features/content_profile.feature
@@ -1408,29 +1408,6 @@ Feature: Content Profile
         """
 
     @auth
-    Scenario: Content profile defaults override user profile defaults
-        Given "content_types"
-        """
-        [{"_id": "foo", "label": "Foo", "schema": {
-            "byline": {"default": "By Foo"},
-            "headline": null,
-            "place": {"default": [{"name": "Prague"}]}
-        }}]
-        """
-        When we patch "/users/#CONTEXT_USER_ID#"
-        """
-        {"byline": "By Admin"}
-        """
-        When we post to "/archive"
-        """
-        {"type": "text", "profile": "foo"}
-        """
-        Then we get new resource
-        """
-        {"byline": "By Foo", "place": [{"name": "Prague"}]}
-        """
-
-    @auth
     Scenario: Validate using content profile when publishing
         Given "vocabularies"
         """


### PR DESCRIPTION
it's deprecated func which can't be managed via ui anymore,
so avoid using that on the backend.

SDNTB-706