### PR TITLE
make sure we return the original sluglines

### DIFF
--- a/apps/archive/autocomplete.py
+++ b/apps/archive/autocomplete.py
@@ -26,8 +26,8 @@ class AutocompleteResource(superdesk.Resource):
 
 class AutocompleteService(superdesk.Service):
 
-    allowed_fields = {
-        "slugline",
+    field_mapping = {
+        "slugline": "slugline.keyword",
     }
 
     def get(self, req, lookup):
@@ -37,7 +37,7 @@ class AutocompleteService(superdesk.Service):
         if not app.config.get(SETTING_ENABLED):
             raise SuperdeskApiError(_("Archive autocomplete is not enabled"), 404)
 
-        if field not in self.allowed_fields:
+        if field not in self.field_mapping:
             raise SuperdeskApiError(_("Field %(field)s is not allowed", field=field), 400)
 
         versioncreated_min = (
@@ -63,7 +63,7 @@ class AutocompleteService(superdesk.Service):
             "aggs": {
                 "values": {
                     "terms": {
-                        "field": field,
+                        "field": self.field_mapping[field],
                         "size": app.config[SETTING_LIMIT],
                         "order": {"_key": "asc"},
                     },

--- a/features/archive_autocomplete.feature
+++ b/features/archive_autocomplete.feature
@@ -17,20 +17,20 @@ Feature: Archive autocomplete
         Given "archive"
         """
         [
-            {"slugline": "published_c", "state": "published", "versioncreated": "2019-01-01T00:00:00+0000"},
-            {"slugline": "published_old", "state": "published", "versioncreated": "1919-01-01T00:00:00+0000"},
-            {"slugline": "draft", "state": "draft", "versioncreated": "2019-01-01T00:00:00+0000"},
-            {"slugline": "czech", "state": "published", "versioncreated": "2019-01-01T00:00:00+0000", "language": "cs"},
-            {"slugline": "published_a", "state": "published", "versioncreated": "2019-01-01T00:00:00+0000", "language": "en"},
-            {"slugline": "published_b", "state": "published", "versioncreated": "2019-01-01T00:00:00+0000", "language": "en"}
+            {"slugline": "PUBLISHED-A", "state": "published", "versioncreated": "2019-01-01T00:00:00+0000"},
+            {"slugline": "PUBLISHED-OLD", "state": "published", "versioncreated": "1919-01-01T00:00:00+0000"},
+            {"slugline": "DRAFT", "state": "draft", "versioncreated": "2019-01-01T00:00:00+0000"},
+            {"slugline": "CZECH", "state": "published", "versioncreated": "2019-01-01T00:00:00+0000", "language": "cs"},
+            {"slugline": "PUBLISHED-C", "state": "published", "versioncreated": "2019-01-01T00:00:00+0000", "language": "en"},
+            {"slugline": "PUBLISHED-B", "state": "published", "versioncreated": "2019-01-01T00:00:00+0000", "language": "en"}
         ]
         """
         When we get "/archive_autocomplete?field=slugline&language=en"
         Then we get list with 3 items
         """
         {"_items": [
-            {"value": "published_a"},
-            {"value": "published_b"},
-            {"value": "published_c"}
+            {"value": "PUBLISHED-A"},
+            {"value": "PUBLISHED-B"},
+            {"value": "PUBLISHED-C"}
         ]}
         """

--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -254,7 +254,10 @@ metadata_schema = {
                     "analyzer": "phrase_prefix_analyzer",
                     "search_analyzer": "phrase_prefix_analyzer",
                     "fielddata": True,
-                }
+                },
+                "keyword": {
+                    "type": "keyword",
+                },
             },
         },
     },


### PR DESCRIPTION
as we use text field the values are analyzed,
which wasn't obvious from the test, but the aggregation
would return each word as a separate bucket

SDESK-6359