### PR TITLE
avoid search lookup in find_one call

### DIFF
--- a/superdesk/eve_backend.py
+++ b/superdesk/eve_backend.py
@@ -69,7 +69,7 @@ class EveBackend:
         backend = self._backend(endpoint_name)
         item = backend.find_one(endpoint_name, req=req, **lookup)
         search_backend = self._lookup_backend(endpoint_name, fallback=True)
-        if search_backend:
+        if search_backend and app.config.get("BACKEND_FIND_ONE_SEARCH_TEST", False):
             # set the parent for the parent child in elastic search
             self._set_parent(endpoint_name, item, lookup)
             item_search = search_backend.find_one(endpoint_name, req=req, **lookup)

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -112,6 +112,10 @@ def update_config(conf):
 
     # auth server
     conf["AUTH_SERVER_SHARED_SECRET"] = "some secret"
+
+    # todo: only activate it for specific tests
+    conf["BACKEND_FIND_ONE_SEARCH_TEST"] = True
+
     return conf
 
 


### PR DESCRIPTION
this is taking quite some time in NH during push:

![find-one](https://github.com/superdesk/superdesk-core/assets/179249/08ff9721-71d1-4c3c-b5dc-ee056f333405)
