### PR TITLE
[SDESK-7551] fix: Support ObjectId value for PublishQueue.encoded_item_id field

### DIFF
--- a/superdesk/publish_async/consumers/asyncio_consumer.py
+++ b/superdesk/publish_async/consumers/asyncio_consumer.py
@@ -90,7 +90,7 @@ class AsyncioPublishConsumer(PublishConsumer):
                 print(task.destination.delivery_type not in registered_transmitters)
                 raise
 
-            response = transmitter.transmit(task.to_dict())
+            response = transmitter.transmit(task.to_dict(context={"use_objectid": True}))
             if isawaitable(response):
                 # TODO-ASYNC: Convert transmitters to use asyncio network calls
                 # otherwise it will halt the processing of other transmission requests

--- a/superdesk/types/publish_queue.py
+++ b/superdesk/types/publish_queue.py
@@ -29,7 +29,7 @@ class PublishQueueResource(ResourceModelWithObjectId):
 
     state: PublishQueueState | None = None  # If None, will allow the resource service to choose the state
     item_encoding: str | None = None
-    encoded_item_id: str | None = None
+    encoded_item_id: str | fields.ObjectId | None = None
 
     subscriber_id: Annotated[fields.ObjectId, validate_data_relation_async("subscribers")]
 


### PR DESCRIPTION
### Purpose
The following exception was raised when attempting to publish an item with media, pointing to the `encoded_item_id` field need to support ObjectId as well:

```
Sending request for 080d2de0-117d-42fc-8a75-3a6a5c8a3260 to PublishExchange(name=content, polling=True, filter=content, formatter=default, router=celery) level=INFO process=ForkPoolWorker-1
Failed to queue item for subscriber level=ERROR process=ForkPoolWorker-1
Traceback (most recent call last):
  File "superdesk/publish_async/formatters/base_exchange_formatter.py", line 79, in get_request_tasks
    subscriber_tasks, subscriber_no_formatters = await self.get_tasks_for_subscriber(
  File "superdesk/publish_async/formatters/base_exchange_formatter.py", line 146, in get_tasks_for_subscriber
    await self.get_task_for_destination(
  File "superdesk/publish_async/formatters/base_exchange_formatter.py", line 277, in get_task_for_destination
    publish_queue_item.encoded_item_id = app.storage.put(binary)
  File "pydantic/main.py", line 922, in __setattr__
    self.__pydantic_validator__.validate_assignment(self, name, value)
pydantic_core._pydantic_core.ValidationError: 1 validation error for PublishQueueResource
encoded_item_id
  Input should be a valid string [type=string_type, input_value=ObjectId('67eb25b66140686f3c86822a'), input_type=ObjectId]
    For further information visit https://errors.pydantic.dev/2.10/v/string_type
publishing 080d2de0-117d-42fc-8a75-3a6a5c8a3260 to [] level=INFO process=ForkPoolWorker-1
```