### PR TITLE
[SDESK-7552] fix: Make async Vocabularies mongo indexes not unique

### DIFF
--- a/superdesk/vocabularies_async/module.py
+++ b/superdesk/vocabularies_async/module.py
@@ -25,6 +25,7 @@ vocabularies_resource_config = ResourceConfig(
             MongoIndexOptions(
                 name="field_type",
                 keys=[("field_type", 1)],
+                unique=False,
             ),
         ],
     ),


### PR DESCRIPTION
### Purpose
The MongoIndexOptions defaults the `unique` attribute to `True`, and we forgot to set it to `False` for the Vocbaularies indexes