### PR TITLE
[SDESK-7531] Add projection to es search

### DIFF
--- a/apps/desks_async/desks_async_service.py
+++ b/apps/desks_async/desks_async_service.py
@@ -66,7 +66,7 @@ class DesksAsyncService(AsyncResourceService[DesksResourceModel]):
         users_service = UsersResourceModel.get_service()
         for doc in docs:
             push_notification(self.notification_key, created=1, desk_id=str(doc.id))
-            await users_service.update_stage_visibility_for_users()
+            await users_service.update_stage_visibility_for_users()  # type: ignore[attr-defined]
 
     async def on_update(self, updates: dict[str, Any], original: DesksResourceModel) -> None:
         if updates.get("content_expiry") == 0:
@@ -169,14 +169,14 @@ class DesksAsyncService(AsyncResourceService[DesksResourceModel]):
                     desk=desk.name,
                 )
                 push_notification("activity", _dest=activity["recipients"])
-                await users_service.update_stage_visibility_for_user(user)
+                await users_service.update_stage_visibility_for_user(user)  # type: ignore[attr-defined]
 
             for removed_user in removed:
                 user = await users_service.find_by_id(removed_user)
                 if user is None:
                     logger.warning(f"Failed sending notification to user '{added_user}: user not found")
                     continue
-                await users_service.update_stage_visibility_for_user(user)
+                await users_service.update_stage_visibility_for_user(user)  # type: ignore[attr-defined]
 
         else:
             push_notification(self.notification_key, updated=1, desk_id=str(desk_id))

--- a/apps/desks_async/desks_async_service.py
+++ b/apps/desks_async/desks_async_service.py
@@ -9,10 +9,8 @@ from superdesk.core.resources import AsyncResourceService
 from superdesk.errors import SuperdeskApiError
 from superdesk.notification import push_notification
 from superdesk.resource_fields import ID_FIELD
-from superdesk.types import DesksResourceModel
+from superdesk.types import DesksResourceModel, UsersResourceModel
 from superdesk.types.enums import DeskTypeEnum
-
-from superdesk.users import UsersAsyncService
 
 
 logger = logging.getLogger(__name__)
@@ -65,7 +63,7 @@ class DesksAsyncService(AsyncResourceService[DesksResourceModel]):
         return docs
 
     async def on_created(self, docs: list[DesksResourceModel]) -> None:
-        users_service = UsersAsyncService()
+        users_service = UsersResourceModel.get_service()
         for doc in docs:
             push_notification(self.notification_key, created=1, desk_id=str(doc.id))
             await users_service.update_stage_visibility_for_users()
@@ -102,7 +100,7 @@ class DesksAsyncService(AsyncResourceService[DesksResourceModel]):
             3. The desk is associated with routing rule(s)
         """
 
-        if await UsersAsyncService().count({"desk": doc.id}):
+        if await UsersResourceModel.get_service().count({"desk": doc.id}):
             raise SuperdeskApiError.preconditionFailedError(
                 message=_("Cannot delete desk as it is assigned as default desk to user(s).")
             )
@@ -147,7 +145,7 @@ class DesksAsyncService(AsyncResourceService[DesksResourceModel]):
 
     async def __send_notification(self, updates: dict[str, Any], desk: DesksResourceModel):
         desk_id = desk.id
-        users_service = UsersAsyncService()
+        users_service = UsersResourceModel.get_service()
 
         if "members" in updates:
             added, removed = self.__compare_members(desk.members, updates["members"])

--- a/apps/preferences.py
+++ b/apps/preferences.py
@@ -277,11 +277,11 @@ class PreferencesService(AsyncBaseService):
         service.system_update(user_id, {_session_preferences_key: session_prefs}, user_doc)
 
     def set_user_initial_prefs(self, user_doc):
-        if _user_preferences_key not in user_doc:
-            orig_user_prefs = user_doc.get(_preferences_key, {})
+        if not hasattr(user_doc, _user_preferences_key):
+            orig_user_prefs = getattr(user_doc, _preferences_key, {})
             available = available_user_preferences()
             available.update(orig_user_prefs)
-            user_doc[_user_preferences_key] = available
+            setattr(user_doc, _user_preferences_key, available)
 
     async def find_one_async(self, req, **lookup):
         # TODO-ASYNC[auth]: Use async ``sessions`` when available

--- a/superdesk/core/elastic/async_client.py
+++ b/superdesk/core/elastic/async_client.py
@@ -104,15 +104,21 @@ class ElasticResourceAsyncClient(BaseElasticResourceClient):
 
         return (await self.count()) == 0
 
-    async def search(self, query: Dict[str, Any], indexes: Optional[List[str]] = None) -> Any:
+    async def search(
+        self,
+        query: Dict[str, Any],
+        indexes: Optional[List[str]] = None,
+        projection: ProjectedFieldSources | ProjectedFieldArg | None = None,
+    ) -> Any:
         """Perform a raw search against the Elasticsearch index
 
         :param query: The search query to filter items by.
         :param indexes: An optional list of indexes to search in.
+        :param projection: The field projections to be applied
         :return: The response from Elasticsearch.
         """
 
-        return await self.elastic.search(**self._get_search_args(query, indexes))
+        return await self.elastic.search(**self._get_search_args(query, indexes, projection))
 
     async def find_by_id(
         self, item_id: str, projection: ProjectedFieldSources | ProjectedFieldArg | None = None
@@ -125,17 +131,9 @@ class ElasticResourceAsyncClient(BaseElasticResourceClient):
         """
 
         try:
-            # Check if ``_source`` or ``_source_excludes`` keys are in the projection param
-            # These are specific to the ``ProjectedFieldSources`` type and Elasticsearch itself
-            # So if these keys aren't there, then have received an instance of ``ProjectedFieldArg`` type
-            # and need to convert it to a ``ProjectedFieldSources`` instance.
-            if (
-                projection
-                and isinstance(projection, dict)
-                and not set(projection.keys()).intersection({"_source", "_source_excludes"})
-            ):
-                projection = self._get_projected_fields(SearchRequest(projection=cast(ProjectedFieldArg, projection)))
-            response = await self.elastic.get(index=self.config.index, id=item_id, **(projection or {}))
+            response = await self.elastic.get(
+                index=self.config.index, id=item_id, **(self._get_projected_fields_from_param(projection) or {})
+            )
 
             if "exists" in response:
                 response["found"] = response["exists"]
@@ -155,6 +153,7 @@ class ElasticResourceAsyncClient(BaseElasticResourceClient):
                         index=self.config.index,
                         body={"query": {"bool": {"must": [{"term": {"_id": item_id}}]}}},
                         size=1,
+                        **(self._get_projected_fields_from_param(projection) or {}),
                     )
                     docs = self._parse_hits(response)
                     return docs.first()
@@ -180,7 +179,9 @@ class ElasticResourceAsyncClient(BaseElasticResourceClient):
         search_request = req if isinstance(req, SearchRequest) else SearchRequest(where=req)
 
         if isinstance(search_request.where, dict) and set(search_request.where.keys()) == {"_id"}:
-            return await self.find_by_id(search_request.where["_id"], self._get_projected_fields(search_request) or {})
+            return await self.find_by_id(
+                search_request.where["_id"], self._get_projected_fields_from_request(search_request) or {}
+            )
 
         try:
             response = await self.elastic.search(**self._get_find_one_args(search_request))

--- a/superdesk/core/elastic/base_client.py
+++ b/superdesk/core/elastic/base_client.py
@@ -8,14 +8,14 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from typing import Dict, Any, Optional, Iterator, List, Tuple, Union, TypedDict
+from typing import Dict, Any, Optional, Iterator, List, Tuple, Union, TypedDict, cast
 import ast
 
 import simplejson as json
 from eve.io.mongo.parser import parse
 
 from superdesk.errors import SuperdeskApiError
-from superdesk.core.types import SearchRequest, SortParam, ElasticResourceConfig, ElasticClientConfig
+from superdesk.core.types import SearchRequest, SortParam, ElasticResourceConfig, ElasticClientConfig, ProjectedFieldArg
 from superdesk.core.resources import get_projection_from_request
 
 
@@ -138,11 +138,17 @@ class BaseElasticResourceClient:
     def _get_count_args(self, query: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         return dict(index=self.config.index, body=query or {"query": {"match_all": {}}})
 
-    def _get_search_args(self, query: Dict[str, Any], indexes: Optional[List[str]] = None) -> Dict[str, Any]:
+    def _get_search_args(
+        self,
+        query: Dict[str, Any],
+        indexes: Optional[List[str]] = None,
+        projection: ProjectedFieldSources | ProjectedFieldArg | None = None,
+    ) -> Dict[str, Any]:
         return dict(
             index=indexes if indexes is not None else self.config.index,
             body=query,
             track_total_hits=self.config.track_total_hits,
+            **(self._get_projected_fields_from_param(projection) or {}),
         )
 
     def _get_find_args(
@@ -235,7 +241,7 @@ class BaseElasticResourceClient:
         return dict(
             index=self.config.index,
             track_total_hits=self.config.track_total_hits,
-            **(self._get_projected_fields(req) or {}),
+            **(self._get_projected_fields_from_request(req) or {}),
             body=query,
         )
 
@@ -249,11 +255,29 @@ class BaseElasticResourceClient:
         return dict(
             index=self.config.index,
             track_total_hits=self.config.track_total_hits,
-            **(self._get_projected_fields(req) or {}),
+            **(self._get_projected_fields_from_request(req) or {}),
             body=query,
         )
 
-    def _get_projected_fields(self, req: SearchRequest) -> ProjectedFieldSources | None:
+    def _get_projected_fields_from_param(
+        self, projection: ProjectedFieldSources | ProjectedFieldArg | None = None
+    ) -> ProjectedFieldSources | None:
+        # Check if ``_source`` or ``_source_excludes`` keys are in the projection param
+        # These are specific to the ``ProjectedFieldSources`` type and Elasticsearch itself
+        # So if these keys aren't there, then have received an instance of ``ProjectedFieldArg`` type
+        # and need to convert it to a ``ProjectedFieldSources`` instance.
+        if (
+            projection
+            and isinstance(projection, dict)
+            and not set(projection.keys()).intersection({"_source", "_source_excludes"})
+        ):
+            return self._get_projected_fields_from_request(
+                SearchRequest(projection=cast(ProjectedFieldArg, projection))
+            )
+
+        return None
+
+    def _get_projected_fields_from_request(self, req: SearchRequest) -> ProjectedFieldSources | None:
         projection_include, projection_fields = get_projection_from_request(req)
 
         if not projection_fields:

--- a/superdesk/core/elastic/sync_client.py
+++ b/superdesk/core/elastic/sync_client.py
@@ -100,15 +100,21 @@ class ElasticResourceClient(BaseElasticResourceClient):
 
         return self.count() == 0
 
-    def search(self, query: Dict[str, Any], indexes: Optional[List[str]] = None) -> Any:
+    async def search(
+        self,
+        query: Dict[str, Any],
+        indexes: Optional[List[str]] = None,
+        projection: ProjectedFieldSources | ProjectedFieldArg | None = None,
+    ) -> Any:
         """Perform a raw search against the Elasticsearch index
 
         :param query: The search query to filter items by
         :param indexes: An optional list of indexes to search in
+        :param projection: The field projections to be applied
         :return: The response from Elasticsearch
         """
 
-        return self.elastic.search(**self._get_search_args(query, indexes))
+        return self.elastic.search(**self._get_search_args(query, indexes, projection))
 
     def find_by_id(
         self, item_id: str, projection: ProjectedFieldSources | ProjectedFieldArg | None = None

--- a/superdesk/core/elastic/sync_client.py
+++ b/superdesk/core/elastic/sync_client.py
@@ -121,17 +121,9 @@ class ElasticResourceClient(BaseElasticResourceClient):
         """
 
         try:
-            # Check if ``_source`` or ``_source_excludes`` keys are in the projection param
-            # These are specific to the ``ProjectedFieldSources`` type and Elasticsearch itself
-            # So if these keys aren't there, then have received an instance of ``ProjectedFieldArg`` type
-            # and need to convert it to a ``ProjectedFieldSources`` instance.
-            if (
-                projection
-                and isinstance(projection, dict)
-                and not set(projection.keys()).intersection({"_source", "_source_excludes"})
-            ):
-                projection = self._get_projected_fields(SearchRequest(projection=cast(ProjectedFieldArg, projection)))
-            response = self.elastic.get(index=self.config.index, id=item_id, **(projection or {}))
+            response = self.elastic.get(
+                index=self.config.index, id=item_id, **(self._get_projected_fields_from_param(projection) or {})
+            )
 
             if "exists" in response:
                 response["found"] = response["exists"]
@@ -150,6 +142,7 @@ class ElasticResourceClient(BaseElasticResourceClient):
                         index=self.config.index,
                         body={"query": {"bool": {"must": [{"term": {"_id": item_id}}]}}},
                         size=1,
+                        **(self._get_projected_fields_from_param(projection) or {}),
                     )
                     docs = self._parse_hits(response)
                     return docs.first()
@@ -175,7 +168,9 @@ class ElasticResourceClient(BaseElasticResourceClient):
         search_request = req if isinstance(req, SearchRequest) else SearchRequest(where=req)
 
         if isinstance(search_request.where, dict) and set(search_request.where.keys()) == {"_id"}:
-            return self.find_by_id(search_request.where["_id"], self._get_projected_fields(search_request) or {})
+            return self.find_by_id(
+                search_request.where["_id"], self._get_projected_fields_from_request(search_request) or {}
+            )
 
         try:
             response = self.elastic.search(**self._get_find_one_args(search_request))

--- a/superdesk/types/users.py
+++ b/superdesk/types/users.py
@@ -15,19 +15,19 @@ from datetime import datetime
 from typing import Annotated, Any
 
 from pydantic import Field
-from superdesk.core.resources import ResourceModel, fields
+from superdesk.core.resources import ResourceModelWithObjectId, fields
 from superdesk.core.resources.fields import ObjectId
 from superdesk.core.resources.validators import validate_unique_value_async, validate_data_relation_async
 from superdesk.types.enums import UserTypeEnum
 
 
-class UsersResourceModel(ResourceModel):
+class UsersResourceModel(ResourceModelWithObjectId):
     username: Annotated[fields.Keyword, validate_unique_value_async("users", "username")]
-    password: str = Field(min_length=5)
+    password: Annotated[str | None, Field(min_length=5)] = None
     password_changed_on: datetime | None = None
-    first_name: str
-    last_name: str
-    display_name: str
+    first_name: str | None = None
+    last_name: str | None = None
+    display_name: str | None = None
     email: Annotated[fields.Keyword, validate_unique_value_async("users", "email")]
     phone: str | None = None
     job_title: str | None = None
@@ -41,8 +41,9 @@ class UsersResourceModel(ResourceModel):
     picture_url: str | None = None
     avatar: Annotated[ObjectId, validate_data_relation_async("upload")] | None = None
     avatar_renditions: dict[str, Any] | None = Field(default=None)
-    role: Annotated[ObjectId, validate_data_relation_async("roles")]
+    role: Annotated[ObjectId | None, validate_data_relation_async("roles")] = None
     privileges: dict[str, Any] = Field(default_factory=dict)
+    active_privileges: dict[str, Any] = Field(default_factory=dict)
     workspace: dict[str, Any] = Field(default_factory=dict)
     user_type: UserTypeEnum = Field(default=UserTypeEnum.USER)
     is_support: bool = Field(default=False)
@@ -70,6 +71,7 @@ class UsersResourceModel(ResourceModel):
     session_preferences: dict[str, Any] = Field(default_factory=dict)
     user_preferences: dict[str, Any] = Field(default_factory=dict)
     last_activity_at: datetime | None = None
+    dateline_source: str | None = None
 
     @classmethod
     async def get_by_user_type(cls, user_type: UserTypeEnum = UserTypeEnum.USER) -> list["UsersResourceModel"]:

--- a/superdesk/users/async_service.py
+++ b/superdesk/users/async_service.py
@@ -34,7 +34,9 @@ from .services import get_invisible_stages_async
 logger = logging.getLogger(__name__)
 
 
-def get_display_name(user):
+def get_display_name(user: dict | UsersResourceModel):
+    if isinstance(user, UsersResourceModel):
+        user = user.to_dict()
     if user.get("first_name") or user.get("last_name"):
         display_name = "%s %s" % (user.get("first_name", ""), user.get("last_name", ""))
         return display_name.strip()
@@ -95,21 +97,30 @@ def is_sensitive_update(updates):
     return "role" in updates or "privileges" in updates or "user_type" in updates
 
 
-def set_sign_off(user):
+def set_sign_off(user: dict | UsersResourceModel):
     """
     Set sign_off property on user if it's not set already.
     """
 
-    if SIGN_OFF not in user or user[SIGN_OFF] is None:
+    current_sign_off = getattr(user, SIGN_OFF, None)
+    if current_sign_off is None:
         sign_off_mapping = get_app_config("SIGN_OFF_MAPPING", None)
-        if sign_off_mapping and sign_off_mapping in user:
-            user[SIGN_OFF] = user[sign_off_mapping]
-        elif SIGN_OFF in user and user[SIGN_OFF] is None:
-            user[SIGN_OFF] = ""
-        elif "first_name" not in user or "last_name" not in user:
-            user[SIGN_OFF] = user["username"][:3].upper()
+        if sign_off_mapping and hasattr(user, sign_off_mapping):
+            setattr(user, SIGN_OFF, getattr(user, sign_off_mapping))
+        elif hasattr(user, SIGN_OFF):
+            setattr(user, SIGN_OFF, "")
+        elif not hasattr(user, "first_name") or not hasattr(user, "last_name"):
+            setattr(user, SIGN_OFF, getattr(user, "username", "")[:3].upper())
         else:
-            user[SIGN_OFF] = "{first_name[0]}{last_name[0]}".format(**user)
+            first_name = getattr(user, "first_name", "")
+            sign_off_value = ""
+            if first_name:
+                sign_off_value = first_name[0]
+
+            last_name = getattr(user, "last_name", "")
+            if last_name:
+                sign_off_value += last_name[0]
+            setattr(user, SIGN_OFF, sign_off_value)
 
 
 def update_sign_off(updates):
@@ -127,10 +138,10 @@ def get_sign_off(user):
     Gets sign_off property on user if it's not set already.
     """
 
-    if SIGN_OFF not in user or user[SIGN_OFF] is None:
+    if not getattr(user, SIGN_OFF, None):
         set_sign_off(user)
 
-    return user[SIGN_OFF]
+    return getattr(user, SIGN_OFF, None)
 
 
 class UsersAsyncService(AsyncResourceService[UsersResourceModel]):
@@ -212,28 +223,30 @@ class UsersAsyncService(AsyncResourceService[UsersResourceModel]):
                 await send_user_type_changed_email([user.to_dict().get("email")])
 
     async def on_create(self, docs: list[UsersResourceModel]) -> None:
-        for user_doc in docs:
-            user_dict = user_doc.to_dict()
-            user_dict.setdefault("password_changed_on", utcnow())
-            user_dict.setdefault("display_name", get_display_name(user_doc))
-            user_dict.setdefault(SIGN_OFF, set_sign_off(user_doc))
-            user_dict.setdefault("role", await get_resource_service("roles").get_default_role_id_async())
-            if user_dict.get("avatar"):
-                user_dict.setdefault("avatar_renditions", self.get_avatar_renditions(user_dict.get("avatar")))
+        for doc in docs:
+            if not doc.password_changed_on:
+                doc.password_changed_on = utcnow()
+            if not doc.display_name:
+                doc.display_name = get_display_name(doc)
+            if not doc.sign_off:
+                set_sign_off(doc)
+            if not doc.role:
+                doc.role = await get_resource_service("roles").get_default_role_id_async()
+            if doc.avatar:
+                doc.avatar_renditions = self.get_avatar_renditions(doc.avatar)
 
-            get_resource_service("preferences").set_user_initial_prefs(user_doc)
-            user_doc = UsersResourceModel(**user_dict)
+            get_resource_service("preferences").set_user_initial_prefs(doc)
 
     async def on_created(self, docs: list[UsersResourceModel]) -> None:
-        for user_doc in docs:
-            await self.__update_user_defaults(user_doc)
+        for doc in docs:
+            await self.__update_user_defaults(doc)
             add_activity(
                 ACTIVITY_CREATE,
                 "created user {{user}}",
                 self.resource_name,
-                user=user_doc.to_dict().get("display_name", user_doc.to_dict().get("username")),
+                user=doc.display_name or doc.username or doc.email,
             )
-            await self.update_stage_visibility_for_user(user_doc)
+            await self.update_stage_visibility_for_user(doc)
 
     async def on_update(self, updates: dict[str, Any], original: UsersResourceModel) -> None:
         """Overriding the method to:
@@ -318,22 +331,14 @@ class UsersAsyncService(AsyncResourceService[UsersResourceModel]):
         await self.__clear_locked_items(str(doc.to_dict().get("_id")))
         await self.__handle_status_changed(updates={"is_enabled": False, "is_active": False}, user=doc)
 
-    async def on_fetched(self, document):
-        for doc in document["_items"]:
-            await self.__update_user_defaults(doc)
-
-    async def on_fetched_item(self, doc: UsersResourceModel):
-        await self.__update_user_defaults(doc)
-
     async def __update_user_defaults(self, doc: UsersResourceModel):
         """Set default fields for users"""
-        user_dict = doc.to_dict()
-        user_dict.pop("password", None)
-        user_dict.setdefault("display_name", get_display_name(doc))
-        user_dict.setdefault("is_enabled", user_dict.get("is_active"))
-        user_dict.setdefault(SIGN_OFF, set_sign_off(doc))
-        user_dict["dateline_source"] = get_app_config("ORGANIZATION_NAME_ABBREVIATION")
-        doc = UsersResourceModel(**user_dict)
+        doc.password = None
+        doc.display_name = get_display_name(doc)
+        doc.is_enabled = doc.is_active
+        if not doc.sign_off:
+            set_sign_off(doc)
+        doc.dateline_source = get_app_config("ORGANIZATION_NAME_ABBREVIATION")
 
     async def user_is_waiting_activation(self, doc: UsersResourceModel):
         return doc.to_dict().get("needs_activation", False)
@@ -349,9 +354,7 @@ class UsersAsyncService(AsyncResourceService[UsersResourceModel]):
         return None
 
     async def set_privileges(self, user: UsersResourceModel, role):
-        user_dict = user.to_dict()
-        user_dict["active_privileges"] = get_privileges(user, role)
-        user = UsersResourceModel(**user_dict)
+        user.active_privileges = get_privileges(user, role)
 
     async def get_invisible_stages_async(self, user_id) -> list:
         return await get_invisible_stages_async(user_id) if user_id else []
@@ -389,7 +392,7 @@ class UsersAsyncService(AsyncResourceService[UsersResourceModel]):
     async def update_stage_visibility_for_user(self, user: UsersResourceModel):
         if not self._updating_stage_visibility:
             return
-        user_id = user.to_dict().get("_id", "")
+        user_id = user.id
         try:
             logger.info("Updating Stage Visibility for user {}.".format(user_id))
             stages = await self.get_invisible_stages_ids(user_id)
@@ -416,12 +419,8 @@ class DBUsersAsyncService(UsersAsyncService):
     async def on_create(self, docs: list[UsersResourceModel]) -> None:
         await super().on_create(docs)
         for doc in docs:
-            user_dict = doc.to_dict()
-            if user_dict.get("password", None) and not is_hashed(user_dict.get("password")):
-                user_dict["password"] = get_hash(
-                    user_dict.get("password"), get_app_config("BCRYPT_GENSALT_WORK_FACTOR", 12)
-                )
-                doc = UsersResourceModel(**user_dict)
+            if doc.password and not is_hashed(doc.password):
+                doc.password = get_hash(doc.password, get_app_config("BCRYPT_GENSALT_WORK_FACTOR", 12))
 
     async def on_created(self, docs: list[UsersResourceModel]) -> None:
         """Send email to user with reset password token."""

--- a/superdesk/users/module.py
+++ b/superdesk/users/module.py
@@ -4,13 +4,13 @@ from superdesk.core.resources import (
     MongoResourceConfig,
 )
 from superdesk.types import UsersResourceModel
-from .async_service import UsersAsyncService
+from .async_service import UsersAsyncService, DBUsersAsyncService
 
 
 users_resource_config = ResourceConfig(
     name="users",
     data_class=UsersResourceModel,
-    service=UsersAsyncService,
+    service=DBUsersAsyncService,
     mongo=MongoResourceConfig(
         indexes=[
             MongoIndexOptions(

--- a/tests/core/resource_privileged_endpoints_test.py
+++ b/tests/core/resource_privileged_endpoints_test.py
@@ -38,13 +38,13 @@ class PrivilegedResourceEndpointsTestCase(AsyncFlaskTestCase):
 
     async def test_unauthorized_user_cannot_access_privileged_endpoint(self):
         regular_user = deepcopy(test_user)
-        regular_user["user_type"] = "unauthorized"
+        regular_user["user_type"] = "user"
 
         headers = [await self._get_auth_header(regular_user)]
         response = await self.test_client.get("/api/privileged_resource", headers=headers)
 
         response_data = await response.get_json()
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 403, response_data)
         self.assertTrue("Insufficient privileges" in response_data["_message"])
 
     async def test_user_with_role_can_access_privileged_endpoint(self):
@@ -55,7 +55,7 @@ class PrivilegedResourceEndpointsTestCase(AsyncFlaskTestCase):
         self.app.data.insert("roles", roles)
 
         regular_user = deepcopy(test_user)
-        regular_user["user_type"] = "test_type"
+        regular_user["user_type"] = "user"
         regular_user["role"] = roles[0]["_id"]
 
         headers = [await self._get_auth_header(regular_user)]
@@ -71,7 +71,7 @@ class PrivilegedResourceEndpointsTestCase(AsyncFlaskTestCase):
         self.app.data.insert("roles", [can_create_only_role])
 
         regular_user = deepcopy(test_user)
-        regular_user["user_type"] = "test_type"
+        regular_user["user_type"] = "user"
         regular_user["role"] = can_create_only_role["_id"]
 
         # user should not be able to "GET" as the role only has "POST" privilege


### PR DESCRIPTION
### Purpose
Our async elastic client did not support a projection argument, which is required by https://github.com/superdesk/superdesk-planning/pull/2237 to allow searching multiple indexes with optional projection applied.

## What has changed
* Add support for a `projection` param to the elastic.search method
* Clean up some usage of generating the elastic projection from supplied params
* Fix user async resource and service after latest changes