### PR TITLE
[SDESK-7284] Fix async commands to build a Superdesk instance

### DIFF
--- a/apps/auth/db/__init__.py
+++ b/apps/auth/db/__init__.py
@@ -13,7 +13,7 @@ from apps.auth import AuthResource
 from .reset_password import ResetPasswordService, ResetPasswordResource, ActiveTokensResource
 import superdesk
 from .db import DbAuthService
-from .commands import CreateUserCommand, HashUserPasswordsCommand  # noqa
+from .commands import create_user_command, HashUserPasswordsCommand  # noqa
 from superdesk.services import BaseService
 from apps.auth.db.change_password import ChangePasswordService, ChangePasswordResource
 

--- a/apps/auth/db/commands.py
+++ b/apps/auth/db/commands.py
@@ -28,13 +28,13 @@ logger = logging.getLogger(__name__)
 USER_FIELDS_NAMES = {"username", "email", "password", "first_name", "last_name", "sign_off", "role"}
 
 
-@cli.register_async_command("users:create", pass_current_app=True)
+@cli.register_async_command("users:create", with_appcontext=True)
 @click.option("--username", "-u", required=True, help="Username for the new user.")
 @click.option("--password", "-p", required=True, help="Password for the new user.")
 @click.option("--email", "-e", required=True, help="Email address for the new user.")
 @click.option("--admin", "-a", is_flag=True, help="Specify if the user is an administrator.")
 @click.option("--support", "-s", is_flag=True, help="Specify if the user is a support user.")
-async def create_user_command(app: Flask, *args, **kwargs):
+async def create_user_command(*args, **kwargs):
     """Create a user with given username, password and email.
 
     If user with given username exists it's noop.
@@ -45,8 +45,7 @@ async def create_user_command(app: Flask, *args, **kwargs):
         $ python manage.py users:create -u admin -p admin -e 'admin@example.com' --admin
 
     """
-    async with app.app_context():
-        return await create_user_command_handler(*args, **kwargs)
+    return await create_user_command_handler(*args, **kwargs)
 
 
 async def create_user_command_handler(username: str, password: str, email: str, admin=False, support=False):

--- a/apps/prepopulate/__init__.py
+++ b/apps/prepopulate/__init__.py
@@ -12,7 +12,7 @@ import superdesk
 
 from .app_prepopulate import PrepopulateService, PrepopulateResource
 from .app_populate import AppPopulateCommand  # NOQA
-from .app_initialize import AppInitializeWithDataCommand  # NOQA
+from .app_initialize import app_initialize_data_command  # NOQA
 from .app_scaffold_data import AppScaffoldDataCommand  # NOQA
 
 

--- a/apps/prepopulate/app_initialize.py
+++ b/apps/prepopulate/app_initialize.py
@@ -10,6 +10,7 @@ import elasticsearch.exceptions
 from pathlib import Path
 from collections import OrderedDict
 
+from superdesk.flask import Flask
 from superdesk.commands import cli
 from superdesk.core import get_current_app, get_app_config
 from superdesk.resource_fields import ETAG
@@ -217,13 +218,13 @@ def get_filepath(filename, path=None):
             return filepath
 
 
-@cli.register_async_command("app:initialize_data")
+@cli.register_async_command("app:initialize_data", pass_current_app=True)
 @click.option("--entity-name", "-n", multiple=True, help="Entity(ies) to initialize")
 @click.option("--full-path", "-p", help="Path of the file to import")
 @click.option("--sample-data", is_flag=True, help="Use sample data")
 @click.option("--force", "-f", is_flag=True, help="Update item even if modified by user")
 @click.option("--init-index-only", "-i", is_flag=True, help="Initialize index only")
-async def app_initialize_data_command(*args, **kwargs):
+async def app_initialize_data_command(app: Flask, *args, **kwargs):
     """Initialize application with predefined data for various entities.
 
     Loads predefined data (vocabularies, desks, etc..) for instance.
@@ -267,8 +268,8 @@ async def app_initialize_data_command(*args, **kwargs):
         $ python manage.py app:initialize_data --entity-name=content_types
 
     """
-
-    return await app_initialize_data_handler(*args, **kwargs)
+    async with app.app_context():
+        return await app_initialize_data_handler(*args, **kwargs)
 
 
 async def app_initialize_data_handler(

--- a/apps/prepopulate/app_initialize.py
+++ b/apps/prepopulate/app_initialize.py
@@ -8,7 +8,6 @@ import superdesk
 import elasticsearch.exceptions
 
 from pathlib import Path
-from functools import wraps
 from collections import OrderedDict
 
 from superdesk.commands import cli
@@ -224,7 +223,7 @@ def get_filepath(filename, path=None):
 @click.option("--sample-data", is_flag=True, help="Use sample data")
 @click.option("--force", "-f", is_flag=True, help="Update item even if modified by user")
 @click.option("--init-index-only", "-i", is_flag=True, help="Initialize index only")
-def app_initialize_data_command(*args, **kwargs):
+async def app_initialize_data_command(*args, **kwargs):
     """Initialize application with predefined data for various entities.
 
     Loads predefined data (vocabularies, desks, etc..) for instance.
@@ -268,9 +267,8 @@ def app_initialize_data_command(*args, **kwargs):
         $ python manage.py app:initialize_data --entity-name=content_types
 
     """
-    from asgiref.sync import async_to_sync
 
-    return async_to_sync(app_initialize_data_handler)(*args, **kwargs)
+    return await app_initialize_data_handler(*args, **kwargs)
 
 
 async def app_initialize_data_handler(

--- a/apps/prepopulate/app_initialize.py
+++ b/apps/prepopulate/app_initialize.py
@@ -1,15 +1,17 @@
-import json
-import logging
 import os
 import re
+import json
+import click
+import logging
+import pymongo
+import superdesk
 import elasticsearch.exceptions
 
-from collections import OrderedDict
 from pathlib import Path
+from functools import wraps
+from collections import OrderedDict
 
-import superdesk
-import pymongo
-
+from superdesk.commands import cli
 from superdesk.core import get_current_app, get_app_config
 from superdesk.resource_fields import ETAG
 from superdesk.commands.flush_elastic_index import FlushElasticIndex
@@ -216,7 +218,13 @@ def get_filepath(filename, path=None):
             return filepath
 
 
-class AppInitializeWithDataCommand(superdesk.Command):
+@cli.register_async_command("app:initialize_data")
+@click.option("--entity-name", "-n", multiple=True, help="Entity(ies) to initialize")
+@click.option("--full-path", "-p", help="Path of the file to import")
+@click.option("--sample-data", is_flag=True, help="Use sample data")
+@click.option("--force", "-f", is_flag=True, help="Update item even if modified by user")
+@click.option("--init-index-only", "-i", is_flag=True, help="Initialize index only")
+def app_initialize_data_command(*args, **kwargs):
     """Initialize application with predefined data for various entities.
 
     Loads predefined data (vocabularies, desks, etc..) for instance.
@@ -247,6 +255,13 @@ class AppInitializeWithDataCommand(superdesk.Command):
     will be updated with the predefined data if it already exists,
     no action will be taken for the other entities.
 
+    Args:
+        entity_name (str | list | None, optional): Entity(ies) to initialize.
+        path (str | None, optional): Path of the file to import.
+        sample_data (bool, optional): If True, sample data will be used.
+        force (bool, optional): If True, update items even if they have been modified by the user.
+        init_index_only (bool, optional): If True, only the indexes are initialized.
+
     Example:
     ::
 
@@ -255,150 +270,140 @@ class AppInitializeWithDataCommand(superdesk.Command):
         $ python manage.py app:initialize_data --entity-name=content_types
 
     """
+    from asgiref.sync import async_to_sync
 
-    name = "app:initialize_data"
+    return async_to_sync(app_initialize_data_handler)(*args, **kwargs)
 
-    option_list = [
-        superdesk.Option("--entity-name", "-n", action="append"),
-        superdesk.Option("--full-path", "-p", dest="path"),
-        superdesk.Option("--sample-data", action="store_true"),
-        superdesk.Option("--force", "-f", action="store_true"),
-        superdesk.Option("--init-index-only", "-i", action="store_true"),
-    ]
 
-    async def run(self, entity_name=None, path=None, sample_data=False, force=False, init_index_only=False, **kwargs):
-        """Run the initialization
+async def app_initialize_data_handler(
+    entity_name=None, full_path=None, sample_data=False, force=False, init_index_only=False
+):
+    logger.info("Starting data initialization")
+    logger.info("Config: %s", get_app_config("APP_ABSPATH"))
 
-        :param str,list,NoneType entity_name: entity(ies) to initialize
-        :param str,NoneType path: path of the file to import
-        :param bool sample_data: True if sample data need to be used
-        :param bool force: if True, update item even if it has been modified by user
-        :param bool init_index_only: if True, it only initializes index only
-        """
-        logger.info("Starting data initialization")
-        logger.info("Config: %s", get_app_config("APP_ABSPATH"))
+    # create indexes in mongo
+    # We can safely ignore duplicate key errors as this only affects performance
+    # As we want the rest of this command to still execute
+    app = get_current_app()
+    app.init_indexes(ignore_duplicate_keys=True)
 
-        # create indexes in mongo
-        # We can safely ignore duplicate key errors as this only affects performance
-        # As we want the rest of this command to still execute
-        app = get_current_app()
-        app.init_indexes(ignore_duplicate_keys=True)
+    rebuild_elastic_on_init_data_error = get_app_config("REBUILD_ELASTIC_ON_INIT_DATA_ERROR")
 
-        rebuild_elastic_on_init_data_error = get_app_config("REBUILD_ELASTIC_ON_INIT_DATA_ERROR")
+    # put mapping to elastic
+    try:
+        await app.data.init_elastic(app, raise_on_mapping_error=rebuild_elastic_on_init_data_error)
+    except elasticsearch.exceptions.TransportError as err:
+        logger.error(err)
+        if rebuild_elastic_on_init_data_error:
+            logger.warning("Can't update the mapping, running app:flush_elastic_index command now.")
+            FlushElasticIndex().run(sd_index=True, capi_index=True)
+        else:
+            logger.warning("Can't update the mapping, please run app:flush_elastic_index command.")
 
-        # put mapping to elastic
-        try:
-            await app.data.init_elastic(app, raise_on_mapping_error=rebuild_elastic_on_init_data_error)
-        except elasticsearch.exceptions.TransportError as err:
-            logger.error(err)
-            if rebuild_elastic_on_init_data_error:
-                logger.warning("Can't update the mapping, running app:flush_elastic_index command now.")
-                FlushElasticIndex().run(sd_index=True, capi_index=True)
-            else:
-                logger.warning("Can't update the mapping, please run app:flush_elastic_index command.")
-
-        if init_index_only:
-            logger.info("Only indexes initialized.")
-            return 0
-
-        if sample_data:
-            if not path:
-                path = INIT_DATA_PATH.parent / "data_sample"
-            else:
-                raise ValueError("path and sample_data should not be set at the same time")
-
-        if entity_name:
-            if isinstance(entity_name, str):
-                entity_name = [entity_name]
-            for name in entity_name:
-                (file_name, index_params, do_patch) = __entities__[name]
-                self.import_file(name, path, file_name, index_params, do_patch, force)
-            return 0
-
-        for name, (file_name, index_params, do_patch) in __entities__.items():
-            try:
-                self.import_file(name, path, file_name, index_params, do_patch, force)
-            except KeyError:
-                continue
-            except Exception as ex:
-                logger.exception(ex)
-                logger.info("Exception loading entity {} from {}".format(name, file_name))
-
-        logger.info("Data import finished")
+    if init_index_only:
+        logger.info("Only indexes initialized.")
         return 0
 
-    def import_file(self, entity_name, path, file_name, index_params, do_patch=False, force=False):
-        """Imports seed data based on the entity_name (resource name) from the file_name specified.
-
-        index_params use to create index for that entity/resource
-
-        :param str entity_name: name of the resource
-        :param str file_name: file name that contains seed data
-        :param list index_params: list of indexes that is created on that entity.
-        For example:
-        [[("first_name", pymongo.ASCENDING), ("last_name", pymongo.ASCENDING)], "username"] will create two indexes
-        - composite index of "first_name", "last_name" field.
-        - index on username field.
-        Alternatively index param can be specified as
-        [[("first_name", pymongo.ASCENDING), ("last_name", pymongo.ASCENDING)], [("username", pymongo.ASCENDING)]]
-        Refer to pymongo create_index documentation for more information.
-        http://api.mongodb.org/python/current/api/pymongo/collection.html
-        :param bool do_patch: if True then patch the document else don't patch.
-        """
-        logger.info("Process %r", entity_name)
-        file_path = file_name and get_filepath(file_name, path)
-        app = get_current_app()
-
-        if not file_path:
-            pass
-        elif not file_path.exists():
-            logger.info(" - file not exists: %s", file_path)
+    path = full_path
+    if sample_data:
+        if not path:
+            path = INIT_DATA_PATH.parent / "data_sample"
         else:
-            logger.info(" - got file path: %s", file_path)
-            with file_path.open("rt", encoding="utf-8") as app_prepopulation:
-                service = superdesk.get_resource_service(entity_name)
-                json_data = json.loads(app_prepopulation.read())
-                data = [fillEnvironmentVariables(item) for item in json_data]
-                data = [app.data.mongo._mongotize(item, service.datasource) for item in data if item]
-                existing_data = []
-                existing = service.get_from_mongo(None, {})
-                update_data = True
-                if not do_patch and existing.count() > 0:
-                    logger.info(" - data already exists none will be loaded")
-                    update_data = False
-                elif do_patch and existing.count() > 0:
-                    logger.info(" - data already exists it will be updated")
+            raise ValueError("path and sample_data should not be set at the same time")
 
-                if update_data:
-                    if do_patch:
-                        for item in existing:
-                            for loaded_item in data:
-                                if "_id" in loaded_item and loaded_item["_id"] == item["_id"]:
-                                    data.remove(loaded_item)
-                                    if force or item.get("init_version", 0) < loaded_item.get("init_version", 0):
-                                        existing_data.append(loaded_item)
+    if entity_name:
+        if isinstance(entity_name, str):
+            entity_name = [entity_name]
+        for name in entity_name:
+            (file_name, index_params, do_patch) = __entities__[name]
+            import_file(name, path, file_name, index_params, do_patch, force)
+        return 0
 
-                    if data:
-                        for item in data:
-                            if not item.get(ETAG):
-                                item.setdefault(ETAG, "init")
-                        service.post(data)
+    for name, (file_name, index_params, do_patch) in __entities__.items():
+        try:
+            import_file(name, path, file_name, index_params, do_patch, force)
+        except KeyError:
+            continue
+        except Exception as ex:
+            logger.exception(ex)
+            logger.info("Exception loading entity {} from {}".format(name, file_name))
 
-                    if existing_data and do_patch:
-                        for item in existing_data:
-                            item["_etag"] = "init"
-                            service.update(item["_id"], item, service.find_one(None, _id=item["_id"]))
+    logger.info("Data import finished")
+    return 0
 
-                logger.info(" - file imported successfully: %s", file_name)
 
-        if index_params:
-            for index in index_params:
-                crt_index = list(index) if isinstance(index, list) else index
-                options = crt_index.pop() if isinstance(crt_index[-1], dict) and isinstance(index, list) else {}
-                collection = app.data.mongo.pymongo(resource=entity_name).db[entity_name]
-                options.setdefault("background", True)
-                index_name = collection.create_index(crt_index, **options)
-                logger.info(" - index: %s for collection %s created successfully.", index_name, entity_name)
+def import_file(entity_name, path, file_name, index_params, do_patch=False, force=False):
+    """Imports seed data based on the entity_name (resource name) from the file_name specified.
+
+    index_params use to create index for that entity/resource
+
+    :param str entity_name: name of the resource
+    :param str file_name: file name that contains seed data
+    :param list index_params: list of indexes that is created on that entity.
+    For example:
+    [[("first_name", pymongo.ASCENDING), ("last_name", pymongo.ASCENDING)], "username"] will create two indexes
+    - composite index of "first_name", "last_name" field.
+    - index on username field.
+    Alternatively index param can be specified as
+    [[("first_name", pymongo.ASCENDING), ("last_name", pymongo.ASCENDING)], [("username", pymongo.ASCENDING)]]
+    Refer to pymongo create_index documentation for more information.
+    http://api.mongodb.org/python/current/api/pymongo/collection.html
+    :param bool do_patch: if True then patch the document else don't patch.
+    """
+    logger.info("Process %r", entity_name)
+    file_path = file_name and get_filepath(file_name, path)
+    app = get_current_app()
+
+    if not file_path:
+        pass
+    elif not file_path.exists():
+        logger.info(" - file not exists: %s", file_path)
+    else:
+        logger.info(" - got file path: %s", file_path)
+        with file_path.open("rt", encoding="utf-8") as app_prepopulation:
+            service = superdesk.get_resource_service(entity_name)
+            json_data = json.loads(app_prepopulation.read())
+            data = [fillEnvironmentVariables(item) for item in json_data]
+            data = [app.data.mongo._mongotize(item, service.datasource) for item in data if item]
+            existing_data = []
+            existing = service.get_from_mongo(None, {})
+            update_data = True
+            if not do_patch and existing.count() > 0:
+                logger.info(" - data already exists none will be loaded")
+                update_data = False
+            elif do_patch and existing.count() > 0:
+                logger.info(" - data already exists it will be updated")
+
+            if update_data:
+                if do_patch:
+                    for item in existing:
+                        for loaded_item in data:
+                            if "_id" in loaded_item and loaded_item["_id"] == item["_id"]:
+                                data.remove(loaded_item)
+                                if force or item.get("init_version", 0) < loaded_item.get("init_version", 0):
+                                    existing_data.append(loaded_item)
+
+                if data:
+                    for item in data:
+                        if not item.get(ETAG):
+                            item.setdefault(ETAG, "init")
+                    service.post(data)
+
+                if existing_data and do_patch:
+                    for item in existing_data:
+                        item["_etag"] = "init"
+                        service.update(item["_id"], item, service.find_one(None, _id=item["_id"]))
+
+            logger.info(" - file imported successfully: %s", file_name)
+
+    if index_params:
+        for index in index_params:
+            crt_index = list(index) if isinstance(index, list) else index
+            options = crt_index.pop() if isinstance(crt_index[-1], dict) and isinstance(index, list) else {}
+            collection = app.data.mongo.pymongo(resource=entity_name).db[entity_name]
+            options.setdefault("background", True)
+            index_name = collection.create_index(crt_index, **options)
+            logger.info(" - index: %s for collection %s created successfully.", index_name, entity_name)
 
 
 def fillEnvironmentVariables(item):
@@ -416,6 +421,3 @@ def fillEnvironmentVariables(item):
         text = text.replace("#ENV_%s#" % name, variables[name])
 
     return json.loads(text)
-
-
-superdesk.register_command(AppInitializeWithDataCommand)

--- a/apps/prepopulate/app_initialize.py
+++ b/apps/prepopulate/app_initialize.py
@@ -218,13 +218,13 @@ def get_filepath(filename, path=None):
             return filepath
 
 
-@cli.register_async_command("app:initialize_data", pass_current_app=True)
+@cli.register_async_command("app:initialize_data", with_appcontext=True)
 @click.option("--entity-name", "-n", multiple=True, help="Entity(ies) to initialize")
 @click.option("--full-path", "-p", help="Path of the file to import")
 @click.option("--sample-data", is_flag=True, help="Use sample data")
 @click.option("--force", "-f", is_flag=True, help="Update item even if modified by user")
 @click.option("--init-index-only", "-i", is_flag=True, help="Initialize index only")
-async def app_initialize_data_command(app: Flask, *args, **kwargs):
+async def app_initialize_data_command(*args, **kwargs):
     """Initialize application with predefined data for various entities.
 
     Loads predefined data (vocabularies, desks, etc..) for instance.
@@ -268,8 +268,7 @@ async def app_initialize_data_command(app: Flask, *args, **kwargs):
         $ python manage.py app:initialize_data --entity-name=content_types
 
     """
-    async with app.app_context():
-        return await app_initialize_data_handler(*args, **kwargs)
+    return await app_initialize_data_handler(*args, **kwargs)
 
 
 async def app_initialize_data_handler(

--- a/apps/prepopulate/app_initialize.py
+++ b/apps/prepopulate/app_initialize.py
@@ -235,17 +235,15 @@ def app_initialize_data_command(*args, **kwargs):
     Supported entities:
     ::
 
-        roles, users, desks, stages, vocabularies, validators,
-        content_templates, content_types, published, activity,
-        archive, archive_versions, ingest, publish_queue, archived,
-        legal_archive, legal_archive_versions, legal_publish_queue,
-        dictionaries, ingest_providers, search_providers, products,
-        subscribers, workspaces, item_comments, audit, contacts,
-        planning_types
+        roles, users, desks, stages, vocabularies, validators, content_templates,
+        content_types, published, activity, archive, archive_versions, ingest,
+        publish_queue, archived, legal_archive, legal_archive_versions, legal_publish_queue,
+        dictionaries, ingest_providers, search_providers, products, subscribers,
+        workspaces, item_comments, audit, contacts, planning_types
 
     If no --entity-name parameter is supplied, all the entities are inserted.
-    The entities:
 
+    The entities:
     ::
 
         vocabularies, validators, content_types, dictionaries, ingest_providers,

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,6 +17,7 @@ python3-saml>=1.9,<1.17
 typing_extensions>=3.7.4
 moto[sqs]<5.0
 pyexiv2>=2.12.0,<2.13; sys_platform == 'linux'
+asgiref
 
 -e .
 -e git+https://github.com/superdesk/superdesk-planning.git@async#egg=superdesk_planning

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,7 +17,6 @@ python3-saml>=1.9,<1.17
 typing_extensions>=3.7.4
 moto[sqs]<5.0
 pyexiv2>=2.12.0,<2.13; sys_platform == 'linux'
-asgiref
 
 -e .
 -e git+https://github.com/superdesk/superdesk-planning.git@async#egg=superdesk_planning

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.2"
 # Note: this file is mainly used for tests. If you want to run Superdesk or its
 # services from docker, please use docker-compose.yml found in main Superdesk
 # repository (https://github.com/superdesk/superdesk)
-
+name: superdesk-core-services
 services:
     elastic:
         image: docker.elastic.co/elasticsearch/elasticsearch:7.17.22

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ install_requires = [
     "eve-elastic @ git+https://github.com/MarkLark86/eve-elastic@use-quart",
     "quart @ git+https://github.com/MarkLark86/quart@fix-test-client-with-utf8-url",
     "quart_babel @ git+https://github.com/MarkLark86/quart-babel@fix-get-format",
+    "asgiref>=3.8.1",
     # Patch Quart, Asyncio to work with Flask extensions
     # TODO-ASYNC: Remove this with our own flask patch (as quart-flask-patch also patches asyncio)
     "quart-flask-patch>=0.3.0,<0.4",

--- a/superdesk/commands/__init__.py
+++ b/superdesk/commands/__init__.py
@@ -29,3 +29,12 @@ def init_app(app) -> None:
         data_manipulation.RestoreRecordResource(endpoint_name, app=app, service=service)
 
         superdesk.intrinsic_privilege(resource_name=endpoint_name, method=["POST"])
+
+
+def configure_cli(app) -> None:
+    """
+    Sets the current app instance into the `AsyncAppGroup` to later be passed as context of the commands.
+    It also registers the commands blueprint
+    """
+    cli.set_current_app(app)
+    app.register_blueprint(commands_blueprint)

--- a/superdesk/commands/__init__.py
+++ b/superdesk/commands/__init__.py
@@ -10,6 +10,7 @@ from .flush_elastic_index import FlushElasticIndex  # noqa
 from .generate_vocabularies import GenerateVocabularies  # noqa
 from . import data_manipulation  # noqa
 from . import schema  # noqa
+from .async_cli import cli, commands_blueprint  # noqa
 import superdesk
 
 

--- a/superdesk/commands/async_cli.py
+++ b/superdesk/commands/async_cli.py
@@ -1,0 +1,71 @@
+from typing import Tuple
+from functools import wraps
+from asgiref.sync import async_to_sync
+
+from ..flask import Blueprint, AppGroup
+
+
+class AsyncAppGroup(AppGroup):
+    """
+    An extension of Quart's AppGroup to support registration of asynchronous command handlers.
+
+    This class provides a mechanism to register asynchronous functions as command line commands,
+    which are automatically handled synchronously using `asgiref.sync.async_to_sync` conversion.
+    """
+
+    def register_async_command(self, name=None, **click_kwargs):
+        """
+        A decorator to register an asynchronous command within the Quart CLI app group.
+
+        Args:
+            name (str): The name of the command. If None, the function's name will be used.
+            **click_kwargs: Arbitrary keyword arguments that are passed to the `AppGroup.command` decorator.
+
+        Returns:
+            function: A decorator that wraps the async function and registers it as a command.
+        """
+
+        def decorator(func):
+            @wraps(func)
+            # This wrapper will convert the async function to a sync function
+            # using async_to_sync when the command is actually called.
+            def sync_wrapper(*args, **kwargs):
+                return async_to_sync(func)(*args, **kwargs)
+
+            # register the sync wrapper as a click command
+            click_command = self.command(name, **click_kwargs)
+            return click_command(sync_wrapper)
+
+        return decorator
+
+
+class CommandsBlueprint(Blueprint):
+    """
+    Custom Blueprint that integrates AsyncAppGroup to register CLI commands that are asynchronous,
+    allowing them to be used in a synchronous context by Quart's command line interface.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.cli = AsyncAppGroup()
+
+
+def create_commands_blueprint(blueprint_name: str) -> Tuple[CommandsBlueprint, AsyncAppGroup]:
+    """
+    Create a Blueprint to organize all superdesk commands.
+
+    By setting cli_group=None, any new CLI commands added to this blueprint
+    will still be compatible with the existing `python manage.py <command-name>`
+    format.
+
+    Returns:
+        Tuple[Blueprint, AppGroup]: A tuple containing the configured Blueprint
+        object and its associated CLI AppGroup for command registration.
+    """
+    blueprint = CommandsBlueprint(blueprint_name, __name__)
+
+    return blueprint, blueprint.cli
+
+
+commands_blueprint, cli = create_commands_blueprint("superdesk")

--- a/superdesk/commands/async_cli.py
+++ b/superdesk/commands/async_cli.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, cast
 from functools import wraps
 from asgiref.sync import async_to_sync
 
@@ -65,7 +65,7 @@ def create_commands_blueprint(blueprint_name: str) -> Tuple[CommandsBlueprint, A
     """
     blueprint = CommandsBlueprint(blueprint_name, __name__)
 
-    return blueprint, blueprint.cli
+    return blueprint, cast(AsyncAppGroup, blueprint.cli)
 
 
 commands_blueprint, cli = create_commands_blueprint("superdesk")

--- a/superdesk/commands/async_cli.py
+++ b/superdesk/commands/async_cli.py
@@ -1,8 +1,8 @@
-from typing import Tuple, cast
 from functools import wraps
+from typing import Any, Callable, Optional, Tuple, cast
 from asgiref.sync import async_to_sync
 
-from ..flask import Blueprint, AppGroup
+from ..flask import Blueprint, AppGroup, Flask
 
 
 class AsyncAppGroup(AppGroup):
@@ -13,23 +13,45 @@ class AsyncAppGroup(AppGroup):
     which are automatically handled synchronously using `asgiref.sync.async_to_sync` conversion.
     """
 
-    def register_async_command(self, name=None, **click_kwargs):
+    app: Flask
+
+    def register_async_command(
+        self, name: Optional[str] = None, pass_current_app=False, **click_kwargs: dict[str, Any]
+    ) -> Callable[..., Any]:
         """
         A decorator to register an asynchronous command within the Quart CLI app group.
+        If your command needs to use the app context, set `pass_current_app=True` to ensure the current app
+        instance is passed to the command upon execution. This is necessary because `get_current_app` may fail
+        in asynchronous command contexts due to execution in different threads or outside of the normal request
+        context lifecycle.
 
         Args:
-            name (str): The name of the command. If None, the function's name will be used.
-            **click_kwargs: Arbitrary keyword arguments that are passed to the `AppGroup.command` decorator.
+            name (str, optional): The name of the command. Defaults to the function's name if None.
+            pass_current_app (bool): If True, passes the current app instance to the command function via keyword arguments.
+                                     This allows commands to access the app context directly.
+            **click_kwargs: Additional keyword arguments that are passed to the `AppGroup.command` decorator.
 
-        Returns:
-            function: A decorator that wraps the async function and registers it as a command.
+        Example:
+        Use the decorator to register a command that requires app context:
+
+        .. code-block:: python
+
+            from superdesk.commands import cli
+
+            @cli.register_async_command(pass_current_app=True)
+            async def my_command("example-command", app):
+                with app.app_context():
+                    # your command logic here
         """
 
-        def decorator(func):
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             @wraps(func)
             # This wrapper will convert the async function to a sync function
             # using async_to_sync when the command is actually called.
-            def sync_wrapper(*args, **kwargs):
+            def sync_wrapper(*args, **kwargs) -> Any:
+                if pass_current_app:
+                    kwargs["app"] = self.get_current_app()
+
                 return async_to_sync(func)(*args, **kwargs)
 
             # register the sync wrapper as a click command
@@ -37,6 +59,15 @@ class AsyncAppGroup(AppGroup):
             return click_command(sync_wrapper)
 
         return decorator
+
+    def set_current_app(self, app: Flask):
+        """
+        Sets current app instance so it can be passed down to commands if needed
+        """
+        self.app = app
+
+    def get_current_app(self) -> Flask:
+        return self.app
 
 
 class CommandsBlueprint(Blueprint):
@@ -63,7 +94,7 @@ def create_commands_blueprint(blueprint_name: str) -> Tuple[CommandsBlueprint, A
         Tuple[Blueprint, AppGroup]: A tuple containing the configured Blueprint
         object and its associated CLI AppGroup for command registration.
     """
-    blueprint = CommandsBlueprint(blueprint_name, __name__)
+    blueprint = CommandsBlueprint(blueprint_name, __name__, cli_group=None)
 
     return blueprint, cast(AsyncAppGroup, blueprint.cli)
 

--- a/superdesk/commands/data_updates.py
+++ b/superdesk/commands/data_updates.py
@@ -182,7 +182,7 @@ async def upgrade_command_handler(data_update_id=None, fake=False, dry=False):
         print(
             "Error argument --id/-i: invalid choice: '{}' (choose from  {})".format(data_update_id, data_updates_files)
         )
-        return False
+        return
 
     # Filter and apply updates
     data_updates_files = [update for update in data_updates_files if not in_db(update, data_updates_service)]

--- a/superdesk/commands/data_updates.py
+++ b/superdesk/commands/data_updates.py
@@ -160,9 +160,9 @@ def common_options(func):
     return wrapper
 
 
-@cli.register_async_command("data:upgrade", pass_current_app=True)
+@cli.register_async_command("data:upgrade", with_appcontext=True)
 @common_options
-async def upgrade_command(app: Flask, *args, **kwargs):
+async def upgrade_command(*args, **kwargs):
     """Runs all the new data updates available.
 
     If ``data_update_id`` is given, runs new data updates until the given one.
@@ -173,8 +173,7 @@ async def upgrade_command(app: Flask, *args, **kwargs):
         $ python manage.py data:upgrade
 
     """
-    async with app.app_context():
-        return await upgrade_command_handler(*args, **kwargs)
+    return await upgrade_command_handler(*args, **kwargs)
 
 
 async def upgrade_command_handler(data_update_id=None, fake=False, dry=False):
@@ -207,9 +206,9 @@ async def upgrade_command_handler(data_update_id=None, fake=False, dry=False):
         print("No data update to apply.")
 
 
-@cli.register_async_command("data:downgrade", pass_current_app=True)
+@cli.register_async_command("data:downgrade", with_appcontext=True)
 @common_options
-async def downgrade_command(app: Flask, *args, **kwargs):
+async def downgrade_command(*args, **kwargs):
     """Runs the latest data update backward.
 
     If ``data_update_id`` is given, runs all the data updates backward until the given one.
@@ -220,8 +219,8 @@ async def downgrade_command(app: Flask, *args, **kwargs):
         $ python manage.py data:downgrade
 
     """
-    async with app.app_context():
-        return await downgrade_command_handler(*args, **kwargs)
+
+    return await downgrade_command_handler(*args, **kwargs)
 
 
 async def downgrade_command_handler(data_update_id=None, fake=False, dry=False):

--- a/superdesk/commands/schema.py
+++ b/superdesk/commands/schema.py
@@ -49,8 +49,8 @@ def update_schema():
     RebuildElasticIndex().run()
 
 
-@cli.register_async_command("schema:migrate", pass_current_app=True)
-async def schema_migrate_command(app: Flask):
+@cli.register_async_command("schema:migrate", with_appcontext=True)
+async def schema_migrate_command():
     """Migrate elastic schema if needed, should be triggered on every deploy.
 
     It compares version set in code (latest) to one stored in db and only updates
@@ -65,8 +65,8 @@ async def schema_migrate_command(app: Flask):
         $ python manage.py schema:migrate
 
     """
-    async with app.app_context():
-        return await schema_migrate_command_handler()
+
+    return await schema_migrate_command_handler()
 
 
 async def schema_migrate_command_handler():

--- a/superdesk/commands/schema.py
+++ b/superdesk/commands/schema.py
@@ -12,6 +12,7 @@
 
 import superdesk
 
+from superdesk.flask import Flask
 from superdesk.lock import lock, unlock
 from superdesk.core import get_app_config, get_current_app
 from superdesk.commands.rebuild_elastic_index import RebuildElasticIndex
@@ -48,8 +49,8 @@ def update_schema():
     RebuildElasticIndex().run()
 
 
-@cli.register_async_command("schema:migrate")
-async def schema_migrate_command():
+@cli.register_async_command("schema:migrate", pass_current_app=True)
+async def schema_migrate_command(app: Flask):
     """Migrate elastic schema if needed, should be triggered on every deploy.
 
     It compares version set in code (latest) to one stored in db and only updates
@@ -64,8 +65,8 @@ async def schema_migrate_command():
         $ python manage.py schema:migrate
 
     """
-
-    return await schema_migrate_command_handler()
+    async with app.app_context():
+        return await schema_migrate_command_handler()
 
 
 async def schema_migrate_command_handler():

--- a/superdesk/commands/schema.py
+++ b/superdesk/commands/schema.py
@@ -12,9 +12,11 @@
 
 import superdesk
 
-from superdesk.core import get_app_config, get_current_app
 from superdesk.lock import lock, unlock
+from superdesk.core import get_app_config, get_current_app
 from superdesk.commands.rebuild_elastic_index import RebuildElasticIndex
+
+from .async_cli import cli
 
 
 VERSION_ID = "schema_version"
@@ -46,7 +48,8 @@ def update_schema():
     RebuildElasticIndex().run()
 
 
-class SchemaMigrateCommand(superdesk.Command):
+@cli.register_async_command("schema:migrate")
+async def schema_migrate_command():
     """Migrate elastic schema if needed, should be triggered on every deploy.
 
     It compares version set in code (latest) to one stored in db and only updates
@@ -62,23 +65,23 @@ class SchemaMigrateCommand(superdesk.Command):
 
     """
 
-    def run(self):
-        lock_name = "schema:migrate"
-
-        if not lock(lock_name, expire=1800):
-            return
-
-        try:
-            app_schema_version = get_schema_version()
-            superdesk_schema_version = get_app_config("SCHEMA_VERSION", superdesk.SCHEMA_VERSION)
-            if app_schema_version < superdesk_schema_version:
-                print("Updating schema from version {} to {}.".format(app_schema_version, superdesk_schema_version))
-                update_schema()
-                set_schema_version(superdesk_schema_version)
-            else:
-                print("App already at version ({}).".format(app_schema_version))
-        finally:
-            unlock(lock_name)
+    return await schema_migrate_command_handler()
 
 
-superdesk.command("schema:migrate", SchemaMigrateCommand())
+async def schema_migrate_command_handler():
+    lock_name = "schema:migrate"
+
+    if not lock(lock_name, expire=1800):
+        return
+
+    try:
+        app_schema_version = get_schema_version()
+        superdesk_schema_version = get_app_config("SCHEMA_VERSION", superdesk.SCHEMA_VERSION)
+        if app_schema_version < superdesk_schema_version:
+            print("Updating schema from version {} to {}.".format(app_schema_version, superdesk_schema_version))
+            update_schema()
+            set_schema_version(superdesk_schema_version)
+        else:
+            print("App already at version ({}).".format(app_schema_version))
+    finally:
+        unlock(lock_name)

--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -28,7 +28,7 @@ from quart_babel import Babel
 from babel import parse_locale
 from pymongo.errors import DuplicateKeyError
 
-from quart import Quart
+from superdesk.commands import configure_cli
 from superdesk.flask import g, url_for, Config, Request as FlaskRequest, abort, Blueprint, request as flask_request
 from superdesk.celery_app import init_celery
 from superdesk.datalayer import SuperdeskDataLayer  # noqa
@@ -39,6 +39,7 @@ from superdesk.storage import ProxyMediaStorage
 from superdesk.validator import SuperdeskValidator
 from superdesk.json_utils import SuperdeskFlaskJSONProvider, SuperdeskJSONEncoder
 from superdesk.cache import cache_backend
+
 from .elastic_apm import setup_apm
 from superdesk.core.app import SuperdeskAsyncApp
 from superdesk.core.web import Endpoint, Request, EndpointGroup, HTTP_METHOD, Response
@@ -399,6 +400,10 @@ def get_app(config=None, media_storage=None, config_object=None, init_elastic=No
         app.jinja_env.filters[name] = jinja_filter
 
     configure_logging(app.config["LOG_CONFIG_FILE"])
+
+    # configure the CLI only after modules and apps have been loaded
+    # to make sure all commands are registered
+    configure_cli(app)
 
     return app
 

--- a/superdesk/flask.py
+++ b/superdesk/flask.py
@@ -36,6 +36,7 @@ from quart import (
     abort,
     send_file,
 )
+from quart.cli import AppGroup
 from quart.json.provider import DefaultJSONProvider
 
 
@@ -60,4 +61,5 @@ __all__ = [
     "Request",
     "abort",
     "send_file",
+    "AppGroup",
 ]

--- a/superdesk/tests/environment.py
+++ b/superdesk/tests/environment.py
@@ -15,7 +15,7 @@ import logging
 
 from superdesk.core import json
 from apps.prepopulate.app_populate import AppPopulateCommand
-from apps.prepopulate.app_initialize import AppInitializeWithDataCommand
+from apps.prepopulate.app_initialize import app_initialize_data_handler
 from superdesk import tests
 from superdesk.factory.app import get_app
 from superdesk.tests import setup_auth_user
@@ -84,8 +84,7 @@ async def setup_before_scenario(context, scenario, config, app_factory):
 
     if scenario.status != "skipped" and "app_init" in scenario.tags:
         async with context.app.app_context():
-            command = AppInitializeWithDataCommand()
-            command.run()
+            await app_initialize_data_handler()
 
 
 def before_all(context):

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -54,7 +54,7 @@ from superdesk.tests import get_prefixed_url, set_placeholder
 from apps.dictionaries.resource import DICTIONARY_FILE
 from superdesk.filemeta import get_filemeta
 from apps.preferences import enhance_document_with_default_prefs
-from apps.prepopulate.app_initialize import AppInitializeWithDataCommand
+from apps.prepopulate.app_initialize import app_initialize_data_handler
 
 # for auth server
 from authlib.jose import jwt
@@ -702,9 +702,10 @@ def run_update_ingest_ftp(*args):
             ("ninjs2.json", "20181111123456"),
             ("ninjs3.json", "20181111123456"),
         )
-        with mock.patch.object(
-            ftp.FTPFeedingService, "_retrieve_and_parse"
-        ) as retrieve_and_parse_mock, mock.patch.object(ftp.FTPFeedingService, "_is_empty") as empty_file_mock:
+        with (
+            mock.patch.object(ftp.FTPFeedingService, "_retrieve_and_parse") as retrieve_and_parse_mock,
+            mock.patch.object(ftp.FTPFeedingService, "_is_empty") as empty_file_mock,
+        ):
             retrieve_and_parse_mock.side_effect = retrieve_and_parse_side_effect
             empty_file_mock.return_value = False
             # run command
@@ -3030,7 +3031,7 @@ async def step_impl_then_we_dont_get_access_token(context):
 @async_run_until_complete
 async def setp_impl_when_we_init_data(context, entity):
     async with context.app.app_context():
-        AppInitializeWithDataCommand().run(entity)
+        await app_initialize_data_handler(entity)
 
 
 @when('we run task "{name}"')

--- a/tests/auth/create_user_command_test.py
+++ b/tests/auth/create_user_command_test.py
@@ -12,19 +12,18 @@ from superdesk import get_resource_service
 from os.path import dirname, join
 from superdesk.tests import TestCase, markers
 from superdesk.utc import utcnow
-from apps.auth.db.commands import CreateUserCommand, ImportUsersCommand
+from apps.auth.db.commands import create_user_command_handler, ImportUsersCommand
 
 
 class CreateUserCommandTestCase(TestCase):
     async def test_create_user_command(self):
         if not self.app.config.get("LDAP_SERVER"):
             user = {"username": "foo", "password": "bar", "email": "baz", "password_changed_on": utcnow()}
-            cmd = CreateUserCommand()
-            await cmd.run(user["username"], user["password"], user["email"], admin=True)
+            await create_user_command_handler(user["username"], user["password"], user["email"], admin=True)
             auth_user = get_resource_service("auth_db").authenticate(user)
             self.assertEquals(auth_user["username"], user["username"])
 
-            await cmd.run(user["username"], user["password"], user["email"], admin=True)
+            await create_user_command_handler(user["username"], user["password"], user["email"], admin=True)
             auth_user2 = get_resource_service("auth_db").authenticate(user)
             self.assertEquals(auth_user2["username"], user["username"])
             self.assertEquals(auth_user2["_id"], auth_user["_id"])
@@ -32,9 +31,9 @@ class CreateUserCommandTestCase(TestCase):
     async def test_create_user_command_no_update(self):
         if not self.app.config.get("LDAP_SERVER"):
             user = {"username": "foo", "password": "bar", "email": "baz", "password_changed_on": utcnow()}
-            cmd = CreateUserCommand()
-            await cmd.run(user["username"], user["password"], user["email"], admin=True)
-            await cmd.run(user["username"], "new_password", user["email"], admin=True)
+            cmd = create_user_command_handler
+            await cmd(user["username"], user["password"], user["email"], admin=True)
+            await cmd(user["username"], "new_password", user["email"], admin=True)
             get_resource_service("auth_db").authenticate(user)
 
     async def test_import_users(self):

--- a/tests/prepopulate/app_initialization_test.py
+++ b/tests/prepopulate/app_initialization_test.py
@@ -4,7 +4,7 @@ import tempfile
 from unittest.mock import patch
 
 from superdesk.core import json
-from apps.prepopulate.app_initialize import AppInitializeWithDataCommand
+from apps.prepopulate.app_initialize import app_initialize_data_handler
 from apps.prepopulate.app_scaffold_data import AppScaffoldDataCommand
 from apps.prepopulate.app_initialize import fillEnvironmentVariables
 from superdesk import get_resource_service
@@ -13,8 +13,8 @@ from superdesk.tests import TestCase
 
 class AppInitializeWithDataCommandTestCase(TestCase):
     async def _run(self, *a, **kw):
-        command = AppInitializeWithDataCommand()
-        return await command.run(*a, **kw)
+        command = app_initialize_data_handler
+        return await command(*a, **kw)
 
     async def test_app_initialization(self):
         result = await self._run()


### PR DESCRIPTION
### Purpose
Migrate the following commands into using `Click` library
- [x] app:initialize_data
- [x] users:create
- [x] data:upgrade
- [x] data:downgrade
- [x] schema:migrate

### What has changed
- Introduce `async_to_sync` from `asgiref.sync` in order to run commands with async code from start to end in the terminal without having event loop issues
- Implemented a new async_cli module https://github.com/superdesk/superdesk-core/pull/2680/commits/89780b367f4a43b562597bafe135fb4649271ce5 to register a custom Blueprint and AppGroup so that we can easily wrap the commands with `async_to_sync` and add the to Quart's cli at the same time
- Rework the commands so they are not function based and using Click lib

Thanks for checking!

**_Notes:_** 
- This is most likely going to break Newshub but I guess we'll have solve that in a separate ticket.
- I'd recommend hiding the white space changes to reduce the noise at the moment to reviewing the code :) 