### PR TITLE
use `formatter.type` in `can_format` method

### DIFF
--- a/superdesk/publish/formatters/__init__.py
+++ b/superdesk/publish/formatters/__init__.py
@@ -49,9 +49,9 @@ class Formatter:
         """Formats the article and returns the output string for export"""
         raise NotImplementedError()
 
-    def can_format(self, format_type, article) -> bool:
+    def can_format(self, format_type: str, article) -> bool:
         """Test if formatter can format for given article."""
-        raise NotImplementedError()
+        return self.type == format_type
 
     def append_body_footer(self, article):
         """

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -167,7 +167,6 @@ class NINJSFormatter(Formatter):
     author_user_fields: Sequence[AuthorFields] = ("facebook", "twitter", "instagram")
 
     def __init__(self):
-        self.format_type = "ninjs"
         self.can_preview = True
         self.can_export = True
         self.internal_renditions = app.config.get("NINJS_COMMON_RENDITIONS", []) + ["original"]
@@ -338,7 +337,7 @@ class NINJSFormatter(Formatter):
         return renditions
 
     def can_format(self, format_type, article):
-        return format_type == self.format_type
+        return format_type == self.type
 
     def _get_type(self, article):
         if article[ITEM_TYPE] == CONTENT_TYPE.PREFORMATTED:
@@ -641,7 +640,7 @@ class NINJSFormatter(Formatter):
         )
 
     def export(self, item):
-        if self.can_format(self.format_type, item):
+        if self.can_format(self.type, item):
             sequence, formatted_doc = self.format(item, {"_id": "0"}, None)[0]
             return formatted_doc.replace("''", "'")
         else:
@@ -670,10 +669,6 @@ class NINJS2Formatter(NINJSFormatter):
         "rewrite_sequence",
         "rewrite_of",
     )
-
-    def __init__(self):
-        super().__init__()
-        self.format_type = "ninjs2"
 
     def _transform_to_ninjs(self, article, subscriber, recursive=True):
         ninjs = super()._transform_to_ninjs(article, subscriber, recursive)

--- a/superdesk/publish/formatters/ninjs_ftp_formatter.py
+++ b/superdesk/publish/formatters/ninjs_ftp_formatter.py
@@ -29,7 +29,6 @@ class FTPNinjsFormatter(NINJSFormatter):
 
     def __init__(self):
         super().__init__()
-        self.format_type = "ftp ninjs"
         self.internal_renditions = []
         self.path = None
 

--- a/superdesk/publish/formatters/ninjs_newsroom_formatter.py
+++ b/superdesk/publish/formatters/ninjs_newsroom_formatter.py
@@ -21,7 +21,6 @@ class NewsroomNinjsFormatter(NINJSFormatter):
     type = "newsroom ninjs"
 
     def __init__(self):
-        self.format_type = "newsroom ninjs"
         self.can_preview = False
         self.can_export = False
         self.internal_renditions = ["original", "viewImage", "baseImage"]

--- a/tests/preferences/preference_tests.py
+++ b/tests/preferences/preference_tests.py
@@ -1,4 +1,5 @@
 """Preference_Tests Class"""
+
 # -*- coding: utf-8; -*-
 #
 # This file is part of Superdesk.

--- a/tests/publish/formatters/ninjs_formatter_test.py
+++ b/tests/publish/formatters/ninjs_formatter_test.py
@@ -777,7 +777,11 @@ class NinjsFormatterTest(TestCase):
                     "parent": "subject:01000000",
                     "qcode": "subject:01000002",
                     "translations": {
-                        "name": {"de": "Ergebnisorientiert", "it": "Orientato ai risultati ", "ja": "アウトカム・オリエンティッド"}
+                        "name": {
+                            "de": "Ergebnisorientiert",
+                            "it": "Orientato ai risultati ",
+                            "ja": "アウトカム・オリエンティッド",
+                        }
                     },
                     "scheme": "subject_custom",
                 },
@@ -1786,8 +1790,8 @@ class Ninjs2FormatterTest(TestCase):
     def setUp(self):
         self.formatter = NINJS2Formatter()
 
-    def test_format_type(self):
-        self.assertEqual("ninjs2", self.formatter.format_type)
+    def test_can_format(self):
+        self.assertTrue(self.formatter.can_format("ninjs2", {}))
 
     def test_correction_sequence_number(self):
         article = {


### PR DESCRIPTION
so we don't need to override init or can_format method later