### PR TITLE
Add minor improvements to core framework

### DIFF
--- a/superdesk/core/resources/model.py
+++ b/superdesk/core/resources/model.py
@@ -110,25 +110,31 @@ class ResourceModel(BaseModel):
             obj["_type"] = item_type
         return instance
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self, **kwargs) -> dict[str, Any]:
         """
         Convert the model instance to a dictionary representation with non-JSON-serializable Python objects.
 
+        :param kwargs: Optional keyword arguments to override the default parameters of model_dump.
         :rtype: dict[str, Any]
         :returns: A dictionary representation of the model instance with field aliases.
                 Only fields that are set (non-default) will be included.
         """
-        return self.model_dump(by_alias=True, exclude_unset=True)
+        default_params = {"by_alias": True, "exclude_unset": True}
+        default_params.update(kwargs)
+        return self.model_dump(**default_params)
 
-    def to_json(self) -> str:
+    def to_json(self, **kwargs) -> str:
         """
         Convert the model instance to a JSON serializable dictionary.
 
+        :param kwargs: Optional keyword arguments to override the default parameters of model_dump_json.
         :rtype: str
         :return: A JSON-compatible dictionary representation of the model instance with field aliases.
                 Only fields that are set (non-default) will be included.
         """
-        return self.model_dump_json(by_alias=True, exclude_unset=True)
+        default_params = {"by_alias": True, "exclude_unset": True}
+        default_params.update(kwargs)
+        return self.model_dump_json(**default_params)
 
 
 async def _run_async_validators_from_model_class(

--- a/superdesk/core/resources/model.py
+++ b/superdesk/core/resources/model.py
@@ -110,6 +110,26 @@ class ResourceModel(BaseModel):
             obj["_type"] = item_type
         return instance
 
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Convert the model instance to a dictionary representation with non-JSON-serializable Python objects.
+
+        :rtype: dict[str, Any]
+        :returns: A dictionary representation of the model instance with field aliases.
+                Only fields that are set (non-default) will be included.
+        """
+        return self.model_dump(by_alias=True, exclude_unset=True)
+
+    def to_json(self) -> str:
+        """
+        Convert the model instance to a JSON serializable dictionary.
+
+        :rtype: str
+        :return: A JSON-compatible dictionary representation of the model instance with field aliases.
+                Only fields that are set (non-default) will be included.
+        """
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
+
 
 async def _run_async_validators_from_model_class(
     model_instance: Any, root_item: ResourceModel, field_name_stack: Optional[List[str]] = None

--- a/superdesk/core/resources/model.py
+++ b/superdesk/core/resources/model.py
@@ -119,7 +119,7 @@ class ResourceModel(BaseModel):
         :returns: A dictionary representation of the model instance with field aliases.
                 Only fields that are set (non-default) will be included.
         """
-        default_params = {"by_alias": True, "exclude_unset": True}
+        default_params: dict[str, Any] = {"by_alias": True, "exclude_unset": True}
         default_params.update(kwargs)
         return self.model_dump(**default_params)
 
@@ -132,7 +132,7 @@ class ResourceModel(BaseModel):
         :return: A JSON-compatible dictionary representation of the model instance with field aliases.
                 Only fields that are set (non-default) will be included.
         """
-        default_params = {"by_alias": True, "exclude_unset": True}
+        default_params: dict[str, Any] = {"by_alias": True, "exclude_unset": True}
         default_params.update(kwargs)
         return self.model_dump_json(**default_params)
 

--- a/superdesk/core/resources/resource_rest_endpoints.py
+++ b/superdesk/core/resources/resource_rest_endpoints.py
@@ -8,7 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from typing import List, Optional, cast, Dict, Any, TypedDict, Type
+from typing import List, Optional, cast, Dict, Any, Type
 import math
 
 from dataclasses import dataclass

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -248,12 +248,12 @@ class AsyncResourceService(Generic[ResourceModelType]):
         :raises Pydantic.ValidationError: If any of the docs provided are not valid
         """
 
+        self._convert_dicts_to_model(docs)
+        await self.on_create(docs)
+
         ids: List[str] = []
 
         for doc in docs:
-            if isinstance(doc, dict):
-                doc = self.get_model_instance_from_dict(doc)
-            await self.on_create([doc])
             await self.validate_create(doc)
             doc_dict = doc.model_dump(
                 by_alias=True,
@@ -509,6 +509,11 @@ class AsyncResourceService(Generic[ResourceModelType]):
                     client_sort.append((sort_arg, 1))
 
         return client_sort
+
+    def _convert_dicts_to_model(self, docs: List[ResourceModelType | dict[str, Any]]):
+        for idx, doc in enumerate(docs):
+            if isinstance(doc, dict):
+                docs[idx] = self.get_model_instance_from_dict(doc)
 
     def validate_etag(self, original: ResourceModelType, etag: str | None) -> None:
         """Validate the provided etag against the original

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -420,12 +420,14 @@ class AsyncResourceService(Generic[ResourceModelType]):
             logger.warning(f"Not enough iterations for resource {self.resource_name}")
 
     @overload
-    async def find(self, req: SearchRequest) -> ResourceCursorAsync[ResourceModelType]: ...
+    async def find(self, req: SearchRequest) -> ResourceCursorAsync[ResourceModelType]:
+        ...
 
     @overload
     async def find(
         self, req: dict, page: int = 1, max_results: int = 25, sort: SortParam | None = None
-    ) -> ResourceCursorAsync[ResourceModelType]: ...
+    ) -> ResourceCursorAsync[ResourceModelType]:
+        ...
 
     async def find(
         self,

--- a/superdesk/core/web/types.py
+++ b/superdesk/core/web/types.py
@@ -43,10 +43,10 @@ class Response:
     body: Any
 
     #: HTTP Status Code of the response
-    status_code: int
+    status_code: int = 200
 
     #: Any additional headers to be added
-    headers: Sequence
+    headers: Sequence = ()
 
 
 #: Function for use with a Endpoint registration and request processing

--- a/tests/core/resource_service_test.py
+++ b/tests/core/resource_service_test.py
@@ -13,7 +13,7 @@ from superdesk.tests import AsyncTestCase
 
 
 from .modules.users import UserResourceService
-from .fixtures.users import all_users, john_doe
+from .fixtures.users import all_users, john_doe, john_doe_dict
 
 
 NOW = utcnow()
@@ -69,6 +69,23 @@ class TestResourceService(AsyncTestCase):
             )
         )
         self.assertEqual(elastic_item, test_user_dict)
+
+    @mock.patch("superdesk.core.resources.service.utcnow", return_value=NOW)
+    async def test_create_from_dict(self, mock_utcnow):
+        test_user = john_doe_dict()
+
+        # Create the new User
+        await self.service.create([test_user])
+
+        # Test the User exists in MongoDB with correct data
+        test_user["created"] = NOW
+        test_user["updated"] = NOW
+
+        mongo_item = await self.service.find_by_id(test_user["_id"])
+        self.assertIsNotNone(mongo_item)
+        self.assertEqual(mongo_item.id, test_user["_id"])
+        self.assertEqual(mongo_item.created, test_user["created"])
+        self.assertEqual(mongo_item.updated, test_user["updated"])
 
     @mock.patch("superdesk.core.resources.service.utcnow", return_value=NOW)
     async def test_find_one(self, mock_utcnow):


### PR DESCRIPTION
### What has changed
- Set default values to `status_code` and `headers` members in `Response` class
- Added two util methods (`to_dict` & `to_json`) to `ResourceModel` to avoid repeating `model_dump(by_alias=True, exclude_unset=True)`
- Fix minor `black` issue in `overload` definitions (latest version of black moves the `...` to same line and flake8 complains)