### PR TITLE
[SDESK-6609] Config to disable item updates via ingest

### DIFF
--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -34,6 +34,7 @@ from superdesk.metadata.item import (
     CONTENT_TYPE,
     CONTENT_STATE,
     ITEM_STATE,
+    PUB_STATUS,
 )
 from superdesk.metadata.utils import generate_guid
 from superdesk.notification import push_notification
@@ -557,12 +558,29 @@ def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=N
         ingest_collection = get_ingest_collection(feeding_service, item)
         ingest_service = superdesk.get_resource_service(ingest_collection)
 
+        try:
+            _is_new_version = ingest_service.is_new_version
+        except AttributeError:
+            _is_new_version = is_new_version
+
+        try:
+            _ingest_cancel = ingest_service.ingest_cancel
+        except AttributeError:
+            _ingest_cancel = ingest_cancel
+
         # determine if we already have this item
         old_item = ingest_service.find_one(guid=item[GUID_FIELD], req=None)
 
         if not old_item:
             item.setdefault(superdesk.config.ID_FIELD, generate_guid(type=GUID_NEWSML))
             item[FAMILY_ID] = item[superdesk.config.ID_FIELD]
+        elif provider.get("disable_item_updates", False):
+            logger.warning(
+                f"Resource '{ingest_collection}' "
+                f"item '{item[GUID_FIELD]}' already exists, "
+                f"updating items is disabled on provider '{provider['name']}'."
+            )
+            return False, []
 
         item["ingest_provider"] = str(provider[superdesk.config.ID_FIELD])
         item.setdefault("source", provider.get("source", ""))
@@ -600,9 +618,9 @@ def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=N
 
         apply_rule_set(item, provider, rule_set)
 
-        if item.get("pubstatus", "") == "canceled":
+        if item.get("pubstatus", "") in [PUB_STATUS.CANCELED, "cancelled"]:  # Planning module uses "cancelled" value
             item[ITEM_STATE] = CONTENT_STATE.KILLED
-            ingest_cancel(item, feeding_service)
+            _ingest_cancel(item, feeding_service)
 
         rend = item.get("renditions", {})
         if rend:
@@ -624,7 +642,7 @@ def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=N
                     assoc["_id"] = ingested["_id"]
                     # update expiry so assoc will stay as long as the item using it
                     ingest_service.system_update(ingested["_id"], {"expiry": item["expiry"]}, ingested)
-                    if is_new_version(assoc, ingested) and assoc.get("renditions"):  # new version
+                    if _is_new_version(assoc, ingested) and assoc.get("renditions"):  # new version
                         logger.info("new assoc version - re-transfer renditions for %s", assoc_name)
                         try:
                             transfer_renditions(assoc["renditions"])
@@ -663,7 +681,7 @@ def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=N
 
         new_version = True
         if old_item:
-            new_version = is_new_version(item, old_item)
+            new_version = _is_new_version(item, old_item)
             updates = deepcopy(item)
             if new_version:
                 ingest_service.patch_in_mongo(old_item[superdesk.config.ID_FIELD], updates, old_item)

--- a/superdesk/io/ingest_provider_model.py
+++ b/superdesk/io/ingest_provider_model.py
@@ -43,6 +43,7 @@ class IngestProviderResource(Resource):
     :param feed_parser: feed parser name
     :param content_types: list of content types of items to ingest from provider
     :param allow_remove_ingested: allow deleting of items from ingest
+    :param disable_item_updates: disables updating items from ingest
     :param content_expiry: ttl for ingested items in minutes
     :param config: provider specific config
     :param private: can contain any data useful for provider (e.g. to manage feeds position)
@@ -72,6 +73,7 @@ class IngestProviderResource(Resource):
             "feed_parser": {"type": "string", "nullable": True, "allowed": allowed_feed_parsers},
             "content_types": {"type": "list", "default": tuple(CONTENT_TYPE), "allowed": tuple(CONTENT_TYPE)},
             "allow_remove_ingested": {"type": "boolean", "default": False},
+            "disable_item_updates": {"type": "boolean", "default": False},
             "content_expiry": {"type": "integer", "default": app.config["INGEST_EXPIRY_MINUTES"]},
             "config": {
                 "type": "dict",


### PR DESCRIPTION
Also allows a resource service to provide the following function to be used on igest:
* is_new_version (determine if item is a new version)
* ingest_cancel (handle cancelling items upon ingest)