### PR TITLE
fix validation error

### DIFF
--- a/apps/validate/validate.py
+++ b/apps/validate/validate.py
@@ -299,6 +299,8 @@ class SchemaValidator(Validator):
             if not media_metadata_schema:
                 continue
             for field, schema in media_metadata_schema.items():
+                if schema is None:
+                    continue
                 if schema.get("required", False) and not assoc_data.get(field):
                     self._error("media's " + field, REQUIRED_FIELD)
                 try:


### PR DESCRIPTION
this is related to https://github.com/superdesk/superdesk-core/pull/2593
actually this should prevent the other error and not sure how it could get there
because it should already fail on `if schema.get("required", False)` when schema is none