### PR TITLE
[SDESK-7371] Support eager mode in async celery

### DIFF
--- a/tests/celery_app/context_task_test.py
+++ b/tests/celery_app/context_task_test.py
@@ -3,17 +3,19 @@ from unittest.mock import patch
 
 from superdesk.errors import SuperdeskError
 from superdesk.celery_app import HybridAppContextTask
-from superdesk.tests import AsyncFlaskTestCase, markers
+from superdesk.tests import AsyncFlaskTestCase
+
+# NOTE: all tasks below are in eager mode because of global
+# tests settings. See `update_config` function in tests.__init__.py
 
 
-@markers.requires_async_celery
 class TestHybridAppContextTask(AsyncFlaskTestCase):
     async def test_sync_task(self):
         @self.app.celery.task(base=HybridAppContextTask)
         def sync_task():
             return "sync result"
 
-        result = sync_task.apply_async().get()
+        result = await sync_task.apply_async()
         self.assertEqual(result, "sync result")
 
     async def test_async_task(self):
@@ -22,7 +24,7 @@ class TestHybridAppContextTask(AsyncFlaskTestCase):
             await asyncio.sleep(0.1)
             return "async result"
 
-        result = await async_task.apply_async().get()
+        result = await async_task.apply_async()
         self.assertEqual(result, "async result")
 
     async def test_sync_task_exception(self):
@@ -31,7 +33,7 @@ class TestHybridAppContextTask(AsyncFlaskTestCase):
             raise SuperdeskError("Test exception")
 
         with patch("superdesk.celery_app.context_task.logger") as mock_logger:
-            sync_task_exception.apply_async().get(propagate=True)
+            await sync_task_exception.apply_async()
             expected_exc = SuperdeskError("Test exception")
             expected_msg = f"Error handling task: {str(expected_exc)}"
             mock_logger.exception.assert_called_once_with(expected_msg)
@@ -42,7 +44,7 @@ class TestHybridAppContextTask(AsyncFlaskTestCase):
             raise SuperdeskError("Async exception")
 
         with patch("superdesk.celery_app.context_task.logger") as mock_logger:
-            await async_task_exception.apply_async().get()
+            await async_task_exception.apply_async()
 
             expected_exc = SuperdeskError("Async exception")
             expected_msg = f"Error handling task: {str(expected_exc)}"


### PR DESCRIPTION
### Purpose
The purpose of this PR is to modify the `HybridAppContextTask` class to support different configurations for Celery task execution, specifically ensuring compatibility with both eager and non-eager execution modes. The changes also aim to make apply_async() and delay() methods asynchronous to allow awaiting the scheduling of a task or either returning the result of the task directly if eager mode is `on`.

### What has changed
- Added config-based handling for Celery execution:
  - **Eager Mode** (`CELERY_TASK_ALWAYS_EAGER` is True): Tasks are executed synchronously and awaited.
  - **Non-Eager Mode** (`CELERY_TASK_ALWAYS_EAGER` is False): If no loop is running, a new one is created; otherwise, the task is scheduled asynchronously.
- Made `apply_async()` and `delay()` await task results in eager mode (no need to override `delay` since it is essentially an alias method of `apply_async`)
- Added `background_tasks` to manage references to tasks created with `asyncio.create_task()`.
- Added `_is_always_eager()` utility function to determine eager mode.

### How to test
Here are two demo tasks that you can call either in eager and non-eager mode and observe the result and behaviour

```python
import asyncio

@celery.task
async def dump_task():
    print("start dump_task")
    await asyncio.sleep(5)
    print("finish dump_task after sleeping 5 seconds")
    return "result dump task"

@celery.task
async def dump_task_2():
    print("start dump_task_2")
    print("finish dump_task 2")
    return "result dump task 2"
```

then run them like 
```python
result = await dump_task.delay()
print(result)

result = await dump_task_2.delay()
print(result)

print("COMPLETED")
```

with eager mode ON, you should have something like this (notice that they run sync)
```python
start dump_task
finish dump_task after sleeping 5 seconds
result dump task
start dump_task_2
finish dump_task 2
result dump task 2
COMPLETED
```

with eager mode OFF, should be like this below. Notice that `dump_task_2` is executed while `dump_task` sleeps for 5 seconds. Then finally dump_task finishes.  
```python
start dump_task
81578173-5564-46af-ba53-292da18795ed
91fb2f57-ccb7-4ff8-b571-0bb5382e1c2f
COMPLETED

start dump_task_2
finish dump_task 2
finish dump_task after sleeping 5 seconds
```

Thanks for checking!

Resolves:  [SDESK-7371]


[SDESK-7371]: https://sofab.atlassian.net/browse/SDESK-7371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ