### PR TITLE
Languagetool spellchecker support

### DIFF
--- a/docs/spellchecking.rst
+++ b/docs/spellchecking.rst
@@ -33,4 +33,6 @@ So far, Superdesk supports the following spellcheckers:
 
 .. autoclass:: superdesk.text_checkers.spellcheckers.leuven_dutch.LeuvenDutch
 
+.. autoclass:: superdesk.text_checkers.spellcheckers.languagetool.Languagetool
+
 .. autoclass:: superdesk.text_checkers.spellcheckers.default.Default

--- a/superdesk/text_checkers/spellcheckers/languagetool.py
+++ b/superdesk/text_checkers/spellcheckers/languagetool.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013-2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import os
+import logging
+import requests
+import json
+from superdesk.errors import SuperdeskApiError
+from superdesk.text_checkers.spellcheckers import CAP_SPELLING, CAP_GRAMMAR, LANG_ANY
+from superdesk.text_checkers.spellcheckers.base import SpellcheckerBase
+
+logger = logging.getLogger(__name__)
+API_URL = "LANGUAGETOOL_API_URL"
+OPT_API_KEY = "LANGUAGETOOL_API_KEY"
+OPT_CONFIG = "LANGUAGETOOL_CONFIG"
+
+
+class Languagetool(SpellcheckerBase):
+    """Languagetool grammar/spellchecker integration
+
+    The LANGUAGETOOL_API_URL setting (or environment variable) must be set
+    """
+
+    name = "languagetool"
+    label = "Languagetool spellchecker"
+    capacities = (CAP_SPELLING, CAP_GRAMMAR)
+    languages = [LANG_ANY]
+
+    def __init__(self, app):
+        super().__init__(app)
+        self.api_url = self.config.get(API_URL, os.environ.get(API_URL))
+        self.api_config = None
+
+    @property
+    def languagetool_config(self):
+        """Retrieve Languagetool config from settings.py or environment variables
+
+        config is cached once retrieved
+        """
+        if self.api_config is None:
+            opt_config = self.config.get(OPT_CONFIG, {})
+            api_key = self.config.get(OPT_API_KEY, os.environ.get(OPT_API_KEY))
+            if api_key:
+                opt_config['apiKey'] = api_key
+            try:
+                env_config = json.loads(os.environ[OPT_CONFIG])
+            except (KeyError, json.JSONDecodeError):
+                env_config = {}
+            if not isinstance(opt_config, dict) or not isinstance(env_config, dict):
+                logger.warning("Invalid type for {label} configuration, must be a dictionary".format(label=self.label))
+                self.api_config = {}
+                return self.api_config
+            opt_config.update(env_config)
+            self.api_config = opt_config
+
+        return self.api_config
+
+    def check(self, text, language=None):
+        payload = {
+            'text': text,
+            'language': language,
+        }
+
+        # Add apiKey and additional options from the environment variable
+        additional_options = self.languagetool_config()
+        payload.update(additional_options)
+
+        try:
+            # Send the POST request to the LanguageTool API
+            response = requests.post(self.api_url, data=payload)
+            response.raise_for_status()
+            response_data = response.json()
+        except (requests.RequestException, json.JSONDecodeError) as e:
+            raise SuperdeskApiError.internalError(
+                "Unexpected error from {label}: {e}".format(
+                    label=self.label, e=str(e)
+                ), exception=e
+            )
+
+        # Initialize an empty list to store errors
+        err_list = []
+
+        # Iterate over the matches in the response
+        matches = response_data.get('matches', [])
+        if not isinstance(matches, list):
+            logger.warning("Unexpected {label} response format: 'matches' should be a list.".format(label=self.label))
+            return {"errors": []}
+
+        for match in matches:
+            issue_type = match.get('rule', {}).get('issueType')
+            if issue_type in ['misspelling', 'whitespace', 'other']:
+                error_type = 'spelling'
+            elif issue_type in ['grammar', 'characters', 'typographical', 'locale-violation']:
+                error_type = 'grammar'
+            else:
+                continue
+
+            error = {
+                "message": match.get('message', ''),
+                "startOffset": match.get('offset', -1),
+                "suggestions": [{"text": replacement.get('value', '')} for replacement in match.get('replacements', [])],
+                "text": text[match.get('offset', 0):match.get('offset', 0) + match.get('length', 0)],
+                "type": error_type,
+            }
+            err_list.append(error)
+
+        check_data = {"errors": err_list}
+        return check_data
+
+    def suggest(self, text, language=None):
+        payload = {
+            'text': text,
+            'language': language,
+        }
+
+        # Add apiKey and additional options from the environment variable
+        additional_options = self.languagetool_config()
+        payload.update(additional_options)
+
+        try:
+            # Send the POST request to the LanguageTool API
+            response = requests.post(self.api_url, data=payload)
+            response.raise_for_status()
+            response_data = response.json()
+        except (requests.RequestException, json.JSONDecodeError) as e:
+            raise SuperdeskApiError.internalError(
+                "Unexpected error from {label}: {e}".format(label=self.label, e=str(e)), exception=e)
+
+        # Initialize an empty list to store all replacement suggestions
+        replacements = []
+
+        matches = response_data.get('matches', [])
+        if not isinstance(matches, list):
+            logger.warning("Unexpected {label} response format: 'matches' should be a list.".format(label=self.label))
+            return []
+
+        for match in matches:
+            issue_type = match.get('rule', {}).get('issueType')
+            if issue_type in ['misspelling', 'whitespace', 'other', 'grammar', 'characters', 'typographical', 'locale-violation']:
+                for replacement in match.get('replacements', []):
+                    replacements.append(replacement.get('value', ''))
+
+        return {"suggestions": self.list2suggestions(replacements)}
+
+    def available(self):
+        if not self.api_url:
+            logger.warning(
+                "API url is not set for {label}, please set {opt} variable to use it".format(
+                    label=self.label, opt=API_URL
+                )
+            )
+            return False
+
+        payload = {
+            'text': 'test',
+            'language': 'auto',
+        }
+        additional_options = self.languagetool_config()
+        payload.update(additional_options)
+
+        try:
+            # Send the POST request to the LanguageTool API
+            response = requests.post(self.api_url, data=payload)
+            response.raise_for_status()
+        except (requests.RequestException, json.JSONDecodeError) as e:
+            logger.warning(
+                "can't request {label} URL ({url}): {e}".format(label=self.label, url=self.api_url, e=str(e))
+            )
+            return False
+        if response.status_code != 200:
+            logger.warning(
+                "{label} URL ({url}) is not returning the expected status".format(label=self.label, url=self.api_url)
+            )
+            return False
+        return True
+
+
+def init_app(app):
+    Languagetool(app)

--- a/superdesk/text_checkers/spellcheckers/languagetool.py
+++ b/superdesk/text_checkers/spellcheckers/languagetool.py
@@ -64,7 +64,7 @@ class Languagetool(SpellcheckerBase):
 
         return self._languagetool_config
 
-    def check(self, text, language=None):
+    def check(self, text, language='auto'):
         payload = {
             'text': text,
             'language': language,
@@ -77,6 +77,7 @@ class Languagetool(SpellcheckerBase):
         try:
             # Send the POST request to the LanguageTool API
             response = requests.post(self.api_url + '/check', data=payload)
+            logger.info("Language payload: %s", json.dumps(payload, indent=2))
             response.raise_for_status()
             response_data = response.json()
         except (requests.RequestException, json.JSONDecodeError) as e:
@@ -116,7 +117,7 @@ class Languagetool(SpellcheckerBase):
         check_data = {"errors": err_list}
         return check_data
 
-    def suggest(self, text, language=None):
+    def suggest(self, text, language='auto'):
         payload = {
             'text': text,
             'language': language,

--- a/superdesk/text_checkers/spellcheckers/languagetool.py
+++ b/superdesk/text_checkers/spellcheckers/languagetool.py
@@ -77,7 +77,6 @@ class Languagetool(SpellcheckerBase):
         try:
             # Send the POST request to the LanguageTool API
             response = requests.post(self.api_url + '/check', data=payload)
-            logger.info("Language payload: %s", json.dumps(payload, indent=2))
             response.raise_for_status()
             response_data = response.json()
         except (requests.RequestException, json.JSONDecodeError) as e:

--- a/superdesk/text_checkers/spellcheckers/languagetool.py
+++ b/superdesk/text_checkers/spellcheckers/languagetool.py
@@ -64,10 +64,10 @@ class Languagetool(SpellcheckerBase):
 
         return self._languagetool_config
 
-    def check(self, text, language='auto'):
+    def check(self, text, language=None):
         payload = {
             'text': text,
-            'language': language,
+            'language': language or 'auto',
         }
 
         # Add apiKey and additional options from the environment variable
@@ -117,10 +117,10 @@ class Languagetool(SpellcheckerBase):
         check_data = {"errors": err_list}
         return check_data
 
-    def suggest(self, text, language='auto'):
+    def suggest(self, text, language=None):
         payload = {
             'text': text,
-            'language': language,
+            'language': language or 'auto',
         }
 
         # Add apiKey and additional options from the environment variable

--- a/superdesk/text_checkers/spellcheckers/languagetool.py
+++ b/superdesk/text_checkers/spellcheckers/languagetool.py
@@ -36,7 +36,7 @@ class Languagetool(SpellcheckerBase):
     def __init__(self, app):
         super().__init__(app)
         self.api_url = self.config.get(API_URL, os.environ.get(API_URL))
-        self.api_config = None
+        self._languagetool_config = None
 
     @property
     def languagetool_config(self):
@@ -44,23 +44,23 @@ class Languagetool(SpellcheckerBase):
 
         config is cached once retrieved
         """
-        if self.api_config is None:
-            opt_config = self.config.get(OPT_CONFIG, {})
+        if self._languagetool_config is None:
+            config = self.config.get(OPT_CONFIG, {})
             api_key = self.config.get(OPT_API_KEY, os.environ.get(OPT_API_KEY))
             if api_key:
-                opt_config['apiKey'] = api_key
+                config['apiKey'] = api_key
             try:
                 env_config = json.loads(os.environ[OPT_CONFIG])
             except (KeyError, json.JSONDecodeError):
                 env_config = {}
-            if not isinstance(opt_config, dict) or not isinstance(env_config, dict):
+            if not isinstance(config, dict) or not isinstance(env_config, dict):
                 logger.warning("Invalid type for {label} configuration, must be a dictionary".format(label=self.label))
-                self.api_config = {}
-                return self.api_config
-            opt_config.update(env_config)
-            self.api_config = opt_config
+                self._languagetool_config = {}
+                return self._languagetool_config
+            config.update(env_config)
+            self._languagetool_config = config
 
-        return self.api_config
+        return self._languagetool_config
 
     def check(self, text, language=None):
         payload = {
@@ -69,7 +69,7 @@ class Languagetool(SpellcheckerBase):
         }
 
         # Add apiKey and additional options from the environment variable
-        additional_options = self.languagetool_config()
+        additional_options = self.languagetool_config
         payload.update(additional_options)
 
         try:
@@ -121,7 +121,7 @@ class Languagetool(SpellcheckerBase):
         }
 
         # Add apiKey and additional options from the environment variable
-        additional_options = self.languagetool_config()
+        additional_options = self.languagetool_config
         payload.update(additional_options)
 
         try:

--- a/superdesk/text_checkers/spellcheckers/languagetool.py
+++ b/superdesk/text_checkers/spellcheckers/languagetool.py
@@ -36,6 +36,8 @@ class Languagetool(SpellcheckerBase):
     def __init__(self, app):
         super().__init__(app)
         self.api_url = self.config.get(API_URL, os.environ.get(API_URL))
+        if self.api_url:
+            self.api_url = self.api_url.rstrip('/')
         self._languagetool_config = None
 
     @property
@@ -74,7 +76,7 @@ class Languagetool(SpellcheckerBase):
 
         try:
             # Send the POST request to the LanguageTool API
-            response = requests.post(self.api_url, data=payload)
+            response = requests.post(self.api_url + '/check', data=payload)
             response.raise_for_status()
             response_data = response.json()
         except (requests.RequestException, json.JSONDecodeError) as e:
@@ -126,7 +128,7 @@ class Languagetool(SpellcheckerBase):
 
         try:
             # Send the POST request to the LanguageTool API
-            response = requests.post(self.api_url, data=payload)
+            response = requests.post(self.api_url + '/check', data=payload)
             response.raise_for_status()
             response_data = response.json()
         except (requests.RequestException, json.JSONDecodeError) as e:

--- a/superdesk/text_checkers/spellcheckers/languagetool.py
+++ b/superdesk/text_checkers/spellcheckers/languagetool.py
@@ -157,28 +157,6 @@ class Languagetool(SpellcheckerBase):
                 )
             )
             return False
-
-        payload = {
-            'text': 'test',
-            'language': 'auto',
-        }
-        additional_options = self.languagetool_config()
-        payload.update(additional_options)
-
-        try:
-            # Send the POST request to the LanguageTool API
-            response = requests.post(self.api_url, data=payload)
-            response.raise_for_status()
-        except (requests.RequestException, json.JSONDecodeError) as e:
-            logger.warning(
-                "can't request {label} URL ({url}): {e}".format(label=self.label, url=self.api_url, e=str(e))
-            )
-            return False
-        if response.status_code != 200:
-            logger.warning(
-                "{label} URL ({url}) is not returning the expected status".format(label=self.label, url=self.api_url)
-            )
-            return False
         return True
 
 

--- a/superdesk/text_checkers/spellcheckers/languagetool.py
+++ b/superdesk/text_checkers/spellcheckers/languagetool.py
@@ -39,6 +39,7 @@ class Languagetool(SpellcheckerBase):
         if self.api_url:
             self.api_url = self.api_url.rstrip('/')
         self._languagetool_config = None
+        self.session = requests.Session()
 
     @property
     def languagetool_config(self):
@@ -76,7 +77,7 @@ class Languagetool(SpellcheckerBase):
 
         try:
             # Send the POST request to the LanguageTool API
-            response = requests.post(self.api_url + '/check', data=payload)
+            response = self.session.post(self.api_url + '/check', data=payload)
             response.raise_for_status()
             response_data = response.json()
         except (requests.RequestException, json.JSONDecodeError) as e:
@@ -128,7 +129,7 @@ class Languagetool(SpellcheckerBase):
 
         try:
             # Send the POST request to the LanguageTool API
-            response = requests.post(self.api_url + '/check', data=payload)
+            response = self.session.post(self.api_url + '/check', data=payload)
             response.raise_for_status()
             response_data = response.json()
         except (requests.RequestException, json.JSONDecodeError) as e:

--- a/tests/text_checkers/spellcheckers/languagetool_test.py
+++ b/tests/text_checkers/spellcheckers/languagetool_test.py
@@ -23,6 +23,7 @@ from superdesk import get_resource_service
 MODEL = {
     "misstake": 1,
 }
+TEST_URL = "https://api.languagetoolplus.com/v2"
 
 
 @responses.activate
@@ -30,7 +31,7 @@ def load_spellcheckers():
     registered_spellcheckers.clear()
     app = Flask(__name__)
     app.config[OPT_API_KEY] = ""
-    app.config[API_URL] = "https://api.languagetoolplus.com/v2/check"
+    app.config[API_URL] = TEST_URL
     tools.import_services(app, spellcheckers.__name__, SpellcheckerBase)
 
 
@@ -71,7 +72,7 @@ class LanguagetoolTestCase(TestCase):
             "use_internal_dict": use_internal_dict,
         }
         spellchecker = get_resource_service("spellchecker")
-        check_url = self.config.get(API_URL)
+        check_url = TEST_URL + '/check'
         responses.add(
             responses.POST,
             check_url,
@@ -158,7 +159,7 @@ class LanguagetoolTestCase(TestCase):
 
         doc = {"spellchecker": "languagetool", "text": "misstake", "suggestions": True}
         spellchecker = get_resource_service("spellchecker")
-        check_url = self.config.get(API_URL)
+        check_url = TEST_URL + '/check'
         responses.add(
             responses.POST,
             check_url,

--- a/tests/text_checkers/spellcheckers/languagetool_test.py
+++ b/tests/text_checkers/spellcheckers/languagetool_test.py
@@ -21,7 +21,7 @@ from superdesk.text_checkers.spellcheckers.languagetool import Languagetool, API
 from superdesk import get_resource_service
 
 MODEL = {
-    "misstake": 1,
+    "speling": 1,
 }
 TEST_URL = "https://api.languagetoolplus.com/v2"
 
@@ -72,34 +72,32 @@ class LanguagetoolTestCase(TestCase):
             "use_internal_dict": use_internal_dict,
         }
         spellchecker = get_resource_service("spellchecker")
-        check_url = TEST_URL + '/check'
+        check_url = TEST_URL + "/check"
         responses.add(
             responses.POST,
             check_url,
             json={
                 "software": {
-                    "name": "LanguageTool", "version": "6.5.9", "apiVersion": 1, "premium": True, "status": ""
+                    "name": "LanguageTool",
+                    "version": "6.5.9",
+                    "apiVersion": 1,
+                    "premium": True,
+                    "status": "",
                 },
                 "warnings": {"incompleteResults": False},
                 "language": {
-                    "name": "English (US)", "code": "en-US", "detectedLanguage": {"name": "English (US)", "code": "en-US", "confidence": 1.0, "source": "ngram"}
+                    "name": "English (US)",
+                    "code": "en-US",
+                    "detectedLanguage": {"name": "English (US)", "code": "en-US", "confidence": 1.0, "source": "ngram"},
                 },
                 "matches": [
                     {
                         "message": "Possible spelling mistake found.",
                         "shortMessage": "Spelling mistake",
-                        "replacements": [
-                            {"value": "spelling"},
-                            {"value": "spewing"},
-                            {"value": "spieling"}
-                        ],
+                        "replacements": [{"value": "spelling"}, {"value": "spewing"}, {"value": "spieling"}],
                         "offset": 29,
                         "length": 7,
-                        "context": {
-                            "text": "This is a simple text with a speling mistake.",
-                            "offset": 29,
-                            "length": 7
-                        },
+                        "context": {"text": "This is a simple text with a speling mistake.", "offset": 29, "length": 7},
                         "sentence": "This is a simple text with a speling mistake.",
                         "type": {"typeName": "UnknownWord"},
                         "rule": {
@@ -107,21 +105,17 @@ class LanguagetoolTestCase(TestCase):
                             "description": "Possible spelling mistake",
                             "issueType": "misspelling",
                             "category": {"id": "TYPOS", "name": "Possible Typo"},
-                            "isPremium": False, "confidence": 0.68
+                            "isPremium": False,
+                            "confidence": 0.68,
                         },
-                        "ignoreForIncompleteSentence": False, "contextForSureMatch": 0
+                        "ignoreForIncompleteSentence": False,
+                        "contextForSureMatch": 0,
                     }
                 ],
-                "sentenceRanges": [
-                    [0, 45]
-                ],
+                "sentenceRanges": [[0, 45]],
                 "extendedSentenceRanges": [
-                    {
-                        "from": 0, "to": 45, "detectedLanguages": [
-                            {"language": "en", "rate": 1.0}
-                        ]
-                    }
-                ]
+                    {"from": 0, "to": 45, "detectedLanguages": [{"language": "en", "rate": 1.0}]}
+                ],
             },
         )
         spellchecker.create([doc])
@@ -131,13 +125,9 @@ class LanguagetoolTestCase(TestCase):
                 {
                     "message": "Possible spelling mistake found.",
                     "startOffset": 29,
-                    "suggestions": [
-                        {"text": "spelling"},
-                        {"text": "spewing"},
-                        {"text": "spieling"}
-                    ],
+                    "suggestions": [{"text": "spelling"}, {"text": "spewing"}, {"text": "spieling"}],
                     "text": "speling",
-                    "type": "spelling"
+                    "type": "spelling",
                 }
             ]
 
@@ -147,9 +137,9 @@ class LanguagetoolTestCase(TestCase):
     def test_checker_with_internal_dict(self):
         """Check that words in personal dictionary are discarded correctly
 
-        This test re-uses test_checker but activate "use_internal_dict" option and mock dictionary to have "misstake" inside
+        This test re-uses test_checker but activate "use_internal_dict" option and mock dictionary to have "speling" inside
         """
-        # misstake is in personal dictionary, so no spelling error should be returned
+        # speling is in personal dictionary, so no spelling error should be returned
         expected = []
         self.test_checker(expected=expected, use_internal_dict=True)
 
@@ -159,7 +149,7 @@ class LanguagetoolTestCase(TestCase):
 
         doc = {"spellchecker": "languagetool", "text": "misstake", "suggestions": True}
         spellchecker = get_resource_service("spellchecker")
-        check_url = TEST_URL + '/check'
+        check_url = TEST_URL + "/check"
         responses.add(
             responses.POST,
             check_url,
@@ -169,17 +159,18 @@ class LanguagetoolTestCase(TestCase):
                 "language": {
                     "name": "English (US)",
                     "code": "en-US",
-                    "detectedLanguage": {"name": "English (US)", "code": "en-US", "confidence": 0.56296706, "source": "ngram"}
+                    "detectedLanguage": {
+                        "name": "English (US)",
+                        "code": "en-US",
+                        "confidence": 0.56296706,
+                        "source": "ngram",
+                    },
                 },
                 "matches": [
                     {
                         "message": "Possible spelling mistake found.",
                         "shortMessage": "Spelling mistake",
-                        "replacements": [
-                            {"value": "mistake"},
-                            {"value": "misstate"},
-                            {"value": "miss take"}
-                        ],
+                        "replacements": [{"value": "mistake"}, {"value": "misstate"}, {"value": "miss take"}],
                         "offset": 0,
                         "length": 8,
                         "context": {"text": "misstake", "offset": 0, "length": 8},
@@ -190,14 +181,17 @@ class LanguagetoolTestCase(TestCase):
                             "description": "Possible spelling mistake",
                             "issueType": "misspelling",
                             "category": {"id": "TYPOS", "name": "Possible Typo"},
-                            "isPremium": False, "confidence": 0.68
+                            "isPremium": False,
+                            "confidence": 0.68,
                         },
                         "ignoreForIncompleteSentence": False,
-                        "contextForSureMatch": 0
+                        "contextForSureMatch": 0,
                     }
                 ],
                 "sentenceRanges": [[0, 8]],
-                "extendedSentenceRanges": [{"from": 0, "to": 8, "detectedLanguages": [{"language": "en", "rate": 1.0}]}]
+                "extendedSentenceRanges": [
+                    {"from": 0, "to": 8, "detectedLanguages": [{"language": "en", "rate": 1.0}]}
+                ],
             },
         )
         spellchecker.create([doc])

--- a/tests/text_checkers/spellcheckers/languagetool_test.py
+++ b/tests/text_checkers/spellcheckers/languagetool_test.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013 - 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from functools import partial
+from unittest.mock import MagicMock, patch
+from .utils import mock_dictionaries
+import responses
+from flask import Flask
+from superdesk.tests import TestCase
+from superdesk.text_checkers import tools
+from superdesk.text_checkers.spellcheckers.base import registered_spellcheckers, SpellcheckerBase
+from superdesk.text_checkers import spellcheckers
+from superdesk.text_checkers.spellcheckers.languagetool import Languagetool, API_URL, OPT_API_KEY
+from superdesk import get_resource_service
+
+MODEL = {
+    "misstake": 1,
+}
+
+
+@responses.activate
+def load_spellcheckers():
+    registered_spellcheckers.clear()
+    app = Flask(__name__)
+    app.config[OPT_API_KEY] = ""
+    app.config[API_URL] = "https://api.languagetoolplus.com/v2/check"
+    tools.import_services(app, spellcheckers.__name__, SpellcheckerBase)
+
+
+class LanguagetoolTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        load_spellcheckers()
+
+    def test_list(self):
+        """Check that Languagetool spellchecker is listed by spellcheckers_list service"""
+        doc = {}
+        spellcheckers_list = get_resource_service("spellcheckers_list")
+        spellcheckers_list.on_fetched(doc)
+        for checker in doc["spellcheckers"]:
+            if (
+                checker["name"] == Languagetool.name
+                and "label" in checker
+                and set(checker["capacities"]) == set(Languagetool.capacities)
+                and checker["languages"] == ["*"]
+            ):
+                return
+        self.fail("Languagetool spellchecker not found")
+
+    @responses.activate
+    def test_checker(self, expected=None, use_internal_dict=False):
+        """Check that spellchecking is working
+
+        :param expected: "errors" expected
+            to be specified if this test is re-used
+        :param use_internal_dict: value to use in request
+            can be changed if this test is re-used
+        """
+        doc = {
+            "spellchecker": Languagetool.name,
+            "text": "This is a simple text with a speling mistake.",
+            "suggestions": False,
+            "use_internal_dict": use_internal_dict,
+        }
+        spellchecker = get_resource_service("spellchecker")
+        check_url = self.config.get(API_URL)
+        responses.add(
+            responses.POST,
+            check_url,
+            json={
+                "software": {
+                    "name": "LanguageTool", "version": "6.5.9", "apiVersion": 1, "premium": True, "status": ""
+                },
+                "warnings": {"incompleteResults": False},
+                "language": {
+                    "name": "English (US)", "code": "en-US", "detectedLanguage": {"name": "English (US)", "code": "en-US", "confidence": 1.0, "source": "ngram"}
+                },
+                "matches": [
+                    {
+                        "message": "Possible spelling mistake found.",
+                        "shortMessage": "Spelling mistake",
+                        "replacements": [
+                            {"value": "spelling"},
+                            {"value": "spewing"},
+                            {"value": "spieling"}
+                        ],
+                        "offset": 29,
+                        "length": 7,
+                        "context": {
+                            "text": "This is a simple text with a speling mistake.",
+                            "offset": 29,
+                            "length": 7
+                        },
+                        "sentence": "This is a simple text with a speling mistake.",
+                        "type": {"typeName": "UnknownWord"},
+                        "rule": {
+                            "id": "MORFOLOGIK_RULE_EN_US",
+                            "description": "Possible spelling mistake",
+                            "issueType": "misspelling",
+                            "category": {"id": "TYPOS", "name": "Possible Typo"},
+                            "isPremium": False, "confidence": 0.68
+                        },
+                        "ignoreForIncompleteSentence": False, "contextForSureMatch": 0
+                    }
+                ],
+                "sentenceRanges": [
+                    [0, 45]
+                ],
+                "extendedSentenceRanges": [
+                    {
+                        "from": 0, "to": 45, "detectedLanguages": [
+                            {"language": "en", "rate": 1.0}
+                        ]
+                    }
+                ]
+            },
+        )
+        spellchecker.create([doc])
+
+        if expected is None:
+            expected = [
+                {
+                    "message": "Possible spelling mistake found.",
+                    "startOffset": 29,
+                    "suggestions": [
+                        {"text": "spelling"},
+                        {"text": "spewing"},
+                        {"text": "spieling"}
+                    ],
+                    "text": "speling",
+                    "type": "spelling"
+                }
+            ]
+
+        self.assertEqual(doc["errors"], expected)
+
+    @patch("superdesk.get_resource_service", MagicMock(side_effect=partial(mock_dictionaries, model=MODEL)))
+    def test_checker_with_internal_dict(self):
+        """Check that words in personal dictionary are discarded correctly
+
+        This test re-uses test_checker but activate "use_internal_dict" option and mock dictionary to have "misstake" inside
+        """
+        # misstake is in personal dictionary, so no spelling error should be returned
+        expected = []
+        self.test_checker(expected=expected, use_internal_dict=True)
+
+    @responses.activate
+    def test_suggest(self):
+        """Check that spelling suggestions are working"""
+
+        doc = {"spellchecker": "languagetool", "text": "misstake", "suggestions": True}
+        spellchecker = get_resource_service("spellchecker")
+        check_url = self.config.get(API_URL)
+        responses.add(
+            responses.POST,
+            check_url,
+            json={
+                "software": {"name": "LanguageTool", "version": "6.5.9", "apiVersion": 1, "status": ""},
+                "warnings": {"incompleteResults": False},
+                "language": {
+                    "name": "English (US)",
+                    "code": "en-US",
+                    "detectedLanguage": {"name": "English (US)", "code": "en-US", "confidence": 0.56296706, "source": "ngram"}
+                },
+                "matches": [
+                    {
+                        "message": "Possible spelling mistake found.",
+                        "shortMessage": "Spelling mistake",
+                        "replacements": [
+                            {"value": "mistake"},
+                            {"value": "misstate"},
+                            {"value": "miss take"}
+                        ],
+                        "offset": 0,
+                        "length": 8,
+                        "context": {"text": "misstake", "offset": 0, "length": 8},
+                        "sentence": "misstake",
+                        "type": {"typeName": "UnknownWord"},
+                        "rule": {
+                            "id": "MORFOLOGIK_RULE_EN_US",
+                            "description": "Possible spelling mistake",
+                            "issueType": "misspelling",
+                            "category": {"id": "TYPOS", "name": "Possible Typo"},
+                            "isPremium": False, "confidence": 0.68
+                        },
+                        "ignoreForIncompleteSentence": False,
+                        "contextForSureMatch": 0
+                    }
+                ],
+                "sentenceRanges": [[0, 8]],
+                "extendedSentenceRanges": [{"from": 0, "to": 8, "detectedLanguages": [{"language": "en", "rate": 1.0}]}]
+            },
+        )
+        spellchecker.create([doc])
+
+        self.assertEqual(
+            doc,
+            {
+                "spellchecker": "languagetool",
+                "suggestions": [
+                    {"text": "mistake"},
+                    {"text": "misstate"},
+                    {"text": "miss take"},
+                ],
+                "text": "misstake",
+            },
+        )


### PR DESCRIPTION
## What does this PR do?
- Adds support for the spellchecker LanguageTool (https://languagetool.org)

### How to test?
Add LanguageTool env-variables to settings.py:
- LANGUAGETOOL_API_URL = env('LANGUAGETOOL_API_URL', 'https://api.languagetoolplus.com/v2/')
- No need to specify API-key for testing against public url above 

### Dependencies
- Additional languages must be added to superdesk-client-core in `scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx` 
- Dependent on superdesk-client-core [PR 4560](https://github.com/superdesk/superdesk-client-core/pull/4560)