### PR TITLE
make type of query_string query configurable

### DIFF
--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -121,6 +121,7 @@ class SearchService(superdesk.Service):
 
     def _enhance_query_string(self, query_string):
         query_string.setdefault("analyze_wildcard", app.config["ELASTIC_QUERY_STRING_ANALYZE_WILDCARD"])
+        query_string.setdefault("type", app.config["ELASTIC_QUERY_STRING_TYPE"])
 
     def _get_projected_fields(self, req):
         """Get elastic projected fields."""

--- a/features/search.feature
+++ b/features/search.feature
@@ -504,3 +504,45 @@ Feature: Search Feature
             ]
         }
         """
+
+    @auth
+    Scenario: Search by multiple words each matching in different field
+        Given "desks"
+        """
+        [{"name": "Sports Desk", "content_expiry": 60}]
+        """
+        Given "archive"
+        """
+        [
+            {
+                "guid": "1",
+                "state": "in_progress",
+                "task": {"desk": "#desks._id#"},
+                "headline": "headline",
+                "body_html": "body"
+            },
+            {
+                "guid": "2",
+                "state": "in_progress",
+                "task": {"desk": "#desks._id#"},
+                "headline": "something completely different",
+                "body_html": "body"
+            },
+            {
+                "guid": "3",
+                "state": "in_progress",
+                "task": {"desk": "#desks._id#"},
+                "headline": "headline",
+                "body_html": "something completely different"
+            }
+        ]
+        """
+        When we get "/search?source={"query": {"filtered": {"query": {"query_string": {"query": "headline body", "lenient": true, "default_operator": "AND"}}}}}"
+        Then we get list with 1 items
+        """
+        {
+            "_items": [
+                {"guid": "1"}
+            ]
+        }
+        """

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -99,6 +99,12 @@ ELASTIC_DEFAULT_SIZE = 10
 #: https://discuss.elastic.co/t/configuring-the-standard-tokenizer/8691/5
 ELASTIC_QUERY_STRING_ANALYZE_WILDCARD = False
 
+#: allow to change type of query string query
+#:
+#: .. versionadded:: 2.5
+#:
+ELASTIC_QUERY_STRING_TYPE = "cross_fields"
+
 #: max api items to get with single query
 #:
 #: .. versionchanged:: 2.4.1

--- a/superdesk/metadata/utils.py
+++ b/superdesk/metadata/utils.py
@@ -97,6 +97,7 @@ def _set_highlight_query(source):
     query_string = source.get("query", {}).get("filtered", {}).get("query", {}).get("query_string")
     if query_string:
         query_string.setdefault("analyze_wildcard", app.config["ELASTIC_QUERY_STRING_ANALYZE_WILDCARD"])
+        query_string.setdefault("type", app.config["ELASTIC_QUERY_STRING_TYPE"])
         highlight_query = get_elastic_highlight_query(query_string)
         if highlight_query:
             source["highlight"] = highlight_query


### PR DESCRIPTION
and set the default to `cross_fields` so each word is checked
in each field instead of requiring all words to match a single field

SDESK-6567 SDBELGA-608