### PR TITLE
when publishing associated item use latest changes

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -727,7 +727,14 @@ class BasePublishService(BaseService):
 
         for key in DEFAULT_SCHEMA.keys():
             if doc.get(key):
-                updates[key] = doc[key]
+                if (
+                    doc.get("_current_version")
+                    and updates.get("_current_version")
+                    and doc["_current_version"] <= updates["_current_version"]
+                ):  # media item was not changed outside, only populate missing data
+                    updates.setdefault(key, doc[key])
+                else:  # media item could be updated outside, so update all fields
+                    updates[key] = doc[key]
 
     def _refresh_associated_items(self, original, skip_related=False):
         """Refreshes associated items with the latest version. Any further updates made to basic metadata done after

--- a/features/content_publish.feature
+++ b/features/content_publish.feature
@@ -4883,3 +4883,69 @@ Feature: Content Publishing
       """
       {"JobId": "1234", "Title": "test publish"}
       """
+
+    @auth
+    Scenario: We update associated picture metadata on publish
+      Given "archive"
+      """
+      [
+        {
+          "_current_version": 1,
+          "type": "picture",
+          "guid": "picture",
+          "slugline": "picture",
+          "state": "fetched"
+        },
+        {
+          "guid": "story",
+          "type": "text",
+          "slugline": "story",
+          "headline": "story headline",
+          "state": "in_progress",
+          "associations": {
+            "picture": {
+              "_current_version": 1,
+              "guid": "picture",
+              "slugline": "picture",
+              "state": "fetched",
+              "type": "picture"
+            }
+          }
+        }
+      ]
+      """
+      And "desks"
+      """
+      [{"name": "Sports", "members":[{"user":"#CONTEXT_USER_ID#"}]}]
+      """
+      When we publish "story" with "publish" type and "published" state
+      """
+      {
+          "guid": "story",
+          "type": "text",
+          "slugline": "story",
+          "state": "in_progress",
+          "headline": "story headline",
+          "associations": {
+            "picture": {
+              "_id": "picture",
+              "_current_version": 1,
+              "guid": "picture",
+              "slugline": "updated slugline",
+              "type": "picture",
+              "state": "fetched"
+            }
+          }
+      }
+      """
+      Then we get OK response
+      When we get "/published"
+      Then we get list with 2 items
+      """
+      {
+        "_items": [
+          {"_id": "picture", "slugline": "updated slugline"},
+          {"_id": "story", "associations": {"picture": {"slugline": "updated slugline"}}}
+        ]
+      }
+      """


### PR DESCRIPTION
instead of overriding it from the standalone media item if that was not updated.

SDCP-851