### PR TITLE
[PUBLISH] Push items directly to publish queue when possible.

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -230,7 +230,9 @@ class BasePublishService(BaseService):
                 self._update_archive(original, updates, should_insert_into_versions=auto_publish)
                 self.update_published_collection(published_item_id=original[ID_FIELD], updated=updated)
 
-            from apps.publish.enqueue import enqueue_published
+            from apps.publish.enqueue import enqueue_published, push_publish
+
+            push_publish.apply_async(str(id))
 
             enqueue_published.apply_async()
 

--- a/apps/publish/published_item.py
+++ b/apps/publish/published_item.py
@@ -39,10 +39,19 @@ PUBLISHED = "published"
 LAST_PUBLISHED_VERSION = "last_published_version"
 QUEUE_STATE = "queue_state"
 ERROR_MESSAGE = "error_message"
-queue_states = ["pending", "in_progress", "queued", "queued_not_transmitted", "error"]
-PUBLISH_STATE = namedtuple("PUBLISH_STATE", ["PENDING", "IN_PROGRESS", "QUEUED", "QUEUED_NOT_TRANSMITTED", "ERROR"])(
-    *queue_states
-)
+QUEUE_STATES = [
+    "pending",
+    #: Item is being pushed with ``publish:push``.
+    "pushed",
+    "in_progress",
+    "queued",
+    "queued_not_transmitted",
+    #: Something went wrong.
+    "error",
+]
+PUBLISH_STATE = namedtuple(
+    "PUBLISH_STATE", ["PENDING", "PUSHED", "IN_PROGRESS", "QUEUED", "QUEUED_NOT_TRANSMITTED", "ERROR"]
+)(*QUEUE_STATES)
 
 published_item_fields = {
     "item_id": {"type": "string", "mapping": not_analyzed},
@@ -54,7 +63,7 @@ published_item_fields = {
     QUEUE_STATE: {
         "type": "string",
         "default": "pending",
-        "allowed": queue_states,
+        "allowed": QUEUE_STATES,
     },
     ERROR_MESSAGE: {"type": "string"},
     "is_take_item": {  # deprecated

--- a/tests/publish/enqueue_service_tests.py
+++ b/tests/publish/enqueue_service_tests.py
@@ -20,6 +20,7 @@ from apps.publish.enqueue import enqueue_service, PushContent
 from apps.publish.enqueue import enqueue_published
 from apps.publish.enqueue.enqueue_service import EnqueueService
 from content_api.publish.service import PublishService
+from superdesk import get_resource_service
 from superdesk.errors import PublishQueueError
 from superdesk.metadata.item import (
     CONTENT_STATE,
@@ -76,8 +77,8 @@ class EnqueueServiceTest(TestCase):
             "_etag": "f28b9af64f169072fb171ec7f316fc03d5826d6b",
             "subscriber_id": "sub1",
             "state": "pending",
-            "_created": "2015-04-17T13:15:20.000Z",
-            "_updated": "2015-04-20T05:04:25.000Z",
+            "_created": "2015-04-17t13:15:20.000z",
+            "_updated": "2015-04-20t05:04:25.000z",
             "item_id": "1",
             "item_version": 1,
             "publishing_action": "corrected",
@@ -321,85 +322,96 @@ class PushContentTest(TestCase):
         self.test_id_1 = ObjectId()
         self.test_id_2 = ObjectId()
         self.test_id_3 = ObjectId()
+        items = [
+            {
+                "_id": self.test_id_1,
+                "item_id": self.test_id_1,
+                "type": "text",
+                "headline": "test headline toto",
+                "version": 1,
+                "task": {},
+                ITEM_STATE: CONTENT_STATE.SCHEDULED,
+                ITEM_OPERATION: "publish",
+                PUBLISH_SCHEDULE: utcnow() + timedelta(hours=1),
+            },
+            {
+                "_id": self.test_id_2,
+                "item_id": "2",
+                "type": "text",
+                "headline": "test headline 2",
+                "version": 1,
+                "task": {},
+                ITEM_STATE: CONTENT_STATE.SCHEDULED,
+                ITEM_OPERATION: "publish",
+                PUBLISH_SCHEDULE: utcnow() - timedelta(hours=1),
+            },
+            {
+                "_id": self.test_id_3,
+                "item_id": "3",
+                "type": "text",
+                "headline": "test headline 3",
+                VERSION: 1,
+                "task": {},
+                ITEM_STATE: CONTENT_STATE.PUBLISHED,
+                ITEM_OPERATION: "publish",
+            },
+        ]
 
-        self.app.data.insert(
-            "archive",
-            [
-                {
-                    "_id": self.test_id_1,
-                    "item_id": self.test_id_1,
-                    "type": "text",
-                    "headline": "test headline toto",
-                    "version": 1,
-                    "task": {},
-                    ITEM_STATE: CONTENT_STATE.SCHEDULED,
-                    ITEM_OPERATION: "publish",
-                    PUBLISH_SCHEDULE: utcnow() + timedelta(hours=1),
-                },
-                {
-                    "_id": self.test_id_2,
-                    "item_id": "2",
-                    "type": "text",
-                    "headline": "test headline 2",
-                    "version": 1,
-                    "task": {},
-                    ITEM_STATE: CONTENT_STATE.SCHEDULED,
-                    ITEM_OPERATION: "publish",
-                    PUBLISH_SCHEDULE: utcnow() - timedelta(hours=1),
-                },
-                {
-                    "_id": self.test_id_3,
-                    "item_id": "3",
-                    "type": "text",
-                    "headline": "test headline 3",
-                    VERSION: 1,
-                    "task": {},
-                    ITEM_STATE: CONTENT_STATE.PUBLISHED,
-                    ITEM_OPERATION: "publish",
-                },
-            ],
-        )
+        self.app.data.insert("archive", items)
+        self.app.data.insert("published", items)
 
     @mock.patch.object(EnqueueService, "enqueue_item")
     async def test_push_scheduled_item_in_future(self, mock_enqueue):
         """``enqueue_item`` is not called if the item is scheduled in the future."""
-        cmd = PushContent()
-        cmd.run(str(self.test_id_1))
-        mock_enqueue.assert_not_called()
+        with mock.patch.object(get_resource_service("published"), "patch") as mock_patch:
+            mock_patch.return_value = None
+            cmd = PushContent()
+            cmd.run(str(self.test_id_1))
+            mock_enqueue.assert_not_called()
 
     @mock.patch.object(EnqueueService, "enqueue_item")
     async def test_push_scheduled_item_in_past(self, mock_enqueue):
         """``enqueue_item`` is called if the item is scheduled but the publish schedule is passed."""
-        cmd = PushContent()
-        cmd.run(str(self.test_id_2))
-        mock_enqueue.assert_called_once()
+        with mock.patch.object(get_resource_service("published"), "patch") as mock_patch:
+            mock_patch.return_value = None
+            cmd = PushContent()
+            cmd.run(str(self.test_id_2))
+            mock_enqueue.assert_called_once()
 
     @mock.patch("apps.publish.enqueue.enqueue_service.get_resource_service", return_value=None)
     async def test_push_non_existent_item(self, mock_get_resource_service):
         """Exception is raise if item is not found."""
-        cmd = PushContent()
-        non_existent_id = ObjectId()
-        with self.assertRaises(PublishQueueError):
-            cmd.run(str(non_existent_id))
+        with mock.patch.object(get_resource_service("published"), "patch") as mock_patch:
+            mock_patch.return_value = None
+            cmd = PushContent()
+            non_existent_id = ObjectId()
+            with self.assertRaises(PublishQueueError):
+                cmd.run(str(non_existent_id))
 
     @mock.patch.object(EnqueueService, "enqueue_item")
     async def test_push_with_content_type(self, mock_enqueue):
         """Content type is used when present."""
-        cmd = PushContent()
-        cmd.run(str(self.test_id_2), "test_content_type")
-        mock_enqueue.assert_called_once_with(mock.ANY, "test_content_type")
+        with mock.patch.object(get_resource_service("published"), "patch") as mock_patch:
+            mock_patch.return_value = None
+            cmd = PushContent()
+            cmd.run(str(self.test_id_2), "test_content_type")
+            mock_enqueue.assert_called_once_with(mock.ANY, "test_content_type")
 
     @mock.patch.object(EnqueueService, "enqueue_item")
     async def test_push_publish(self, mock_enqueue):
         """Push publish calls ``enqueue_item`` when it's not scheduled."""
-        cmd = PushContent()
-        cmd.run(str(self.test_id_3))
-        mock_enqueue.assert_called_once()
+        with mock.patch.object(get_resource_service("published"), "patch") as mock_patch:
+            mock_patch.return_value = None
+            cmd = PushContent()
+            cmd.run(str(self.test_id_3))
+            mock_enqueue.assert_called_once()
 
     @mock.patch.object(EnqueueService, "enqueue_item", side_effect=Exception("Test error"))
     async def test_push_with_enqueue_error(self, mock_enqueue):
         """Exception is propagated when ``enqueue_item`` raises one."""
-        cmd = PushContent()
-        with self.assertRaises(Exception) as context:
-            cmd.run(str(self.test_id_2))
-        assert str(context.exception) == "Test error"
+        with mock.patch.object(get_resource_service("published"), "patch") as mock_patch:
+            mock_patch.return_value = None
+            cmd = PushContent()
+            with self.assertRaises(Exception) as context:
+                cmd.run(str(self.test_id_2))
+            assert str(context.exception) == "Test error"


### PR DESCRIPTION
This patch add a `publish:push` command which directly put items to publish services queue without passing by the `published` collection.

SDESK-7448