### PR TITLE
fix filter condition value errors with cache

### DIFF
--- a/apps/content_filters/filter_condition/filter_condition.py
+++ b/apps/content_filters/filter_condition/filter_condition.py
@@ -60,10 +60,7 @@ class FilterCondition:
                 type(self.operator) is NotInOperator
                 or type(self.operator) is NotLikeOperator
                 or self.operator.operator is FilterConditionOperatorsEnum.ne
-                or (
-                    self.operator.operator is FilterConditionOperatorsEnum.eq
-                    and self.value.value.lower() in ("no", "false", "f", "0")
-                )
+                or (self.operator.operator is FilterConditionOperatorsEnum.eq and self.value.is_false())
             )
 
         article_value = self.field.get_value(article)

--- a/apps/content_filters/filter_condition/filter_condition_operator.py
+++ b/apps/content_filters/filter_condition/filter_condition_operator.py
@@ -30,6 +30,10 @@ class FilterConditionOperatorsEnum(Enum):
 
 
 class FilterConditionOperator:
+    operator: FilterConditionOperatorsEnum
+    mongo_operator: str
+    elastic_operator: str
+
     @staticmethod
     def factory(operator):
         if operator + "_" == FilterConditionOperatorsEnum.in_.name:

--- a/tests/content_filters/filter_condition_tests.py
+++ b/tests/content_filters/filter_condition_tests.py
@@ -8,11 +8,13 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 import json
+import bson
 import re
 import os
 from datetime import timedelta
 
 from eve.utils import ParsedRequest
+from apps.content_filters.filter_condition.filter_condition_field import FilterConditionDeskField
 
 from superdesk.utc import utcnow
 from superdesk import get_resource_service
@@ -20,6 +22,7 @@ from superdesk.tests import TestCase
 from apps.content_filters.filter_condition.filter_condition_service import FilterConditionService
 from apps.content_filters.filter_condition.filter_condition import FilterCondition
 from apps.content_filters.filter_condition.filter_condition_operator import FilterConditionOperator
+from apps.content_filters.filter_condition.filter_condition_value import FilterConditionValue
 from apps.prepopulate.app_populate import AppPopulateCommand
 
 
@@ -807,3 +810,9 @@ class FilterConditionTests(TestCase):
             doc_ids = [d["_id"] for d in docs]
             self.assertEqual(1, docs.count())
             self.assertTrue("4" in doc_ids)
+
+    def test_filter_condition_value_deserialized(self):
+        desk_id = bson.ObjectId()
+        field = FilterConditionDeskField("")
+        value = FilterConditionValue(FilterConditionOperator.factory("in"), desk_id)
+        self.assertEqual([str(desk_id)], value._get_value(field))


### PR DESCRIPTION
there were other places where it was using the value assuming it's a string, so cast it when creating an instance.

SDESK-6883