### PR TITLE
[SDESK-7574] Implement Elastic async eve layer

### DIFF
--- a/apps/desks.py
+++ b/apps/desks.py
@@ -476,7 +476,7 @@ class SluglineDeskService(AsyncBaseService):
         docs = []
         # rest of the world docs
         row_docs = []
-        for item in desk_items:
+        async for item in desk_items:
             slugline = self._get_slugline_with_legal(item)
             headline = item.get(self.HEADLINE)
             versioncreated = item.get(self.VERSION_CREATED)
@@ -711,7 +711,7 @@ class OverviewService(AsyncBaseService):
         req.projection = json.dumps({"members": 1})
         found = await desks_service.get_async(req, desk_filter)
         members = set()
-        for d in found:
+        async for d in found:
             members.update({m["user"] for m in d.get("members", [])})
 
         app = get_current_app()

--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -250,9 +250,9 @@ class SearchService(AsyncBaseService):
         for resource in types:
             response = {ITEMS: [doc for doc in cursor if doc["_type"] == resource]}
             app = get_current_app().as_any()
-            getattr(app, "on_fetched_resource")(resource, response)
+            await getattr(app, "on_fetched_resource").call_async(resource, response)
             await getattr(app, "on_fetched_resource_%s_async" % resource).call_async(response)
-            getattr(app, "on_fetched_resource_%s" % resource)(response)
+            await getattr(app, "on_fetched_resource_%s" % resource).call_async(response)
 
         return cursor
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,5 +18,5 @@ moto[sqs]==5.0.18
 pyexiv2>=2.12.0,<2.13; sys_platform == 'linux'
 
 -e .
--e git+https://github.com/superdesk/superdesk-planning.git@release/3.0#egg=superdesk_planning
+-e git+https://github.com/superdesk/superdesk-planning.git@async#egg=superdesk_planning
 -e git+https://github.com/superdesk/sams.git@develop#egg=sams_client&subdirectory=src/clients/python/

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     "pydantic>=2.7.4,<3.0",
     # Custom repos, with patches applied
     "eve @ git+https://github.com/superdesk/eve@async",
-    "eve-elastic @ git+https://github.com/superdesk/eve-elastic@async",
+    "eve-elastic @ git+https://github.com/MarkLark86/eve-elastic@SDESK-7574",
     "quart @ git+https://github.com/MarkLark86/quart@fix-test-client-with-utf8-url",
     "quart_babel>=1.0.7,<1.1",
     "asgiref>=3.8.1",

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     "pydantic>=2.7.4,<3.0",
     # Custom repos, with patches applied
     "eve @ git+https://github.com/superdesk/eve@async",
-    "eve-elastic @ git+https://github.com/MarkLark86/eve-elastic@SDESK-7574",
+    "eve-elastic @ git+https://github.com/superdesk/eve-elastic@async",
     "quart @ git+https://github.com/MarkLark86/quart@fix-test-client-with-utf8-url",
     "quart_babel>=1.0.7,<1.1",
     "asgiref>=3.8.1",

--- a/superdesk/core/types/__init__.py
+++ b/superdesk/core/types/__init__.py
@@ -1,4 +1,4 @@
-from .common import DefaultNoValue
+from .common import DefaultNoValue, ItemId
 from .model import BaseModel
 from .search import (
     ProjectedFieldArg,
@@ -34,6 +34,7 @@ from .storage import SuperdeskFile, AsyncBuffer, SuperdeskAsyncFile
 __all__ = [
     # common
     "DefaultNoValue",
+    "ItemId",
     # web
     "HTTP_METHOD",
     "Response",

--- a/superdesk/core/types/common.py
+++ b/superdesk/core/types/common.py
@@ -1,1 +1,4 @@
+from bson import ObjectId
+
 DefaultNoValue = object()
+ItemId = ObjectId | str

--- a/superdesk/datalayer.py
+++ b/superdesk/datalayer.py
@@ -8,6 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from typing import overload, Literal
 from inspect import isawaitable
 
 import superdesk
@@ -20,7 +21,7 @@ from superdesk.core import get_current_async_app, get_config
 from superdesk.lock import lock, unlock
 from superdesk.json_utils import SuperdeskJSONEncoder
 
-from .eve_async import MongoAsync
+from .eve_async import MongoAsync, ElasticAsync
 
 
 class SuperdeskDataLayer(DataLayer):
@@ -45,6 +46,9 @@ class SuperdeskDataLayer(DataLayer):
         self.driver = self.mongo.driver
         self.storage = self.driver
         self.elastic = Elastic(
+            app, serializer=SuperdeskJSONEncoder(), skip_index_init=True, retry_on_timeout=True, max_retries=3
+        )
+        self.elastic_async = ElasticAsync(
             app, serializer=SuperdeskJSONEncoder(), skip_index_init=True, retry_on_timeout=True, max_retries=3
         )
 
@@ -192,19 +196,44 @@ class SuperdeskDataLayer(DataLayer):
     async def is_empty_async(self, resource):
         return self._backend(resource, use_async=True).is_empty(resource)
 
-    def _search_backend(self, resource):
+    @overload
+    def _search_backend(self, resource) -> Elastic | None:
+        ...
+
+    @overload
+    def _search_backend(self, resource, use_async: Literal[False] = False) -> Elastic | None:
+        ...
+
+    @overload
+    def _search_backend(self, resource, use_async: Literal[True]) -> ElasticAsync | None:
+        ...
+
+    def _search_backend(self, resource, use_async: bool = False) -> Elastic | ElasticAsync | None:
         if resource.endswith(get_config(str, "VERSIONS")):
-            return
+            return None
         datasource = self.datasource(resource)
         try:
             backend = get_config(dict, "SOURCES", {})[datasource[0]]["search_backend"]
         except (KeyError, TypeError, AttributeError):
             backend = None
 
-        # TODO-ASYNC: Add self.elastic_async datalayer
+        if backend and use_async:
+            backend += "_async"
         return getattr(self, backend) if backend is not None else None
 
-    def _backend(self, resource: str, use_async: bool = False):
+    @overload
+    def _backend(self, resource: str) -> Mongo | None:
+        ...
+
+    @overload
+    def _backend(self, resource: str, use_async: Literal[False]) -> Mongo | None:
+        ...
+
+    @overload
+    def _backend(self, resource: str, use_async: Literal[True]) -> MongoAsync | None:
+        ...
+
+    def _backend(self, resource: str, use_async: bool = False) -> Mongo | MongoAsync | None:
         datasource = self.datasource(resource)
         try:
             backend = get_config(dict, "SOURCES", {})[datasource[0]]["backend"]

--- a/superdesk/eve_async/__init__.py
+++ b/superdesk/eve_async/__init__.py
@@ -1,4 +1,14 @@
+from .cursors import AsyncEveCursor, MongoAsyncEveCursor, ElasticAsyncEveCursor
 from .mongo_datalayer import MongoAsync
+from .elastic_datalayer import ElasticAsync
+from .service import AsyncBaseService
 
 
-__all__ = ["MongoAsync"]
+__all__ = [
+    "AsyncEveCursor",
+    "MongoAsyncEveCursor",
+    "ElasticAsyncEveCursor",
+    "MongoAsync",
+    "ElasticAsync",
+    "AsyncBaseService",
+]

--- a/superdesk/eve_async/cursors.py
+++ b/superdesk/eve_async/cursors.py
@@ -1,0 +1,88 @@
+from typing import TYPE_CHECKING
+
+from pymongo.cursor_shared import _Hint as MongoCursorHint
+from motor.motor_asyncio import AsyncIOMotorCursor
+
+
+if TYPE_CHECKING:
+
+    class MongoAsyncEveCursor(AsyncIOMotorCursor):
+        # Adding the ``count`` method to the cursor, as our ``EveBackend`` adds it
+        async def count(self) -> int:
+            ...  # type: ignore[empty-body]
+
+        # Make sure ``sort`` function returns our cursor class
+        def sort(self, key_or_list: MongoCursorHint, direction: int | str | None = None) -> "MongoAsyncEveCursor":
+            ...  # type: ignore[empty-body]
+
+        # Seems like ``motor-types`` incorrectly assumes length is not optional
+        # compared to the ``motor`` library where it's optional
+        async def to_list(self, length: int | None = None) -> list[dict]:  # type: ignore[override]
+            ...  # type: ignore[empty-body]
+
+else:
+    MongoAsyncEveCursor = AsyncIOMotorCursor
+
+
+class ElasticAsyncEveCursor:
+    """Search results cursor.
+
+    Note: Adds methods to provide similar interface to MongoDB's AsyncIOMotorCursor
+    """
+
+    _index: int
+    hits: dict
+    no_hits = {"hits": {"total": 0, "hits": []}}
+    docs: list[dict]
+
+    def __init__(self, hits: dict | None = None, docs: list[dict] | None = None):
+        """Parse hits into docs."""
+        self._index = 0
+        self.hits = hits if hits else self.no_hits
+        self.docs = docs if docs else []
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> dict:
+        item = await self.next()
+        if item is not None:
+            return item
+        raise StopAsyncIteration
+
+    async def next(self) -> dict | None:
+        try:
+            doc = self.docs[self._index]
+            self._index += 1
+            return doc
+        except (IndexError, KeyError, TypeError):
+            self._index = 0
+            return None
+
+    async def to_list(self, length: int | None = None) -> list[dict]:
+        return self.docs if length is None else self.docs[:length]
+
+    def rewind(self) -> None:
+        """Rewind cursor to the beginning."""
+        self._index = 0
+
+    async def count(self, **kwargs) -> int:
+        """Get hits count."""
+        hits = self.hits.get("hits")
+        if hits:
+            total = hits.get("total")
+            if isinstance(total, int):
+                return total
+            elif isinstance(total, dict) and total.get("value"):
+                return int(total["value"])
+        return 0
+
+    def extra(self, response) -> None:
+        """Add extra info to response"""
+        if "facets" in self.hits:
+            response["_facets"] = self.hits["facets"]
+        if "aggregations" in self.hits:
+            response["_aggregations"] = self.hits["aggregations"]
+
+
+AsyncEveCursor = MongoAsyncEveCursor | ElasticAsyncEveCursor

--- a/superdesk/eve_async/elastic_datalayer.py
+++ b/superdesk/eve_async/elastic_datalayer.py
@@ -116,7 +116,7 @@ class ElasticAsync(Elastic):
         await self._refresh_resource_index_async(resource)
         return res
 
-    async def update(self, resource, id_, updates, original = None):
+    async def update(self, resource, id_, updates, original=None):
         """Update document in index."""
         args = self._es_args(resource, refresh=True)
         if self._get_retry_on_conflict():
@@ -124,7 +124,7 @@ class ElasticAsync(Elastic):
         doc = self._prepare_for_storage(resource, updates, args)
         return await self.elastic_async(resource).update(id=id_, body={"doc": doc}, **args)
 
-    async def replace(self, resource, id_, document, original = None):
+    async def replace(self, resource, id_, document, original=None):
         """Replace document in index."""
         args = self._es_args(resource, refresh=True)
         doc = self._prepare_for_storage(resource, document, args)

--- a/superdesk/eve_async/elastic_datalayer.py
+++ b/superdesk/eve_async/elastic_datalayer.py
@@ -1,0 +1,228 @@
+from elasticsearch import AsyncElasticsearch, exceptions as elastic_exceptions
+from elasticsearch.helpers import async_bulk
+
+from eve_elastic import Elastic, ElasticJSONSerializer, InvalidSearchString
+from eve_elastic.elastic import fix_query, RESOURCE_FIELD
+
+from superdesk.resource_fields import ID_FIELD
+
+from .cursors import ElasticAsyncEveCursor
+
+
+def get_es_async(url: str, **kwargs) -> AsyncElasticsearch:
+    """Create async elasticsearch instance.
+
+    :param url: elasticsearch url
+    """
+
+    urls = [url] if isinstance(url, str) else url
+    kwargs.setdefault("serializer", ElasticJSONSerializer())
+    es = AsyncElasticsearch(urls, **kwargs)
+    return es
+
+
+class ElasticAsync(Elastic):
+    es_async: AsyncElasticsearch
+
+    def init_app(self, app):
+        super().init_app(app)
+        self.es_async = get_es_async(app.config["ELASTICSEARCH_URL"], **self.kwargs)
+
+    def elastic_async(self, resource: str) -> AsyncElasticsearch:
+        """Get ElasticSearch instance for given resource."""
+        px = self._resource_prefix(resource)
+
+        if px not in self.elastics:
+            url = self._resource_config(resource, "URL")
+            assert url, "no url for %s" % px
+            self.elastics[px] = get_es_async(url, **self.kwargs)
+
+        return self.elastics[px]
+
+    def _parse_hits_async(self, hits, resource):
+        return ElasticAsyncEveCursor(hits, self.get_hits_docs(hits, resource))
+
+    async def find(self, resource, req, sub_resource_lookup, **kwargs) -> tuple[ElasticAsyncEveCursor, int]:
+        """Find documents for resource"""
+
+        search_args = self.get_find_kwargs(resource, req, sub_resource_lookup)
+
+        try:
+            hits = await self.elastic_async(resource).search(**search_args)
+        except elastic_exceptions.RequestError as e:
+            if e.status_code == 400 and "No mapping found for" in e.error:
+                hits = {}
+            elif e.status_code == 400 and "SearchParseException" in e.error:
+                raise InvalidSearchString
+            else:
+                raise
+
+        cursor = self._parse_hits_async(hits, resource)
+        return cursor, await cursor.count()
+
+    async def find_one(self, resource, req, **lookup) -> dict | None:
+        if ID_FIELD in lookup:
+            return await self._find_by_id(
+                resource=resource,
+                _id=lookup[ID_FIELD],
+                parent=lookup.get("parent"),
+            )
+
+        search_args = self.get_find_one_kwargs(resource, **lookup)
+        try:
+            hits = await self.elastic_async(resource).search(**search_args)
+            docs = self._parse_hits_async(hits, resource)
+            return await docs.next()
+        except elastic_exceptions.NotFoundError:
+            return None
+
+    async def find_one_raw(self, resource, **lookup):
+        item_id = lookup.get(ID_FIELD)
+        return await self._find_by_id(resource=resource, _id=item_id)
+
+    async def find_list_of_ids(self, resource, ids, client_projection=None):
+        """Find documents by ids."""
+        args = self._es_args(resource)
+        return self._parse_hits_async(self.elastic_async(resource).mget(body={"ids": ids}, **args), resource)
+
+    async def insert(self, resource, doc_or_docs, **kwargs):
+        """Insert document, it must be new if there is ``_id`` in it."""
+        ids = []
+        es_args = self._es_args(resource)
+        es_args.update(kwargs)
+        for doc in doc_or_docs:
+            _id = doc.pop("_id", None)
+            body = self._prepare_for_storage(resource, doc, es_args)
+            res = await self.elastic_async(resource).index(body=body, id=_id, **es_args)
+            doc.setdefault("_id", res.get("_id", _id))
+            ids.append(doc.get("_id"))
+        await self._refresh_resource_index_async(resource)
+        return ids
+
+    async def bulk_insert(self, resource, docs, **kwargs):
+        """Bulk insert documents."""
+        kwargs.update(self._es_args(resource))
+        parent_type = self._get_parent_type(resource)
+        actions = []
+        for doc in docs:
+            doc[RESOURCE_FIELD] = resource
+            if parent_type and doc.get(parent_type.get("field")):
+                doc["_parent"] = doc.get(parent_type.get("field"))
+            action = {"_source": self._prepare_for_storage(resource, doc, kwargs)}
+            if doc.get("_id"):
+                action["_id"] = doc["_id"]
+            actions.append(action)
+        res = await async_bulk(self.elastic_async(resource), actions, stats_only=False, **kwargs)
+        await self._refresh_resource_index_async(resource)
+        return res
+
+    async def update(self, resource, id_, updates, original = None):
+        """Update document in index."""
+        args = self._es_args(resource, refresh=True)
+        if self._get_retry_on_conflict():
+            args["retry_on_conflict"] = self._get_retry_on_conflict()
+        doc = self._prepare_for_storage(resource, updates, args)
+        return await self.elastic_async(resource).update(id=id_, body={"doc": doc}, **args)
+
+    async def replace(self, resource, id_, document, original = None):
+        """Replace document in index."""
+        args = self._es_args(resource, refresh=True)
+        doc = self._prepare_for_storage(resource, document, args)
+        return await self.elastic_async(resource).index(body=doc, id=id_, **args)
+
+    async def remove(self, resource, lookup=None, parent=None, **kwargs):
+        """Remove docs for resource.
+
+        :param resource: resource name
+        :param lookup: filter
+        :param parent: parent id
+        """
+        kwargs.update(self._es_args(resource))
+        if parent:
+            kwargs["parent"] = parent
+
+        if lookup:
+            if lookup.get("_id"):
+                try:
+                    return await self.elastic_async(resource).delete(id=lookup.get("_id"), refresh=True, **kwargs)
+                except elastic_exceptions.NotFoundError:
+                    return
+        return ValueError("there must be `lookup._id` specified")
+
+    async def is_empty(self, resource):
+        """Test if there is no document for resource.
+
+        :param resource: resource name
+        """
+        args = self._es_args(resource)
+        res = await self.elastic_async(resource).count(body={"query": {"match_all": {}}}, **args)
+        return res.get("count", 0) == 0
+
+    async def search(self, query, resources, params=None):
+        """Search multiple resources at the same time.
+
+        They must use all same elastic instance and should be same schema.
+        """
+
+        default_params = self._get_default_search_params()
+
+        if params is not None:
+            default_params.update(params)
+
+        params = default_params
+
+        if isinstance(resources, str):
+            resources = resources.split(",")
+        index = [self._resource_index(resource) for resource in resources]
+        try:
+            hits = await self.elastic_async(resources[0]).search(body=fix_query(query), index=index, **params)
+            return self._parse_hits_async(hits, resources[0])
+        except elastic_exceptions.RequestError:
+            raise
+
+    async def _refresh_resource_index_async(self, resource, force=False):
+        """Refresh index for given resource.
+
+        :param resource: resource name
+        """
+        if self._resource_config(resource, "FORCE_REFRESH", True) or force:
+            await self.elastic_async(resource).indices.refresh(index=self._resource_index(resource))
+
+    async def _find_by_id(self, resource, _id, parent=None):
+        """Find the document by Id. If parent is not provided then on
+        routing exception try to find using search.
+        """
+
+        def is_found(hit):
+            if "exists" in hit:
+                hit["found"] = hit["exists"]
+            return hit.get("found", False)
+
+        args = self._es_args(resource)
+        try:
+            # set the parent if available
+            if parent:
+                args["parent"] = parent
+
+            hit = await self.elastic_async(resource).get(id=_id, **args)
+
+            if not is_found(hit):
+                return
+
+            docs = self._parse_hits_async({"hits": {"hits": [hit]}}, resource)
+            return await docs.next()
+
+        except elastic_exceptions.NotFoundError:
+            return
+        except elastic_exceptions.TransportError as tex:
+            if tex.error == "routing_missing_exception" or "RoutingMissingException" in tex.error:
+                # search for the item
+                args = self._es_args(resource)
+                query = {"query": {"bool": {"must": [{"term": {"_id": _id}}]}}}
+                try:
+                    args["size"] = 1
+                    hits = await self.elastic_async(resource).search(body=fix_query(query), **args)
+                    docs = self._parse_hits_async(hits, resource)
+                    return await docs.next()
+                except elastic_exceptions.NotFoundError:
+                    return

--- a/superdesk/eve_async/mongo_datalayer.py
+++ b/superdesk/eve_async/mongo_datalayer.py
@@ -185,7 +185,7 @@ class MongoAsync(Mongo):
     async def _change_request(self, resource, id_, changes, original, replace=False):
         id_field = config.DOMAIN[resource]["id_field"]
         query = {id_field: id_}
-        if config.ETAG in original:
+        if original and config.ETAG in original:
             query[config.ETAG] = original[config.ETAG]
 
         datasource, filter_, _, _ = self._datasource_ex(resource, query)
@@ -193,7 +193,7 @@ class MongoAsync(Mongo):
         coll = self.get_collection_with_write_concern(datasource, resource)
         try:
             result = await (coll.replace_one(filter_, changes) if replace else coll.update_one(filter_, changes))
-            if config.ETAG in original and result and result.acknowledged and result.modified_count == 0:
+            if original and config.ETAG in original and result and result.acknowledged and result.modified_count == 0:
                 raise self.OriginalChangedError()
         except pymongo.errors.DuplicateKeyError as e:
             abort(

--- a/superdesk/eve_async/service.py
+++ b/superdesk/eve_async/service.py
@@ -33,10 +33,10 @@ class AsyncBaseService(BaseService):
     async def on_updated_async(self, updates: dict, original: dict) -> None:
         pass
 
-    async def on_replace_async(self, document: dict, original: dict) -> None:
+    async def on_replace_async(self, document: dict, original: dict | None) -> None:
         pass
 
-    async def on_replaced_async(self, document: dict, original: dict) -> None:
+    async def on_replaced_async(self, document: dict, original: dict | None) -> None:
         pass
 
     async def on_delete_async(self, doc: dict) -> None:
@@ -61,7 +61,7 @@ class AsyncBaseService(BaseService):
     async def system_update_async(self, id: ItemId, updates: dict, original: dict, **kwargs) -> dict:
         return await self.backend.system_update_async(self.datasource, id, updates, original, **kwargs)
 
-    async def replace_async(self, id: ItemId, document: dict, original: dict) -> None:
+    async def replace_async(self, id: ItemId, document: dict, original: dict | None) -> None:
         return await self.backend.replace_async(self.datasource, id, document, original)
 
     async def delete_async(self, lookup: dict) -> list[ItemId]:
@@ -187,9 +187,6 @@ class AsyncBaseService(BaseService):
     async def put_async(self, id: ItemId, document: dict) -> None:
         self._resolve_defaults(document)
         original = await self.find_one_async(req=None, _id=id)
-        if original is None:
-            raise SuperdeskApiError.notFoundError(gettext(f"Item with id {id} not found"))
-
         await self.on_replace_async(document, original)
         self.on_replace(document, original)
         resolve_document_etag(document, self.datasource)

--- a/superdesk/eve_async/service.py
+++ b/superdesk/eve_async/service.py
@@ -1,14 +1,18 @@
+from typing import AsyncIterator, cast
 import logging
 
+from bson import ObjectId
 import pymongo
-from motor.motor_asyncio import AsyncIOMotorCursor
 from eve.utils import ParsedRequest
 from eve.methods.common import resolve_document_etag
+from quart_babel import gettext
 
 from superdesk.services import BaseService, CacheableService
 from superdesk.resource_fields import ETAG
 from superdesk.utc import utcnow
 from superdesk.errors import SuperdeskApiError
+
+from .cursors import AsyncEveCursor, MongoAsyncEveCursor, ElasticAsyncEveCursor
 
 
 logger = logging.getLogger(__name__)
@@ -17,56 +21,56 @@ logger = logging.getLogger(__name__)
 class AsyncBaseService(BaseService):
     is_async = True
 
-    async def on_create_async(self, docs):
+    async def on_create_async(self, docs: list[dict]) -> None:
         pass
 
-    async def on_created_async(self, docs):
+    async def on_created_async(self, docs: list[dict]) -> None:
         pass
 
-    async def on_update_async(self, updates, original):
+    async def on_update_async(self, updates: dict, original: dict) -> None:
         pass
 
-    async def on_updated_async(self, updates, original):
+    async def on_updated_async(self, updates: dict, original: dict) -> None:
         pass
 
-    async def on_replace_async(self, document, original):
+    async def on_replace_async(self, document: dict, original: dict) -> None:
         pass
 
-    async def on_replaced_async(self, document, original):
+    async def on_replaced_async(self, document: dict, original: dict) -> None:
         pass
 
-    async def on_delete_async(self, doc):
+    async def on_delete_async(self, doc: dict) -> None:
         pass
 
-    async def on_deleted_async(self, doc):
+    async def on_deleted_async(self, doc: dict) -> None:
         pass
 
-    async def on_fetched_async(self, doc):
+    async def on_fetched_async(self, doc: dict) -> None:
         pass
 
-    async def on_fetched_item_async(self, doc):
+    async def on_fetched_item_async(self, doc: dict) -> None:
         pass
 
-    async def create_async(self, docs, **kwargs):
+    async def create_async(self, docs: list[dict], **kwargs) -> list[ObjectId | str]:
         ids = await self.backend.create_async(self.datasource, docs, **kwargs)
         return ids
 
-    async def update_async(self, id, updates, original):
+    async def update_async(self, id: ObjectId | str, updates: dict, original: dict) -> dict:
         return await self.backend.update_async(self.datasource, id, updates, original)
 
-    async def system_update_async(self, id, updates, original, **kwargs):
+    async def system_update_async(self, id: ObjectId | str, updates: dict, original: dict, **kwargs) -> dict:
         return await self.backend.system_update_async(self.datasource, id, updates, original, **kwargs)
 
-    async def replace_async(self, id, document, original):
+    async def replace_async(self, id: ObjectId | str, document: dict, original: dict) -> None:
         return await self.backend.replace_async(self.datasource, id, document, original)
 
-    async def delete_async(self, lookup):
+    async def delete_async(self, lookup: dict) -> list[ObjectId | str]:
         return await self.backend.delete_async(self.datasource, lookup)
 
-    async def delete_ids_from_mongo_async(self, ids):
+    async def delete_ids_from_mongo_async(self, ids: list[ObjectId | str]) -> list[ObjectId | str]:
         return await self.backend.delete_ids_from_mongo_async(self.datasource, ids)
 
-    async def delete_from_mongo_async(self, lookup: dict):
+    async def delete_from_mongo_async(self, lookup: dict) -> None:
         """Delete items from mongo only
 
         .. versionadded:: 2.4.0
@@ -79,7 +83,7 @@ class AsyncBaseService(BaseService):
 
         await self.backend.delete_from_mongo_async(self.datasource, lookup)
 
-    async def delete_docs_async(self, docs):
+    async def delete_docs_async(self, docs: list[dict]) -> list[ObjectId | str]:
         for doc in docs:
             self.on_delete(doc)
             await self.on_delete_async(doc)
@@ -89,22 +93,24 @@ class AsyncBaseService(BaseService):
             await self.on_deleted_async(doc)
         return res
 
-    async def find_one_async(self, req, **lookup):
+    async def find_one_async(self, req: ParsedRequest | None, **lookup) -> dict | None:
         return await self.backend.find_one_async(self.datasource, req=req, **lookup)
 
-    async def find_async(self, where, **kwargs):
+    async def find_async(self, where, **kwargs) -> MongoAsyncEveCursor:
         """Find items in service collection using mongo query.
 
         :param dict where:
         """
         return await self.backend.find_async(self.datasource, where, **kwargs)
 
-    async def get_async(self, req, lookup):
+    async def get_async(self, req: ParsedRequest | None, lookup: dict | None) -> AsyncEveCursor:
         if req is None:
             req = ParsedRequest()
         return await self.backend.get_async(self.datasource, req=req, lookup=lookup)
 
-    async def get_from_mongo_async(self, req, lookup, projection=None) -> AsyncIOMotorCursor:
+    async def get_from_mongo_async(
+        self, req: ParsedRequest | None, lookup: dict | None, projection: dict | None = None
+    ) -> MongoAsyncEveCursor:
         if req is None:
             req = ParsedRequest()
         if not req.projection and projection:
@@ -113,19 +119,22 @@ class AsyncBaseService(BaseService):
             req.projection = json.dumps(projection)
         return await self.backend.get_from_mongo_async(self.datasource, req=req, lookup=lookup)
 
-    async def get_all_async(self):
+    async def get_all_async(self) -> MongoAsyncEveCursor:
         return (await self.get_from_mongo_async(None, {})).sort("_id")
 
-    async def find_and_modify_async(self, query, update, **kwargs):
+    async def find_and_modify_async(self, query: dict, update: dict, **kwargs) -> dict:
         return await self.backend.find_and_modify_async(self.datasource, filter=query, update=update, **kwargs)
 
-    async def get_all_batch_async(self, size=500, max_iterations=10000, lookup=None):
+    async def get_all_batch_async(
+        self, size: int = 500, max_iterations: int = 10000, lookup: dict | None = None
+    ) -> AsyncIterator[dict]:
         """Gets all items using multiple queries.
 
         When processing big collection and doing something time consuming you might get
         a mongo cursor timeout, this should avoid it fetching `size` items in memory
         and closing the cursor in between.
         """
+
         last_id = None
         if lookup is None:
             lookup = {}
@@ -135,16 +144,18 @@ class AsyncBaseService(BaseService):
                 _lookup = {"_id": {"$gt": last_id}}
 
             cursor = (await self.get_from_mongo_async(req=None, lookup=_lookup)).sort("_id").limit(size)
+            # As the consumer might be doing something time-consuming, we consume the entire cursor now
+            # to get all items, otherwise there may be a cursor timeout
             items = [item async for item in cursor]
             if not len(items):
                 break
             for item in items:
-                yield item
+                yield cast(dict, item)
                 last_id = item["_id"]
         else:
             logger.warning("Not enough iterations for resource %s", self.datasource)
 
-    async def post_async(self, docs, **kwargs):
+    async def post_async(self, docs: list[dict], **kwargs) -> list[ObjectId | str]:
         for doc in docs:
             self._resolve_defaults(doc)
         await self.on_create_async(docs)
@@ -154,10 +165,13 @@ class AsyncBaseService(BaseService):
         self.on_created(docs)
         return ids
 
-    async def patch_async(self, id, updates):
+    async def patch_async(self, id: ObjectId | str, updates: dict) -> dict:
         from superdesk.core import get_app_config
 
         original = await self.find_one_async(req=None, _id=id)
+        if original is None:
+            raise SuperdeskApiError.notFoundError(gettext(f"Item with id {id} not found"))
+
         updated = original.copy()
         await self.on_update_async(updates, original)
         self.on_update(updates, original)
@@ -170,46 +184,46 @@ class AsyncBaseService(BaseService):
         self.on_updated(updates, original)
         return res
 
-    async def put_async(self, id, document):
+    async def put_async(self, id: ObjectId | str, document: dict) -> None:
         self._resolve_defaults(document)
         original = await self.find_one_async(req=None, _id=id)
+        if original is None:
+            raise SuperdeskApiError.notFoundError(gettext(f"Item with id {id} not found"))
+
         await self.on_replace_async(document, original)
         self.on_replace(document, original)
         resolve_document_etag(document, self.datasource)
-        res = await self.replace_async(id, document, original)
+        await self.replace_async(id, document, original)
         await self.on_replaced_async(document, original)
         self.on_replaced(document, original)
-        return res
 
-    async def delete_action_async(self, lookup=None):
+    async def delete_action_async(self, lookup: dict | None = None) -> list[ObjectId | str]:
         if lookup is None:
             lookup = {}
             docs = []
         else:
             cursor = (await self.get_from_mongo_async(None, lookup)).sort("_id", pymongo.ASCENDING)
-            docs = [doc async for doc in cursor]
+            docs = [dict(doc) async for doc in cursor]
         if not docs:
-            return self.delete_async(lookup)
-        return self.delete_docs_async(docs)
+            return await self.delete_async(lookup)
+        return await self.delete_docs_async(docs)
 
-    async def search_async(self, source):
+    async def search_async(self, source: dict) -> ElasticAsyncEveCursor | None:
         """Search using search backend.
 
         :param source: query source param
         """
-        # TODO-ASYNC: Convert this to use elastic async
-        return self.backend.search(self.datasource, source)
+        return await self.backend.search_async(self.datasource, source)
 
-    async def remove_from_search_async(self, item):
+    async def remove_from_search_async(self, item: dict) -> dict:
         """Remove item from search.
 
         :param dict item: item
         """
 
-        # TODO-ASYNC: Convert this to use elastic async
-        return self.backend.remove_from_search(self.datasource, item)
+        return await self.backend.remove_from_search_async(self.datasource, item)
 
-    async def update_data_from_json_async(self, items):
+    async def update_data_from_json_async(self, items: dict) -> dict:
         success = []
         for item in items:
             try:

--- a/superdesk/eve_async/service.py
+++ b/superdesk/eve_async/service.py
@@ -1,12 +1,12 @@
 from typing import AsyncIterator, cast
 import logging
 
-from bson import ObjectId
 import pymongo
 from eve.utils import ParsedRequest
 from eve.methods.common import resolve_document_etag
 from quart_babel import gettext
 
+from superdesk.core.types import ItemId
 from superdesk.services import BaseService, CacheableService
 from superdesk.resource_fields import ETAG
 from superdesk.utc import utcnow
@@ -51,23 +51,23 @@ class AsyncBaseService(BaseService):
     async def on_fetched_item_async(self, doc: dict) -> None:
         pass
 
-    async def create_async(self, docs: list[dict], **kwargs) -> list[ObjectId | str]:
+    async def create_async(self, docs: list[dict], **kwargs) -> list[ItemId]:
         ids = await self.backend.create_async(self.datasource, docs, **kwargs)
         return ids
 
-    async def update_async(self, id: ObjectId | str, updates: dict, original: dict) -> dict:
+    async def update_async(self, id: ItemId, updates: dict, original: dict) -> dict:
         return await self.backend.update_async(self.datasource, id, updates, original)
 
-    async def system_update_async(self, id: ObjectId | str, updates: dict, original: dict, **kwargs) -> dict:
+    async def system_update_async(self, id: ItemId, updates: dict, original: dict, **kwargs) -> dict:
         return await self.backend.system_update_async(self.datasource, id, updates, original, **kwargs)
 
-    async def replace_async(self, id: ObjectId | str, document: dict, original: dict) -> None:
+    async def replace_async(self, id: ItemId, document: dict, original: dict) -> None:
         return await self.backend.replace_async(self.datasource, id, document, original)
 
-    async def delete_async(self, lookup: dict) -> list[ObjectId | str]:
+    async def delete_async(self, lookup: dict) -> list[ItemId]:
         return await self.backend.delete_async(self.datasource, lookup)
 
-    async def delete_ids_from_mongo_async(self, ids: list[ObjectId | str]) -> list[ObjectId | str]:
+    async def delete_ids_from_mongo_async(self, ids: list[ItemId]) -> list[ItemId]:
         return await self.backend.delete_ids_from_mongo_async(self.datasource, ids)
 
     async def delete_from_mongo_async(self, lookup: dict) -> None:
@@ -83,7 +83,7 @@ class AsyncBaseService(BaseService):
 
         await self.backend.delete_from_mongo_async(self.datasource, lookup)
 
-    async def delete_docs_async(self, docs: list[dict]) -> list[ObjectId | str]:
+    async def delete_docs_async(self, docs: list[dict]) -> list[ItemId]:
         for doc in docs:
             self.on_delete(doc)
             await self.on_delete_async(doc)
@@ -155,7 +155,7 @@ class AsyncBaseService(BaseService):
         else:
             logger.warning("Not enough iterations for resource %s", self.datasource)
 
-    async def post_async(self, docs: list[dict], **kwargs) -> list[ObjectId | str]:
+    async def post_async(self, docs: list[dict], **kwargs) -> list[ItemId]:
         for doc in docs:
             self._resolve_defaults(doc)
         await self.on_create_async(docs)
@@ -165,7 +165,7 @@ class AsyncBaseService(BaseService):
         self.on_created(docs)
         return ids
 
-    async def patch_async(self, id: ObjectId | str, updates: dict) -> dict:
+    async def patch_async(self, id: ItemId, updates: dict) -> dict:
         from superdesk.core import get_app_config
 
         original = await self.find_one_async(req=None, _id=id)
@@ -184,7 +184,7 @@ class AsyncBaseService(BaseService):
         self.on_updated(updates, original)
         return res
 
-    async def put_async(self, id: ObjectId | str, document: dict) -> None:
+    async def put_async(self, id: ItemId, document: dict) -> None:
         self._resolve_defaults(document)
         original = await self.find_one_async(req=None, _id=id)
         if original is None:
@@ -197,7 +197,7 @@ class AsyncBaseService(BaseService):
         await self.on_replaced_async(document, original)
         self.on_replaced(document, original)
 
-    async def delete_action_async(self, lookup: dict | None = None) -> list[ObjectId | str]:
+    async def delete_action_async(self, lookup: dict | None = None) -> list[ItemId]:
         if lookup is None:
             lookup = {}
             docs = []

--- a/superdesk/eve_backend.py
+++ b/superdesk/eve_backend.py
@@ -98,15 +98,11 @@ class EveBackend:
         """
         backend = self._backend(endpoint_name, use_async=True)
         item = await backend.find_one(endpoint_name, req=req, **lookup)
-        # TODO-ASYNC: Change `use_async=True` once Elastic supports async
-        search_backend = self._lookup_backend(endpoint_name, fallback=True, use_async=False)
+        search_backend = self._lookup_backend(endpoint_name, fallback=True, use_async=True)
         if search_backend and get_app_config("BACKEND_FIND_ONE_SEARCH_TEST", False):
             # set the parent for the parent child in elastic search
             self._set_parent(endpoint_name, item, lookup)
-            # TODO-ASYNC: Use elastic async
-            item_search = search_backend.find_one(endpoint_name, req=req, **lookup)
-            if isawaitable(item_search):
-                item_search = await item_search
+            item_search = await search_backend.find_one(endpoint_name, req=req, **lookup)
 
             if item is None and item_search:
                 item = item_search
@@ -115,9 +111,7 @@ class EveBackend:
                 logger.warn(item_msg("item is only in mongo", item))
                 try:
                     logger.info(item_msg("trying to add item to elastic", item))
-                    response = search_backend.insert(endpoint_name, [item])
-                    if isawaitable(response):
-                        await response
+                    await search_backend.insert(endpoint_name, [item])
                 except RequestError as e:
                     logger.error(item_msg("failed to add item into elastic error={}".format(str(e)), item))
         return item
@@ -166,6 +160,22 @@ class EveBackend:
         if search_backend:
             return search_backend.find(endpoint_name, req, {})[0]
         else:
+            # Should we raise an exception here?
+            logger.warn("there is no search backend for %s" % endpoint_name)
+
+    async def search_async(self, endpoint_name, source):
+        """Search for items using search backend
+
+        :param string endpoint_name
+        :param dict source
+        """
+        req = ParsedRequest()
+        req.args = {"source": json.dumps(source)}
+        search_backend = self._lookup_backend(endpoint_name, use_async=True)
+        if search_backend:
+            return (await search_backend.find(endpoint_name, req, {}))[0]
+        else:
+            # Should we raise an exception here?
             logger.warn("there is no search backend for %s" % endpoint_name)
 
     def get(self, endpoint_name, req, lookup, **kwargs):
@@ -178,14 +188,9 @@ class EveBackend:
         backend = self._lookup_backend(endpoint_name, fallback=True)
         is_mongo = self._backend(endpoint_name) == backend
 
-        cursor, _ = backend.find(endpoint_name, req, lookup, perform_count=False)
+        cursor, count = backend.find(endpoint_name, req, lookup, perform_count=req.if_modified_since)
 
-        try:
-            has_items = cursor[0] is not None
-        except IndexError:
-            has_items = False
-
-        if req.if_modified_since and has_items:
+        if req.if_modified_since and count:
             # fetch all items, not just updated
             req.if_modified_since = None
             cursor, count = backend.find(endpoint_name, req, lookup, perform_count=False)
@@ -207,20 +212,11 @@ class EveBackend:
         backend = self._lookup_backend(endpoint_name, fallback=True, use_async=True)
         is_mongo = self._backend(endpoint_name, use_async=True) == backend
 
-        # TODO-ASYNC: This will cause an issue until Elastic is upgraded to async
-        cursor, _ = await backend.find(endpoint_name, req, lookup, perform_count=False)
+        cursor, count = await backend.find(endpoint_name, req, lookup, perform_count=req.if_modified_since)
 
-        try:
-            has_items = (await cursor.next()) is not None
-        except (IndexError, StopAsyncIteration):
-            has_items = False
-
-        cursor.rewind()
-
-        if req.if_modified_since and has_items:
+        if req.if_modified_since and count:
             # fetch all items, not just updated
             req.if_modified_since = None
-            # TODO-ASYNC: This will cause an issue until Elastic is upgraded to async
             cursor, count = await backend.find(endpoint_name, req, lookup, perform_count=False)
 
         source_config = get_app_config("DOMAIN")[endpoint_name]
@@ -375,10 +371,9 @@ class EveBackend:
         :param docs: list of docs
         """
 
-        # TODO-ASYNC: Use async elastic
         search_backend = self._lookup_backend(endpoint_name, use_async=True)
         if search_backend:
-            search_backend.insert(endpoint_name, docs, **kwargs)
+            await search_backend.insert(endpoint_name, docs, **kwargs)
 
     def update(self, endpoint_name, id, updates, original):
         """Update document with given id.
@@ -528,8 +523,7 @@ class EveBackend:
             if not await backend.find_one(endpoint_name, req=None, _id=id) and search_backend:
                 # item is in elastic, not in mongo - not good
                 logger.warn("Item is missing in mongo resource={} id={}".format(endpoint_name, id))
-                # TODO-ASYNC: use async elastic
-                item = search_backend.find_one(endpoint_name, req=None, _id=id)
+                item = await search_backend.find_one(endpoint_name, req=None, _id=id)
                 if item:
                     await self.remove_from_search_async(endpoint_name, item)
                 raise SuperdeskApiError.notFoundError()
@@ -550,18 +544,15 @@ class EveBackend:
             doc = await backend.find_one(endpoint_name, req=None, _id=id)
             if not doc:  # there is no doc in mongo, remove it from elastic
                 logger.warn("Item is missing in mongo resource={} id={}".format(endpoint_name, id))
-                # TODO-ASYNC: Use elastic async
-                item = search_backend.find_one(endpoint_name, req=None, _id=id)
+                item = await search_backend.find_one(endpoint_name, req=None, _id=id)
                 if item:
                     await self.remove_from_search_async(endpoint_name, item)
                 raise SuperdeskApiError.notFoundError()
             try:
-                # TODO-ASYNC: Use elastic async
-                search_backend.update(endpoint_name, id, doc)
+                await search_backend.update(endpoint_name, id, doc)
             except NotFoundError:
                 logger.warning("Item is missing in elastic resource=%s id=%s", endpoint_name, id)
-                # TODO-ASYNC: Use elastic async
-                search_backend.insert(endpoint_name, [doc])
+                await search_backend.insert(endpoint_name, [doc])
 
         cache.clean([endpoint_name])
         return updates
@@ -612,6 +603,26 @@ class EveBackend:
         res = backend.update(endpoint_name, id, updates, original)
         return res if res is not None else updates
 
+    async def update_in_mongo_async(self, endpoint_name, id, updates, original):
+        """Update item in mongo.
+
+        Modifies ``_updated`` timestamp and ``_etag``.
+
+        :param endpoint_name: resource name
+        :param id: item id
+        :param updates: updates to item to be saved
+        :param original: current version of the item
+        """
+        updates.setdefault(LAST_UPDATED, utcnow())
+        if ETAG not in updates:
+            updated = original.copy()
+            updated.update(updates)
+            resolve_document_etag(updated, endpoint_name)
+            updates[ETAG] = updated[ETAG]
+        backend = self._backend(endpoint_name, use_async=True)
+        res = await backend.update(endpoint_name, id, updates, original)
+        return res if res is not None else updates
+
     def replace_in_mongo(self, endpoint_name, id, document, original):
         """Replace item in mongo.
 
@@ -655,10 +666,9 @@ class EveBackend:
         :param document: next version of item
         :param original: current version of item
         """
-        # TODO-ASYNC: Use elastic async
         search_backend = self._lookup_backend(endpoint_name, use_async=True)
         if search_backend is not None:
-            search_backend.replace(endpoint_name, id, document)
+            await search_backend.replace(endpoint_name, id, document)
 
     def delete(self, endpoint_name, lookup):
         """Delete method to delete by using mongo query syntax.
@@ -702,8 +712,7 @@ class EveBackend:
         elif "_id" in lookup and search_backend:
             logger.warning("Item missing in mongo, deleting from elastic resource=%s lookup=%s", endpoint_name, lookup)
             try:
-                # TODO-ASYNC: Use elastic async
-                search_backend.remove(endpoint_name, lookup)
+                await search_backend.remove(endpoint_name, lookup)
                 removed_ids = [lookup["_id"]]
             except NotFoundError:
                 pass  # not found in elastic and not in mongo
@@ -839,9 +848,8 @@ class EveBackend:
         :param dict doc: Document to delete
         """
 
-        # TODO-ASYNC: Use elastic async
-        search_backend = get_current_app().data._search_backend(endpoint_name)
-        search_backend.remove(
+        search_backend = get_current_app().data._search_backend(endpoint_name, use_async=True)
+        await search_backend.remove(
             endpoint_name, {"_id": doc.get(ID_FIELD)}, search_backend.get_parent_id(endpoint_name, doc)
         )
 
@@ -853,7 +861,7 @@ class EveBackend:
 
     def _lookup_backend(self, endpoint_name, fallback=False, use_async: bool = False):
         app = get_current_app()
-        backend = app.data._search_backend(endpoint_name)
+        backend = app.data._search_backend(endpoint_name, use_async=use_async)
         if backend is None and fallback:
             backend = app.data._backend(endpoint_name, use_async)
         return backend

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -585,6 +585,9 @@ class MockWSGI:
     def register_endpoint(self, endpoint):
         pass
 
+    def as_any(self):
+        return self
+
 
 class AsyncTestCase(IsolatedAsyncioTestCase):
     app: SuperdeskAsyncApp

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -22,6 +22,7 @@ from unittest import IsolatedAsyncioTestCase
 from quart import Response
 from quart.testing import QuartClient
 from werkzeug.datastructures import Authorization
+from eve.events import Events
 
 from superdesk.core import json
 from superdesk.flask import Config
@@ -576,7 +577,7 @@ def teardown_notification(context):
 
 
 @dataclass
-class MockWSGI:
+class MockWSGI(Events):
     config: Dict[str, Any]
 
     def add_url_rule(self, *args, **kwargs):

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -103,6 +103,7 @@ def update_config(conf, auto_add_apps: bool = True):
     conf["LEGAL_ARCHIVE"] = True
     if auto_add_apps:
         conf["INSTALLED_APPS"].extend(["planning", "superdesk.macros.imperial", "apps.rundowns"])
+        conf["MODULES"].extend(["planning"])
 
     # limit mongodb connections
     conf["MONGO_CONNECT"] = False

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -182,6 +182,7 @@ def setup_config(config, auto_add_apps: bool = True):
     app_abspath = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
     app_config = Config(app_abspath)
     app_config.from_object("superdesk.default_settings")
+    app_config = deepcopy(app_config)
     cwd = Path.cwd()
     for p in [cwd] + list(cwd.parents):
         settings = p / "settings.py"

--- a/superdesk/tests/utils.py
+++ b/superdesk/tests/utils.py
@@ -28,7 +28,7 @@ async def post_items(resource: str, items: list[dict]) -> None:
     # except KeyError:
     service = get_resource_service(resource)
     if hasattr(service, "post_async"):
-        return await service.post_async(items)
+        await service.post_async(items)
     else:
         return service.post(items)
 
@@ -41,7 +41,7 @@ async def patch_item(resource: str, item_id: str | ObjectId, updates: dict) -> N
     # except KeyError:
     service = get_resource_service(resource)
     if hasattr(service, "patch_async"):
-        return await service.patch_async(item_id, updates)
+        await service.patch_async(item_id, updates)
     else:
         return service.patch(item_id, updates)
 
@@ -54,7 +54,7 @@ async def system_update(resource: str, item_id: str | ObjectId, updates: dict, o
     # except KeyError:
     service = get_resource_service(resource)
     if hasattr(service, "system_update_async"):
-        return await service.system_update_async(item_id, updates, original)
+        await service.system_update_async(item_id, updates, original)
     else:
         return service.system_update(item_id, updates, original)
 
@@ -69,6 +69,6 @@ async def delete_items(resource: str, lookup: dict | None = None) -> None:
     # except KeyError:
     service = get_resource_service(resource)
     if hasattr(service, "delete_action_async"):
-        return await service.delete_action_async(lookup)
+        await service.delete_action_async(lookup)
     else:
         return service.delete_action(lookup)

--- a/superdesk/users/async_service.py
+++ b/superdesk/users/async_service.py
@@ -267,7 +267,7 @@ class UsersAsyncService(AsyncResourceService[UsersResourceModel]):
 
     async def on_updated(self, updates: dict[str, Any], original: UsersResourceModel) -> None:
         if "role" in updates or "privileges" in updates:
-            await get_resource_service("preferences").on_update_async(updates, original)
+            await get_resource_service("preferences").on_update_async(updates, original.to_dict())
         await self.__handle_status_changed(updates, original)
         await self.handle_user_type_changed(updates, original)
         await self.__send_notification(updates, original)

--- a/tests/core/resource_hateoas_test.py
+++ b/tests/core/resource_hateoas_test.py
@@ -3,7 +3,7 @@ from tests.core.modules.module_related_resources import RingBearerService, RingO
 
 
 class ResourceHateoasTestCase(AsyncFlaskTestCase):
-    use_default_apps = True
+    use_default_apps = False
     app_config = {
         "MODULES": [
             "tests.core.modules.module_related_resources",

--- a/tests/core/resource_privileged_endpoints_test.py
+++ b/tests/core/resource_privileged_endpoints_test.py
@@ -5,13 +5,22 @@ from superdesk.tests import AsyncFlaskTestCase, setup_auth_user, test_user
 
 
 class PrivilegedResourceEndpointsTestCase(AsyncFlaskTestCase):
-    use_default_apps = True
+    use_default_apps = False
     app_config = {
         "MODULES": [
             "tests.core.modules.users",
             "tests.core.modules.module_with_privileges",
             "superdesk.users",
-        ]
+        ],
+        "CORE_APPS": [
+            "superdesk.activity",
+            "apps.auth",
+            "superdesk.users",
+            "apps.auth.db",
+            "superdesk.roles",
+            "apps.preferences",
+            "apps.stages",
+        ],
     }
 
     async def _get_auth_token(self, user: dict[str, Any] | None = None):

--- a/tests/core/signals_test.py
+++ b/tests/core/signals_test.py
@@ -275,7 +275,7 @@ class ResourceWebSignalsTestCase(AsyncFlaskTestCase):
                 ANY,
                 Response(
                     {
-                        **test_user.to_dict(exclude_unset=False, exclude_defaults=False),
+                        **test_user.to_dict(),
                         "_status": "OK",
                         "_links": {"self": {"title": "User", "href": "users_async/user_1"}},
                     },


### PR DESCRIPTION
### Purpose
Implement an async Eve datalayer for Elasticsearch.

### What has changed:
* Add new Elastic async eve datalayer
* Add common Eve async cursor types
* Improves types for async eve service class (more type improvements to be added later to eve_backend and datalayer)
* Fix various async issues found
* Use my branch for eve-elastic (will revert back to superdesk/eve-elastic once it's merged)

Depends on: https://github.com/superdesk/eve-elastic/pull/131