### PR TITLE
FIX: 500: Failed to publish the item, error when publishing text item with newly uploaded associated media [SDESK-6150]

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -245,7 +245,7 @@ class BasePublishService(BaseService):
                 # send notification so that marked for me list can be updated
                 get_resource_service("archive").handle_mark_user_notifications(updates, original, False)
 
-        except SuperdeskApiError:
+        except (SuperdeskApiError, SuperdeskValidationError):
             raise
         except KeyError as e:
             logger.exception(e)


### PR DESCRIPTION
adjust the error message to be more clear while publish