### PR TITLE
article embeds

### DIFF
--- a/apps/content_types/content_types.py
+++ b/apps/content_types/content_types.py
@@ -98,6 +98,10 @@ class ContentTypesResource(superdesk.Resource):
             "type": "boolean",
             "default": False,
         },
+        "embeddable": {
+            "type": "boolean",
+            "default": False,
+        },
         "created_by": superdesk.Resource.rel("users", nullable=True),
         "updated_by": superdesk.Resource.rel("users", nullable=True),
         "init_version": {"type": "integer"},

--- a/superdesk/editor_utils.py
+++ b/superdesk/editor_utils.py
@@ -38,6 +38,7 @@ MEDIA = "MEDIA"
 TABLE = "TABLE"
 MULTI_LINE_QUOTE = "MULTI-LINE_QUOTE"
 IMAGE = "IMAGE"
+ARTICLE_EMBED = "ARTICLE_EMBED"
 
 EDITOR_STATE = "draftjsState"
 ENTITY_MAP = "entityMap"
@@ -314,6 +315,9 @@ class DraftJSHTMLExporter:
                     TABLE: self.render_table,
                     MULTI_LINE_QUOTE: self.render_table,
                     IMAGE: self.render_image,
+
+                    # TODO: needs to be fixed. I added this for now to simply avoid it from crashing.
+                    ARTICLE_EMBED: lambda props: DOM.create_element("hr"),
                 },
             }
         )


### PR DESCRIPTION
TGA-66

@petrjasek you'll have to finish the back-end. That TODO comment I added and handling of media which Aleksa said is essential since primary use case is infographics.

One thing I'm not totally sure about how to best handle is generation of HTML. I generate it now on the front-end, same as for tables or any other atomic blocks. Another approach I was thinking about is NOT to generate it on front-end in order unexpected states. For example now if I generate to HTML, change content profile, disable article embeds and reopen the article - it might discard editor3 state and create a new one from HTML which would result with former embed becoming regular editable content. Not sure if we want that and also whether back-end would be able to pick up media info correctly.


Uploading article embeds edge case.mp4…

