### PR TITLE
[SDESK-7482] fix ContentProfile async resource

### DIFF
--- a/apps/templates/__init__.py
+++ b/apps/templates/__init__.py
@@ -12,10 +12,11 @@ from typing import Any
 import superdesk
 from superdesk import register_jinja_filter
 from superdesk.text_utils import get_text
+from superdesk.types import ContentTypes
 from .content_templates import ContentTemplatesResource, ContentTemplatesService, CONTENT_TEMPLATE_PRIVILEGE
 from .content_templates import ContentTemplatesApplyResource, ContentTemplatesApplyService
 from .content_templates import create_scheduled_content  # noqa
-from .content_templates import create_template_for_profile
+from .content_templates import create_template_for_profile, create_template_for_content_type
 from .filters import format_datetime_filter, first_paragraph_filter, iso_datetime, add_timedelta
 from quart_babel import lazy_gettext
 
@@ -45,3 +46,4 @@ def init_app(app) -> None:
     register_jinja_filter("add_timedelta", add_timedelta)
 
     app.on_inserted_content_types += create_template_for_profile
+    ContentTypes.get_signals().data.on_created += create_template_for_content_type

--- a/apps/templates/content_templates.py
+++ b/apps/templates/content_templates.py
@@ -19,6 +19,7 @@ from superdesk.core import get_current_app, get_app_config
 from superdesk.resource_fields import ID_FIELD, DATE_CREATED, LAST_UPDATED, ETAG, VERSION, ITEMS
 from superdesk.flask import render_template_string
 from superdesk.services import BaseService
+from superdesk.types import ContentTypes
 from superdesk import Resource, Service, get_resource_service
 from superdesk.utils import SuperdeskBaseEnum, plaintext_filter
 from superdesk.resource import build_custom_hateoas
@@ -694,6 +695,10 @@ def create_template_for_profile(items):
             )
     if templates:
         superdesk.get_resource_service(CONTENT_TEMPLATE_RESOURCE).post(templates)
+
+
+def create_template_for_content_type(item: ContentTypes) -> None:
+    create_template_for_profile([item.to_dict()])
 
 
 def remove_profile_from_templates(item):

--- a/superdesk/content_types_async/module.py
+++ b/superdesk/content_types_async/module.py
@@ -10,8 +10,9 @@ from apps.content_types.content_types import CONTENT_TYPE_PRIVILEGE
 from superdesk.core.resources import ResourceConfig, MongoResourceConfig, MongoIndexOptions
 from superdesk.core.resources.resource_rest_endpoints import RestEndpointConfig
 from superdesk.types.content_types import ContentTypes
-from .service import ContentTypesService
 from superdesk.core.auth.privilege_rules import http_method_privilege_based_rules
+
+from .service import ContentTypesService
 
 
 content_types_resource_config = ResourceConfig(

--- a/superdesk/content_types_async/service.py
+++ b/superdesk/content_types_async/service.py
@@ -65,13 +65,9 @@ HARDCODED_CVS = ("languages",)
 class ContentTypesService(AsyncCacheableService[ContentTypes]):
     resource_name = "content_types"
 
-    async def _set_created_by(self, doc: ContentTypes) -> None:
-        doc.created_by = get_user_id()
-
     async def on_create(self, docs: list[ContentTypes]) -> None:
         for doc in docs:
-            doc.updated_by = get_user_id()
-            await self._set_created_by(doc)
+            doc.created_by = doc.updated_by = get_user_id()
 
     async def on_delete(self, doc: ContentTypes) -> None:
         if doc.is_used:

--- a/superdesk/content_types_async/service.py
+++ b/superdesk/content_types_async/service.py
@@ -8,7 +8,7 @@
 
 
 from copy import deepcopy
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 import bson
 from bson import ObjectId
@@ -28,6 +28,7 @@ from superdesk.types.desks import DesksResourceModel
 from superdesk.utc import utcnow
 from superdesk.utils import format_content_type_name
 from superdesk.vocabularies_async.service import VocabulariesService
+from superdesk.flask import request
 
 
 CONTENT_TYPE_PRIVILEGE = "content_type"
@@ -146,21 +147,22 @@ class ContentTypesService(AsyncCacheableService[ContentTypes]):
             if processed:
                 superdesk.get_resource_service("content_templates").patch(template.get("_id"), {"data": data})
 
-    async def find_one(
+    async def find_by_id_raw(
         self,
-        req: SearchRequest | None = None,
-        projection: ProjectedFieldArg | None = None,
-        use_mongo: bool = False,
+        item_id: str | ObjectId,
         version: int | None = None,
-        **lookup,
-    ) -> ContentTypes | None:
-        is_edit = req and "edit" in lookup
-        doc = await super().find_one(req, **lookup)
-        if doc and is_edit:
+        projection: ProjectedFieldArg | None = None,
+    ) -> dict | None:
+        doc_dict = await super().find_by_id_raw(item_id, version, projection)
+        if not doc_dict:
+            return None
+
+        doc = ContentTypes.from_dict(doc_dict)
+        if request and request.args.get("edit"):
             await prepare_for_edit_content_type(doc)
-        if doc:
+        else:
             await clean_doc(doc)
-        return doc
+        return doc.to_dict()
 
     async def set_used(self, profile_ids: list[str]) -> None:
         query = {"_id": {"$in": list(profile_ids)}, "is_used": {"$ne": True}}
@@ -181,12 +183,12 @@ class ContentTypesService(AsyncCacheableService[ContentTypes]):
             raise ValueError("No profile_id found.")
         profile = await self.find_by_id(profile_id)
         if profile:
-            return profile.schema
+            return profile.content_schema
         return DEFAULT_SCHEMA_MAP.get(profile_id)
 
 
 async def clean_doc(doc: ContentTypes) -> None:
-    schema = doc.schema
+    schema = doc.content_schema
     editor = doc.editor
 
     vocabularies_service = VocabulariesService()
@@ -205,7 +207,7 @@ async def clean_doc(doc: ContentTypes) -> None:
 
 
 def clean_null(doc: ContentTypes) -> None:
-    for field in ("editor", "schema"):
+    for field in ("editor", "content_schema"):
         data = getattr(doc, field)
         to_delete = [key for key, val in data.items() if val is None]
         for key in to_delete:
@@ -216,7 +218,7 @@ async def prepare_for_edit_content_type(doc: ContentTypes) -> None:
     await clean_doc(doc)
     init_default(doc)
     editor = doc.editor
-    schema = doc.schema
+    schema = doc.content_schema
     fields_map, field_names = await get_fields_map_and_names()
     init_custom(editor, schema, fields_map)
     expand_subject(editor, schema, fields_map)
@@ -272,7 +274,7 @@ async def get_fields_map_and_names() -> tuple[dict[str, str], dict[str, str]]:
 
 def init_default(doc: ContentTypes) -> None:
     editor = doc.editor
-    schema = doc.schema
+    schema = doc.content_schema
     if editor and schema:
         for field in DEFAULT_EDITOR:
             # add missing fields in editor with enabled = false
@@ -285,7 +287,7 @@ def init_default(doc: ContentTypes) -> None:
                 schema[field] = deepcopy(DEFAULT_SCHEMA[field])
     else:
         doc.editor = deepcopy(DEFAULT_EDITOR)
-        doc.schema = deepcopy(DEFAULT_SCHEMA)
+        doc.content_schema = deepcopy(DEFAULT_SCHEMA)
 
 
 def init_custom(editor: dict[str, Any], schema: dict[str, Any], fields_map: dict[str, str]) -> None:
@@ -417,7 +419,7 @@ async def prepare_for_save_content_type(original: ContentTypes, updates: dict[st
     original = deepcopy(original)
     await prepare_for_edit_content_type(original)
     concatenate_dictionary(original.editor, editor)
-    concatenate_dictionary(original.schema, schema)
+    concatenate_dictionary(original.content_schema, schema)
     delete_disabled_fields(editor, schema)
     fields_map, _ = await get_fields_map_and_names()
     clean_editor(editor)
@@ -560,8 +562,8 @@ async def apply_schema(item: dict[str, Any]) -> dict[str, Any]:
         profile = await get_profile(item["profile"])
         if profile:
             assert isinstance(profile, ContentTypes)
-            if profile.schema:
-                schema = profile.schema
+            if profile.content_schema:
+                schema = profile.content_schema
 
     return {key: val for key, val in item.items() if is_enabled(key, schema) or key in allowed_keys}
 
@@ -572,10 +574,10 @@ async def remove_profile_from_templates(item: ContentTypes) -> None:
     :param item: deleted content profile
     """
     # TODO-ASYNC: "content_templates" is not async yet
-    templates = list(await superdesk.get_resource_service("content_templates").get_templates_by_profile_id(item.id))
+    templates = list(superdesk.get_resource_service("content_templates").get_templates_by_profile_id(item.id))
     for template in templates:
         template.data.pop("profile", None)
-        await superdesk.get_resource_service("content_templates").patch(template.id, template)
+        superdesk.get_resource_service("content_templates").patch(template.id, template)
 
 
 async def get_profile(_id: str) -> dict[str, Any] | ContentTypes | None:

--- a/superdesk/types/__init__.py
+++ b/superdesk/types/__init__.py
@@ -4,6 +4,7 @@ from .desks import DesksResourceModel
 from .users import UsersResourceModel
 from .vocabularies import VocabulariesResourceModel
 
+from .content_types import ContentTypes
 from .products import ProductsResource, ProductTypes, ProductFilterType
 from .subscribers import SubscribersResource, SubscriberDestination, SubscriberSequenceSettings, SubscriberType
 from .sequences import SequencesResource
@@ -16,6 +17,7 @@ __all__ = [
     "UsersResourceModel",
     "DesksResourceModel",
     "VocabulariesResourceModel",
+    "ContentTypes",
     "ProductsResource",
     "ProductTypes",
     "ProductFilterType",

--- a/superdesk/types/content_types.py
+++ b/superdesk/types/content_types.py
@@ -14,10 +14,9 @@ from typing import Annotated, Any, cast
 from typing_extensions import LiteralString
 
 from pydantic import Field
-from quart_babel import gettext as _
+from quart_babel import gettext
 
 from superdesk.core.resources import ResourceModel, fields
-from superdesk.core.resources.model import ResourceModel
 from superdesk.core.resources.validators import validate_data_relation_async, validate_iunique_value_async
 
 from pydantic_core import PydanticCustomError
@@ -31,8 +30,8 @@ async def _validate_content_type(item: ResourceModel, _) -> None:
     item = cast(ContentTypes, item)
     if not item.content_type or item.content_type.lower() == "text":
         return
-    if await ContentTypes.get_service().count({"type": item.content_type}) > 0:
-        msg: LiteralString = _("Only 1 instance is allowed.")
+    if await ContentTypes.get_service().count({"type": item.content_type, "_id": {"$ne": item.id}}) > 0:
+        msg: LiteralString = gettext("Only 1 instance is allowed.")
         raise PydanticCustomError("unique", msg)
 
 
@@ -50,7 +49,7 @@ class ContentTypes(ResourceModel):
     icon: str | None = None
     description: str | None = None
     # TODO-ASYNC: Field name "schema" in "ContentTypes" shadows an attribute in parent "ResourceModel"
-    schema: dict[str, Any] = Field(default_factory=dict)  # type: ignore[assignment]
+    content_schema: dict[str, Any] = Field(default_factory=dict, alias="schema")
     editor: dict[str, Any] = Field(default_factory=dict)
     widgets_config: list[WidgetConfig] = Field(default_factory=list)
     priority: int = 0

--- a/superdesk/types/content_types.py
+++ b/superdesk/types/content_types.py
@@ -48,7 +48,6 @@ class ContentTypes(ResourceModel):
     label: Annotated[str, validate_iunique_value_async("content_types", "label")]
     icon: str | None = None
     description: str | None = None
-    # TODO-ASYNC: Field name "schema" in "ContentTypes" shadows an attribute in parent "ResourceModel"
     content_schema: dict[str, Any] = Field(default_factory=dict, alias="schema")
     editor: dict[str, Any] = Field(default_factory=dict)
     widgets_config: list[WidgetConfig] = Field(default_factory=list)

--- a/superdesk/types/content_types.py
+++ b/superdesk/types/content_types.py
@@ -16,7 +16,7 @@ from typing_extensions import LiteralString
 from pydantic import Field
 from quart_babel import gettext as _
 
-from superdesk.core.resources import ResourceModel
+from superdesk.core.resources import ResourceModel, fields
 from superdesk.core.resources.model import ResourceModel
 from superdesk.core.resources.validators import validate_data_relation_async, validate_iunique_value_async
 
@@ -45,10 +45,11 @@ class WidgetConfig(ResourceModel):
 
 
 class ContentTypes(ResourceModel):
-    content_type: Annotated[str | None, validate_content_type, Field(alias="type")]
+    content_type: Annotated[str | None, validate_content_type, Field(alias="type")] = None
     label: Annotated[str, validate_iunique_value_async("content_types", "label")]
     icon: str | None = None
-    description: str
+    description: str | None = None
+    # TODO-ASYNC: Field name "schema" in "ContentTypes" shadows an attribute in parent "ResourceModel"
     schema: dict[str, Any] = Field(default_factory=dict)  # type: ignore[assignment]
     editor: dict[str, Any] = Field(default_factory=dict)
     widgets_config: list[WidgetConfig] = Field(default_factory=list)
@@ -56,7 +57,7 @@ class ContentTypes(ResourceModel):
     enabled: bool = False
     is_used: bool = False
     embeddable: bool = False
-    created_by: Annotated[str | None, validate_data_relation_async("users")] = None
-    updated_by: Annotated[str | None, validate_data_relation_async("users")] = None
+    created_by: Annotated[fields.ObjectId | None, validate_data_relation_async("users")] = None
+    updated_by: Annotated[fields.ObjectId | None, validate_data_relation_async("users")] = None
     init_version: int | None = None
     output_name: str | None = None

--- a/superdesk/types/desks.py
+++ b/superdesk/types/desks.py
@@ -16,18 +16,18 @@ class MonitoringSetting:
 
 class DesksResourceModel(ResourceModel):
     name: Annotated[fields.Keyword, validate_unique_value_async("desks", "name")]
-    description: str
+    description: str | None = None
     members: list[dict[str, Annotated[ObjectId, validate_data_relation_async("users")]]] = Field(default_factory=list)
     incoming_stage: Annotated[ObjectId, validate_data_relation_async("stages")] | None = None
     working_stage: Annotated[ObjectId, validate_data_relation_async("stages")] | None = None
-    content_expiry: int
-    source: str
+    content_expiry: int | None = None
+    source: str | None = None
     send_to_desk_not_allowed: bool = Field(default=False)
     monitoring_settings: list[MonitoringSetting] = Field(default_factory=list)
     desk_type: DeskTypeEnum = Field(default=DeskTypeEnum.AUTHORING)
     desk_metadata: dict[str, Any] = Field(default_factory=dict)
     content_profiles: dict[str, Any] = Field(default_factory=dict)
-    desk_language: str
+    desk_language: str | None = None
     monitoring_default_view: MonitoringViewEnum | None = None
     default_content_profile: Annotated[ObjectId, validate_data_relation_async("content_types")] | None = None
     default_content_template: Annotated[ObjectId, validate_data_relation_async("content_templates")] | None = None


### PR DESCRIPTION
### Purpose
Managing ContentTypes (aka ContentProfiles) through the front-end was not possible. The front-end code does not like when editor/schema keys have a `null` value, so we fix it up in the service.

### What has changed
* Connect `ContentType.data.on_created` signal to a function to create a Content Template
* Rename `schema` field on `ContentTypes` to an alias `content_schema` (due to clashes in Pydantic schema method)
* Make `description`, `content_expiry`, `source` and `language` optional fields in DeskResourceModel
* Make `description` optional in ContentType
* Use `ObjectId` for `created_by` and `updated_by` fields on ContentType
* Fix `ContentType.type` validation to exclude current item being checked