### PR TITLE
[SDESK-6384] fix: Pass updates to item_publish signal

### DIFF
--- a/.fireq.json
+++ b/.fireq.json
@@ -1,3 +1,4 @@
 {
-    "elastic": 7
+    "elastic": 7,
+    "superdesk_branch": "support/2.3"
 }

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -225,12 +225,7 @@ class BasePublishService(BaseService):
                 if updated.get(ASSOCIATIONS):
                     self._fix_related_references(updated, updates)
 
-                signals.item_publish.send(self, item=updated)
-
-                # Merge changes from ``updated`` into ``updates``, otherwise changes to the item
-                # from a signal will only be reflected in the ``published`` collection and not ``archive``
-                updates.update(updated)
-
+                signals.item_publish.send(self, item=updated, updates=updates)
                 self._update_archive(original, updates, should_insert_into_versions=auto_publish)
                 self.update_published_collection(published_item_id=original[config.ID_FIELD], updated=updated)
 

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -226,6 +226,11 @@ class BasePublishService(BaseService):
                     self._fix_related_references(updated, updates)
 
                 signals.item_publish.send(self, item=updated)
+
+                # Merge changes from ``updated`` into ``updates``, otherwise changes to the item
+                # from a signal will only be reflected in the ``published`` collection and not ``archive``
+                updates.update(updated)
+
                 self._update_archive(original, updates, should_insert_into_versions=auto_publish)
                 self.update_published_collection(published_item_id=original[config.ID_FIELD], updated=updated)
 

--- a/superdesk/signals.py
+++ b/superdesk/signals.py
@@ -25,6 +25,8 @@ __all__ = [
     "item_duplicate",
     "item_duplicated",
     "archived_item_removed",
+    "item_resend",
+    "item_resent",
 ]
 
 signals = blinker.Namespace()
@@ -158,6 +160,22 @@ item_duplicated = signals.signal("item:duplicated")
 #: :param sender: archived service
 #: :param item: item being removed from archived
 archived_item_removed = signals.signal("archived:removed")
+
+#: Sent before item is resent
+#:
+#: ..versionadded: 2.3.8
+#:
+#: :param sender: ResendService
+#: :param item: item being resent
+item_resend = signals.signal("item:resend")
+
+#: Sent after item is resent
+#:
+#: ..versionadded: 2.3.8
+#:
+#: :param sender: ResendService
+#: :param item: item that was resent
+item_resent = signals.signal("item:resent")
 
 
 def connect(signal, subscriber):


### PR DESCRIPTION
Also include `item_resend` and `item_resent` signals