### PR TITLE
[SDESK-7487] Add docstrings about usage of url in endpoints 

### DIFF
--- a/superdesk/core/resources/resource_rest_endpoints.py
+++ b/superdesk/core/resources/resource_rest_endpoints.py
@@ -9,8 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import math
-from inspect import get_annotations
-from typing import Annotated, List, Optional, cast, Dict, Any, Type, get_args, get_origin
+from typing import List, Optional, cast, Dict, Any, Type
 
 from dataclasses import dataclass
 from pydantic import ValidationError, BaseModel, NonNegativeInt
@@ -20,7 +19,9 @@ from werkzeug.datastructures import MultiDict
 from bson import ObjectId
 
 from superdesk.core import json
-from superdesk.core.app import get_app_config, get_current_async_app
+from superdesk.utils import get_cors_headers
+from superdesk.errors import SuperdeskApiError
+from superdesk.core.app import get_current_async_app
 from superdesk.core.types import (
     SearchRequest,
     SearchArgs,
@@ -31,14 +32,12 @@ from superdesk.core.types import (
     Response,
     RestGetResponse,
 )
-from superdesk.errors import SuperdeskApiError
 from superdesk.resource_fields import STATUS, STATUS_OK, ITEMS
 from superdesk.core.web import RestEndpoints, ItemRequestViewArgs, Endpoint
-from superdesk.utils import get_cors_headers, join_url_parts
 
 from .model import ResourceModel
 from .resource_config import ResourceConfig
-from .validators import AsyncValidator, convert_pydantic_validation_error_for_response
+from .validators import convert_pydantic_validation_error_for_response
 
 
 @dataclass

--- a/superdesk/core/types/search.py
+++ b/superdesk/core/types/search.py
@@ -54,6 +54,7 @@ class SearchArgs(TypedDict, total=False):
     filters: list[dict[str, Any]]
 
     #: A JSON string containing the field projections to filter out the returned fields
+    # Kept for compatibility with python-eve. Use `SearchRequest.projection` preferably.
     projections: str
 
     version: VersionParam | None

--- a/superdesk/core/types/web.py
+++ b/superdesk/core/types/web.py
@@ -222,6 +222,11 @@ class Endpoint:
     """Base class used for registering and processing endpoints"""
 
     #: URL for the endpoint
+    #: If the URL starts with "/", it will be used as-is.
+    #: Otherwise, the API prefix will be prepended to the URL.
+    #: For example:
+    #: - "items" -> "{api_prefix}{api_version}/items"
+    #: - "/custom/path" -> "/custom/path"
     url: str
 
     #: Name of the endpoint (must be unique)

--- a/superdesk/core/web/endpoints.py
+++ b/superdesk/core/web/endpoints.py
@@ -145,7 +145,7 @@ class EndpointGroup(EndpointGroupProtocol):
 
         def fdec(func: EndpointFunction):
             endpoint_func = Endpoint(
-                f"/{self.url_prefix}{url}" if self.url_prefix else url,
+                f"{self.url}/{url}" if self.url else url,
                 func,
                 methods=methods,
                 name=name,
@@ -163,12 +163,16 @@ class EndpointGroup(EndpointGroupProtocol):
 
 def endpoint(url: str, name: str | None = None, methods: list[HTTP_METHOD] | None = None, auth: AuthConfig = None):
     """Decorator function to convert a pure function to an Endpoint instance
+    which is later used to register with a Module or the app.
 
-    This is then later used to register with a Module or the app.
-
-    :param url: The URL of the endpoint
-    :param name: The optional name of the endpoint
-    :param methods: The optional list of HTTP methods allowed
+    Args:
+        url: The URL of the endpoint. If it starts with "/", it will be used exactly as provided.
+            Otherwise, the API prefix and version will be automatically prepended.
+            For example:
+            - "items" becomes "{api_prefix}{api_version}/items"
+            - "/custom/path" stays as "/custom/path"
+        name: The optional name of the endpoint
+        methods: The optional list of HTTP methods allowed
     """
 
     def convert_to_endpoint(func: EndpointFunction):

--- a/superdesk/core/web/endpoints.py
+++ b/superdesk/core/web/endpoints.py
@@ -145,7 +145,7 @@ class EndpointGroup(EndpointGroupProtocol):
 
         def fdec(func: EndpointFunction):
             endpoint_func = Endpoint(
-                f"{self.url}/{url}" if self.url else url,
+                f"/{self.url_prefix}{url}" if self.url_prefix else url,
                 func,
                 methods=methods,
                 name=name,


### PR DESCRIPTION
### Purpose
~- Fix a bug that the `url_prefix` was not being added to the endpoint urls even when it was provided to the `EndpointGroup` definition.~

Update: I have found what was the problem on my local not picking up the the url prefix and api version. I turned this PR into just adding some docstrings regarding the usage of the `url_prefix` when registering an endpoint. 

[SDESK-7487]

[SDESK-7487]: https://sofab.atlassian.net/browse/SDESK-7487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ