### PR TITLE
fix content api assets endpoint when using s3

### DIFF
--- a/content_api/assets/__init__.py
+++ b/content_api/assets/__init__.py
@@ -26,8 +26,10 @@ def get_media_streamed(media_id):
     if not app.auth.authorized([], "assets", "GET"):
         return app.auth.authenticate()
     try:
-        media_id = media_id.split(".")[0]
         media_file = app.media.get(media_id, "upload")
+        if not media_file:
+            media_id = media_id.split(".")[0]
+            media_file = app.media.get(media_id, "upload")
     except bson.errors.InvalidId:
         media_file = None
     if media_file:


### PR DESCRIPTION
it has the extension as part of the id, so first
try to fetch that and only when missing remove
the extension.