### PR TITLE
[NHUB-537] Various core changes for Newshub Agenda async

### DIFF
--- a/content_api/items/model.py
+++ b/content_api/items/model.py
@@ -31,6 +31,7 @@ ContentAssociation = Annotated[
 class CVItem:
     qcode: fields.Keyword
     name: fields.Keyword
+    scheme: fields.Keyword | None = None
     schema: fields.Keyword | None = None
 
 
@@ -110,6 +111,7 @@ class ContentType(str, Enum):
 
 class ContentAPIItem(ResourceModel, ModelWithVersions):
     id: Annotated[str, Field(alias="_id")]
+    guid: str | None = None
     associations: ContentAssociation | None = None
     anpa_category: list[CVItem] = Field(default_factory=list)
     body_html: fields.HTML | None = None

--- a/superdesk/core/elastic/base_client.py
+++ b/superdesk/core/elastic/base_client.py
@@ -281,10 +281,10 @@ class BaseElasticResourceClient:
 
         if hit.get("inner_hits"):
             doc["_inner_hits"] = {}
-            for key, value in hit["innter_hits"].items():
-                doc["inner_hits"][key] = []
+            for key, value in hit["inner_hits"].items():
+                doc["_inner_hits"][key] = []
                 for item in value.get("hits", {}).get("hits", []):
-                    doc["_inner_hits"][key].append(item)
+                    doc["_inner_hits"][key].append(item.get("_source", {}))
 
         return doc
 

--- a/superdesk/core/elastic/mapping.py
+++ b/superdesk/core/elastic/mapping.py
@@ -30,6 +30,10 @@ def _get_field_type_from_json_schema(
             return type_schema["elastic_mapping"]
 
         properties: Dict[str, Any] = {}
+
+        if not type_schema.get("properties"):
+            if "enum" in type_schema:
+                return {"type": "keyword"}
         for type_field, type_props in type_schema["properties"].items():
             type_field_type = _get_field_type_from_json_schema(schema, type_props)
             if type_field_type is not None:

--- a/superdesk/core/errors.py
+++ b/superdesk/core/errors.py
@@ -1,0 +1,3 @@
+class ElasticNotConfiguredForResource(KeyError):
+    def __init__(self, resource_name: str):
+        super().__init__(f"Elasticsearch not enabled on resource '{resource_name}'")

--- a/superdesk/core/resources/fields.py
+++ b/superdesk/core/resources/fields.py
@@ -171,6 +171,10 @@ def keyword_mapping() -> WithJsonSchema:
     return Field(json_schema_extra={"elastic_mapping": {"type": "keyword"}})
 
 
+def dynamic_mapping() -> WithJsonSchema:
+    return Field(json_schema_extra={"elastic_mapping": {"type": "object", "dynamic": True}})
+
+
 def mapping_disabled(data_type: str) -> WithJsonSchema:
     return Field(json_schema_extra={"elastic_mapping": {"type": data_type, "enabled": False}})
 

--- a/superdesk/core/resources/utils.py
+++ b/superdesk/core/resources/utils.py
@@ -15,7 +15,7 @@ from superdesk.core.types import SearchRequest, ProjectedFieldArg
 from superdesk.errors import SuperdeskApiError
 
 
-SYSTEM_FIELDS = ["_id", "_type", "_resource", "_etag"]
+SYSTEM_FIELDS = {"_id", "_type", "_resource", "_etag"}
 
 
 def get_projection_from_request(req: SearchRequest) -> tuple[bool, list[str]] | tuple[None, None]:
@@ -38,14 +38,14 @@ def get_projection_from_request(req: SearchRequest) -> tuple[bool, list[str]] | 
     if not projection_data:
         # No projection will be used
         return None, None
-    elif isinstance(projection_data, list):
+    elif isinstance(projection_data, (list, set)):
         # Projection: include these fields only
-        return True, list(set(projection_data + SYSTEM_FIELDS))
+        return True, list(set(projection_data) | SYSTEM_FIELDS)
     elif isinstance(projection_data, dict):
         if next(iter(projection_data.values()), None) in [True, 1]:
             # Projection: include these fields only
             return True, list(
-                set([field for field, value in projection_data.items() if value is True or value == 1] + SYSTEM_FIELDS)
+                set([field for field, value in projection_data.items() if value is True or value == 1]) | SYSTEM_FIELDS
             )
         else:
             # Projection: exclude these fields

--- a/superdesk/core/types/search.py
+++ b/superdesk/core/types/search.py
@@ -83,6 +83,7 @@ class ESQuery:
     query: ESBoolQuery = Field(default_factory=ESBoolQuery)
     post_filter: ESBoolQuery = Field(default_factory=ESBoolQuery)
     aggs: dict[str, Any] = Field(default_factory=dict)
+    exclude_fields: list[str] = Field(default_factory=list)
 
     def generate_query_dict(self, query: dict[str, Any] | None = None) -> dict[str, Any]:
         if query is None:
@@ -120,6 +121,9 @@ class ESQuery:
                 )
             if self.post_filter.filter:
                 query["post_filter"]["bool"]["filter"] = self.post_filter.filter
+
+        if self.exclude_fields:
+            query.setdefault("_source", {}).setdefault("excludes", []).extend(self.exclude_fields)
 
         return query
 

--- a/superdesk/core/types/web.py
+++ b/superdesk/core/types/web.py
@@ -310,3 +310,6 @@ class RestGetResponse(TypedDict, total=False):
 
     #: Response metadata
     _meta: RestResponseMeta
+
+    #: Elasticsearch aggregations result
+    _aggregations: dict[str, Any]

--- a/superdesk/core/utils.py
+++ b/superdesk/core/utils.py
@@ -57,3 +57,17 @@ def generate_guid(**hints) -> str:
         "timestamp": t.isoformat(),
         "identifier": hints["id"],
     }
+
+
+def str_to_date(value: str | None) -> datetime | None:
+    """Convert a string to a datetime instance"""
+
+    date_format: str = get_app_config("DATE_FORMAT") or "%Y-%m-%dT%H:%M:%S+0000"
+    return datetime.strptime(value, date_format) if value else None
+
+
+def date_to_str(value: datetime | None) -> str | None:
+    """Convert a datetime instance to a string"""
+
+    date_format: str = get_app_config("DATE_FORMAT") or "%Y-%m-%dT%H:%M:%S+0000"
+    return datetime.strftime(value, date_format) if value else None


### PR DESCRIPTION
### Purpose
Various changes needed by the Newshub Agenda async upgrade task.

### What has changed
* Fixed typo with `_inner_hits` when processing elasticsearch response
* Add support in elastic mapping for enum to keyword for nested types
* Raise `ElasticNotConfiguredForResource` exception instead of generic `KeyError` when Elastic not configured for a resource (allows to catch more errors by narrowing down the try...except statements in the resource service)
* Add elasticsearch field dynamic mapping helper function
* Add `find_by_ids` and `find_by_ids_raw` to async resource service
* When sending dicts to async service create method, the dict will be updated with the ID and Etag of the stored resource item (handy in tests)
* Support `set[str]` in search projection param
* Support `exclude_fields` in ESQuery, shorthand for `_source` field in elastic
* Add date helpers to `superdesk.core.utils`