### PR TITLE
avoid extra push notifications when editing desk members

### DIFF
--- a/apps/desks.py
+++ b/apps/desks.py
@@ -298,7 +298,7 @@ class DesksService(BaseService):
                 users_service.update_stage_visibility_for_user(user)
 
             for removed_user in removed:
-                user = users_service.get_resource_service("users").find_one(req=None, _id=removed_user)
+                user = users_service.find_one(req=None, _id=removed_user)
                 users_service.update_stage_visibility_for_user(user)
 
         else:

--- a/apps/desks.py
+++ b/apps/desks.py
@@ -274,6 +274,7 @@ class DesksService(BaseService):
 
     def __send_notification(self, updates, desk):
         desk_id = desk[config.ID_FIELD]
+        users_service = superdesk.get_resource_service("users")
 
         if "members" in updates:
             added, removed = self.__compare_members(desk.get("members", {}), updates["members"])
@@ -283,7 +284,7 @@ class DesksService(BaseService):
                 )
 
             for added_user in added:
-                user = superdesk.get_resource_service("users").find_one(req=None, _id=added_user)
+                user = users_service.find_one(req=None, _id=added_user)
                 activity = add_activity(
                     ACTIVITY_UPDATE,
                     "user {{user}} has been added to desk {{desk}}: Please re-login.",
@@ -294,11 +295,11 @@ class DesksService(BaseService):
                     desk=desk.get("name"),
                 )
                 push_notification("activity", _dest=activity["recipients"])
-                get_resource_service("users").update_stage_visibility_for_user(user)
+                users_service.update_stage_visibility_for_user(user)
 
             for removed_user in removed:
-                user = superdesk.get_resource_service("users").find_one(req=None, _id=removed_user)
-                get_resource_service("users").update_stage_visibility_for_user(user)
+                user = users_service.get_resource_service("users").find_one(req=None, _id=removed_user)
+                users_service.update_stage_visibility_for_user(user)
 
         else:
             push_notification(self.notification_key, updated=1, desk_id=str(desk.get(config.ID_FIELD)))

--- a/apps/desks.py
+++ b/apps/desks.py
@@ -294,8 +294,12 @@ class DesksService(BaseService):
                     desk=desk.get("name"),
                 )
                 push_notification("activity", _dest=activity["recipients"])
+                get_resource_service("users").update_stage_visibility_for_user(user)
 
-            get_resource_service("users").update_stage_visibility_for_users()
+            for removed_user in removed:
+                user = superdesk.get_resource_service("users").find_one(req=None, _id=removed_user)
+                get_resource_service("users").update_stage_visibility_for_user(user)
+
         else:
             push_notification(self.notification_key, updated=1, desk_id=str(desk.get(config.ID_FIELD)))
 

--- a/superdesk/eve_backend.py
+++ b/superdesk/eve_backend.py
@@ -260,9 +260,9 @@ class EveBackend:
             else:
                 backend.update(endpoint_name, id, updates, original)
             if push_notification:
-                self._push_resource_notification(
-                    "updated", endpoint_name, _id=str(id), fields=get_diff_keys(updates, original)
-                )
+                updated_fields = get_diff_keys(updates, original)
+                if updated_fields:
+                    self._push_resource_notification("updated", endpoint_name, _id=str(id), fields=updated_fields)
         except eve.io.base.DataLayer.OriginalChangedError:
             if not backend.find_one(endpoint_name, req=None, _id=id) and search_backend:
                 # item is in elastic, not in mongo - not good


### PR DESCRIPTION
- only updated visible stages for users added/removed from desk
- don't push `resource:updated` notifications when there are no fields updated.

SDANSA-526