### PR TITLE
[SDESK-7381] fix: Return items from async post & patch REST requests

### DIFF
--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -42,6 +42,7 @@ from superdesk.cache import cache_backend
 
 from .elastic_apm import setup_apm
 from superdesk.core.app import SuperdeskAsyncApp
+from superdesk.core.resources import ResourceModel
 from superdesk.core.web import Endpoint, Request, EndpointGroup, HTTP_METHOD, Response
 
 SUPERDESK_PATH = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
@@ -261,6 +262,8 @@ class SuperdeskEve(eve.Eve):
             # We may have received a different response, such as a flask redirect call
             # So we return it here
             return response
+        elif isinstance(response.body, ResourceModel):
+            response.body = response.body.to_dict()
 
         return response.body, response.status_code, response.headers
 

--- a/tests/core/resource_parent_links_test.py
+++ b/tests/core/resource_parent_links_test.py
@@ -89,11 +89,8 @@ class ResourceParentLinksTestCase(AsyncFlaskTestCase):
             f"/api/users_async/{test_user1.id}/topic_folders", json=dict(name="Sports", section="wire")
         )
         self.assertEqual(response.status_code, 201)
-        folder_id = (await response.get_json())[0]
-
-        # Get the folder, so we can use it's etag
-        response = await self.test_client.get(f"/api/users_async/{test_user1.id}/topic_folders/{folder_id}")
         folder = await response.get_json()
+        folder_id = folder["_id"]
 
         # Update the users folder
         response = await self.test_client.patch(


### PR DESCRIPTION
### Purpose
The response data from REST async resource endpoints are different than what Eve returns. This causes issues for code that expects the response to be the same as Eve.

<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
Modify the ResourceRestEndpoints class to return the item from POST requests, the updates from PATCH requests and HATEOAS self link for both.

Resolves: [SDESK-7381](https://sofab.atlassian.net/browse/SDESK-7381)

[SDESK-7381]: https://sofab.atlassian.net/browse/SDESK-7381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ