### PR TITLE
[SDESK-7460] Create async auth rules for user privileges

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,5 @@ exclude = '''
 [tool.pytest.ini_options]
 testpaths = ["tests", "superdesk", "apps", "content_api"]
 python_files = "*_test.py *_tests.py test_*.py tests_*.py tests.py test.py"
-asyncio_mode = "auto"
+asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,5 @@ exclude = '''
 [tool.pytest.ini_options]
 testpaths = ["tests", "superdesk", "apps", "content_api"]
 python_files = "*_test.py *_tests.py test_*.py tests_*.py tests.py test.py"
-asyncio_mode = "strict"
+asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/superdesk/core/auth/privilege_rules.py
+++ b/superdesk/core/auth/privilege_rules.py
@@ -1,0 +1,62 @@
+from typing import Any, cast
+
+from quart_babel import gettext
+from superdesk.errors import SuperdeskApiError
+from superdesk.users.async_service import get_privileges, is_admin
+from superdesk.core.types import HTTP_METHOD, AuthRule, Request
+
+
+def required_privilege_rule(privilege: str) -> AuthRule:
+    """
+    Creates an authentication rule that restricts access based on a specific privilege.
+
+    Args:
+        privilege (str): The privilege required to access the resource.
+
+    Returns:
+        AuthRule: An asynchronous rule function that checks if the user has the required privilege.
+
+    The rule verifies:
+    - If the user is an admin, access is granted without further checks.
+    - Otherwise, the user's privileges are retrieved and checked against the required privilege.
+
+    Raises:
+        SuperdeskApiError: If the user does not have the required privilege.
+    """
+
+    async def internal_rule(request: Request):
+        current_user = request.user
+
+        # TODO-ASYNC: Check if for admin we need to pull all privileges instead
+        if is_admin(current_user):
+            return None
+
+        user_role = request.storage.request.get("role")
+        user_privileges = get_privileges(request.user, user_role)
+
+        if user_privileges.get(privilege, False):
+            return None
+
+        raise SuperdeskApiError.forbiddenError(message=gettext("Insufficient privileges for the requested operation."))
+
+    return internal_rule
+
+
+def privilege_based_rules(rules: dict[HTTP_METHOD, str]) -> dict[str, AuthRule]:
+    """
+    Generates a dictionary of authentication rules for HTTP methods based on privileges.
+
+    Args:
+        rules (dict[HTTP_METHOD, str]): A mapping of HTTP methods (e.g., GET, POST) to the required privileges
+        for those methods.
+
+    Returns:
+        dict[str, list[AuthRule]]: A dictionary where each HTTP method is mapped to a list of authentication
+        rules that restrict access based on the specified privilege.
+    """
+
+    auth_rules: dict[str, AuthRule] = {}
+    for method, privilege_name in rules.items():
+        auth_rules[method] = required_privilege_rule(privilege_name)
+
+    return auth_rules

--- a/superdesk/core/auth/privilege_rules.py
+++ b/superdesk/core/auth/privilege_rules.py
@@ -27,7 +27,6 @@ def required_privilege_rule(privilege: str) -> AuthRule:
     async def internal_rule(request: Request):
         current_user = request.user
 
-        # TODO-ASYNC: Check if for admin we need to pull all privileges instead
         if is_admin(current_user):
             return None
 
@@ -42,7 +41,7 @@ def required_privilege_rule(privilege: str) -> AuthRule:
     return internal_rule
 
 
-def privilege_based_rules(rules: dict[HTTP_METHOD, str]) -> dict[str, AuthRule]:
+def http_method_privilege_based_rules(rules: dict[HTTP_METHOD, str]) -> dict[str, AuthRule]:
     """
     Generates a dictionary of authentication rules for HTTP methods based on privileges.
 

--- a/superdesk/core/auth/token_auth.py
+++ b/superdesk/core/auth/token_auth.py
@@ -1,20 +1,35 @@
+import base64
+import arrow
+
 from typing import Any, cast
 from datetime import timedelta
 
-from superdesk.core import get_app_config
+from superdesk.utc import utcnow
+from superdesk.core import json, get_app_config
 from superdesk.core.types import Request
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError
 from superdesk.resource_fields import LAST_UPDATED, ID_FIELD
-from superdesk.utc import utcnow
 
 from .user_auth import UserAuthProtocol
 
 
 class TokenAuthorization(UserAuthProtocol):
+    @staticmethod
+    def _decode_token(token: str) -> str:
+        """
+        Tries to decode the auth header token. Decode logic based on internal logic from
+        `werkzeug.datastructures.Authorization`
+        """
+        try:
+            return base64.b64decode(token).decode().partition(":")[0]
+        except Exception:
+            return token
+
     async def authenticate(self, request: Request):
         token = request.get_header("Authorization")
         new_session = True
+
         if token:
             token = token.strip()
             if token.lower().startswith(("token", "bearer")):
@@ -29,6 +44,10 @@ class TokenAuthorization(UserAuthProtocol):
 
         # Check provided token is valid
         auth_service = get_resource_service("auth")
+
+        # tokens are no longer decoded internally by flask/quart
+        # so we need to do it ourselves
+        token = self._decode_token(token)
         auth_token = auth_service.find_one(token=token, req=None)
 
         if not auth_token:
@@ -54,11 +73,14 @@ class TokenAuthorization(UserAuthProtocol):
             await self.stop_session(request)
             raise SuperdeskApiError.unauthorizedError()
 
-        request.storage.session.set("session_token", auth_token)
+        request.storage.session.set("session_token", json.dumps(auth_token))
         await super().start_session(request, user, **kwargs)
 
     async def continue_session(self, request: Request, user: dict[str, Any], **kwargs) -> None:
         auth_token = request.storage.session.get("session_token")
+
+        if isinstance(auth_token, str):
+            auth_token = json.loads(auth_token)
 
         if not auth_token:
             await self.stop_session(request)
@@ -74,7 +96,9 @@ class TokenAuthorization(UserAuthProtocol):
             now = utcnow()
             auth_updated = False
             session_update_seconds = cast(int, get_app_config("SESSION_UPDATE_SECONDS", 30))
-            if auth_token[LAST_UPDATED] + timedelta(seconds=session_update_seconds) < now:
+            auth_last_updated = arrow.get(auth_token[LAST_UPDATED])
+
+            if auth_last_updated + timedelta(seconds=session_update_seconds) < now:
                 auth_service = get_resource_service("auth")
                 auth_service.update_session({LAST_UPDATED: now})
                 auth_updated = True

--- a/superdesk/core/auth/user_auth.py
+++ b/superdesk/core/auth/user_auth.py
@@ -1,5 +1,6 @@
 from typing import Any, cast
 
+from superdesk.utils import flatten
 from superdesk.errors import SuperdeskApiError
 from superdesk.core.types import Request, AuthRule
 
@@ -27,7 +28,10 @@ class UserAuthProtocol:
         elif isinstance(endpoint_rules, dict):
             endpoint_rules = cast(list[AuthRule], endpoint_rules.get(request.method) or [])
 
-        for rule in self.get_default_auth_rules() + (endpoint_rules or []):
+        auth_rules = self.get_default_auth_rules()
+        auth_rules.append(endpoint_rules or [])
+
+        for rule in flatten(auth_rules):
             response = await rule(request)
             if response is not None:
                 return response

--- a/superdesk/core/auth/user_auth.py
+++ b/superdesk/core/auth/user_auth.py
@@ -29,7 +29,7 @@ class UserAuthProtocol:
             endpoint_rules = cast(list[AuthRule], endpoint_rules.get(request.method) or [])
 
         auth_rules = self.get_default_auth_rules()
-        auth_rules.append(endpoint_rules or [])
+        auth_rules.append(endpoint_rules or [])  # type: ignore[arg-type]
 
         for rule in flatten(auth_rules):
             response = await rule(request)

--- a/superdesk/core/mongo/mongo_manager.py
+++ b/superdesk/core/mongo/mongo_manager.py
@@ -8,10 +8,10 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from typing import Dict, List, Tuple
-from dataclasses import asdict
-from copy import deepcopy
 import logging
+from copy import deepcopy
+from dataclasses import asdict
+from typing import Dict, List, Tuple
 
 from pymongo import MongoClient
 from pymongo.database import Database, Collection
@@ -250,7 +250,7 @@ class MongoResources:
 
         if not self._mongo_clients_async.get(mongo_config.prefix):
             client_config, dbname = get_mongo_client_config(self.app.wsgi.config, mongo_config.prefix)
-            client = AsyncIOMotorClient(**client_config)
+            client: AsyncIOMotorClient = AsyncIOMotorClient(**client_config)
             db = client.get_database(dbname if not versioning else f"{dbname}_versions")
             self._mongo_clients_async[mongo_config.prefix] = (client, db)
 

--- a/superdesk/errors.py
+++ b/superdesk/errors.py
@@ -130,7 +130,7 @@ class SuperdeskApiError(SuperdeskError):
         """Create dict for json response."""
         rv = {}
         rv[STATUS] = STATUS_ERR
-        rv["_message"] = self.message or ""
+        rv["_message"] = str(self.message or "")
         if hasattr(self, "payload"):
             rv[ISSUES] = self.payload
         return rv

--- a/superdesk/privilege.py
+++ b/superdesk/privilege.py
@@ -24,9 +24,9 @@ GLOBAL_SEARCH_PRIVILEGE = "use_global_saved_searches"
 
 def privilege(
     name,
-    label: Optional[LazyString] = None,
-    description: Optional[LazyString] = None,
-    category: Optional[LazyString] = None,
+    label: LazyString | str | None = None,
+    description: LazyString | str | None = None,
+    category: LazyString | str | None = None,
     **kwargs,
 ):
     """Register privilege.

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -480,11 +480,13 @@ async def setup_db_user(context, user):
         user["password"] = original_password
         auth_data = json.dumps({"username": user["username"], "password": user["password"]})
 
-        context.headers.append(["Content-Type", "application/json"])
+        auth_request_headers = deepcopy(context.headers)
+        auth_request_headers.append(["Content-Type", "application/json"])
+
         auth_response = await context.client.post(
             get_prefixed_url(context.app, "/auth_db"),
             data=auth_data,
-            headers=context.headers,
+            headers=auth_request_headers,
         )
 
         auth_data = json.loads(await auth_response.get_data())

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -479,8 +479,12 @@ async def setup_db_user(context, user):
 
         user["password"] = original_password
         auth_data = json.dumps({"username": user["username"], "password": user["password"]})
+
+        context.headers.append(["Content-Type", "application/json"])
         auth_response = await context.client.post(
-            get_prefixed_url(context.app, "/auth_db"), data=auth_data, headers=context.headers
+            get_prefixed_url(context.app, "/auth_db"),
+            data=auth_data,
+            headers=context.headers,
         )
 
         auth_data = json.loads(await auth_response.get_data())

--- a/superdesk/utils.py
+++ b/superdesk/utils.py
@@ -388,3 +388,19 @@ def format_content_type_name(item: Dict[str, str], default_name: str) -> str:
     """
     name = item.get("output_name") or item.get("label", default_name)
     return re.compile("[^0-9a-zA-Z_]").sub("", name)
+
+
+def flatten(nested_list) -> list:
+    """
+    Recursively flattens an arbitrarily nested list into a single flat list.
+
+    Returns:
+        list: A single flat list containing all elements from the nested structure.
+    """
+    result = []
+    for i in nested_list:
+        if isinstance(i, list):
+            result.extend(flatten(i))
+        else:
+            result.append(i)
+    return result

--- a/tests/core/modules/module_with_privileges.py
+++ b/tests/core/modules/module_with_privileges.py
@@ -1,6 +1,6 @@
 from quart_babel import lazy_gettext
 
-from superdesk.core.auth.privilege_rules import privilege_based_rules
+from superdesk.core.auth.privilege_rules import http_method_privilege_based_rules
 from superdesk.core.module import Module
 from superdesk.core.privileges import Privilege
 from superdesk.core.resources import ResourceConfig, ResourceModel, RestEndpointConfig
@@ -12,7 +12,7 @@ resource_config = ResourceConfig(
     data_class=ResourceModel,
     rest_endpoints=RestEndpointConfig(
         resource_methods=["GET", "POST"],
-        auth=privilege_based_rules({"GET": test_privileges[0], "POST": test_privileges[1]}),
+        auth=http_method_privilege_based_rules({"GET": test_privileges[0], "POST": test_privileges[1]}),
     ),
 )
 

--- a/tests/core/modules/module_with_privileges.py
+++ b/tests/core/modules/module_with_privileges.py
@@ -1,12 +1,27 @@
 from quart_babel import lazy_gettext
 
+from superdesk.core.auth.privilege_rules import privilege_based_rules
 from superdesk.core.module import Module
 from superdesk.core.privileges import Privilege
+from superdesk.core.resources import ResourceConfig, ResourceModel, RestEndpointConfig
+
+test_privileges = ["can_read", "can_create"]
+
+resource_config = ResourceConfig(
+    name="privileged_resource",
+    data_class=ResourceModel,
+    rest_endpoints=RestEndpointConfig(
+        resource_methods=["GET", "POST"],
+        auth=privilege_based_rules({"GET": test_privileges[0], "POST": test_privileges[1]}),
+    ),
+)
+
 
 module = Module(
     name="tests.module_with_privileges",
+    resources=[resource_config],
     privileges=[
-        Privilege(name="can_test", description=lazy_gettext("Test privilege can test")),
-        Privilege(name="can_play", description=lazy_gettext("Test privilege can play")),
+        Privilege(name="can_read", description=lazy_gettext("Test privilege can read")),
+        Privilege(name="can_create", description=lazy_gettext("Test privilege can create")),
     ],
 )

--- a/tests/core/modules/module_with_privileges.py
+++ b/tests/core/modules/module_with_privileges.py
@@ -1,8 +1,8 @@
 from quart_babel import lazy_gettext
 
-from superdesk.core.auth.privilege_rules import http_method_privilege_based_rules
 from superdesk.core.module import Module
 from superdesk.core.privileges import Privilege
+from superdesk.core.auth.privilege_rules import http_method_privilege_based_rules
 from superdesk.core.resources import ResourceConfig, ResourceModel, RestEndpointConfig
 
 test_privileges = ["can_read", "can_create"]

--- a/tests/core/privilege_rules_test.py
+++ b/tests/core/privilege_rules_test.py
@@ -1,0 +1,69 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from superdesk.errors import SuperdeskApiError
+from superdesk.core.auth.privilege_rules import privilege_based_rules, required_privilege_rule
+
+
+@patch("superdesk.core.auth.privilege_rules.is_admin")
+@patch("superdesk.core.auth.privilege_rules.get_privileges")
+async def test_required_privilege_rule_admin(mock_get_privileges, mock_is_admin):
+    mock_is_admin.return_value = True
+    mock_request = MagicMock()
+
+    rule = required_privilege_rule("test_privilege")
+    result = await rule(mock_request)
+
+    # admin user should pass without checking privileges
+    assert result is None
+    mock_get_privileges.assert_not_called()
+
+
+@patch("superdesk.core.auth.privilege_rules.is_admin")
+@patch("superdesk.core.auth.privilege_rules.get_privileges")
+async def test_required_privilege_rule_insufficient_privileges(mock_get_privileges, mock_is_admin):
+    mock_is_admin.return_value = False
+    mock_get_privileges.return_value = {"test_privilege": False}
+
+    mock_request = MagicMock()
+    mock_request.user = "test_user"
+    mock_request.storage.request.get.return_value = "user_role"
+
+    rule = required_privilege_rule("test_privilege")
+
+    with pytest.raises(SuperdeskApiError) as error:
+        await rule(mock_request)
+
+    assert error.value.status_code == 403
+    assert "Insufficient privileges" in str(error.value)
+    mock_get_privileges.assert_called_once_with("test_user", "user_role")
+
+
+@patch("superdesk.core.auth.privilege_rules.is_admin")
+@patch("superdesk.core.auth.privilege_rules.get_privileges")
+async def test_required_privilege_rule_sufficient_privileges(mock_get_privileges, mock_is_admin):
+    mock_is_admin.return_value = False
+    mock_get_privileges.return_value = {"test_privilege": True}
+
+    mock_request = MagicMock()
+    mock_request.user = "test_user"
+    mock_request.storage.request.get.return_value = "user_role"
+
+    rule = required_privilege_rule("test_privilege")
+
+    result = await rule(mock_request)
+    assert result is None
+    mock_get_privileges.assert_called_once_with("test_user", "user_role")
+
+
+def test_privilege_based_rules():
+    rules = {
+        "GET": "read_articles",
+        "POST": "create_articles",
+        "DELETE": "delete_articles",
+    }
+
+    auth_rules = privilege_based_rules(rules)
+
+    assert "GET" in auth_rules
+    assert "POST" in auth_rules
+    assert "DELETE" in auth_rules

--- a/tests/core/privilege_rules_test.py
+++ b/tests/core/privilege_rules_test.py
@@ -1,72 +1,67 @@
-import pytest
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch, MagicMock
 from superdesk.errors import SuperdeskApiError
 from superdesk.core.auth.privilege_rules import http_method_privilege_based_rules, required_privilege_rule
 
 
-@pytest.mark.asyncio
-@patch("superdesk.core.auth.privilege_rules.is_admin")
-@patch("superdesk.core.auth.privilege_rules.get_privileges")
-async def test_required_privilege_rule_admin(mock_get_privileges, mock_is_admin):
-    mock_is_admin.return_value = True
-    mock_request = MagicMock()
+class TestPrivilegeRules(IsolatedAsyncioTestCase):
+    @patch("superdesk.core.auth.privilege_rules.is_admin")
+    @patch("superdesk.core.auth.privilege_rules.get_privileges")
+    async def test_required_privilege_rule_admin(self, mock_get_privileges, mock_is_admin):
+        mock_is_admin.return_value = True
+        mock_request = MagicMock()
 
-    rule = required_privilege_rule("test_privilege")
-    result = await rule(mock_request)
+        rule = required_privilege_rule("test_privilege")
+        result = await rule(mock_request)
 
-    # admin user should pass without checking privileges
-    assert result is None
-    mock_get_privileges.assert_not_called()
+        # admin user should pass without checking privileges
+        self.assertIsNone(result)
+        mock_get_privileges.assert_not_called()
 
+    @patch("superdesk.core.auth.privilege_rules.is_admin")
+    @patch("superdesk.core.auth.privilege_rules.get_privileges")
+    async def test_required_privilege_rule_insufficient_privileges(self, mock_get_privileges, mock_is_admin):
+        mock_is_admin.return_value = False
+        mock_get_privileges.return_value = {"test_privilege": False}
 
-@pytest.mark.asyncio
-@patch("superdesk.core.auth.privilege_rules.is_admin")
-@patch("superdesk.core.auth.privilege_rules.get_privileges")
-async def test_required_privilege_rule_insufficient_privileges(mock_get_privileges, mock_is_admin):
-    mock_is_admin.return_value = False
-    mock_get_privileges.return_value = {"test_privilege": False}
+        mock_request = MagicMock()
+        mock_request.user = "test_user"
+        mock_request.storage.request.get.return_value = "user_role"
 
-    mock_request = MagicMock()
-    mock_request.user = "test_user"
-    mock_request.storage.request.get.return_value = "user_role"
+        rule = required_privilege_rule("test_privilege")
 
-    rule = required_privilege_rule("test_privilege")
+        with self.assertRaises(SuperdeskApiError) as error:
+            result = await rule(mock_request)
 
-    with pytest.raises(SuperdeskApiError) as error:
-        await rule(mock_request)
+        self.assertEqual(error.exception.status_code, 403)
+        self.assertIn("Insufficient privileges", str(error.exception))
+        mock_get_privileges.assert_called_once_with("test_user", "user_role")
 
-    assert error.value.status_code == 403
-    assert "Insufficient privileges" in str(error.value)
-    mock_get_privileges.assert_called_once_with("test_user", "user_role")
+    @patch("superdesk.core.auth.privilege_rules.is_admin")
+    @patch("superdesk.core.auth.privilege_rules.get_privileges")
+    async def test_required_privilege_rule_sufficient_privileges(self, mock_get_privileges, mock_is_admin):
+        mock_is_admin.return_value = False
+        mock_get_privileges.return_value = {"test_privilege": True}
 
+        mock_request = MagicMock()
+        mock_request.user = "test_user"
+        mock_request.storage.request.get.return_value = "user_role"
 
-@pytest.mark.asyncio
-@patch("superdesk.core.auth.privilege_rules.is_admin")
-@patch("superdesk.core.auth.privilege_rules.get_privileges")
-async def test_required_privilege_rule_sufficient_privileges(mock_get_privileges, mock_is_admin):
-    mock_is_admin.return_value = False
-    mock_get_privileges.return_value = {"test_privilege": True}
+        rule = required_privilege_rule("test_privilege")
 
-    mock_request = MagicMock()
-    mock_request.user = "test_user"
-    mock_request.storage.request.get.return_value = "user_role"
+        result = await rule(mock_request)
+        self.assertIsNone(result)
+        mock_get_privileges.assert_called_once_with("test_user", "user_role")
 
-    rule = required_privilege_rule("test_privilege")
+    def test_privilege_based_rules(self):
+        rules = {
+            "GET": "read_articles",
+            "POST": "create_articles",
+            "DELETE": "delete_articles",
+        }
 
-    result = await rule(mock_request)
-    assert result is None
-    mock_get_privileges.assert_called_once_with("test_user", "user_role")
+        auth_rules = http_method_privilege_based_rules(rules)
 
-
-def test_privilege_based_rules():
-    rules = {
-        "GET": "read_articles",
-        "POST": "create_articles",
-        "DELETE": "delete_articles",
-    }
-
-    auth_rules = http_method_privilege_based_rules(rules)
-
-    assert "GET" in auth_rules
-    assert "POST" in auth_rules
-    assert "DELETE" in auth_rules
+        self.assertIn("GET", auth_rules)
+        self.assertIn("POST", auth_rules)
+        self.assertIn("DELETE", auth_rules)

--- a/tests/core/privilege_rules_test.py
+++ b/tests/core/privilege_rules_test.py
@@ -1,9 +1,10 @@
 import pytest
 from unittest.mock import patch, MagicMock
 from superdesk.errors import SuperdeskApiError
-from superdesk.core.auth.privilege_rules import privilege_based_rules, required_privilege_rule
+from superdesk.core.auth.privilege_rules import http_method_privilege_based_rules, required_privilege_rule
 
 
+@pytest.mark.asyncio
 @patch("superdesk.core.auth.privilege_rules.is_admin")
 @patch("superdesk.core.auth.privilege_rules.get_privileges")
 async def test_required_privilege_rule_admin(mock_get_privileges, mock_is_admin):
@@ -18,6 +19,7 @@ async def test_required_privilege_rule_admin(mock_get_privileges, mock_is_admin)
     mock_get_privileges.assert_not_called()
 
 
+@pytest.mark.asyncio
 @patch("superdesk.core.auth.privilege_rules.is_admin")
 @patch("superdesk.core.auth.privilege_rules.get_privileges")
 async def test_required_privilege_rule_insufficient_privileges(mock_get_privileges, mock_is_admin):
@@ -38,6 +40,7 @@ async def test_required_privilege_rule_insufficient_privileges(mock_get_privileg
     mock_get_privileges.assert_called_once_with("test_user", "user_role")
 
 
+@pytest.mark.asyncio
 @patch("superdesk.core.auth.privilege_rules.is_admin")
 @patch("superdesk.core.auth.privilege_rules.get_privileges")
 async def test_required_privilege_rule_sufficient_privileges(mock_get_privileges, mock_is_admin):
@@ -62,7 +65,7 @@ def test_privilege_based_rules():
         "DELETE": "delete_articles",
     }
 
-    auth_rules = privilege_based_rules(rules)
+    auth_rules = http_method_privilege_based_rules(rules)
 
     assert "GET" in auth_rules
     assert "POST" in auth_rules

--- a/tests/core/resource_endpoints_test.py
+++ b/tests/core/resource_endpoints_test.py
@@ -435,9 +435,6 @@ class PrivilegedResourceEndpointsTestCase(AsyncFlaskTestCase):
         ]
     }
 
-    async def asyncSetUp(self):
-        await super().asyncSetUp()
-
     async def _get_auth_token(self, user: dict[str, Any] | None = None):
         self.headers: list = []
         await setup_auth_user(self, user)

--- a/tests/core/resource_endpoints_test.py
+++ b/tests/core/resource_endpoints_test.py
@@ -1,10 +1,12 @@
+from copy import deepcopy
+from typing import Any
 from unittest import mock
 import simplejson as json
 
 from superdesk.utc import utcnow
 from superdesk.utils import format_time
 
-from superdesk.tests import AsyncFlaskTestCase
+from superdesk.tests import AsyncFlaskTestCase, setup_auth_user, test_user
 
 from .modules.users import UserResourceService
 from .fixtures.users import john_doe, jane_doe
@@ -422,3 +424,82 @@ class ResourceEndpointsTestCase(AsyncFlaskTestCase):
         response = await self.test_client.get("/api/hello/world")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(await response.get_json(), {"hello": "world"})
+
+
+class PrivilegedResourceEndpointsTestCase(AsyncFlaskTestCase):
+    use_default_apps = True
+    app_config = {
+        "MODULES": [
+            "tests.core.modules.users",
+            "tests.core.modules.module_with_privileges",
+        ]
+    }
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+
+    async def _get_auth_token(self, user: dict[str, Any] | None = None):
+        self.headers: list = []
+        await setup_auth_user(self, user)
+
+        auth_header = next((header for header in self.headers if header[0] == "Authorization"), None)
+        if auth_header:
+            return auth_header[1].replace("Basic", "Token")
+
+        return ""
+
+    async def _get_auth_header(self, user: dict[str, Any] | None = None) -> tuple:
+        auth_token = await self._get_auth_token(user)
+        return "Authorization", auth_token
+
+    async def test_admin_can_access_privileged_endpoint(self):
+        admin_user = deepcopy(test_user)
+        admin_user["user_type"] = "administrator"
+
+        headers = [await self._get_auth_header(admin_user)]
+        response = await self.test_client.get("/api/privileged_resource", headers=headers)
+        self.assertEqual(response.status_code, 200)
+
+    async def test_unauthorized_user_cannot_access_privileged_endpoint(self):
+        regular_user = deepcopy(test_user)
+        regular_user["user_type"] = "unauthorized"
+
+        headers = [await self._get_auth_header(regular_user)]
+        response = await self.test_client.get("/api/privileged_resource", headers=headers)
+
+        response_data = await response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue("Insufficient privileges" in response_data["_message"])
+
+    async def test_user_with_role_can_access_privileged_endpoint(self):
+        from tests.core.modules.module_with_privileges import test_privileges
+
+        can_read_privilege = test_privileges[0]
+        roles = [{"name": "Can Read Role", "privileges": {can_read_privilege: 1}}]
+        self.app.data.insert("roles", roles)
+
+        regular_user = deepcopy(test_user)
+        regular_user["user_type"] = "test_type"
+        regular_user["role"] = roles[0]["_id"]
+
+        headers = [await self._get_auth_header(regular_user)]
+        response = await self.test_client.get("/api/privileged_resource", headers=headers)
+
+        self.assertEqual(response.status_code, 200)
+
+    async def test_cannot_access_endpoint_with_incorrect_privilege(self):
+        from tests.core.modules.module_with_privileges import test_privileges
+
+        can_create_privilege = test_privileges[1]
+        can_create_only_role = {"name": "Can Read Role", "privileges": {can_create_privilege: 1}}
+        self.app.data.insert("roles", [can_create_only_role])
+
+        regular_user = deepcopy(test_user)
+        regular_user["user_type"] = "test_type"
+        regular_user["role"] = can_create_only_role["_id"]
+
+        # user should not be able to "GET" as the role only has "POST" privilege
+        headers = [await self._get_auth_header(regular_user)]
+        response = await self.test_client.get("/api/privileged_resource", headers=headers)
+
+        self.assertEqual(response.status_code, 403)


### PR DESCRIPTION
### Purpose
To implement privilege-based authentication rules for async rest endpoints.

### What has changed
- Added new privilege rules and configurations to ensure that only users with the right permissions can access certain resources.
- Updated the test files to include scenarios for checking access to privileged resources.
- Introduced new utility functions to help with privilege and role management. Also another one to flat nested lists.
- Fixed json serialisation issue when saving session (`SecureCookieSessionInterface` not being able to handle `ObjectId` values).
- Made some small tweaks to the error handling and configuration files to support the new privilege system.
- Added tests to make sure the new rules work as expected.

### Pending
~- I will push some changes to fix all (**_unrelated_**) `mypy` issues tomorrow~. Done!

Resolves: [SDESK-7460]

Thanks for checking!

[SDESK-7460]: https://sofab.atlassian.net/browse/SDESK-7460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ