### PR TITLE
[NHUB-598] fix(data): Include default values on service.create, exclude `None` values

### DIFF
--- a/content_api/items/model.py
+++ b/content_api/items/model.py
@@ -4,7 +4,7 @@ from enum import Enum, unique
 
 from pydantic import Field, field_validator
 
-from superdesk.core.resources import ResourceModel, dataclass, fields, validators, ModelWithVersions
+from superdesk.core.resources import ResourceModel, dataclass, Dataclass, fields, validators, ModelWithVersions
 from superdesk.utc import utcnow
 
 
@@ -29,7 +29,7 @@ ContentAssociation = Annotated[
 
 
 @dataclass
-class CVItem:
+class CVItem(Dataclass):
     qcode: fields.Keyword
     name: fields.Keyword
     scheme: fields.Keyword | None = None
@@ -37,7 +37,7 @@ class CVItem:
 
 
 @dataclass
-class CVItemWithCode:
+class CVItemWithCode(Dataclass):
     code: fields.Keyword
     name: fields.Keyword
     schema: fields.Keyword | None = None
@@ -45,7 +45,7 @@ class CVItemWithCode:
 
 
 @dataclass
-class Place:
+class Place(Dataclass):
     scheme: fields.Keyword | None = None
     qcode: fields.Keyword | None = None
     code: fields.Keyword | None = None
@@ -64,14 +64,14 @@ class Place:
 
 
 @dataclass
-class Annotation:
+class Annotation(Dataclass):
     id: int
     type: fields.Keyword
     body: fields.Keyword
 
 
 @dataclass
-class ContentAuthor:
+class ContentAuthor(Dataclass):
     uri: fields.Keyword | None = None
     parent: fields.Keyword | None = None
     name: fields.TextWithKeyword | None = None
@@ -83,7 +83,7 @@ class ContentAuthor:
 
 
 @dataclass
-class ContentReference:
+class ContentReference(Dataclass):
     id: Annotated[fields.Keyword, Field(alias="_id")]
     key: fields.Keyword | None = None
     uri: fields.Keyword | None = None

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -360,6 +360,10 @@ class AsyncResourceService(Generic[ResourceModelType]):
                 versioned_model.current_version = 1
             doc_dict = doc.to_dict(
                 context={"use_objectid": True} if not self.config.query_objectid_as_string else {},
+                # Include default values, but exclude ``None`` on creation
+                exclude_none=True,
+                exclude_unset=False,
+                exclude_defaults=False,
             )
             doc.etag = doc_dict["_etag"] = self.generate_etag(doc_dict, self.config.etag_ignore_fields)
             response = await self.mongo_async.insert_one(doc_dict)

--- a/tests/core/resource_service_test.py
+++ b/tests/core/resource_service_test.py
@@ -216,8 +216,18 @@ class TestResourceService(AsyncTestCase):
 
         for i in range(3):
             self.assertEqual(
-                docs[i].to_dict(),
-                users[i].to_dict(),
+                docs[i].to_dict(
+                    context={"use_objectid": True},
+                    exclude_none=True,
+                    exclude_unset=False,
+                    exclude_defaults=False,
+                ),
+                users[i].to_dict(
+                    context={"use_objectid": True},
+                    exclude_none=True,
+                    exclude_unset=False,
+                    exclude_defaults=False,
+                ),
             )
 
     async def test_get_all_batch(self):
@@ -231,8 +241,18 @@ class TestResourceService(AsyncTestCase):
         self.assertEqual(len(docs), 3)
         for i in range(3):
             self.assertEqual(
-                docs[i].to_dict(),
-                users[i].to_dict(),
+                docs[i].to_dict(
+                    context={"use_objectid": True},
+                    exclude_none=True,
+                    exclude_unset=False,
+                    exclude_defaults=False,
+                ),
+                users[i].to_dict(
+                    context={"use_objectid": True},
+                    exclude_none=True,
+                    exclude_unset=False,
+                    exclude_defaults=False,
+                ),
             )
 
         docs = []
@@ -242,8 +262,18 @@ class TestResourceService(AsyncTestCase):
         self.assertEqual(len(docs), 2)
         for i in range(2):
             self.assertEqual(
-                docs[i].to_dict(),
-                users[i].to_dict(),
+                docs[i].to_dict(
+                    context={"use_objectid": True},
+                    exclude_none=True,
+                    exclude_unset=False,
+                    exclude_defaults=False,
+                ),
+                users[i].to_dict(
+                    context={"use_objectid": True},
+                    exclude_none=True,
+                    exclude_unset=False,
+                    exclude_defaults=False,
+                ),
             )
 
     async def test_elastic_search(self):


### PR DESCRIPTION
### Purpose
Support unknown fields in ContentAPI (and Newshub's Wire & Agenda items)

### What has changed
* On service.create, make sure to include default values but exclude `None` values
* Make sure `@dataclass` models inherit from `superdesk.core.resources.Dataclass` class
* In `Dataclass.to_dict`, support unknown fields but exclude aliased fields

Resolves: [NHUB-598](https://sofab.atlassian.net/browse/NHUB-598)

[NHUB-598]: https://sofab.atlassian.net/browse/NHUB-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ