### PR TITLE
improve: Add get_service to ResourceModel, and allow any fields not defined

### DIFF
--- a/superdesk/core/resources/__init__.py
+++ b/superdesk/core/resources/__init__.py
@@ -17,6 +17,8 @@ from .model import (
     ModelWithVersions,
     ResourceConfig,
     dataclass,
+    Dataclass,
+    default_model_config,
 )
 from .resource_rest_endpoints import RestEndpointConfig, RestParentLink, get_id_url_type
 from .service import AsyncResourceService, AsyncCacheableService

--- a/superdesk/core/types/model.py
+++ b/superdesk/core/types/model.py
@@ -74,7 +74,7 @@ class BaseModel(PydanticModel):
         cls,
         values: dict[str, Any],
         context: dict[str, Any] | None = None,
-        include_unknown: bool = False,
+        include_unknown: bool | None = None,
     ) -> Self:
         """Construct a model instance from the provided dictionary, and validate its values
 
@@ -86,7 +86,7 @@ class BaseModel(PydanticModel):
         :returns: The validated model instance
         """
 
-        return cls.model_validate(values, context=context, include_unknown=include_unknown)
+        return cls.model_validate(values, context=context, include_unknown=include_unknown or False)
 
     @classmethod
     def from_json(cls, data: str | bytes | bytearray, **kwargs):

--- a/tests/core/modules/users/types.py
+++ b/tests/core/modules/users/types.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from pydantic import Field
 
-from superdesk.core.resources import ResourceModel, fields, dataclass, validators
+from superdesk.core.resources import ResourceModel, fields, dataclass, validators, default_model_config
 
 
 @dataclass
@@ -31,6 +31,11 @@ class MyCustomString(str, fields.CustomStringField):
 
 
 class User(ResourceModel):
+    model_config = {
+        **default_model_config,
+        "extra": "forbid",
+    }
+
     first_name: fields.TextWithKeyword
     last_name: fields.TextWithKeyword
     email: Annotated[

--- a/tests/core/resource_projection_test.py
+++ b/tests/core/resource_projection_test.py
@@ -2,7 +2,7 @@ from bson import ObjectId
 from pydantic import ValidationError
 
 from superdesk.core import json
-from superdesk.core.resources import ResourceModelWithObjectId, ResourceConfig
+from superdesk.core.resources import ResourceModelWithObjectId, ResourceConfig, default_model_config
 from superdesk.tests import AsyncFlaskTestCase, AsyncTestCase
 
 from .modules.users import UserResourceService
@@ -99,6 +99,11 @@ class ResourceFieldProjectionTestCase(AsyncFlaskTestCase):
 class ResourceModelProjectionTestCase(AsyncTestCase):
     async def test_manual_registration(self):
         class User(ResourceModelWithObjectId):
+            model_config = {
+                **default_model_config,
+                "extra": "forbid",
+            }
+
             email: str
             is_enabled: bool
 

--- a/tests/core/resource_service_test.py
+++ b/tests/core/resource_service_test.py
@@ -5,6 +5,7 @@ import simplejson as json
 from bson import ObjectId
 
 from superdesk.core.types import SearchRequest
+from superdesk.core.resources import AsyncResourceService
 from superdesk.core.elastic.base_client import ElasticCursor
 from superdesk.utc import utcnow
 from superdesk.utils import format_time
@@ -12,7 +13,7 @@ from superdesk.utils import format_time
 from superdesk.tests import AsyncTestCase
 
 
-from .modules.users import UserResourceService
+from .modules.users import UserResourceService, User
 from .fixtures.users import all_users, john_doe, john_doe_dict
 
 
@@ -29,12 +30,12 @@ class ResourceServiceWithoutAppTestCase(AsyncTestCase):
 
 class TestResourceService(AsyncTestCase):
     app_config = {"MODULES": ["tests.core.modules.users"]}
-    service: UserResourceService
+    service: AsyncResourceService[User]
 
     async def asyncSetUp(self):
         await super().asyncSetUp()
         self.app.elastic.init_index("users_async")
-        self.service = UserResourceService()
+        self.service = User.get_service()
 
     @mock.patch("superdesk.core.resources.service.utcnow", return_value=NOW)
     async def test_create(self, mock_utcnow):


### PR DESCRIPTION
### Purpose
Improve usage of ResourceModel to make it easier for developers

### What has changed
* Implement our own Dataclass class, so we have common `from_dict`, `from_json`, `to_dict` and `to_json` at that level too
* Allow any field by default on the ResourceModel and Dataclass based data
* Default `ResourceModel.from_dict` to include unknown fields, if `model_config.extra != 'forbit'`
* Add `get_service` to `ResourceModel`, so we can import just the type and use it for CRUD operations (further reduces cyclic imports)