### PR TITLE
Allow disabling auto creation of es index from async resource

### DIFF
--- a/superdesk/archive_async/module.py
+++ b/superdesk/archive_async/module.py
@@ -42,7 +42,7 @@ archive_resource_config = ResourceConfig(
             ),
         ],
     ),
-    elastic=ElasticResourceConfig(),
+    elastic=ElasticResourceConfig(auto_create_index=False),
     # FIXME: To be activated at a later point.
     # rest_endpoints=RestEndpointConfig(
     #     item_methods=["GET", "PATCH", "PUT"],

--- a/superdesk/archived_async/module.py
+++ b/superdesk/archived_async/module.py
@@ -8,7 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from superdesk.core.resources import ResourceConfig, MongoResourceConfig, MongoIndexOptions
+from superdesk.core.resources import ResourceConfig, MongoResourceConfig, MongoIndexOptions, ElasticResourceConfig
 from superdesk.core.resources.resource_rest_endpoints import RestEndpointConfig
 from superdesk.types.archived import ArchivedResourceModel
 from .service import ArchivedService
@@ -27,6 +27,7 @@ archived_resource_config = ResourceConfig(
             ),
         ],
     ),
+    elastic=ElasticResourceConfig(auto_create_index=False),
     # FIXME: To be activated at a later point.
     # rest_endpoints=RestEndpointConfig(
     #     item_methods=["GET", "PATCH", "DELETE"],

--- a/superdesk/commands/flush_elastic_index.py
+++ b/superdesk/commands/flush_elastic_index.py
@@ -82,6 +82,7 @@ class FlushElasticIndex:
         app = get_current_app()
         await app.data.init_elastic(app)
         resources = app.data.get_elastic_resources()
+        resources_processed: list[str] = []
 
         for resource in resources:
             # get es prefix per resource
@@ -94,21 +95,27 @@ class FlushElasticIndex:
 
             print(f'Indexing mongo collections into "{index_prefix}" elastic index.')
             IndexFromMongo.copy_resource(resource, IndexFromMongo.default_page_size)
+            resources_processed.append(resource)
 
         # let's now index async resources
-        self._index_from_mongo_async_resources(index_prefix)
+        self._index_from_mongo_async_resources(index_prefix, resources_processed)
 
-    def _index_from_mongo_async_resources(self, index_prefix: str | None = None):
+    def _index_from_mongo_async_resources(self, index_prefix: str, resources_processed: list[str]):
         """
         Index into elastic search from mongo async resources. If `index_prefix` is provided,
         only the resources that belong to that index prefix will be indexed.
         """
         async_app = get_current_async_app()
         for config in async_app.resources.get_all_configs():
-            if config.elastic is None:
+            if config.elastic is None or not config.elastic.auto_create_index:
                 continue
 
             resource_name = config.name
+            if resource_name in resources_processed:
+                # This resource has already been processed by the eve resource
+                # No need to reindex this one
+                continue
+
             if index_prefix:
                 resource_elastic_config = async_app.elastic.get_client_async(resource_name).config
                 if resource_elastic_config.index != f"{index_prefix}_{resource_name}":

--- a/superdesk/commands/rebuild_elastic_index.py
+++ b/superdesk/commands/rebuild_elastic_index.py
@@ -48,7 +48,7 @@ class RebuildElasticIndex(superdesk.Command):
 
         resources_processed = []
         for config in async_resource_configs:
-            if config.elastic is None:
+            if config.elastic is None or not config.elastic.auto_create_index:
                 continue
             async_app.elastic.reindex(config.name, requests_per_second=requests_per_second)
             resources_processed.append(config.name)

--- a/superdesk/core/elastic/resources.py
+++ b/superdesk/core/elastic/resources.py
@@ -244,7 +244,7 @@ class ElasticResources:
         """
 
         for config in self.app.resources.get_all_configs():
-            if config.elastic is None:
+            if config.elastic is None or not config.elastic.auto_create_index:
                 # Elasticsearch is not configured for this resource
                 continue
 

--- a/superdesk/core/elastic/resources.py
+++ b/superdesk/core/elastic/resources.py
@@ -231,7 +231,7 @@ class ElasticResources:
 
         resources_indexed: List[str] = []
         for config in self.app.resources.get_all_configs():
-            if config.elastic is None:
+            if config.elastic is None or not config.elastic.auto_create_index:
                 continue
             self.init_index(config.name, raise_on_mapping_error)
             resources_indexed.append(config.name)

--- a/superdesk/core/types/elastic.py
+++ b/superdesk/core/types/elastic.py
@@ -33,6 +33,9 @@ class ElasticResourceConfig:
     #: An optional list of facets to be applied (Will this be required in new version?)
     facets: dict[str, Any] | None = None
 
+    #: If ``False`` will skip auto-creating the index for this resource (eve resource will be used instead)
+    auto_create_index: bool = True
+
 
 class ElasticClientConfig(ConfigModel):
     """Dataclass for storing an Elastic config for a specific resource"""


### PR DESCRIPTION
### Purpose
There are errors in our test async superdesk instance regarding elastic index. To rule out the mapping of the newer archive/d async resource, it would be good to disable index creation from that one and use eve resource instead.

Example error:
`
elasticsearch.exceptions.RequestError: RequestError(400, 'search_phase_execution_exception', 'Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [guid] in order to load field data by uninverting the inverted index. Note that this can use significant memory.')
`

### What has changed:
* Add new async elastic config, `auto_create_index`
* Disable auto index creation for async archive/d resources.