### PR TITLE
[SDESK-7156] Allow FeedingServices to provide request kwards for association downloading

### DIFF
--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -1120,3 +1120,6 @@ EMBED_PRODUCT_FILTERING = strtobool(env("EMBED_PRODUCT_FILTERING", "false"))
 #: .. versionadded:: 2.7
 #:
 UNPUBLISH_TO_MATCHING_SUBSCRIBERS = True
+
+
+AP_MEDIA_API_VERIFY_SSL = strtobool(env("AP_MEDIA_API_VERIFY_SSL", "true"))

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -1122,4 +1122,8 @@ EMBED_PRODUCT_FILTERING = strtobool(env("EMBED_PRODUCT_FILTERING", "false"))
 UNPUBLISH_TO_MATCHING_SUBSCRIBERS = True
 
 
+#: If disabled, it will disable SSL verification for AP Media ingest feeds
+#:
+#: .. versionadded:: 2.7
+#:
 AP_MEDIA_API_VERIFY_SSL = strtobool(env("AP_MEDIA_API_VERIFY_SSL", "true"))

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -628,12 +628,11 @@ def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=N
             _ingest_cancel(item, feeding_service)
 
         rend = item.get("renditions", {})
-        request_kwargs = feeding_service.get_request_kwargs()
         if rend:
             baseImageRend = rend.get("baseImage") or next(iter(rend.values()))
             if baseImageRend and not baseImageRend.get("media"):  # if there is media should be processed already
                 href = feeding_service.prepare_href(baseImageRend["href"], rend.get("mimetype"))
-                update_renditions(item, href, old_item, request_kwargs)
+                update_renditions(item, href, old_item, feeding_service=feeding_service)
 
         # if the item has associated media
         for key, assoc in item.get("associations", {}).items():
@@ -651,7 +650,7 @@ def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=N
                     if _is_new_version(assoc, ingested) and assoc.get("renditions"):  # new version
                         logger.info("new assoc version - re-transfer renditions for %s", assoc_name)
                         try:
-                            transfer_renditions(assoc["renditions"], request_kwargs)
+                            transfer_renditions(assoc["renditions"], feeding_service=feeding_service)
                         except SuperdeskApiError:
                             logger.exception(
                                 "failed to update associated item renditions",
@@ -667,7 +666,7 @@ def ingest_item(item, provider, feeding_service, rule_set=None, routing_scheme=N
                     if assoc.get("renditions") and has_system_renditions(assoc):  # all set, just download
                         logger.info("new association with system renditions - transfer %s", assoc_name)
                         try:
-                            transfer_renditions(assoc["renditions"], request_kwargs)
+                            transfer_renditions(assoc["renditions"], feeding_service=feeding_service)
                         except SuperdeskApiError:
                             logger.exception(
                                 "failed to download renditions",

--- a/superdesk/io/feed_parsers/ap_media.py
+++ b/superdesk/io/feed_parsers/ap_media.py
@@ -230,7 +230,7 @@ class APMediaFeedParser(FeedParser):
 
         if in_item.get("type") == "picture":
             if in_item.get("renditions"):
-                self._parse_renditions(in_item["renditions"], item, provider)
+                self._parse_renditions(in_item["renditions"], item)
 
             if in_item.get("description_caption"):
                 item["description_text"] = in_item.get("description_caption")
@@ -277,31 +277,19 @@ class APMediaFeedParser(FeedParser):
             for key, raw in associations.items():
                 item["associations"]["{}--{}".format(related_id, key)] = self.parse(raw, provider)
 
-    def _parse_renditions(self, renditions, item, provider=None):
+    def _parse_renditions(self, renditions, item):
         try:
             item["renditions"] = {}
             for dest, src in self.RENDITIONS_MAPPING.items():
                 rend = renditions[src]
                 item["renditions"][dest] = {
-                    "href": with_apikey(rend["href"], provider),
+                    "href": rend["href"],
                     "mimetype": rend["mimetype"],
                     "width": rend["width"],
                     "height": rend["height"],
                 }
         except KeyError:
             pass
-
-
-def with_apikey(href, provider):
-    if "apikey" in href:
-        return href
-    try:
-        key = provider["config"]["apikey"]
-        separator = "?" if "?" not in href else "&"
-        return f"{href}{separator}apikey={key}"
-    except (KeyError, TypeError):
-        pass
-    return href
 
 
 register_feed_parser(APMediaFeedParser.NAME, APMediaFeedParser())

--- a/superdesk/io/feeding_services/__init__.py
+++ b/superdesk/io/feeding_services/__init__.py
@@ -8,7 +8,6 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from typing import Dict, Any
 import logging
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -249,9 +248,6 @@ class FeedingService(metaclass=ABCMeta):
         :rtype: str
         """
         return href
-
-    def get_request_kwargs(self) -> Dict[str, Any]:
-        return {}
 
     def get_feed_parser(self, provider, article=None):
         """

--- a/superdesk/io/feeding_services/__init__.py
+++ b/superdesk/io/feeding_services/__init__.py
@@ -8,6 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from typing import Dict, Any
 import logging
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -248,6 +249,9 @@ class FeedingService(metaclass=ABCMeta):
         :rtype: str
         """
         return href
+
+    def get_request_kwargs(self) -> Dict[str, Any]:
+        return {}
 
     def get_feed_parser(self, provider, article=None):
         """

--- a/superdesk/io/feeding_services/ap_media.py
+++ b/superdesk/io/feeding_services/ap_media.py
@@ -102,7 +102,7 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
         :param provider:
         :return:
         """
-        r = requests.get(
+        r = self.session.get(
             provider.get("config", {}).get("products_url"),
             **self.get_request_kwargs(),
         )

--- a/superdesk/io/feeding_services/ap_media.py
+++ b/superdesk/io/feeding_services/ap_media.py
@@ -9,19 +9,22 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
+from typing import Dict, Any
 import json
 import requests
-import superdesk
 import logging
+from datetime import timedelta, datetime
 
-from superdesk.io.feed_parsers.ap_media import with_apikey
+from lxml import etree
+from flask import current_app as app
+
+import superdesk
 from superdesk.io.registry import register_feeding_service
 from superdesk.io.feeding_services.http_base_service import HTTPFeedingServiceBase
 from superdesk.errors import IngestApiError
 from superdesk.io.feed_parsers import nitf
-from lxml import etree
 from superdesk.utc import utcnow
-from datetime import timedelta, datetime
+
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +85,7 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
     HTTP_TIMEOUT = 40
 
     def config_test(self, provider=None):
+        self.provider = provider
         self._get_products(provider)
         original = superdesk.get_resource_service("ingest_providers").find_one(req=None, _id=provider.get("_id"))
         # If there has been a change in the required products then reset the next link
@@ -98,12 +102,9 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
         :param provider:
         :return:
         """
-        api_key = provider.get("config", {}).get("apikey")
         r = requests.get(
-            provider.get("config", {}).get("products_url") + "?apikey={}".format(api_key),
-            timeout=self.HTTP_TIMEOUT,
-            verify=False,
-            allow_redirects=True,
+            provider.get("config", {}).get("products_url"),
+            **self.get_request_kwargs(),
         )
         r.raise_for_status()
         productList = []
@@ -113,24 +114,16 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
                 productList.append("{}".format(entitlement.get("id")))
         provider["config"]["availableProducts"] = ",".join(productList)
 
-    def prepare_href(self, href, mimetype=None):
-        return with_apikey(href, self.provider)
-
     def _update(self, provider, update):
         self.HTTP_URL = provider.get("config", {}).get("api_url", "")
         self.provider = provider
 
-        # Set the apikey parameter we're going to use it on all calls
-        params = dict()
-        params["apikey"] = provider.get("config", {}).get("apikey")
-
         # Use the next link if one is available in the config
         if provider.get("config", {}).get("next_link"):
-            r = self.get_url(
-                url=provider.get("config", {}).get("next_link"), params=params, verify=False, allow_redirects=True
-            )
+            r = self.get_url(url=provider.get("config", {}).get("next_link"))
             r.raise_for_status()
         else:
+            params = dict()
             id_list = provider.get("config", {}).get("productList", "").strip()
             recovery_time = provider.get("config", {}).get("recoverytime", "1")
             recovery_time = recovery_time.strip() if recovery_time else ""
@@ -149,7 +142,7 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
             params["versions"] = "all"
 
             logger.info("AP Media Start/Recovery time: {} params {}".format(recovery_time, params))
-            r = self.get_url(params=params, verify=False, allow_redirects=True)
+            r = self.get_url(params=params)
             r.raise_for_status()
         try:
             response = json.loads(r.text)
@@ -172,7 +165,7 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
                         item.get("item", {}).get("headline"), item.get("item", {}).get("uri")
                     )
                 )
-                r = self.api_get(item.get("item", {}).get("uri"), provider)
+                r = self.api_get(item.get("item", {}).get("uri"))
                 complete_item = json.loads(r.text)
 
                 # Get the nitf rendition of the item
@@ -181,7 +174,7 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
                 )
                 if nitf_ref:
                     logger.info("Get AP nitf : {}".format(nitf_ref))
-                    r = self.api_get(nitf_ref, provider)
+                    r = self.api_get(nitf_ref)
                     root_elt = etree.fromstring(r.content)
 
                     # If the default namespace definition is the nitf namespace then remove it
@@ -203,7 +196,7 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
                     for key, assoc in associations.items():
                         logger.info('Get AP association "%s"', assoc.get("headline"))
                         try:
-                            related_json = self.api_get(assoc["uri"], provider).json()
+                            related_json = self.api_get(assoc["uri"]).json()
                             complete_item["associations"][key] = related_json
                         except IngestApiError:
                             logger.warning("Could not fetch AP association", extra=assoc)
@@ -222,12 +215,23 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
 
         return [parsed_items]
 
-    def api_get(self, url, provider):
-        resp = self.get_url(
-            url=url, params={"apikey": provider["config"]["apikey"]}, verify=False, allow_redirects=True
-        )
+    def api_get(self, url):
+        resp = self.get_url(url=url)
         resp.raise_for_status()
         return resp
+
+    def get_request_kwargs(self) -> Dict[str, Any]:
+        request_kwargs = dict(
+            timeout=self.HTTP_TIMEOUT,
+            verify=app.config.get("AP_MEDIA_API_VERIFY_SSL", True),
+            allow_redirects=True,
+        )
+        try:
+            request_kwargs["headers"] = {"x-api-key": self.provider["config"]["apikey"]}
+        except (KeyError, TypeError):
+            pass
+
+        return request_kwargs
 
 
 register_feeding_service(APMediaFeedingService)

--- a/superdesk/io/feeding_services/http_base_service.py
+++ b/superdesk/io/feeding_services/http_base_service.py
@@ -184,8 +184,12 @@ class HTTPFeedingServiceBase(FeedingService):
                 params.update(self.HTTP_DEFAULT_PARAMETERS)
             kwargs["params"] = params
 
+        # Let the provided ``kwargs`` override the feeding service's ``kwargs``
+        request_kwargs = self.get_request_kwargs()
+        request_kwargs.update(kwargs)
+
         try:
-            response = requests.get(url, timeout=self.HTTP_TIMEOUT, **kwargs)
+            response = requests.get(url, timeout=self.HTTP_TIMEOUT, **request_kwargs)
         except requests.exceptions.Timeout as exception:
             raise IngestApiError.apiTimeoutError(exception, self.provider)
         except requests.exceptions.ConnectionError as exception:

--- a/superdesk/io/feeding_services/http_base_service.py
+++ b/superdesk/io/feeding_services/http_base_service.py
@@ -187,9 +187,10 @@ class HTTPFeedingServiceBase(FeedingService):
         # Let the provided ``kwargs`` override the feeding service's ``kwargs``
         request_kwargs = self.get_request_kwargs()
         request_kwargs.update(kwargs)
+        request_kwargs.setdefault("timeout", self.HTTP_TIMEOUT)
 
         try:
-            response = requests.get(url, timeout=self.HTTP_TIMEOUT, **request_kwargs)
+            response = requests.get(url, **request_kwargs)
         except requests.exceptions.Timeout as exception:
             raise IngestApiError.apiTimeoutError(exception, self.provider)
         except requests.exceptions.ConnectionError as exception:

--- a/superdesk/io/feeding_services/http_base_service.py
+++ b/superdesk/io/feeding_services/http_base_service.py
@@ -148,6 +148,9 @@ class HTTPFeedingServiceBase(FeedingService):
         if url and not url.strip().startswith("http"):
             raise SuperdeskIngestError.notConfiguredError(Exception("URL must be a valid HTTP link."))
 
+    def get_request_kwargs(self) -> Dict[str, Any]:
+        return {}
+
     def get_url(self, url=None, **kwargs):
         """Do an HTTP Get on URL
 

--- a/superdesk/io/feeding_services/http_base_service.py
+++ b/superdesk/io/feeding_services/http_base_service.py
@@ -8,11 +8,13 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from typing import List, Dict, Optional, Union
+from typing import List, Dict, Optional, Tuple, Any
+from io import BytesIO
 import traceback
 import requests
 from superdesk.errors import IngestApiError, SuperdeskIngestError
 from superdesk.io.feeding_services import FeedingService
+from superdesk.media.media_operations import download_file_from_url
 
 
 class HTTPFeedingServiceBase(FeedingService):
@@ -111,6 +113,7 @@ class HTTPFeedingServiceBase(FeedingService):
     def __init__(self):
         super().__init__()
         self.token = None
+        self.session = requests.Session()
 
     @property
     def auth_info(self):
@@ -190,7 +193,7 @@ class HTTPFeedingServiceBase(FeedingService):
         request_kwargs.setdefault("timeout", self.HTTP_TIMEOUT)
 
         try:
-            response = requests.get(url, **request_kwargs)
+            response = self.session.get(url, **request_kwargs)
         except requests.exceptions.Timeout as exception:
             raise IngestApiError.apiTimeoutError(exception, self.provider)
         except requests.exceptions.ConnectionError as exception:
@@ -211,6 +214,12 @@ class HTTPFeedingServiceBase(FeedingService):
                 raise IngestApiError.apiGeneralError(exc, self.provider)
 
         return response
+
+    def download_file(self, url: str, **kwargs: Dict[str, Any]) -> Tuple[BytesIO, str, str]:
+        request_kwargs = self.get_request_kwargs()
+        request_kwargs.update(kwargs)
+        request_kwargs.setdefault("timeout", self.HTTP_TIMEOUT)
+        return download_file_from_url(url, request_kwargs, self.session)
 
     def update(self, provider, update):
         self.provider = provider

--- a/superdesk/media/media_operations.py
+++ b/superdesk/media/media_operations.py
@@ -81,7 +81,7 @@ def download_file_from_url(
     try:
         rv = session.get(url, **request_kwargs)
     except requests.exceptions.MissingSchema:  # any route will do here, we only need host
-        rv = session.get(urljoin(url_for("static", filename="x", _external=True), url), timeout=15, **request_kwargs)
+        rv = session.get(urljoin(url_for("static", filename="x", _external=True), url), **request_kwargs)
     if rv.status_code not in (200, 201):
         raise SuperdeskApiError.internalError("Failed to retrieve file from URL: %s" % url)
     content = BytesIO(rv.content)

--- a/superdesk/media/renditions.py
+++ b/superdesk/media/renditions.py
@@ -367,7 +367,7 @@ def update_renditions(item, href, old_item, request_kwargs=None, feeding_service
                 item["filemeta_json"] = old_item.get("filemeta_json")
                 return
 
-        if feeding_service is not None and getattr(feeding_service, "download_file"):
+        if feeding_service is not None and hasattr(feeding_service, "download_file"):
             content, filename, content_type = feeding_service.download_file(href, **request_kwargs or {})
         else:
             content, filename, content_type = download_file_from_url(href, request_kwargs)
@@ -406,7 +406,7 @@ def transfer_renditions(renditions, request_kwargs=None, feeding_service=None):
                 rend["href"] = app.media.url_for_media(rend["media"], local.content_type)
                 continue
 
-        if feeding_service is not None and getattr(feeding_service, "download_file"):
+        if feeding_service is not None and hasattr(feeding_service, "download_file"):
             content, filename, content_type = feeding_service.download_file(rend.get("href"), **request_kwargs or {})
         else:
             content, filename, content_type = download_file_from_url(rend.get("href"), request_kwargs)

--- a/superdesk/media/renditions.py
+++ b/superdesk/media/renditions.py
@@ -25,7 +25,6 @@ from eve.utils import config
 from superdesk import get_resource_service
 from superdesk.filemeta import set_filemeta
 import os
-from superdesk.io.feeding_services import FeedingService
 
 
 logger = logging.getLogger(__name__)
@@ -346,7 +345,7 @@ def get_renditions_spec(without_internal_renditions=False, no_custom_crops=False
 
 
 def download_file_from_feeding_service_or_directly(
-    url: str, feeding_service: Optional[FeedingService] = None, **kwargs: Dict[str, Any]
+    url: str, feeding_service: Optional[Any] = None, **kwargs: Dict[str, Any]
 ) -> Tuple[BytesIO, str, str]:
     if feeding_service is not None and hasattr(feeding_service, "download_file"):
         return feeding_service.download_file(url, **kwargs)
@@ -358,7 +357,7 @@ def update_renditions(
     href: str,
     old_item: Optional[Dict[str, Any]],
     request_kwargs: Optional[Dict[str, Any]] = None,
-    feeding_service: Optional[FeedingService] = None,
+    feeding_service: Optional[Any] = None,
 ):
     """Update renditions for an item.
 
@@ -409,7 +408,7 @@ def update_renditions(
 def transfer_renditions(
     renditions: Dict[str, Any],
     request_kwargs: Optional[Dict[str, Any]] = None,
-    feeding_service: Optional[FeedingService] = None,
+    feeding_service: Optional[Any] = None,
 ):
     """Transfer the passed renditions to localy held renditions
 

--- a/superdesk/media/renditions.py
+++ b/superdesk/media/renditions.py
@@ -9,6 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from __future__ import absolute_import
+from typing import Dict, Optional, Tuple, Any
 from PIL import Image
 from io import BytesIO
 import logging
@@ -24,6 +25,7 @@ from eve.utils import config
 from superdesk import get_resource_service
 from superdesk.filemeta import set_filemeta
 import os
+from superdesk.io.feeding_services import FeedingService
 
 
 logger = logging.getLogger(__name__)
@@ -343,7 +345,21 @@ def get_renditions_spec(without_internal_renditions=False, no_custom_crops=False
     return rendition_spec
 
 
-def update_renditions(item, href, old_item, request_kwargs=None, feeding_service=None):
+def download_file_from_feeding_service_or_directly(
+    url: str, feeding_service: Optional[FeedingService] = None, **kwargs: Dict[str, Any]
+) -> Tuple[BytesIO, str, str]:
+    if feeding_service is not None and hasattr(feeding_service, "download_file"):
+        return feeding_service.download_file(url, **kwargs)
+    return download_file_from_url(url, kwargs)
+
+
+def update_renditions(
+    item: Dict[str, Any],
+    href: str,
+    old_item: Optional[Dict[str, Any]],
+    request_kwargs: Optional[Dict[str, Any]] = None,
+    feeding_service: Optional[FeedingService] = None,
+):
     """Update renditions for an item.
 
     If the old_item has renditions uploaded in to media then the old rendition details are
@@ -353,6 +369,8 @@ def update_renditions(item, href, old_item, request_kwargs=None, feeding_service
     :param item: parsed item from source
     :param href: reference to original
     :param old_item: the item that we have already ingested, if it exists
+    :param request_kwargs: Optional keyword arguments for the download request
+    :param feeding_service: Optional Feeding Service to use for downloading the renditions
     :return: item with renditions
     """
     inserted = []
@@ -367,10 +385,9 @@ def update_renditions(item, href, old_item, request_kwargs=None, feeding_service
                 item["filemeta_json"] = old_item.get("filemeta_json")
                 return
 
-        if feeding_service is not None and hasattr(feeding_service, "download_file"):
-            content, filename, content_type = feeding_service.download_file(href, **request_kwargs or {})
-        else:
-            content, filename, content_type = download_file_from_url(href, request_kwargs)
+        content, filename, content_type = download_file_from_feeding_service_or_directly(
+            href, feeding_service, **request_kwargs or {}
+        )
         file_type, ext = content_type.split("/")
         metadata = process_file(content, file_type)
         file_guid = app.media.put(content, filename=filename, content_type=content_type, metadata=metadata)
@@ -389,12 +406,18 @@ def update_renditions(item, href, old_item, request_kwargs=None, feeding_service
         raise
 
 
-def transfer_renditions(renditions, request_kwargs=None, feeding_service=None):
+def transfer_renditions(
+    renditions: Dict[str, Any],
+    request_kwargs: Optional[Dict[str, Any]] = None,
+    feeding_service: Optional[FeedingService] = None,
+):
     """Transfer the passed renditions to localy held renditions
 
     Download the renditions as passed and upload them to this instances storage
     Adjust the rendition references
-    :param renditions:
+    :param renditions: A dictionary of renditions to transfer
+    :param request_kwargs: Optional keyword arguments for the download request
+    :param feeding_service: Optional Feeding Service to use for downloading the renditions
     :return: Updated renditions
     """
     if not renditions:
@@ -406,10 +429,9 @@ def transfer_renditions(renditions, request_kwargs=None, feeding_service=None):
                 rend["href"] = app.media.url_for_media(rend["media"], local.content_type)
                 continue
 
-        if feeding_service is not None and hasattr(feeding_service, "download_file"):
-            content, filename, content_type = feeding_service.download_file(rend.get("href"), **request_kwargs or {})
-        else:
-            content, filename, content_type = download_file_from_url(rend.get("href"), request_kwargs)
+        content, filename, content_type = download_file_from_feeding_service_or_directly(
+            rend.get("href"), feeding_service, **request_kwargs or {}
+        )
         file_type, ext = content_type.split("/")
         metadata = process_file(content, file_type)
         file_guid = app.media.put(content, filename=filename, content_type=content_type, metadata=metadata)

--- a/superdesk/media/renditions.py
+++ b/superdesk/media/renditions.py
@@ -386,7 +386,7 @@ def update_renditions(item, href, old_item, request_kwargs=None):
         raise
 
 
-def transfer_renditions(renditions):
+def transfer_renditions(renditions, request_kwargs=None):
     """Transfer the passed renditions to localy held renditions
 
     Download the renditions as passed and upload them to this instances storage
@@ -403,7 +403,7 @@ def transfer_renditions(renditions):
                 rend["href"] = app.media.url_for_media(rend["media"], local.content_type)
                 continue
 
-        content, filename, content_type = download_file_from_url(rend.get("href"))
+        content, filename, content_type = download_file_from_url(rend.get("href"), request_kwargs)
         file_type, ext = content_type.split("/")
         metadata = process_file(content, file_type)
         file_guid = app.media.put(content, filename=filename, content_type=content_type, metadata=metadata)

--- a/tests/io/feeding_services/ap_test.py
+++ b/tests/io/feeding_services/ap_test.py
@@ -45,11 +45,11 @@ class APTestCase(TestCase):
     @mock.patch.object(ap.APFeedingService, "get_feed_parser")
     def test_feeding(self, get_feed_parser, requests):
         get_feed_parser.return_value = newsml_2_0.NewsMLTwoFeedParser()
-        mock_get = requests.get.return_value
-        mock_get.content = self.feed_raw
         provider = deepcopy(PROVIDER)
         service = ap.APFeedingService()
         service.provider = provider
+        mock_get = service.session.get.return_value
+        mock_get.content = self.feed_raw
         items = service._update(provider, {})[0]
         self.assertEqual(len(items), 3)
 
@@ -65,11 +65,11 @@ class APTestCase(TestCase):
         """
         feed_parser = newsml_2_0.NewsMLTwoFeedParser()
         get_feed_parser.return_value = feed_parser
-        mock_get = requests.get.return_value
-        mock_get.content = self.feed_raw
         provider = deepcopy(PROVIDER)
         service = ap.APFeedingService()
         service.provider = provider
+        mock_get = service.session.get.return_value
+        mock_get.content = self.feed_raw
 
         self.assertNotIn("private", provider)
         with mock.patch.object(feed_parser, "parse"):

--- a/tests/io/feeding_services/ritzau_tests.py
+++ b/tests/io/feeding_services/ritzau_tests.py
@@ -38,10 +38,10 @@ class RitzauTestCase(TestCase):
     @mock.patch.object(ritzau.RitzauFeedingService, "get_feed_parser")
     def test_feeding(self, get_feed_parser, requests):
         get_feed_parser.return_value = ritzau_feed.RitzauFeedParser()
-        mock_get = requests.get.return_value
-        mock_get.text = self.feed_raw
         provider = PROVIDER.copy()
         service = ritzau.RitzauFeedingService()
         service.provider = provider
+        mock_get = service.session.get.return_value
+        mock_get.text = self.feed_raw
         items = service._update(provider, {})[0]
         self.assertEqual(len(items), 2)


### PR DESCRIPTION
This is used by AP Media API to provide x-api-key header, among others.

Also adds a new config `AP_MEDIA_API_VERIFY_SSL`, which defaults to True. This is to help prevent MITM style attacks, but can be turned off by env. variable if SSL verification fails for some reason.