### PR TITLE
Fix: Update logic for publish internal destination [SDNTB-837]

### DIFF
--- a/features/internal_destinations.feature
+++ b/features/internal_destinations.feature
@@ -808,4 +808,72 @@ Feature: Internal Destinations
         Then we get list with 0 items
         When we get "/published"
         Then we get list with 1 items
+    @auth
+    Scenario: Item created sucessfully for destinations on publish does not depend on send_after_schedule internal destinations
+        When we post to "archive" with success
+        """
+        [{
+            "guid": "123",
+            "type": "text",
+            "headline": "Take-1 headline",
+            "abstract": "Take-1 abstract",
+            "task": {
+                "user": "#CONTEXT_USER_ID#",
+                "desk": "#origin_desk#",
+                "stage": "#origin_stage#"
+            },
+            "body_html": "Body",
+            "state": "submitted",
+            "slugline": "Take-1 slugline",
+            "urgency": "4",
+            "pubstatus": "usable",
+            "subject":[{"qcode": "17004000", "name": "Statistics"}],
+            "anpa_category": [{"qcode": "A", "name": "Sport"}],
+            "anpa_take_key": "Take"
+        }]
+        """
+        Given "internal_destinations"
+        """
+        [{"name": "copy", "is_active": true,  "desk": "#destination_desk#", "macro": "Internal_Destination_Auto_Publish",
+        "send_after_schedule": true}]
+        """
+        When we publish "#archive._id#" with "publish" type and "published" state
+        Then we get OK response
+        When we get "/archive"
+        Then we get list with 0 items
+        When we get "/published"
+        Then we get list with 2 items
 
+        When we post to "archive" with success
+        """
+        [{
+            "guid": "1234",
+            "type": "text",
+            "headline": "Take-2 headline",
+            "abstract": "Take-2 abstract",
+            "task": {
+                "user": "#CONTEXT_USER_ID#",
+                "desk": "#origin_desk#",
+                "stage": "#origin_stage#"
+            },
+            "body_html": "Body",
+            "state": "submitted",
+            "slugline": "Take-2 slugline",
+            "urgency": "4",
+            "pubstatus": "usable",
+            "subject":[{"qcode": "17004000", "name": "Statistics"}],
+            "anpa_category": [{"qcode": "A", "name": "Sport"}],
+            "anpa_take_key": "Take"
+        }]
+        """
+        Given "internal_destinations"
+        """
+        [{"name": "copy", "is_active": true,  "desk": "#destination_desk#", "macro": "Internal_Destination_Auto_Publish",
+        "send_after_schedule": false}]
+        """
+        When we publish "#archive._id#" with "publish" type and "published" state
+        Then we get OK response
+        When we get "/archive"
+        Then we get list with 0 items
+        When we get "/published"
+        Then we get list with 4 items

--- a/superdesk/internal_destinations.py
+++ b/superdesk/internal_destinations.py
@@ -63,8 +63,8 @@ def handle_item_published(sender, item, desk=None, **extra):
                 continue
             if not filters_service.does_match(content_filter, item):
                 continue
-        if not extra.get("after_scheduled") and dest.get("send_after_schedule"):
-            # if after_schedule is set to False and send_after_schedule is True
+        if not extra.get("after_scheduled") and item[PUBLISH_SCHEDULE] != None and dest.get("send_after_schedule"):
+            # if after_schedule is set to False and item[PUBLISH_SCHEDULE] is not None and send_after_schedule is True
             # then don't execute
             continue
         if extra.get("after_scheduled") and not dest.get("send_after_schedule"):

--- a/superdesk/internal_destinations.py
+++ b/superdesk/internal_destinations.py
@@ -64,8 +64,9 @@ def handle_item_published(sender, item, desk=None, **extra):
             if not filters_service.does_match(content_filter, item):
                 continue
         if not extra.get("after_scheduled") and item[PUBLISH_SCHEDULE] is not None and dest.get("send_after_schedule"):
-            # if after_schedule is set to False and item[PUBLISH_SCHEDULE] is not None and send_after_schedule is True
-            # then don't execute
+            # if "after_schedule" is set to False  and item[PUBLISH_SCHEDULE] is not None (in case of scheduled item)
+            # and send_after_schedule is True then don't execute
+            # item is being published immediately not depend on config send_after_schedule
             continue
         if extra.get("after_scheduled") and not dest.get("send_after_schedule"):
             # if after_schedule is set to True and send_after_schedule is False

--- a/superdesk/internal_destinations.py
+++ b/superdesk/internal_destinations.py
@@ -63,7 +63,7 @@ def handle_item_published(sender, item, desk=None, **extra):
                 continue
             if not filters_service.does_match(content_filter, item):
                 continue
-        if not extra.get("after_scheduled") and item[PUBLISH_SCHEDULE] != None and dest.get("send_after_schedule"):
+        if not extra.get("after_scheduled") and item[PUBLISH_SCHEDULE] is not None and dest.get("send_after_schedule"):
             # if after_schedule is set to False and item[PUBLISH_SCHEDULE] is not None and send_after_schedule is True
             # then don't execute
             continue


### PR DESCRIPTION
Updated logic with the addition of `item[PUBLISH_SCHEDULE]`  so that when an item is published, it is not dependent on the config `send_after_schedule`.
`item[PUBLISH_SCHEDULE]` is `None` when item is published.