### PR TITLE
SDAAP-112 Stop the generation of html on the server throwing an exception

### DIFF
--- a/superdesk/editor_utils.py
+++ b/superdesk/editor_utils.py
@@ -313,6 +313,13 @@ class DraftJSHTMLExporter:
                     TABLE: self.render_table,
                     IMAGE: self.render_image,
                 },
+                "block_map": dict(
+                    BLOCK_MAP,
+                    **{
+                        # Provide a fallback for block types.
+                        BLOCK_TYPES.FALLBACK: self.block_fallback
+                    },
+                ),
             }
         )
 
@@ -512,6 +519,12 @@ class DraftJSHTMLExporter:
             return
         logger.info("No style renderer for {type_!r}".format(type_=type_))
         return props["children"]
+
+    def block_fallback(self, props):
+        # <section> and <article> tags are not handled
+        type_ = props["block"]["type"]
+        logging.warning(f'Missing draft_export config for "{type_}". Using p instead.')
+        return DOM.create_element("p", {}, props["children"])
 
 
 class Editor3Content(EditorContent):

--- a/superdesk/editor_utils.py
+++ b/superdesk/editor_utils.py
@@ -523,8 +523,8 @@ class DraftJSHTMLExporter:
     def block_fallback(self, props):
         # <section> and <article> tags are not handled
         type_ = props["block"]["type"]
-        logging.warning(f'Missing draft_export config for "{type_}". Using p instead.')
-        return DOM.create_element("p", {}, props["children"])
+        logging.warning(f'Missing draft_export config for "{type_}". Using div instead.')
+        return DOM.create_element("div", {}, props["children"])
 
 
 class Editor3Content(EditorContent):

--- a/tests/editor_utils_test.py
+++ b/tests/editor_utils_test.py
@@ -2112,3 +2112,54 @@ class Editor3TestCase(unittest.TestCase):
         editor = Editor3Content(item)
         html = editor.html
         self.assertEqual(html, expected)
+
+    def test_fallback_on_section(self):
+        field_state = json.loads(
+            """
+            {
+                "entityMap": {},
+                        "blocks" : [
+                        {
+                            "key" : "1sftv",
+                            "text" : "Apple",
+                            "type" : "header-one",
+                            "depth" : 0,
+                            "inlineStyleRanges" : [],
+                            "entityRanges" : [],
+                            "data" : {
+                                "MULTIPLE_HIGHLIGHTS" : {}
+                            }
+                        },
+                        {
+                            "key" : "5fm93",
+                            "text" : "Introduction This document provides a guide to help with the important task of choosing the correct Apple.",
+                            "type" : "section",
+                            "depth" : 0,
+                            "inlineStyleRanges" : [],
+                            "entityRanges" : [],
+                            "data" : {}
+                        },
+                        {
+                            "key" : "1sktt",
+                            "text" : "Criteria There are many different criteria to be considered when choosing an Apple — size, color, firmness, sweetness, tartness...",
+                            "type" : "section",
+                            "depth" : 0,
+                            "inlineStyleRanges" : [],
+                            "entityRanges" : [],
+                            "data" : {}
+                        }
+                    ]
+            }
+        """
+        )
+        item = self.build_item(field_state)
+        body_editor = Editor3Content(item)
+        body_editor.update_item()
+        expected = (
+            "<h1>Apple</h1>\n"
+            "<p>Introduction This document provides a guide to help with the important task of choosing the "
+            "correct Apple.</p>\n"
+            "<p>Criteria There are many different criteria to be considered when choosing an Apple — size,"
+            " color, firmness, sweetness, tartness...</p>"
+        )
+        self.assertEqual(expected, item["body_html"])

--- a/tests/editor_utils_test.py
+++ b/tests/editor_utils_test.py
@@ -2157,9 +2157,9 @@ class Editor3TestCase(unittest.TestCase):
         body_editor.update_item()
         expected = (
             "<h1>Apple</h1>\n"
-            "<p>Introduction This document provides a guide to help with the important task of choosing the "
-            "correct Apple.</p>\n"
-            "<p>Criteria There are many different criteria to be considered when choosing an Apple — size,"
-            " color, firmness, sweetness, tartness...</p>"
+            "<div>Introduction This document provides a guide to help with the important task of choosing the "
+            "correct Apple.</div>\n"
+            "<div>Criteria There are many different criteria to be considered when choosing an Apple — size,"
+            " color, firmness, sweetness, tartness...</div>"
         )
         self.assertEqual(expected, item["body_html"])


### PR DESCRIPTION

The front end sends draftjs state blocks of type section, article etc. This causes the server to throw an exception when generating the html. 

To replicate the issue paste the html from the output panel on the page https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section the auto save will fail, also just saving the article.

Maybe a fix should be implemented on the front end, but this will at least stop the grief!

I think this issue exists in the current develop version as well.

@petrjasek @MarkLark86  I'm not sure if bundling the unhandled elements into a p tag is best? would a div be better?