### PR TITLE
[SDESK-7482] fix: Exception raised when removing profile from templates

### DIFF
--- a/superdesk/content_types_async/service.py
+++ b/superdesk/content_types_async/service.py
@@ -575,8 +575,8 @@ async def remove_profile_from_templates(item: ContentTypesResourceModel) -> None
     # TODO-ASYNC: "content_templates" is not async yet
     templates = list(superdesk.get_resource_service("content_templates").get_templates_by_profile_id(item.id))
     for template in templates:
-        template.data.pop("profile", None)
-        superdesk.get_resource_service("content_templates").patch(template.id, template)
+        template.get("data", {}).pop("profile", None)
+        superdesk.get_resource_service("content_templates").patch(template[ID_FIELD], template)
 
 
 async def get_profile(_id: str) -> dict[str, Any] | ContentTypesResourceModel | None:


### PR DESCRIPTION
### Purpose
An exception was raised when attempting to delete a Content Profile. Looks like it was not treating the template as a dict, with the following exception raised:

```
Exception on request DELETE /api/content_types/8c97f14d-c7ed-4c8d-906f-2599a6f7c101
Traceback (most recent call last):
  File "quart/app.py", line 1406, in handle_request
    return await self.full_dispatch_request(request_context)
  File "quart_flask_patch/app.py", line 27, in new_full_dispatch_request
    return await old_full_dispatch_request(self, request_context)
  File "quart/app.py", line 1444, in full_dispatch_request
    result = await self.handle_user_exception(error)
  File "quart/app.py", line 1031, in handle_user_exception
    raise error
  File "quart/app.py", line 1442, in full_dispatch_request
    result = await self.dispatch_request(request_context)
  File "quart/app.py", line 1538, in dispatch_request
    return await self.ensure_async(handler)(**request_.view_args)  # type: ignore
  File "superdesk-core/superdesk/factory/app.py", line 387, in _process_async_endpoint
    response = await request.endpoint(
  File "superdesk-core/superdesk/core/web/endpoints.py", line 67, in __call__
    response = await response
  File "superdesk-core/superdesk/core/resources/resource_rest_endpoints.py", line 561, in delete_item
    await service.delete(original, if_match)
  File "superdesk-core/superdesk/core/resources/service.py", line 538, in delete
    await self.on_delete(doc)
  File "superdesk-core/superdesk/content_types_async/service.py", line 76, in on_delete
    await remove_profile_from_templates(doc)
  File "superdesk-core/superdesk/content_types_async/service.py", line 578, in remove_profile_from_templates
    template.data.pop("profile", None)
AttributeError: 'dict' object has no attribute 'data'
```