### PR TITLE
fix filter conditions with like/startswith/endswith

### DIFF
--- a/apps/content_filters/filter_condition/filter_condition_operator.py
+++ b/apps/content_filters/filter_condition/filter_condition_operator.py
@@ -109,7 +109,7 @@ class NotLikeOperator(FilterConditionOperator):
         self.elastic_operator = "query_string"
 
     def does_match(self, article_value, filter_value):
-        return filter_value.match(article_value) is None
+        return filter_value.search(article_value) is None
 
     def contains_not(self):
         return True
@@ -174,7 +174,7 @@ class RegexOperator(FilterConditionOperator):
         self.elastic_operator = "query_string"
 
     def does_match(self, article_value, filter_value):
-        return filter_value.match(article_value) is not None
+        return filter_value.search(article_value) is not None
 
 
 class MatchOperator(FilterConditionOperator):

--- a/apps/content_filters/filter_condition/filter_condition_value.py
+++ b/apps/content_filters/filter_condition/filter_condition_value.py
@@ -21,7 +21,7 @@ class FilterConditionValue:
         FilterConditionOperatorsEnum.startswith: "^{}",
         FilterConditionOperatorsEnum.like: ".*{}.*",
         FilterConditionOperatorsEnum.notlike: ".*{}.*",
-        FilterConditionOperatorsEnum.endswith: ".*{}",
+        FilterConditionOperatorsEnum.endswith: ".*{}$",
     }
 
     elastic_mapper = {

--- a/tests/content_filters/filter_condition_tests.py
+++ b/tests/content_filters/filter_condition_tests.py
@@ -465,7 +465,7 @@ class FilterConditionTests(TestCase):
         self.assertEqual(f.value.get_mongo_value(f.field), re.compile("^test", re.IGNORECASE))
 
         f = FilterCondition("headline", "endswith", "test")
-        self.assertEqual(f.value.get_mongo_value(f.field), re.compile(".*test", re.IGNORECASE))
+        self.assertEqual(f.value.get_mongo_value(f.field), re.compile(".*test$", re.IGNORECASE))
 
     def test_does_match_with_eq(self):
         f = FilterCondition("urgency", "eq", "1")
@@ -557,6 +557,15 @@ class FilterConditionTests(TestCase):
         self.assertFalse(f.does_match(self.articles[3]))
         self.assertFalse(f.does_match(self.articles[4]))
         self.assertFalse(f.does_match(self.articles[5]))
+
+    def test_does_match_with_like_complex(self):
+        f = FilterCondition("headline", "like", "Foo|Bar|Baz|Test Multiword")
+        self.assertTrue(f.does_match({"headline": "Bar"}))
+        self.assertTrue(f.does_match({"headline": "Bar Something"}))
+        self.assertTrue(f.does_match({"headline": "Something Bar"}))
+        self.assertTrue(f.does_match({"headline": "Something Baz"}))
+        self.assertFalse(f.does_match({"headline": "Something Test"}))
+        self.assertTrue(f.does_match({"headline": "Something Test Multiword"}))
 
     def test_does_match_with_startswith_filter(self):
         f = FilterCondition("headline", "startswith", "Sto")


### PR DESCRIPTION
use `regex.search` instead of `regex.match` which is not looking for the whole thing to match but it can match anywhere in the value.

we're adding `.*` before and after the regex, but that doesn't work with filters like `Foo|Bar|Baz` as those `.*` are only applied to the begging and then `Bar` would only match if it's the only content in the field.

SDESK-6755