### PR TITLE
[SDESK-6312] fix: Use Lax for cookie samesite

### DIFF
--- a/superdesk/auth/oauth.py
+++ b/superdesk/auth/oauth.py
@@ -149,7 +149,7 @@ def configure_google(app, extra_scopes: Optional[List[str]] = None, refresh: boo
             if OAuth is used for Superdesk login, url_id is None.
             Otherwise, it is used to associate the token with the provider needing it
         """
-        superdesk.app.redis.set(KEY_GOOGLE_PROVIDER_ID, url_id, ex=TTL_GOOGLE_PROVIDER_ID)
+        superdesk.app.redis.set(KEY_GOOGLE_PROVIDER_ID, url_id or "", ex=TTL_GOOGLE_PROVIDER_ID)
         redirect_uri = url_for(".google_authorized", _external=True)
         return oauth.google.authorize_redirect(redirect_uri)
 

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -158,7 +158,7 @@ SESSION_COOKIE_SECURE = CLIENT_URL.startswith("https")
 #: But still allow cross-origin/same-site requests
 #:
 #: .. versionadded:: 2.4.0
-SESSION_COOKIE_SAMESITE = "Strict"
+SESSION_COOKIE_SAMESITE = "Lax"
 
 #: mongo db name, only used when mongo_uri is not set
 MONGO_DBNAME = env("MONGO_DBNAME", "superdesk")


### PR DESCRIPTION
This allows cookies to be sent along with requests initiated by third party services.
This was causing issues with Google OAuth