### PR TITLE
[SDCP-673] fix: Add mongo index assignment_id to archive collection

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -321,6 +321,7 @@ class ArchiveResource(Resource):
         "ingest_id_1": ([("ingest_id", 1)], {"background": True}),
         "unique_id_1": ([("unique_id", 1)], {"background": True}),
         "processed_from_1": ([(PROCESSED_FROM, 1)], {"background": True}),
+        "assignment_id_1": ([("assignment_id", 1)], {"background": True}),
     }
 
 


### PR DESCRIPTION
There is this query: https://github.com/superdesk/superdesk-planning/blob/develop/server/planning/assignments/assignments.py#L1081 which results in a timeout if the collection is too big