### PR TITLE
Improvements to unify the functionality from decorator & `Dataclass` in a single class

### DIFF
--- a/superdesk/core/resources/model.py
+++ b/superdesk/core/resources/model.py
@@ -107,17 +107,16 @@ class DataclassBase:
 class DataclassMeta(type):
     """Metaclass to enhance Dataclass functionality."""
 
-    def __new__(cls, name, bases, dct):
-        custom_config = dct.pop("Config", {})
+    def __new__(cls: type, name: str, bases: tuple[type, ...], attrs: dict[str, Any]) -> type:
+        custom_config = attrs.pop("Config", {})
 
         # merge with default configuration
         config = deepcopy(default_model_config)
         config.update(custom_config)
 
         # create the class and apply the Pydantic dataclass decorator
-        new_cls = super().__new__(cls, name, bases, dct)
-        new_cls = pydataclass(new_cls, config=config)
-        return new_cls
+        new_cls = super().__new__(cls, name, bases, attrs)  # type: ignore[misc]
+        return pydataclass(new_cls, config=config)
 
 
 class Dataclass(DataclassBase, metaclass=DataclassMeta):

--- a/superdesk/core/resources/model.py
+++ b/superdesk/core/resources/model.py
@@ -34,7 +34,7 @@ from pydantic import (
     SerializerFunctionWrapHandler,
     RootModel,
 )
-from pydantic_core import InitErrorDetails, PydanticCustomError
+from pydantic_core import InitErrorDetails, PydanticCustomError, from_json
 from pydantic.dataclasses import dataclass as pydataclass
 
 from superdesk.core.types import SortListParam, ProjectedFieldArg, BaseModel
@@ -86,12 +86,13 @@ class DataclassBase:
         return result
 
     @classmethod
-    def from_dict(cls: type[Self], values: dict[str, Any], **kwargs) -> Self:
-        return RootModel.model_validate(values, **kwargs).root
+    def from_dict(cls: type[Self], values: dict[str, Any]) -> Self:
+        return cls(**values)
 
     @classmethod
-    def from_json(cls: type[Self], data: str | bytes | bytearray, **kwargs) -> Self:
-        return RootModel.model_validate_json(data, **kwargs).root
+    def from_json(cls: type[Self], data: str | bytes | bytearray) -> Self:
+        values = from_json(data)
+        return cls(**values)
 
     def to_dict(self, **kwargs) -> dict[str, Any]:
         default_params: dict[str, Any] = {"by_alias": True, "exclude_unset": True}
@@ -104,6 +105,7 @@ class DataclassBase:
         return RootModel(self).model_dump_json(**default_params)
 
 
+@dataclass_transform(field_specifiers=(dataclass_field, Field))
 class DataclassMeta(type):
     """Metaclass to enhance Dataclass functionality."""
 

--- a/superdesk/core/resources/model.py
+++ b/superdesk/core/resources/model.py
@@ -65,9 +65,14 @@ def dataclass(*args, **kwargs):
     return pydataclass(*args, **kwargs, config=config)
 
 
-class Dataclass:
+class DataclassBase:
+    """Provides type-safe utility methods for Dataclass."""
+
     @model_serializer(mode="wrap")
     def ser_model(self, nxt: SerializerFunctionWrapHandler):
+        """
+        Serialize the model, including extra fields not part of the schema.
+        """
         aliased_fields = get_model_aliased_fields(self.__class__)
         result = nxt(self)
 
@@ -81,11 +86,11 @@ class Dataclass:
         return result
 
     @classmethod
-    def from_dict(cls, values: dict[str, Any], **kwargs) -> Self:
+    def from_dict(cls: type[Self], values: dict[str, Any], **kwargs) -> Self:
         return RootModel.model_validate(values, **kwargs).root
 
     @classmethod
-    def from_json(cls, data: str | bytes | bytearray, **kwargs) -> Self:
+    def from_json(cls: type[Self], data: str | bytes | bytearray, **kwargs) -> Self:
         return RootModel.model_validate_json(data, **kwargs).root
 
     def to_dict(self, **kwargs) -> dict[str, Any]:
@@ -97,6 +102,28 @@ class Dataclass:
         default_params: dict[str, Any] = {"by_alias": True, "exclude_unset": True}
         default_params.update(kwargs)
         return RootModel(self).model_dump_json(**default_params)
+
+
+class DataclassMeta(type):
+    """Metaclass to enhance Dataclass functionality."""
+
+    def __new__(cls, name, bases, dct):
+        custom_config = dct.pop("Config", {})
+
+        # merge with default configuration
+        config = deepcopy(default_model_config)
+        config.update(custom_config)
+
+        # create the class and apply the Pydantic dataclass decorator
+        new_cls = super().__new__(cls, name, bases, dct)
+        new_cls = pydataclass(new_cls, config=config)
+        return new_cls
+
+
+class Dataclass(DataclassBase, metaclass=DataclassMeta):
+    """Unified base class for dataclasses with Pydantic features."""
+
+    pass
 
 
 class ResourceModel(BaseModel):

--- a/tests/core/dataclass_test.py
+++ b/tests/core/dataclass_test.py
@@ -1,0 +1,38 @@
+from unittest import TestCase
+
+from pydantic_core import ValidationError
+from superdesk.core.resources import Dataclass
+
+
+class RingBearer(Dataclass):
+    name: str
+    race: str
+
+
+class DataclassTest(TestCase):
+    def test_dataclass_model_proper_types(self):
+        frodo = RingBearer(name="Frodo", race="Hobbit")
+        frodo_from_dict = RingBearer.from_dict(dict(name="Frodo", race="Hobbit"))
+        frodo_from_json = RingBearer.from_json('{"name":"Frodo","race":"Hobbit"}')
+
+        self.assertEqual(type(frodo), RingBearer)
+        self.assertEqual(type(frodo_from_dict), RingBearer)
+        self.assertEqual(type(frodo_from_json), RingBearer)
+
+    def test_dataclass_model_utils(self):
+        frodo = RingBearer(name="Frodo", race="Hobbit")
+
+        self.assertEqual(frodo.to_dict(), {"name": "Frodo", "race": "Hobbit"})
+        self.assertEqual(frodo.to_json(), '{"name":"Frodo","race":"Hobbit"}')
+
+    def test_dataclass_validation_error(self):
+        with self.assertRaises(ValidationError, msg="1 validation error for RingBearer"):
+            RingBearer(name="Frodo")
+
+        with self.assertRaises(ValidationError):
+            RingBearer(name=1, race="Hobbit")
+
+    def test_dataclass_should_validate_on_assignment(self):
+        with self.assertRaises(ValidationError):
+            frodo = RingBearer(name="Frodo", race="Hobbit")
+            frodo.name = 1


### PR DESCRIPTION
### Purpose
The intention to avoid needing to have both a `Dataclass` and a `@dataclass` decorator

### What has changed
- Introduced `DataclassBase` for reusable utility methods (`to_dict`, `from_dict`, `ser_model`).
- Added `DataclassMeta` to handle automatic Pydantic dataclass wrapping and custom `Config` merging.
- Enabled per-class custom configuration via a `Config` dictionary in child classes.

### Example usage

```python
class RingBearer(Dataclass):
    name: str
    race: str

    # custom configuration that will merge/override default one
    Config = {
        "extra": "allow",
    }

frodo = RingBearer(name="Frodo Baggins", race="Hobbit")

# unexpected fields are allowed due to 'extra': 'allow' (allowed by default, this is just for tests)
frodo.unknown_item = "Mithril Coat" 
frodo.secret_mission = "Destroy the One Ring"
```

@MarkLark86 following up on our [conversation here](https://github.com/superdesk/superdesk-planning/pull/2131#discussion_r1863719653) what do you think? If you think it looks good I'd merge it and replace the usages of the decorator. Also extend the documentation a little bit to make it clear what is the intention.

Thanks for checking!

