### PR TITLE
[SDESK-7459] Implement ability for a Module to register new privileges

### DIFF
--- a/superdesk/core/app.py
+++ b/superdesk/core/app.py
@@ -12,7 +12,9 @@ from typing import Dict, List, Optional, Any, cast
 import importlib
 
 from superdesk.core.types import WSGIApp
+
 from .auth.user_auth import UserAuthProtocol
+from .privileges import PrivilegesRegistry
 
 
 def get_app_config(key: str, default: Optional[Any] = None) -> Optional[Any]:
@@ -47,6 +49,8 @@ class SuperdeskAsyncApp:
 
     auth: UserAuthProtocol
 
+    privileges: PrivilegesRegistry
+
     def __init__(self, wsgi: WSGIApp):
         self._running = False
         self._imported_modules = {}
@@ -57,6 +61,7 @@ class SuperdeskAsyncApp:
         self.resources = Resources(self)
         self.auth = self.load_auth_module()
         self._store_app()
+        self.privileges = PrivilegesRegistry()
 
     @property
     def running(self) -> bool:
@@ -142,10 +147,14 @@ class SuperdeskAsyncApp:
             for endpoint in module.endpoints or []:
                 self.wsgi.register_endpoint(endpoint)
 
-        # then init all modules
+        # init all modules
         for module in self.get_module_list():
             if module.init is not None:
                 module.init(self)
+
+            # then register all module privileges
+            for privilege in module.privileges or []:
+                self.privileges.add(privilege)
 
     def start(self):
         """Start the app
@@ -162,6 +171,9 @@ class SuperdeskAsyncApp:
         self._store_app()
         self._load_modules(self.wsgi.config.get("MODULES", []))
         self._running = True
+
+        # after app is running is longer possible to add more privileges
+        self.privileges.lock()
 
     def stop(self):
         """Stops the app

--- a/superdesk/core/module.py
+++ b/superdesk/core/module.py
@@ -11,8 +11,10 @@
 from typing import Callable, Optional, List, Union
 from dataclasses import dataclass
 
-from .config import ConfigModel
 from superdesk.core.types import Endpoint, EndpointGroup
+
+from .config import ConfigModel
+from .privileges import Privilege
 
 
 @dataclass
@@ -49,6 +51,9 @@ class Module:
 
     #: Optional list of HTTP endpoints to register with the system
     endpoints: Optional[List[Union[Endpoint, EndpointGroup]]] = None
+
+    # Optional list of privileges to register
+    privileges: list[Privilege] | None = None
 
 
 from .app import SuperdeskAsyncApp  # noqa: E402

--- a/superdesk/core/privileges.py
+++ b/superdesk/core/privileges.py
@@ -1,0 +1,45 @@
+from typing import cast
+from dataclasses import dataclass
+from quart_babel.speaklater import LazyString
+
+
+@dataclass(frozen=True)
+class Privilege:
+    name: str
+    label: LazyString | None = None
+    category: LazyString | None = None
+    description: LazyString | None = None
+
+
+class PrivilegesRegistry:
+    __privileges: set[Privilege] | frozenset[Privilege] = set()
+
+    def add(self, privilege: Privilege):
+        """Add a privilege if the registry is not locked."""
+
+        if self.is_locked:
+            raise RuntimeError("Cannot add privileges after the app has started.")
+
+        # mypy does not pick the `is_locked` condition
+        self.__privileges = cast(set[Privilege], self.__privileges)
+        self.__privileges.add(privilege)
+
+    @property
+    def is_locked(self):
+        return isinstance(self.__privileges, frozenset)
+
+    def lock(self):
+        """Lock the registry by converting the privileges to a frozenset."""
+
+        if not self.is_locked:
+            self.__privileges = frozenset(self.__privileges)
+
+    def get_all(self) -> list[Privilege]:
+        """Retrieve all privileges."""
+
+        return list(self.__privileges)
+
+    def __contains__(self, name: str) -> bool:
+        """Check if a privilege exists."""
+
+        return any(priv.name == name for priv in self.__privileges)

--- a/superdesk/core/privileges.py
+++ b/superdesk/core/privileges.py
@@ -1,4 +1,3 @@
-from typing import cast
 from dataclasses import dataclass
 from quart_babel.speaklater import LazyString
 
@@ -12,7 +11,10 @@ class Privilege:
 
 
 class PrivilegesRegistry:
-    __privileges: set[Privilege] | frozenset[Privilege] = set()
+    __privileges: set[Privilege] | frozenset[Privilege]
+
+    def __init__(self):
+        self.__privileges = set()
 
     def add(self, privilege: Privilege):
         """Add a privilege if the registry is not locked."""
@@ -20,9 +22,7 @@ class PrivilegesRegistry:
         if self.is_locked:
             raise RuntimeError("Cannot add privileges after the app has started.")
 
-        # mypy does not pick the `is_locked` condition
-        self.__privileges = cast(set[Privilege], self.__privileges)
-        self.__privileges.add(privilege)
+        self.__privileges.add(privilege)  # type: ignore[union-attr]
 
     @property
     def is_locked(self):

--- a/tests/core/modules/module_with_privileges.py
+++ b/tests/core/modules/module_with_privileges.py
@@ -1,0 +1,12 @@
+from quart_babel import lazy_gettext
+
+from superdesk.core.module import Module
+from superdesk.core.privileges import Privilege
+
+module = Module(
+    name="tests.module_with_privileges",
+    privileges=[
+        Privilege(name="can_test", description=lazy_gettext("Test privilege can test")),
+        Privilege(name="can_play", description=lazy_gettext("Test privilege can play")),
+    ],
+)

--- a/tests/core/privileges_registry_test.py
+++ b/tests/core/privileges_registry_test.py
@@ -1,0 +1,65 @@
+import pytest
+from superdesk.core.privileges import PrivilegesRegistry, Privilege
+
+
+@pytest.fixture(scope="function")
+def registry():
+    reg = PrivilegesRegistry()
+    yield reg
+
+    print("*" * 100)
+    reg = None
+
+
+def test_add_privilege_before_lock(registry):
+    privilege = Privilege(name="edit_article")
+
+    registry.add(privilege)
+
+    assert "edit_article" in registry
+    assert registry.get_all() == [privilege]
+
+
+def test_add_multiple_privileges(registry):
+    privilege1 = Privilege(name="edit_article")
+    privilege2 = Privilege(name="delete_article")
+
+    registry.add(privilege1)
+    registry.add(privilege2)
+
+    assert "edit_article" in registry
+    assert "delete_article" in registry
+    assert len(registry.get_all()) == 2
+
+
+def test_lock_registry(registry):
+    privilege = Privilege(name="edit_article")
+
+    registry.add(privilege)
+    registry.lock()
+
+    assert registry.is_locked
+    assert "edit_article" in registry
+
+
+def test_cannot_add_after_lock(registry):
+    privilege = Privilege(name="edit_article")
+
+    registry.add(privilege)
+    registry.lock()
+
+    with pytest.raises(RuntimeError):
+        registry.add(Privilege(name="new_privilege"))
+
+
+def test_lock_prevents_further_additions(registry):
+    privilege = Privilege(name="edit_article")
+
+    registry.add(privilege)
+    registry.lock()
+
+    with pytest.raises(RuntimeError, match="Cannot add privileges after the app has started."):
+        registry.add(Privilege(name="new_privilege"))
+
+    assert len(registry.get_all()) == 1
+    assert registry.is_locked

--- a/tests/core/privileges_registry_test.py
+++ b/tests/core/privileges_registry_test.py
@@ -4,11 +4,7 @@ from superdesk.core.privileges import PrivilegesRegistry, Privilege
 
 @pytest.fixture(scope="function")
 def registry():
-    reg = PrivilegesRegistry()
-    yield reg
-
-    print("*" * 100)
-    reg = None
+    return PrivilegesRegistry()
 
 
 def test_add_privilege_before_lock(registry):


### PR DESCRIPTION
### Purpose
Add support for modules to register privileges within the system. Ensure privileges can only be added before the application starts to maintain immutability.

### What has changed
- Introduced `PrivilegesRegistry` class to manage privilege registration.
- Added privileges field to the `Module` class to allow modules to define privileges.
- Ensured privileges are stored as an immutable `frozenset` after the app locks the registry.
- Prevented privilege additions after the registry is locked.
- Added methods to retrieve all registered privileges and check for existing privileges.

Thanks for checking!

Resolves: [SDESK-7459] 

[SDESK-7459]: https://sofab.atlassian.net/browse/SDESK-7459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ