### PR TITLE
set the item type early in the create process

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -344,7 +344,7 @@ class ArchiveService(BaseService, HighlightsSearchMixin):
             handle_existing_data(item)
 
     def on_create(self, docs):
-        on_create_item(docs)
+        on_create_item(docs, media_service=self.mediaService)
 
         for doc in docs:
             if doc.get("body_footer") and is_normal_package(doc):
@@ -371,9 +371,6 @@ class ArchiveService(BaseService, HighlightsSearchMixin):
                 if not is_related_content(key):
                     self._set_association_timestamps(assoc, doc)
                     remove_unwanted(assoc)
-
-            if doc.get("media"):
-                self.mediaService.on_create([doc])
 
             # let client create version 0 docs
             if doc.get("version") == 0:

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -155,10 +155,13 @@ def update_version(updates, original):
         updates.setdefault("version", updates[config.VERSION])
 
 
-def on_create_item(docs, repo_type=ARCHIVE):
+def on_create_item(docs, repo_type=ARCHIVE, media_service=None):
     """Make sure item has basic fields populated."""
 
     for doc in docs:
+        if doc.get("media") and media_service:
+            media_service.on_create([doc])
+
         editor_utils.generate_fields(doc)
         update_dates_for(doc)
         set_original_creator(doc)
@@ -182,8 +185,8 @@ def on_create_item(docs, repo_type=ARCHIVE):
             # set the source for the article
             set_default_source(doc)
 
-            if "profile" not in doc and app.config.get("DEFAULT_CONTENT_TYPE"):
-                doc["profile"] = app.config.get("DEFAULT_CONTENT_TYPE", None)
+            if doc.get("type", "text") == "text" and app.config.get("DEFAULT_CONTENT_TYPE"):
+                doc.setdefault("profile", app.config["DEFAULT_CONTENT_TYPE"])
 
         copy_metadata_from_profile(doc)
         copy_metadata_from_user_preferences(doc, repo_type)

--- a/features/archive.feature
+++ b/features/archive.feature
@@ -1285,3 +1285,17 @@ Feature: News Items Archive
             }
         }
         """
+
+    @auth
+    @vocabulary
+    Scenario: Uploaded image should not get DEFAULT_CONTENT_TYPE assigned
+        Given config
+        """
+        {"DEFAULT_CONTENT_TYPE": "bar"}
+        """
+        Given empty "archive"
+        When we upload a file "bike.jpg" to "archive"
+        Then we get new resource
+        """
+        {"profile": "__no_value__"}
+        """

--- a/tests/archive/archive_test.py
+++ b/tests/archive/archive_test.py
@@ -487,7 +487,7 @@ class ArchiveTestCase(TestCase):
 
     def test_republished_associated_item_datetime(self):
         """
-        check rescheduled item and its associated item has same published_schedule date time
+        Check rescheduled item and its associated item has same published_schedule date time
         """
         archive_service = superdesk.get_resource_service("archive")
         publish_service = superdesk.get_resource_service("archive_publish")


### PR DESCRIPTION
and only assign `DEFAULT_CONTENT_TYPE` to text items.

SDNTB-799