### PR TITLE
[SDESK-7535] Upgrade search eve resource to async service

### DIFF
--- a/apps/archive_broadcast/broadcast.py
+++ b/apps/archive_broadcast/broadcast.py
@@ -152,6 +152,7 @@ class ArchiveBroadcastService(BaseService):
             repos = "archive,published,archived"
 
         req.args = {"source": json.dumps(query), "repo": repos}
+        # TODO-ASYNC[search]: Use `get_async` when upgrading this module
         return get_resource_service("search").get(req=req, lookup=None)
 
     def get_broadcast_items_from_master_story(self, item, include_archived_repo=False):

--- a/apps/desks.py
+++ b/apps/desks.py
@@ -331,12 +331,9 @@ class DesksService(AsyncBaseService):
         # find display_name from the users document for each member in desks document
         for desk in res["_items"]:
             if "members" in desk:
-                users = tuple(
-                    user
-                    async for user in db_users.find(
-                        {"_id": {"$in": [member["user"] for member in desk.get("members", [])]}}, {"display_name": 1}
-                    )
-                )
+                users = await db_users.find(
+                    {"_id": {"$in": [member["user"] for member in desk.get("members", [])]}}, {"display_name": 1}
+                ).to_list()
                 members_set |= {(m["_id"], m["display_name"]) for m in users}
 
         if members_set:

--- a/apps/highlights/service.py
+++ b/apps/highlights/service.py
@@ -52,6 +52,7 @@ def get_highlighted_items(highlights_id):
     }
     request = ParsedRequest()
     request.args = {"source": json.dumps(query), "repo": "archive,published"}
+    # TODO-ASYNC[search]: Use `get_async` when upgrading this module
     return list(get_resource_service("search").get(req=request, lookup=None))
 
 

--- a/apps/marked_desks/service.py
+++ b/apps/marked_desks/service.py
@@ -21,6 +21,7 @@ from superdesk.utc import utcnow
 from apps.archive.common import ITEM_MARK, ITEM_UNMARK
 
 
+# TODO-ASYNC[search]: Is this used anywhere?
 def get_marked_items(desk_id):
     """Get items marked for given desk"""
     query = {
@@ -30,6 +31,7 @@ def get_marked_items(desk_id):
     }
     request = ParsedRequest()
     request.args = {"source": json.dumps(query), "repo": "archive,published"}
+    # TODO-ASYNC[search]: Use `get_async` when upgrading this module
     return list(get_resource_service("search").get(req=request, lookup=None))
 
 

--- a/apps/publish/published_item.py
+++ b/apps/publish/published_item.py
@@ -325,6 +325,7 @@ class PublishedItemService(BaseService, HighlightsSearchMixin):
 
             request = ParsedRequest()
             request.args = {"source": json.dumps(query), "repo": "archive,published"}
+            # TODO-ASYNC[search]: Use `get_async` when upgrading this module
             return list(get_resource_service("search").get(req=request, lookup=None))
         except Exception:
             return []

--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -244,7 +244,7 @@ class SearchService(AsyncBaseService):
         indexes = [async_app.elastic.get_elastic_index_name(resource) for resource in types]
 
         elastic = ArchiveResourceModel.get_service().elastic
-        hits = await elastic.search(fix_query(query), indexes)
+        hits = await elastic.search(fix_query(query), indexes, projection)
         cursor = self.elastic._parse_hits(hits, types[0])
 
         for resource in types:

--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -13,8 +13,10 @@ import superdesk
 from copy import deepcopy
 from eve_elastic.elastic import set_filters
 
-from superdesk.core import json, get_current_app, get_app_config
+from superdesk.core import json, get_current_app, get_app_config, get_current_async_app
 from superdesk.resource_fields import ITEMS
+from superdesk.types import ArchiveResourceModel
+from superdesk.eve_async.service import AsyncBaseService
 from superdesk import get_resource_service
 from superdesk.metadata.item import CONTENT_STATE, ITEM_STATE, get_schema
 from superdesk.metadata.utils import aggregations as common_aggregations, item_url, _set_highlight_query
@@ -24,7 +26,7 @@ from apps.publish.published_item import published_item_fields
 from superdesk import es_utils
 
 
-class SearchService(superdesk.Service):
+class SearchService(AsyncBaseService):
     """Federated search service.
 
     It can search against different collections like Ingest, Production, Archived etc.. at the same time.
@@ -161,6 +163,31 @@ class SearchService(superdesk.Service):
 
         return stages
 
+    async def get_stages_to_exclude_async(self):
+        """
+        Returns the list of the current users invisible stages
+        """
+        user = get_current_app().get_current_user_dict() or {}
+        if "invisible_stages" in user:
+            stages = user.get("invisible_stages")
+        else:
+            stages = await get_resource_service("users").get_invisible_stages_ids_async(user.get("_id"))
+
+        return stages
+
+    def _get_es_index(self, resource_name: str) -> str:
+        return get_current_app().data.elastic._resource_index(resource_name)
+
+    def _get_projection(self, req) -> list[str]:
+        fields = self._get_projected_fields(req)
+        projection = (fields or "").split(",")
+
+        if projection and "type" not in projection:
+            # Make sure `type` is always included in the projection
+            projection.append("type")
+
+        return projection
+
     def get(self, req, lookup):
         """
         Runs elastic search on multiple doc types.
@@ -193,6 +220,40 @@ class SearchService(superdesk.Service):
 
         return docs
 
+    async def get_async(self, req, lookup):
+        """
+        Runs elastic search on multiple doc types.
+        """
+
+        query = self._get_query(req)
+        projection = self._get_projection(req)
+        types = self._get_types(req)
+        excluded_stages = await self.get_stages_to_exclude_async()
+        filters = self._get_filters(types, excluded_stages)
+
+        # if the system has a setting value for the maximum search depth then apply the filter
+        if not get_app_config("MAX_SEARCH_DEPTH") == -1:
+            query["terminate_after"] = get_app_config("MAX_SEARCH_DEPTH")
+
+        if filters:
+            set_filters(query, filters)
+
+        async_app = get_current_async_app()
+        indexes = [async_app.elastic.get_elastic_index_name(resource) for resource in types]
+
+        elastic = ArchiveResourceModel.get_service().elastic
+        docs = await elastic.search(query, indexes, projection)
+
+        for resource in types:
+            response = {ITEMS: [doc for doc in docs if doc["_type"] == resource]}
+            app = get_current_app().as_any()
+            await getattr(app, "on_fetched_resource_async")(resource, response)
+            getattr(app, "on_fetched_resource")(resource, response)
+            await getattr(app, "on_fetched_resource_%s_async" % resource)(response)
+            getattr(app, "on_fetched_resource_%s" % resource)(response)
+
+        return docs
+
     def _get_docs(self, hits):
         """Parse hits from elastic and return only docs.
 
@@ -202,17 +263,21 @@ class SearchService(superdesk.Service):
         """
         return self.elastic._parse_hits(hits, "ingest")  # any resource with item schema will do
 
-    def find_one(self, req, **lookup):
+    async def find_one_async(self, req, **lookup):
         """Find item by id in all collections."""
         _id = lookup["_id"]
         for resource in self._get_types(req):
             id_field = "item_id" if resource == "published" else "_id"
             resource_lookup = {id_field: _id}
-            item = get_resource_service(resource).find_one(req=req, **resource_lookup)
+            service = get_resource_service(resource)
+            if hasattr(service, "find_one_async"):
+                item = await service.find_one_async(req=req, **resource_lookup)
+            else:
+                item = service.find_one(req=req, **resource_lookup)
             if item:
                 return item
 
-    def on_fetched(self, doc):
+    async def on_fetched_async(self, doc):
         """
         Overriding to add HATEOS for each individual item in the response.
 

--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -11,9 +11,10 @@
 import superdesk
 
 from copy import deepcopy
-from eve_elastic.elastic import set_filters
+from eve_elastic.elastic import set_filters, fix_query
 
 from superdesk.core import json, get_current_app, get_app_config, get_current_async_app
+from superdesk.core.resources.cursor import ElasticsearchResourceCursorAsync
 from superdesk.resource_fields import ITEMS
 from superdesk.types import ArchiveResourceModel
 from superdesk.eve_async.service import AsyncBaseService
@@ -24,6 +25,7 @@ from apps.archive.archive import SOURCE as ARCHIVE, ArchiveResource, private_con
 from superdesk.resource import build_custom_hateoas
 from apps.publish.published_item import published_item_fields
 from superdesk import es_utils
+from superdesk.utils import ListCursor
 
 
 class SearchService(AsyncBaseService):
@@ -242,17 +244,17 @@ class SearchService(AsyncBaseService):
         indexes = [async_app.elastic.get_elastic_index_name(resource) for resource in types]
 
         elastic = ArchiveResourceModel.get_service().elastic
-        docs = await elastic.search(query, indexes, projection)
+        hits = await elastic.search(fix_query(query), indexes)
+        cursor = self.elastic._parse_hits(hits, types[0])
 
         for resource in types:
-            response = {ITEMS: [doc for doc in docs if doc["_type"] == resource]}
+            response = {ITEMS: [doc for doc in cursor if doc["_type"] == resource]}
             app = get_current_app().as_any()
-            await getattr(app, "on_fetched_resource_async")(resource, response)
             getattr(app, "on_fetched_resource")(resource, response)
-            await getattr(app, "on_fetched_resource_%s_async" % resource)(response)
+            await getattr(app, "on_fetched_resource_%s_async" % resource).call_async(response)
             getattr(app, "on_fetched_resource_%s" % resource)(response)
 
-        return docs
+        return cursor
 
     def _get_docs(self, hits):
         """Parse hits from elastic and return only docs.

--- a/apps/suggestions/service.py
+++ b/apps/suggestions/service.py
@@ -48,6 +48,7 @@ class SuggestionsService(BaseService):
         req = ParsedRequest()
         req.args = {"source": json.dumps(query), "repo": "archive,published,archived"}
 
+        # TODO-ASYNC[search]: Use `get_async` when upgrading this module
         return get_resource_service("search").get(req=req, lookup=None)
 
     def _transform(self, item):

--- a/content_api/items/model.py
+++ b/content_api/items/model.py
@@ -4,7 +4,7 @@ from enum import Enum, unique
 from pydantic import Field, field_validator
 
 from superdesk.core.resources import fields, ModelWithVersions
-from superdesk.types.base import BaseContentItem, CVItemWithCode, ContentType, Place
+from superdesk.types.base import BaseContentItem, CVItemWithCode, ContentType, Place, CVItem
 
 
 @unique

--- a/superdesk/archive_async/module.py
+++ b/superdesk/archive_async/module.py
@@ -8,7 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from superdesk.core.resources import ResourceConfig, MongoResourceConfig, MongoIndexOptions
+from superdesk.core.resources import ResourceConfig, MongoResourceConfig, MongoIndexOptions, ElasticResourceConfig
 from superdesk.core.resources.resource_rest_endpoints import RestEndpointConfig
 from superdesk.types.archive import ArchiveResourceModel
 from .service import AsyncArchiveService
@@ -42,6 +42,7 @@ archive_resource_config = ResourceConfig(
             ),
         ],
     ),
+    elastic=ElasticResourceConfig(),
     # FIXME: To be activated at a later point.
     # rest_endpoints=RestEndpointConfig(
     #     item_methods=["GET", "PATCH", "PUT"],

--- a/superdesk/core/elastic/resources.py
+++ b/superdesk/core/elastic/resources.py
@@ -105,6 +105,13 @@ class ElasticResources:
             source_name, client_config, resource_config
         )
 
+    def get_elastic_index_name(self, resource_name: str) -> str:
+        try:
+            return self._resource_clients[resource_name].config.index
+        except (KeyError, TypeError):
+            # Fallback to trying eve-elastic
+            return self.app.wsgi.data.elastic._resource_index(resource_name)
+
     def get_client(self, resource_name) -> ElasticResourceClient:
         """Get a synchronous ElasticResourceClient for a registered resource
 

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -428,6 +428,7 @@ MODULES = [
     "superdesk.content_types_async",
     "superdesk.publish.subscriber_token",
     "superdesk.publish_async.module",
+    "superdesk.archive_async",
 ]
 
 ASYNC_AUTH_CLASS = "superdesk.core.auth.token_auth:TokenAuthorization"

--- a/superdesk/tests/mocks/search_provider.py
+++ b/superdesk/tests/mocks/search_provider.py
@@ -13,6 +13,7 @@ class TestSearchProvider(SearchProvider):
     def find(self, query):
         request = ParsedRequest()
         request.args = {"source": json.dumps(query), "repo": "archive,published"}
+        # TODO-ASYNC[search]: Use `get_async` when upgrading this module
         return get_resource_service("search").get(req=request, lookup=None)
 
     def fetch(self, guid):

--- a/superdesk/types/base.py
+++ b/superdesk/types/base.py
@@ -429,10 +429,8 @@ class MetadataResource(BaseContentItem):
     rewritten_by: fields.Keyword | None = None
     # FIXME: duplicate of ItemSchema
     sequence: int | None = None
-    keywords: Annotated[
-        list[fields.Keyword], fields.elastic_mapping({"type": "list", "mapping": "html_field_analyzer"})
-    ]
-    word_count: int
+    keywords: list[fields.HTML] | None = None
+    word_count: int | None = None
     profile: fields.Keyword | None = None
     state: ContentStates
     revert_state: ContentStates | None = None


### PR DESCRIPTION
### Purpose
To upgrade the content search endpoint to use async elastic to perform the search.

### What has changed
* Fix issue with desks.on_fetched_async in the eve async service
* Upgrade the content search eve service to async (keep existing sync search, for other code that cannot be upgraded yet)
* Fix archive async resource, add elastic config to it