### PR TITLE
fix proxy media storage config not working on CAPI

### DIFF
--- a/content_api/app/settings.py
+++ b/content_api/app/settings.py
@@ -40,6 +40,7 @@ from superdesk.default_settings import (  # noqa
     CLIENT_URL,
     DEBUG,
     URN_DOMAIN,
+    PROXY_MEDIA_STORAGE_CHECK_EXISTS,
 )
 
 CONTENTAPI_INSTALLED_APPS = [

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -544,7 +544,9 @@ MEDIA_STORAGE_PROVIDER = env("MEDIA_STORAGE_PROVIDER")
 #: it should only check during migration, otherwise this generates unnecessary load on the s3
 #:
 #: .. versionadded:: 2.5
-PROXY_MEDIA_STORAGE_CHECK_EXISTS = strtobool(env("PROXY_MEDIA_STORAGE_CHECK_EXISTS", "false"))
+#: .. versionchanged:: 2.8.4
+#:    Default value changed to ``True``
+PROXY_MEDIA_STORAGE_CHECK_EXISTS = strtobool(env("PROXY_MEDIA_STORAGE_CHECK_EXISTS", "true"))
 
 #: uses for generation of media url ``(<media_prefix>/<media_id>)``::
 MEDIA_PREFIX = env("MEDIA_PREFIX", "%s/upload-raw" % SERVER_URL.rstrip("/"))


### PR DESCRIPTION
and allow it by default so there is no need for
additional config when switching from mongo to S3.

SDBELGA-909