### PR TITLE
fix ninjs description is empty when abstract is empty

### DIFF
--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -227,12 +227,16 @@ class NINJSFormatter(Formatter):
             ninjs["order"] = article["order"]
 
         # SDPA-317
-        if "abstract" in article:
-            abstract = article.get("abstract", "")
-            ninjs["description_html"] = abstract
-            ninjs["description_text"] = text_utils.get_text(abstract)
+        if article.get("abstract"):
+            ninjs["description_html"] = article["abstract"]
+            ninjs["description_text"] = text_utils.get_text(article["abstract"])
         elif article.get("description_text"):
-            ninjs["description_text"] = article.get("description_text")
+            ninjs["description_text"] = article["description_text"]
+            ninjs["description_html"] = article.get("description_html") or "<p>{}</p>".format(
+                article["description_text"]
+            )
+        elif "abstract" in article:  # BC
+            ninjs["description_text"] = ninjs["description_html"] = ""
 
         if article.get("company_codes"):
             ninjs["organisation"] = [

--- a/tests/publish/formatters/ninjs_formatter_test.py
+++ b/tests/publish/formatters/ninjs_formatter_test.py
@@ -344,6 +344,7 @@ class NinjsFormatterTest(TestCase):
                     "task": {},
                     "copyrightholder": "Foo ltd.",
                     "description_text": "Foo picture",
+                    "abstract": "",
                     "renditions": {
                         "original": {
                             "href": "http://example.com",
@@ -534,7 +535,7 @@ class NinjsFormatterTest(TestCase):
         seq, doc = self.formatter.format(article, {"name": "Test Subscriber"})[0]
         return json.loads(doc)
 
-    def test_empty_amstract(self):
+    def test_empty_abstract(self):
         article = {"_id": "urn:bar", "_current_version": 1, "guid": "urn:bar", "type": "text", "abstract": ""}
 
         seq, doc = self.formatter.format(article, {"name": "Test Subscriber"})[0]

--- a/tests/publish/formatters/ninjs_ftp_formatter_test.py
+++ b/tests/publish/formatters/ninjs_ftp_formatter_test.py
@@ -375,6 +375,7 @@ class FTPNinjsFormatterTest(TestCase):
                         }
                     },
                     "description_text": "Steam rises from the brown coal-fired power plant",
+                    "description_html": "<p>Steam rises from the brown coal-fired power plant</p>",
                     "pubstatus": "usable",
                     "version": "1",
                     "body_text": "Power plant",


### PR DESCRIPTION
SDESK-6707 EWTN-280