### PR TITLE
fix error when updating ingest provider

### DIFF
--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -90,7 +90,7 @@ def is_closed(provider):
 def is_not_expired(item, delta):
     if item.get("expiry") or item.get("versioncreated"):
         try:
-            expiry = item.get("expiry", item["versioncreated"] + delta)
+            expiry = item.get("expiry") or item.get("versioncreated") + delta
         except OverflowError:  # this will never expire
             return True
         if expiry.tzinfo:

--- a/tests/io/item_expiry_test.py
+++ b/tests/io/item_expiry_test.py
@@ -22,3 +22,8 @@ class ItemExpiryTestCase(TestCase):
         item = {"versioncreated": datetime.now()}
         delta = timedelta(minutes=999999999999)
         self.assertTrue(is_not_expired(item, delta))
+
+    def test_expiry_None(self):
+        item = {"expiry": None, "versioncreated": datetime.now()}
+        delta = timedelta(minutes=5)
+        self.assertTrue(is_not_expired(item, delta))


### PR DESCRIPTION
expiry can be set to `None` and then the ingest fails with:

```
'NoneType' object has no attribute 'tzinfo'
```