### PR TITLE
enable languages endpoint by default

### DIFF
--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -412,6 +412,7 @@ CORE_APPS = [
     "superdesk.locales",
     "apps.usage_metrics",
     "superdesk.system.health",
+    "apps.languages",
 ]
 
 #: Specify what modules should be enabled


### PR DESCRIPTION
it's always used by client to get available languages