### PR TITLE
set explicit sorting in delete_action

### DIFF
--- a/superdesk/services.py
+++ b/superdesk/services.py
@@ -9,6 +9,8 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from typing import Dict, Any
+
+import pymongo
 import logging
 
 from typing import Union
@@ -181,7 +183,7 @@ class BaseService:
             lookup = {}
             docs = []
         else:
-            docs = list(doc for doc in self.get_from_mongo(None, lookup))
+            docs = list(doc for doc in self.get_from_mongo(None, lookup).sort("_id", pymongo.ASCENDING))
         for doc in docs:
             self.on_delete(doc)
         res = self.delete(lookup)


### PR DESCRIPTION
otherwise this might fallback to default resource sort which can cause mongo errors like:

```
Executor error during find command :: caused by :: Sort operation used more than the maximum 33554432 bytes of RAM. Add an index, or specify a smaller limit.
```

SDESK-6614