### PR TITLE
fix searching by author name

### DIFF
--- a/superdesk/metadata/item.py
+++ b/superdesk/metadata/item.py
@@ -341,9 +341,10 @@ metadata_schema = {
             "properties": {
                 "uri": not_analyzed,
                 "parent": not_analyzed,
-                "name": not_analyzed,
+                "name": text_with_keyword,
                 "role": not_analyzed,
                 "jobtitle": not_enabled,
+                "sub_label": text_with_keyword,
             },
         },
     },


### PR DESCRIPTION
- index `authors.sub_label` field where we store the name
- index `authors.name` as text with keyword so we can do parial matches and exact as well

SDESK-6567