### PR TITLE
when copying/translating article remove auto_publish flag

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -759,6 +759,7 @@ class ArchiveService(BaseService, HighlightsSearchMixin):
                 "translation_id",
                 "translated_from",
                 "firstpublished",
+                "auto_publish",
             ]
         )
         if delete_keys:

--- a/features/content_duplication.feature
+++ b/features/content_duplication.feature
@@ -638,3 +638,16 @@ Feature: Duplication of Content
       """
       When we get "/archive/#duplicate._id#"
       Then we get "assignment_id" does not exist
+
+    @auth
+    Scenario: Auto publish flag is removed on duplication
+      When we patch given
+      """
+      {"auto_publish": true}
+      """
+      When we post to "/archive/123/duplicate" with success
+      """
+      {"desk": "#desks._id#","type": "archive"}
+      """
+      When we get "/archive/#duplicate._id#"
+      Then we get "auto_publish" does not exist


### PR DESCRIPTION
it was causing the same id to be used in the ninjs output later for translations of ingested items.

SDCP-753