### PR TITLE
fix unit tests

### DIFF
--- a/.github/workflows/nose-tests.yml
+++ b/.github/workflows/nose-tests.yml
@@ -20,9 +20,8 @@ jobs:
     - run: ./scripts/tests_setup
     - run: pip install -U pip wheel setuptools
     - run: pip install -r dev-requirements.txt
-    - run: ulimit -n 4096
-    - run: pytest --log-level=ERROR --disable-warnings tests/core
-    - run: pytest --log-level=ERROR --disable-warnings --ignore=tests/core
+    - run: pytest -p no:asyncio --log-level=ERROR --disable-warnings tests/core
+    - run: pytest -p no:asyncio --log-level=ERROR --disable-warnings --ignore=tests/core
 
   pip-compile:
     runs-on: ubuntu-latest

--- a/.github/workflows/nose-tests.yml
+++ b/.github/workflows/nose-tests.yml
@@ -20,6 +20,7 @@ jobs:
     - run: ./scripts/tests_setup
     - run: pip install -U pip wheel setuptools
     - run: pip install -r dev-requirements.txt
+    - run: ulimit -n 4096
     - run: pytest --log-level=ERROR --disable-warnings tests/core
     - run: pytest --log-level=ERROR --disable-warnings --ignore=tests/core
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,5 @@ exclude = '''
 [tool.pytest.ini_options]
 testpaths = ["tests", "superdesk", "apps", "content_api"]
 python_files = "*_test.py *_tests.py test_*.py tests_*.py tests.py test.py"
-asyncio_mode = "auto"
+asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ install_requires = [
     "lxml_html_clean>=0.1.1,<0.4",
     "python-twitter>=3.5,<3.6",
     "chardet<6.0",
-    "pymongo>=4.7.3,<4.8",
+    "pymongo>=4.9.1,<4.10",
     "croniter<3.1",
     "python-dateutil<2.10",
     "unidecode>=0.04.21,<=1.3.8",

--- a/superdesk/celery_app/serializer.py
+++ b/superdesk/celery_app/serializer.py
@@ -2,12 +2,12 @@ import arrow
 from bson import ObjectId
 from typing import Any, Callable
 
-from eve.utils import str_to_date
 from eve.io.mongo import MongoJSONEncoder
 from kombu.serialization import register
 
 from superdesk.core import json
 from superdesk.core.types import WSGIApp
+from superdesk.core.utils import str_to_date
 
 
 CELERY_SERIALIZER_NAME = "context-aware/json"

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -406,7 +406,7 @@ async def setup(context=None, config=None, app_factory=get_app, reset=False, aut
         context.client = app.test_client()
         if not hasattr(context, "BEHAVE") and not hasattr(context, "test_context"):
             context.test_context = app.test_request_context("/")
-            context.test_context.push()
+            await context.test_context.push()
 
     async with app.app_context():
         await clean_dbs(app, force=bool(config))

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -362,16 +362,40 @@ def use_snapshot(app, name, funcs=(snapshot_es, snapshot_mongo), force=False):
 use_snapshot.cache = {}  # type: ignore
 
 
+async def stop_previous_app():
+    if not hasattr(setup, "async_app") and not hasattr(setup, "app"):
+        return
+
+    if hasattr(setup, "async_app"):
+        async_app: SuperdeskAsyncApp | None = getattr(setup, "async_app", None)
+
+        for resource_name, resource_config in async_app.mongo.get_all_resource_configs().items():
+            client, db = async_app.mongo.get_client_async(resource_name)
+            await client.drop_database(db)
+
+        async_app.elastic.drop_indexes()
+        await async_app.elastic.stop()
+
+        for service in async_app.resources._resource_services:
+            if hasattr(service, "_instance"):
+                del service._instance
+
+        async_app.stop()
+        del setup.async_app
+
+    if hasattr(setup, "app"):
+        app: SuperdeskApp | None = getattr(setup, "app", None)
+
+        # Close all PyMongo Connections (new ones will be created with ``app_factory`` call)
+        for key, val in app.extensions["pymongo"].items():
+            val[0].close()
+
+        app.extensions["pymongo"] = {}
+        del setup.app
+
+
 async def setup(context=None, config=None, app_factory=get_app, reset=False, auto_add_apps: bool = True):
     if not hasattr(setup, "app") or hasattr(setup, "reset") or config:  # type: ignore[attr-defined]
-        if hasattr(setup, "app"):
-            # Close all PyMongo Connections (new ones will be created with ``app_factory`` call)
-            for key, val in setup.app.extensions["pymongo"].items():
-                val[0].close()
-
-            if getattr(setup.app, "async_app", None):
-                setup.app.async_app.stop()
-
         cfg = setup_config(config, auto_add_apps)
         setup.app = app_factory(cfg)  # type: ignore[attr-defined]
         setup.reset = reset  # type: ignore[attr-defined]
@@ -553,13 +577,9 @@ class AsyncTestCase(IsolatedAsyncioTestCase):
     autorun: bool = True
 
     def setupApp(self):
-        if getattr(self, "app", None):
-            self.app.stop()
-
-        core_app._global_app = None
-
         self.app_config = setup_config(deepcopy(self.app_config))
         self.app = SuperdeskAsyncApp(MockWSGI(config=self.app_config))
+        setattr(setup, "async_app", self.app)
         self.startApp()
 
     def startApp(self):
@@ -570,17 +590,7 @@ class AsyncTestCase(IsolatedAsyncioTestCase):
             return
 
         self.setupApp()
-        for resource_name, resource_config in self.app.mongo.get_all_resource_configs().items():
-            client, db = self.app.mongo.get_client_async(resource_name)
-            await client.drop_database(db)
-
-    async def asyncTearDown(self):
-        if not getattr(self, "app", None):
-            return
-
-        self.app.elastic.drop_indexes()
-        self.app.stop()
-        await self.app.elastic.stop()
+        self.addAsyncCleanup(stop_previous_app)
 
     def get_fixture_path(self, filename):
         rootpath = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -618,10 +628,6 @@ class AsyncFlaskTestCase(AsyncTestCase):
     use_default_apps: bool = False
 
     async def asyncSetUp(self):
-        if getattr(self, "async_app", None):
-            self.async_app.stop()
-            await self.async_app.elastic.stop()
-
         config = deepcopy(self.app_config)
 
         if self.use_default_apps:
@@ -631,6 +637,7 @@ class AsyncFlaskTestCase(AsyncTestCase):
             config.setdefault("INSTALLED_APPS", [])
             await setup(self, config=config, reset=True, auto_add_apps=False)
         self.async_app = self.app.async_app
+        setattr(setup, "async_app", self.async_app)
         self.app.test_client_class = TestClient
         self.test_client = self.app.test_client()
         self.ctx = self.app.app_context()
@@ -644,15 +651,8 @@ class AsyncFlaskTestCase(AsyncTestCase):
                     pass
 
         self.addAsyncCleanup(clean_ctx)
+        self.addAsyncCleanup(stop_previous_app)
         self.async_app.elastic.init_all_indexes()
-
-    async def asyncTearDown(self):
-        if not getattr(self, "async_app", None):
-            return
-
-        self.async_app.elastic.drop_indexes()
-        self.async_app.stop()
-        await self.async_app.elastic.stop()
 
     async def get_resource_etag(self, resource: str, item_id: str):
         return (await (await self.test_client.get(f"/api/{resource}/{item_id}")).get_json())["_etag"]

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -119,7 +119,7 @@ class BackendTestCase(TestCase):
         backend = get_backend()
         updates = {"name": "foo"}
         item = {"name": "bar"}
-        with self.app.app_context():
+        async with self.app.app_context():
             ids = backend.create_in_mongo("ingest", [item])
             items = backend.search("ingest", {"query": {"match_all": {}}})
             self.assertEqual(0, items.count())
@@ -128,10 +128,10 @@ class BackendTestCase(TestCase):
             items = backend.search("ingest", {"query": {"match_all": {}}})
             self.assertEqual(1, items.count())
 
-    def test_delete_item_missing_in_mongo(self):
+    async def test_delete_item_missing_in_mongo(self):
         backend = get_backend()
         item = {"_id": bson.ObjectId(), "name": "bar"}
-        with self.app.app_context():
+        async with self.app.app_context():
             backend.create_in_search("ingest", [item])
             items = backend.search("ingest", {"query": {"match_all": {}}})
             self.assertEqual(1, items.count())
@@ -140,10 +140,10 @@ class BackendTestCase(TestCase):
             items = backend.search("ingest", {"query": {"match_all": {}}})
             self.assertEqual(0, items.count())
 
-    def test_delete_docs_missing_in_mongo(self):
+    async def test_delete_docs_missing_in_mongo(self):
         backend = get_backend()
         item = {"_id": bson.ObjectId(), "name": "bar"}
-        with self.app.app_context():
+        async with self.app.app_context():
             backend.create_in_search("ingest", [item])
             items = backend.search("ingest", {"query": {"match_all": {}}})
             self.assertEqual(1, items.count())

--- a/tests/celery_app/context_task_test.py
+++ b/tests/celery_app/context_task_test.py
@@ -11,7 +11,7 @@ from superdesk.tests import AsyncFlaskTestCase
 
 class TestHybridAppContextTask(AsyncFlaskTestCase):
     async def test_sync_task(self):
-        @self.app.celery.task(base=HybridAppContextTask)
+        @self.app.celery.task()
         def sync_task():
             return "sync result"
 
@@ -19,7 +19,7 @@ class TestHybridAppContextTask(AsyncFlaskTestCase):
         self.assertEqual(result, "sync result")
 
     async def test_async_task(self):
-        @self.app.celery.task(base=HybridAppContextTask)
+        @self.app.celery.task()
         async def async_task():
             await asyncio.sleep(0.1)
             return "async result"
@@ -28,7 +28,7 @@ class TestHybridAppContextTask(AsyncFlaskTestCase):
         self.assertEqual(result, "async result")
 
     async def test_sync_task_exception(self):
-        @self.app.celery.task(base=HybridAppContextTask)
+        @self.app.celery.task()
         def sync_task_exception():
             raise SuperdeskError("Test exception")
 
@@ -39,7 +39,7 @@ class TestHybridAppContextTask(AsyncFlaskTestCase):
             mock_logger.exception.assert_called_once_with(expected_msg)
 
     async def test_async_task_exception(self):
-        @self.app.celery.task(base=HybridAppContextTask)
+        @self.app.celery.task()
         async def async_task_exception():
             raise SuperdeskError("Async exception")
 

--- a/tests/celery_app/serializer_test.py
+++ b/tests/celery_app/serializer_test.py
@@ -3,12 +3,12 @@ from datetime import datetime
 from unittest.mock import MagicMock
 
 from superdesk.celery_app.serializer import ContextAwareSerializerFactory
-from superdesk.tests import TestCase, markers
+from superdesk.tests import AsyncFlaskTestCase
 
 
-@markers.requires_async_celery
-class TestContextAwareSerializerFactory(TestCase):
-    def setUp(self):
+class TestContextAwareSerializerFactory(AsyncFlaskTestCase):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
         self.get_current_app = MagicMock(return_value=self.app)
         self.factory = ContextAwareSerializerFactory(self.get_current_app)
 

--- a/tests/content_filters/content_filter_tests.py
+++ b/tests/content_filters/content_filter_tests.py
@@ -432,7 +432,7 @@ class FilteringDataTests(ContentFilterTests):
         self.assertTrue(len(r3[0]["selected_subscribers"]) == 2)
         self.assertTrue(len(r4[0]["selected_subscribers"]) == 1)
 
-    def test_does_match_return_with_caching_mechanism(self):
+    async def test_does_match_return_with_caching_mechanism(self):
         self.app.data.insert(
             "filter_conditions",
             [

--- a/tests/publish/transmitters/http_push_transmitter_tests.py
+++ b/tests/publish/transmitters/http_push_transmitter_tests.py
@@ -169,8 +169,7 @@ class HTTPPushServiceTestCase(TestCase):
     @mock.patch("superdesk.errors.notifiers")
     @mock.patch("requests.post")
     async def test_client_publish_error_thrown(self, fake_post, fake_notifiers):
-        with self.app.app_context():
-            raise_http_exception = Mock(side_effect=PublishHTTPPushClientError.httpPushError(Exception("client 4xx")))
+        raise_http_exception = Mock(side_effect=PublishHTTPPushClientError.httpPushError(Exception("client 4xx")))
 
         fake_post.return_value = Mock(status_code=401, text="client 4xx", raise_for_status=raise_http_exception)
 
@@ -186,8 +185,7 @@ class HTTPPushServiceTestCase(TestCase):
     @mock.patch("superdesk.errors.notifiers")
     @mock.patch("requests.post")
     async def test_server_publish_error_thrown(self, fake_post, fake_notifiers):
-        with self.app.app_context():
-            raise_http_exception = Mock(side_effect=PublishHTTPPushServerError.httpPushError(Exception("server 5xx")))
+        raise_http_exception = Mock(side_effect=PublishHTTPPushServerError.httpPushError(Exception("server 5xx")))
 
         fake_post.return_value = Mock(status_code=503, text="server 5xx", raise_for_status=raise_http_exception)
 


### PR DESCRIPTION
### Purpose
Previously most of the unit tests were failing

### What has changed:
* Deepcopy the app config when running the tests, so previous runs do not affect others
* Use our own `str_to_date` function instead of the one from eve
* Fix `CELERY_TASK_ALWAYS_EAGER` from a string to bool in test config
* Fix app context in a few tests