### PR TITLE
avoid version=None in newsroom ninjs output

### DIFF
--- a/superdesk/publish/formatters/ninjs_newsroom_formatter.py
+++ b/superdesk/publish/formatters/ninjs_newsroom_formatter.py
@@ -39,7 +39,8 @@ class NewsroomNinjsFormatter(NINJSFormatter):
 
         if article.get("ingest_id") and article.get("auto_publish"):
             ninjs["guid"] = article.get("ingest_id")
-            ninjs["version"] = article.get("ingest_version")
+            if article.get("ingest_version"):
+                ninjs["version"] = article["ingest_version"]
 
         ninjs["products"] = self._format_products(article)
 


### PR DESCRIPTION
that makes publisher not accept the payload due to strict validation

SDESK-6556