### PR TITLE
when we fetch association update the metadata on the root item

### DIFF
--- a/apps/duplication/archive_fetch.py
+++ b/apps/duplication/archive_fetch.py
@@ -155,7 +155,7 @@ class FetchService(BaseService):
                 new_item["stage"] = stage
                 new_item["state"] = state
                 new_ids = self.fetch([new_item], id=None, notify=False)
-                item[config.ID_FIELD] = new_ids[0]
+                item.update(new_item)
 
     def __fetch_items_in_package(self, dest_doc, desk, stage, state):
         # Note: macro and target information is not user for package publishing.

--- a/features/content_fetch.feature
+++ b/features/content_fetch.feature
@@ -796,3 +796,60 @@ Feature: Fetch Items from Ingest
         }
         ]}
       """
+
+    @auth
+    Scenario: Fetch item with associations
+        Given "ingest"
+        """
+        [
+            {
+                "_id": "picture",
+                "type": "picture",
+                "state": "ingested"
+            },
+            {
+                "_id": "text",
+                "type": "text",
+                "associations": {
+                    "featured": {
+                        "_id": "picture",
+                        "type": "picture",
+                        "state": "ingested"
+                    }
+                }
+            }
+        ]
+        """
+        And "desks"
+        """
+        [{"name": "Sports"}]
+        """
+
+        When we post to "/ingest/text/fetch"
+        """
+        {"desk": "#desks._id#"}
+        """
+        Then we get new resource
+        When we get "archive"
+        Then we get list with 2 items
+        """
+        {
+            "_items": [
+                {
+                    "type": "picture",
+                    "_current_version": 1,
+                    "state": "fetched"
+                },
+                {
+                    "type": "text",
+                    "_current_version": 1,
+                    "associations": {
+                        "featured": {
+                            "_current_version": 1,
+                            "state": "fetched"
+                        }
+                    }
+                }
+            ]
+        }
+        """


### PR DESCRIPTION
so any changes done there in eg. featured image won't be
overriden on publishing due to not having the same _current_version.

SDESK-6423