### PR TITLE
[FEEDING SERVICES][EMAIL]Don't use None or empty string for criterion

### DIFF
--- a/superdesk/io/feeding_services/email.py
+++ b/superdesk/io/feeding_services/email.py
@@ -110,7 +110,9 @@ class EmailFeedingService(FeedingService):
                 if rv != "OK":
                     raise IngestEmailError.emailMailboxError()
                 try:
-                    rv, data = imap.search(None, config.get("filter", "(UNSEEN)"))
+                    # at least one criterion must be set
+                    # (see file:///usr/share/doc/python/html/library/imaplib.html#imaplib.IMAP4.search)
+                    rv, data = imap.search(None, config.get("filter") or "(UNSEEN)")
                     if rv != "OK":
                         raise IngestEmailError.emailFilterError()
                     for num in data[0].split():


### PR DESCRIPTION
At least one criterion must be used, thus `(UNSEEN)` is used in case of
empty string or None value.

fix SDESK-6344