### PR TITLE
fix schema maxlength error when value is None

### DIFF
--- a/apps/validate/validate.py
+++ b/apps/validate/validate.py
@@ -303,7 +303,7 @@ class SchemaValidator(Validator):
                     self._error("media's " + field, REQUIRED_FIELD)
                 try:
                     max_length = int(schema["maxlength"])
-                except KeyError:
+                except (KeyError, TypeError):
                     pass
                 except ValueError:
                     logger.error("Invalid max length value for media field {field}".format(field=field))


### PR DESCRIPTION
If the `maxlength` value is `None` the following exception is `TypeError` raised
```
Invalid validator schema value "int() argument must be a string, a bytes-like object or a number, not 'NoneType'" for 
```