### PR TITLE
Add missing bits of resource service search functionality

### DIFF
--- a/superdesk/core/elastic/base_client.py
+++ b/superdesk/core/elastic/base_client.py
@@ -204,7 +204,8 @@ class BaseElasticResourceClient:
 
         if req.where:
             try:
-                filters.append({"term": json.loads(req.where)})
+                term = json.loads(req.where) if isinstance(req.where, str) else req.where
+                filters.append({"term": term})
             except ValueError:
                 try:
                     filters.append({"term": parse(req.where)})

--- a/superdesk/core/resources/cursor.py
+++ b/superdesk/core/resources/cursor.py
@@ -10,7 +10,6 @@
 
 from typing import Dict, Any, Generic, TypeVar, Type, Optional, List, Union, Literal
 from typing_extensions import TypedDict
-from dataclasses import dataclass
 
 from pydantic import BaseModel, ConfigDict
 from motor.motor_asyncio import AsyncIOMotorCollection, AsyncIOMotorCursor
@@ -66,8 +65,8 @@ class SearchRequest(BaseModel):
     #: The page number to be returned
     page: int = 1
 
-    #: A JSON string contianing an Elasticsearch where query
-    where: Optional[str] = None
+    #: A JSON string containing an Elasticsearch where query
+    where: Optional[Union[str, Dict]] = None
 
     #: If `True`, will include aggregations with the result
     aggregations: bool = False

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -425,11 +425,9 @@ class AsyncResourceService(Generic[ResourceModelType]):
         if sort:
             args["sort"] = sort
 
-        where = req.where or {}
-        if isinstance(req.where, str):
-            where = json.loads(req.where)
-
+        where = json.loads(req.where) if isinstance(req.where, str) else (req.where or {})
         args["filter"] = where
+
         cursor = self.mongo.find(**args)
 
         return MongoResourceCursorAsync(self.config.data_class, self.mongo, cursor, where)

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -425,7 +425,11 @@ class AsyncResourceService(Generic[ResourceModelType]):
         if sort:
             args["sort"] = sort
 
-        where = json.loads(req.where or "{}")
+        where = req.where or {}
+        if isinstance(req.where, str):
+            where = json.loads(req.where)
+
+        args["filter"] = where
         cursor = self.mongo.find(**args)
 
         return MongoResourceCursorAsync(self.config.data_class, self.mongo, cursor, where)


### PR DESCRIPTION
This allows the `SearchRequest` to accept not only a `str` for `where` member but also a `Dict`. It also completes a small missing bit in the find/search functionality while using Mongo. 