### PR TITLE
[SDESK-7564] fix: Raised SuperdeskValidationError required async code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     - run: ./scripts/tests_setup
     - run: pip install -U pip wheel setuptools
     - run: pip install -Ur dev-requirements.txt
-#    - run: pytest -p no:asyncio --log-level=ERROR --disable-warnings tests/core
+    - run: pytest -p no:asyncio --log-level=ERROR --disable-warnings tests/core
     - run: pytest -p no:asyncio --log-level=ERROR --disable-warnings --ignore=tests/core
 
   pip-compile:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     - run: pip install -U pip wheel setuptools
     - run: pip install -Ur dev-requirements.txt
     - run: pytest -p no:asyncio --log-level=ERROR --disable-warnings tests/core
-    - run: ulimit -n 2048 && pytest -p no:asyncio --log-level=ERROR --disable-warnings --ignore=tests/core
+    - run: pytest -p no:asyncio --log-level=ERROR --disable-warnings --ignore=tests/core
 
   pip-compile:
     runs-on: ubuntu-22.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     - run: pip install -U pip wheel setuptools
     - run: pip install -Ur dev-requirements.txt
     - run: pytest -p no:asyncio --log-level=ERROR --disable-warnings tests/core
-    - run: pytest -p no:asyncio --log-level=ERROR --disable-warnings --ignore=tests/core
+    - run: ulimit -n 2048 && pytest -p no:asyncio --log-level=ERROR --disable-warnings --ignore=tests/core
 
   pip-compile:
     runs-on: ubuntu-22.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     - run: ./scripts/tests_setup
     - run: pip install -U pip wheel setuptools
     - run: pip install -Ur dev-requirements.txt
-    - run: pytest -p no:asyncio --log-level=ERROR --disable-warnings tests/core
+#    - run: pytest -p no:asyncio --log-level=ERROR --disable-warnings tests/core
     - run: pytest -p no:asyncio --log-level=ERROR --disable-warnings --ignore=tests/core
 
   pip-compile:

--- a/apps/prepopulate/app_prepopulate.py
+++ b/apps/prepopulate/app_prepopulate.py
@@ -201,10 +201,7 @@ class PrepopulateService(AsyncBaseService):
         app = get_current_app()
         for doc in docs:
             if doc.get("remove_first"):
-                await clean_dbs(app, force=True)
-
-            app.init_indexes()
-            await app.data.init_elastic(app)
+                await clean_dbs(app, force=True, init_indexes=True)
 
             get_resource_service("users").stop_updating_stage_visibility()
 

--- a/apps/vidible/vidible.py
+++ b/apps/vidible/vidible.py
@@ -55,9 +55,9 @@ def get_vidible_metadata(bcid, pid):
 
 
 @bp.route("/vidible/bcid/<bcid>/pid/<pid>", methods=["GET", "OPTIONS"])
-def vidible(**kwargs):
+async def vidible(**kwargs):
     meta = get_vidible_metadata(**kwargs)
     if meta:
-        return send_response(None, (meta, utcnow(), None, 200))
+        return await send_response(None, (meta, utcnow(), None, 200))
     else:
-        return send_response(None, ({"error": "not found"}, utcnow(), None, 404))
+        return await send_response(None, ({"error": "not found"}, utcnow(), None, 404))

--- a/superdesk/core/app.py
+++ b/superdesk/core/app.py
@@ -229,6 +229,7 @@ class SuperdeskAsyncApp(SignalGroup):
 
         self.on_app_shutdown.send(self)
         self.mongo.stop()
+        self.resources.stop()
         self._imported_modules.clear()
         self._remove_app()
         self._running = False

--- a/superdesk/core/resources/resource_manager.py
+++ b/superdesk/core/resources/resource_manager.py
@@ -82,3 +82,9 @@ class Resources(SignalGroup):
 
     def get_resource_service(self, resource_name: str) -> AsyncResourceService:
         return self._resource_services[resource_name]
+
+    def stop(self):
+        # Remove any singleton instances from services
+        for service in self._resource_services:
+            if hasattr(service, "_instance"):
+                del service._instance

--- a/superdesk/errors.py
+++ b/superdesk/errors.py
@@ -11,7 +11,6 @@
 import logging
 
 from cerberus import DocumentError
-from eve.endpoints import send_response
 from werkzeug.exceptions import HTTPException
 from elasticsearch.exceptions import ConnectionTimeout  # noqa
 
@@ -772,20 +771,27 @@ class SuperdeskValidationError(HTTPException):
         self.fields = fields
 
         try:
-            self.response = send_response(
-                None,
-                (
+            # Importing here due to circular import issues
+            from superdesk.core import get_current_app, get_config, json
+
+            self.response = get_current_app().response_class(
+                json.dumps(
                     {
                         STATUS: STATUS_ERR,
                         ISSUES: {
                             "validator exception": str([self.errors]),  # BC
                             "fields": self.fields,
                         },
-                    },
-                    None,
-                    None,
-                    400,
+                    }
                 ),
+                400,
+                {
+                    "Access-Control-Allow-Origin": get_config(str, "CLIENT_URL"),
+                    "Access-Control-Allow-Headers": ",".join(get_config(list, "X_HEADERS")),
+                    "Access-Control-Allow-Credentials": "true",
+                    "Access-Control-Allow-Methods": "*",
+                    "Content-Type": "application/json",
+                },
             )
         except RuntimeError as e:
             # the exception is run outside of request context

--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -17,6 +17,7 @@ import importlib
 import superdesk
 import logging
 import sentry_sdk
+import asyncio
 
 from pydantic import ValidationError
 from celery import Celery
@@ -238,8 +239,10 @@ class SuperdeskEve(eve.Eve):
     media: Any
     data: Any
     celery: Celery
+    shutdown_event: asyncio.Event | None
 
     def __init__(self, **kwargs):
+        self.shutdown_event = None
         self.json_provider_class = SuperdeskFlaskJSONProvider
         self._endpoints = []
         self._endpoint_groups = []
@@ -474,6 +477,46 @@ class SuperdeskEve(eve.Eve):
                             "title": endpoint.name or endpoint.url.replace("/", "_"),
                         }
                     )
+
+    async def shutdown(self) -> None:
+        if not self.shutdown_event:
+            # Flask/Quart uses ``shutdown_event``, but it's not always set
+            # so make sure it is set here before we shut down
+            self.shutdown_event = asyncio.Event()
+
+        # Call Flask/Quart shutdown, so any background tasks etc are run before we close our DB connections
+        await super().shutdown()
+
+        await self.async_app.elastic.stop()
+        self.async_app.stop()
+
+        # Close all the eve-mongo datalayer clients
+        for extension_name in {"pymongo", "pymongo_async"}:
+            for key, val in self.extensions.get(extension_name, {}).items():
+                val[0].close()
+            self.extensions[extension_name] = {}
+
+        # Close all the eve-elastic datalayer clients
+        self.data.elastic.es.close()
+        for client in self.data.elastic.elastics.values():
+            client.close()
+        self.data.elastic.elastics = {}
+
+        # Close all the eve-elastic async datalayer clients
+        self.data.elastic_async.es.close()
+        await self.data.elastic_async.es_async.close()
+        for client in self.data.elastic_async.elastics.values():
+            await client.close()
+        self.data.elastic_async.elastics = {}
+
+        # Close all redis and cache clients
+        if hasattr(self.redis, "close"):
+            self.redis.close()
+
+        if hasattr(self.extensions.get("superdesk_cache"), "client") and hasattr(
+            self.extensions["superdesk_cache"].client, "close"
+        ):
+            self.extensions["superdesk_cache"].client.close()
 
 
 def get_media_storage_class(app_config: Dict[str, Any], use_provider_config: bool = True) -> Type[MediaStorage]:

--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -190,39 +190,43 @@ def set_error_handlers(app):
     """
 
     @app.errorhandler(ValidationError)
-    def handle_pydantic_validation_error(error: ValidationError):
+    async def handle_pydantic_validation_error(error: ValidationError):
         """
         Gets the ValidationException error raised from Core framework's models/services, parses and returns it
         to the client in a valid json format.
         """
         logger.error(f"HTTP Exception 400 has been raised: {error}")
         error_dict = convert_pydantic_validation_error_for_response(error)
-        return send_response(None, (error_dict, None, None, 400))
+        return await send_response(None, (error_dict, None, None, 400))
 
     @app.errorhandler(SuperdeskError)
-    def client_error_handler(error):
+    async def client_error_handler(error):
         error_dict = error.to_dict()
         error_dict.update(internal_error=error.status_code)
         status_code = error.status_code or 422
-        return send_response(None, (error_dict, None, None, status_code))
+        return await send_response(None, (error_dict, None, None, status_code))
 
     @app.errorhandler(403)
-    def server_forbidden_handler(error):
-        return send_response(None, ({"code": 403, "error": error.response}, None, None, 403))
+    async def server_forbidden_handler(error):
+        return await send_response(None, ({"code": 403, "error": error.response}, None, None, 403))
 
     @app.errorhandler(AssertionError)
-    def assert_error_handler(error):
-        return send_response(None, ({"code": 400, "error": str(error) if str(error) else "assert"}, None, None, 400))
+    async def assert_error_handler(error):
+        return await send_response(
+            None, ({"code": 400, "error": str(error) if str(error) else "assert"}, None, None, 400)
+        )
 
     @app.errorhandler(DocumentError)
-    def document_error_handler(error):
-        return send_response(None, ({"code": 400, "error": str(error) if str(error) else "assert"}, None, None, 400))
+    async def document_error_handler(error):
+        return await send_response(
+            None, ({"code": 400, "error": str(error) if str(error) else "assert"}, None, None, 400)
+        )
 
     @app.errorhandler(500)
-    def server_error_handler(error):
+    async def server_error_handler(error):
         """Log server errors."""
         return_error = SuperdeskApiError.internalError(error)
-        return client_error_handler(return_error)
+        return await client_error_handler(return_error)
 
 
 class SuperdeskEve(eve.Eve):

--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -17,7 +17,6 @@ import importlib
 import superdesk
 import logging
 import sentry_sdk
-import asyncio
 
 from pydantic import ValidationError
 from celery import Celery
@@ -239,10 +238,8 @@ class SuperdeskEve(eve.Eve):
     media: Any
     data: Any
     celery: Celery
-    shutdown_event: asyncio.Event | None
 
     def __init__(self, **kwargs):
-        self.shutdown_event = None
         self.json_provider_class = SuperdeskFlaskJSONProvider
         self._endpoints = []
         self._endpoint_groups = []
@@ -477,46 +474,6 @@ class SuperdeskEve(eve.Eve):
                             "title": endpoint.name or endpoint.url.replace("/", "_"),
                         }
                     )
-
-    async def shutdown(self) -> None:
-        if not self.shutdown_event:
-            # Flask/Quart uses ``shutdown_event``, but it's not always set
-            # so make sure it is set here before we shut down
-            self.shutdown_event = asyncio.Event()
-
-        # Call Flask/Quart shutdown, so any background tasks etc are run before we close our DB connections
-        await super().shutdown()
-
-        await self.async_app.elastic.stop()
-        self.async_app.stop()
-
-        # Close all the eve-mongo datalayer clients
-        for extension_name in {"pymongo", "pymongo_async"}:
-            for key, val in self.extensions.get(extension_name, {}).items():
-                val[0].close()
-            self.extensions[extension_name] = {}
-
-        # Close all the eve-elastic datalayer clients
-        self.data.elastic.es.close()
-        for client in self.data.elastic.elastics.values():
-            client.close()
-        self.data.elastic.elastics = {}
-
-        # Close all the eve-elastic async datalayer clients
-        self.data.elastic_async.es.close()
-        await self.data.elastic_async.es_async.close()
-        for client in self.data.elastic_async.elastics.values():
-            await client.close()
-        self.data.elastic_async.elastics = {}
-
-        # Close all redis and cache clients
-        if hasattr(self.redis, "close"):
-            self.redis.close()
-
-        if hasattr(self.extensions.get("superdesk_cache"), "client") and hasattr(
-            self.extensions["superdesk_cache"].client, "close"
-        ):
-            self.extensions["superdesk_cache"].client.close()
 
 
 def get_media_storage_class(app_config: Dict[str, Any], use_provider_config: bool = True) -> Type[MediaStorage]:

--- a/superdesk/io/subjectcodes.py
+++ b/superdesk/io/subjectcodes.py
@@ -74,10 +74,10 @@ def get_parent_subjectcode(code):
 
 @bp.route("/subjectcodes/", methods=["GET", "OPTIONS"])
 @blueprint_auth()
-def render_subjectcodes():
+async def render_subjectcodes():
     items = get_subjectcodeitems()
     response_data = {"_items": items, "_meta": {"total": len(items)}}
-    return send_response(None, (response_data, get_current_app().subjects.last_modified, None, 200))
+    return await send_response(None, (response_data, get_current_app().subjects.last_modified, None, 200))
 
 
 def get_subjectcodeitems():

--- a/superdesk/locales.py
+++ b/superdesk/locales.py
@@ -26,11 +26,11 @@ def get_timezones():
 
 @bp.route("/locales/timezones", methods=["GET", "OPTIONS"])
 @blueprint_auth("locales")
-def locales_view():
+async def locales_view():
     resp = None
     if request.method == "GET":
         resp = {"timezones": get_timezones()}
-    return send_response(None, (resp, None, None, 200))
+    return await send_response(None, (resp, None, None, 200))
 
 
 def init_app(app) -> None:

--- a/superdesk/locators/locators.py
+++ b/superdesk/locators/locators.py
@@ -114,7 +114,7 @@ class LocatorIndex:
 @bp.route("/country/<country_code>", methods=["GET", "OPTIONS"])
 @bp.route("/country/<country_code>/state/<state_code>", methods=["GET", "OPTIONS"])
 @blueprint_auth()
-def get_cities(country_code=None, state_code=None):
+async def get_cities(country_code=None, state_code=None):
     """
     Fetches cities and sends the list as response body.
 
@@ -129,6 +129,6 @@ def get_cities(country_code=None, state_code=None):
 
     if cities and len(cities):
         response_data = {"_items": cities, "_meta": {"total": len(cities)}}
-        return send_response(None, (response_data, utcnow(), None, 200))
+        return await send_response(None, (response_data, utcnow(), None, 200))
     else:
-        return send_response(None, ({}, utcnow(), None, 404))
+        return await send_response(None, ({}, utcnow(), None, 404))

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -242,26 +242,38 @@ def update_config_from_step(context, config):
             m.start()
 
 
-async def clean_dbs(app, force=False, init_indexes: bool = False):
-    async with app.app_context():
-        async_app: SuperdeskAsyncApp = app.async_app
+async def clean_dbs(app=None, async_app: SuperdeskAsyncApp | None = None, force=False, init_indexes: bool = False):
+    if async_app is None:
+        if app is None:
+            raise RuntimeError("Async app not provided nor found")
+        async_app = app.async_app
 
-        if init_indexes:
+    if init_indexes:
+        if app:
             await _clean_es(app)
             await drop_mongo(app)
 
+        if async_app:
             for resource_name, resource_config in async_app.mongo.get_all_resource_configs().items():
                 client, db = async_app.mongo.get_client(resource_name)
                 client.drop_database(db)
             async_app.elastic.drop_indexes()
 
+        if app:
             app.init_indexes()
             await app.data.init_elastic(app)
-        else:
+        elif async_app:
+            async_app.mongo.create_indexes_for_all_resources()
+            async_app.elastic.init_all_indexes()
+
+    else:
+        resources_processed: set[str] = set()
+
+        if app:
             es = app.data.elastic
             for resource in es._get_elastic_resources():
+                alias = es._resource_index(resource)
                 try:
-                    alias = es._resource_index(resource)
                     alias_info = es.elastic(resource).indices.get_alias(name=alias)
                     for index in alias_info:
                         es.elastic(resource).indices.refresh(index=index)
@@ -280,13 +292,34 @@ async def clean_dbs(app, force=False, init_indexes: bool = False):
                     except elasticsearch.exceptions.NotFoundError:
                         pass
 
+                resources_processed.add(resource)
+
             await drop_mongo(app)
 
-            for resource_name, resource_config in async_app.mongo.get_all_resource_configs().items():
-                client, db = async_app.mongo.get_client(resource_name)
-                client.drop_database(db)
+        if async_app:
+            for resource_config in async_app.resources.get_all_configs():
+                if resource_config.name in resources_processed:
+                    continue
 
-        cache.clean()
+                mongo_client, mongo_db = async_app.mongo.get_client(resource_config.name)
+                mongo_client.drop_database(mongo_db)
+
+                if not resource_config.elastic:
+                    continue
+
+                try:
+                    es_client = async_app.elastic.get_client(resource_config.name)
+                    es_client.elastic.indices.refresh(index=es_client.config.index)
+                    es_client.elastic.delete_by_query(
+                        index=es_client.config.index,
+                        body={"query": {"match_all": {}}},
+                    )
+                except elasticsearch.exceptions.NotFoundError:
+                    print(f"ES Index not found for {resource_config.name}")
+                    pass
+
+        if app:
+            cache.clean()
 
 
 def retry(exc, count=1):
@@ -408,30 +441,44 @@ def use_snapshot(app, name, funcs=(snapshot_es, snapshot_mongo), force=False):
 use_snapshot.cache = {}  # type: ignore
 
 
-async def setup(context=None, config=None, app_factory=get_app, reset=False, auto_add_apps: bool = True):
-    current_app = getattr(setup, "app", None)
+def copy_db_connections(current_app):
+    previous_app = getattr(setup, "app", None)
+    if not previous_app:
+        return
 
-    if not current_app or hasattr(setup, "reset") or config:  # type: ignore[attr-defined]
+    # Copy the database connections from the previous app
+    # so we re-use them
+    current_app.extensions = previous_app.extensions
+
+    current_app.data.mongo.driver = previous_app.data.mongo.driver
+    current_app.data.mongo_async.driver = previous_app.data.mongo_async.driver
+    current_app.data.elastic.es = previous_app.data.elastic.es
+    current_app.data.elastic.elastics = previous_app.data.elastic.elastics
+
+    current_app.data.elastic_async.es_async = previous_app.data.elastic_async.es_async
+    current_app.data.elastic_async.elastics = previous_app.data.elastic_async.elastics
+
+
+def copy_async_db_connections(current_app):
+    previous_app = getattr(setup, "app", None)
+    if not previous_app:
+        return
+
+    current_app.mongo._mongo_clients = previous_app.async_app.mongo._mongo_clients
+    current_app.mongo._mongo_clients_async = previous_app.async_app.mongo._mongo_clients_async
+    current_app.elastic._elastic_connections = previous_app.async_app.elastic._elastic_connections
+    current_app.elastic._elastic_async_connections = previous_app.async_app.elastic._elastic_async_connections
+
+
+async def setup(context=None, config=None, app_factory=get_app, reset=False, auto_add_apps: bool = True):
+    previous_app = getattr(setup, "app", None)
+
+    if not previous_app or hasattr(setup, "reset") or config:  # type: ignore[attr-defined]
         cfg = setup_config(config, auto_add_apps)
         app = app_factory(cfg)  # type: ignore[attr-defined]
 
-        if current_app:
-            # Copy the database connections from the previous app
-            # so we re-use them
-            app.extensions = current_app.extensions
-
-            app.data.mongo.driver = current_app.data.mongo.driver
-            app.data.mongo_async.driver = current_app.data.mongo_async.driver
-            app.data.elastic.es = current_app.data.elastic.es
-            app.data.elastic.elastics = current_app.data.elastic.elastics
-
-            app.data.elastic_async.es_async = current_app.data.elastic_async.es_async
-            app.data.elastic_async.elastics = current_app.data.elastic_async.elastics
-
-            app.async_app.mongo._mongo_clients = current_app.async_app.mongo._mongo_clients
-            app.async_app.mongo._mongo_clients_async = current_app.async_app.mongo._mongo_clients_async
-            app.async_app.elastic._elastic_connections = current_app.async_app.elastic._elastic_connections
-            app.async_app.elastic._elastic_async_connections = current_app.async_app.elastic._elastic_async_connections
+        copy_db_connections(app)
+        copy_async_db_connections(app.async_app)
 
         setup.app = app  # type: ignore[attr-defined]
         setup.async_app = setup.app.async_app  # type: ignore[attr-defined]
@@ -447,7 +494,8 @@ async def setup(context=None, config=None, app_factory=get_app, reset=False, aut
             context.test_context = app.test_request_context("/")
             await context.test_context.push()
 
-    await clean_dbs(app, init_indexes=True)
+    async with app.app_context():
+        await clean_dbs(app, init_indexes=True)
 
 
 async def setup_auth_user(context, user=None):
@@ -626,11 +674,18 @@ class AsyncTestCase(IsolatedAsyncioTestCase):
     app_config: Dict[str, Any] = {}
     autorun: bool = True
 
-    def setupApp(self):
-        self.app_config = setup_config(deepcopy(self.app_config))
-        self.app = SuperdeskAsyncApp(MockWSGI(config=self.app_config))
-        setattr(setup, "async_app", self.app)
-        self.startApp()
+    @classmethod
+    async def asyncSetUpClass(cls):
+        app_config = setup_config(deepcopy(cls.app_config))
+        cls.app = SuperdeskAsyncApp(MockWSGI(config=app_config))
+        copy_async_db_connections(cls.app)
+        setattr(setup, "async_app", cls.app)
+        await cls.resetDatabase(True)
+        cls.app.start()
+
+    @classmethod
+    async def resetDatabase(cls, init_indexes: bool = False):
+        await clean_dbs(app=None, async_app=cls.app, init_indexes=init_indexes)
 
     def startApp(self):
         self.app.start()
@@ -639,7 +694,7 @@ class AsyncTestCase(IsolatedAsyncioTestCase):
         if not self.autorun:
             return
 
-        self.setupApp()
+        await self.resetDatabase()
 
     def get_fixture_path(self, filename):
         rootpath = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -685,6 +740,7 @@ class AsyncFlaskTestCase(AsyncTestCase):
     app: SuperdeskApp
     use_default_apps: bool = False
     test_client: TestClient
+    clean_reset_db: bool = True
 
     @classmethod
     async def asyncSetUpClass(cls):
@@ -702,10 +758,9 @@ class AsyncFlaskTestCase(AsyncTestCase):
         cls.test_client = cls.app.test_client()
 
     async def asyncSetUp(self):
-        await clean_dbs(self.app, init_indexes=False)
-
         self.ctx = self.app.app_context()
         await self.ctx.push()
+        await clean_dbs(self.app, init_indexes=self.clean_reset_db)
 
         async def clean_ctx():
             if self.ctx:
@@ -719,9 +774,11 @@ class AsyncFlaskTestCase(AsyncTestCase):
     async def get_resource_etag(self, resource: str, item_id: str):
         return (await (await self.test_client.get(f"/api/{resource}/{item_id}")).get_json())["_etag"]
 
-    async def resetDatabase(self):
-        await clean_dbs(self.app, init_indexes=False)
+    @classmethod
+    async def resetDatabase(cls, init_indexes: bool = False):
+        await clean_dbs(cls.app, init_indexes=False)
 
 
 class TestCase(AsyncFlaskTestCase):
     use_default_apps: bool = True
+    clean_reset_db: bool = False

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -373,34 +373,26 @@ async def stop_previous_app():
         async_app: SuperdeskAsyncApp | None = getattr(setup, "async_app", None)
 
         for resource_name, resource_config in async_app.mongo.get_all_resource_configs().items():
-            client, db = async_app.mongo.get_client_async(resource_name)
-            await client.drop_database(db)
+            client, db = async_app.mongo.get_client(resource_name)
+            client.drop_database(db)
 
         async_app.elastic.drop_indexes()
-        await async_app.elastic.stop()
-
-        for service in async_app.resources._resource_services:
-            if hasattr(service, "_instance"):
-                del service._instance
-
-        async_app.stop()
         del setup.async_app
 
     if hasattr(setup, "app"):
         app: SuperdeskApp | None = getattr(setup, "app", None)
-
-        # Close all PyMongo Connections (new ones will be created with ``app_factory`` call)
-        for key, val in app.extensions["pymongo"].items():
-            val[0].close()
-
-        app.extensions["pymongo"] = {}
+        await app.shutdown()
         del setup.app
 
 
 async def setup(context=None, config=None, app_factory=get_app, reset=False, auto_add_apps: bool = True):
     if not hasattr(setup, "app") or hasattr(setup, "reset") or config:  # type: ignore[attr-defined]
+        # As we're constructing a new App instance, we need to stop the previous instance
+        await stop_previous_app()
+
         cfg = setup_config(config, auto_add_apps)
         setup.app = app_factory(cfg)  # type: ignore[attr-defined]
+        setup.async_app = setup.app.async_app  # type: ignore[attr-defined]
         setup.reset = reset  # type: ignore[attr-defined]
     app = setup.app  # type: ignore[attr-defined]
 

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -18,11 +18,12 @@ from dataclasses import dataclass
 
 from copy import deepcopy
 from unittest.mock import patch
-from unittest import IsolatedAsyncioTestCase
+from .async_case import IsolatedAsyncioTestCase
 from quart import Response
 from quart.testing import QuartClient
 from werkzeug.datastructures import Authorization
 from eve.events import Events
+import elasticsearch
 
 from superdesk.core import json
 from superdesk.flask import Config
@@ -241,9 +242,51 @@ def update_config_from_step(context, config):
             m.start()
 
 
-async def clean_dbs(app, force=False):
-    await _clean_es(app)
-    await drop_mongo(app)
+async def clean_dbs(app, force=False, init_indexes: bool = False):
+    async with app.app_context():
+        async_app: SuperdeskAsyncApp = app.async_app
+
+        if init_indexes:
+            await _clean_es(app)
+            await drop_mongo(app)
+
+            for resource_name, resource_config in async_app.mongo.get_all_resource_configs().items():
+                client, db = async_app.mongo.get_client(resource_name)
+                client.drop_database(db)
+            async_app.elastic.drop_indexes()
+
+            app.init_indexes()
+            await app.data.init_elastic(app)
+        else:
+            es = app.data.elastic
+            for resource in es._get_elastic_resources():
+                try:
+                    alias = es._resource_index(resource)
+                    alias_info = es.elastic(resource).indices.get_alias(name=alias)
+                    for index in alias_info:
+                        es.elastic(resource).indices.refresh(index=index)
+                        es.elastic(resource).delete_by_query(
+                            index=index,
+                            body={"query": {"match_all": {}}},
+                        )
+                except elasticsearch.exceptions.NotFoundError:
+                    try:
+                        es.elastic(resource).indices.refresh(index=alias)
+                        es.elastic(resource).delete_by_query(
+                            index=alias,
+                            body={"query": {"match_all": {}}},
+                            refresh="wait_for",
+                        )
+                    except elasticsearch.exceptions.NotFoundError:
+                        pass
+
+            await drop_mongo(app)
+
+            for resource_name, resource_config in async_app.mongo.get_all_resource_configs().items():
+                client, db = async_app.mongo.get_client(resource_name)
+                client.drop_database(db)
+
+        cache.clean()
 
 
 def retry(exc, count=1):
@@ -365,33 +408,32 @@ def use_snapshot(app, name, funcs=(snapshot_es, snapshot_mongo), force=False):
 use_snapshot.cache = {}  # type: ignore
 
 
-async def stop_previous_app():
-    if not hasattr(setup, "async_app") and not hasattr(setup, "app"):
-        return
-
-    if hasattr(setup, "async_app"):
-        async_app: SuperdeskAsyncApp | None = getattr(setup, "async_app", None)
-
-        for resource_name, resource_config in async_app.mongo.get_all_resource_configs().items():
-            client, db = async_app.mongo.get_client(resource_name)
-            client.drop_database(db)
-
-        async_app.elastic.drop_indexes()
-        del setup.async_app
-
-    if hasattr(setup, "app"):
-        app: SuperdeskApp | None = getattr(setup, "app", None)
-        await app.shutdown()
-        del setup.app
-
-
 async def setup(context=None, config=None, app_factory=get_app, reset=False, auto_add_apps: bool = True):
-    if not hasattr(setup, "app") or hasattr(setup, "reset") or config:  # type: ignore[attr-defined]
-        # As we're constructing a new App instance, we need to stop the previous instance
-        await stop_previous_app()
+    current_app = getattr(setup, "app", None)
 
+    if not current_app or hasattr(setup, "reset") or config:  # type: ignore[attr-defined]
         cfg = setup_config(config, auto_add_apps)
-        setup.app = app_factory(cfg)  # type: ignore[attr-defined]
+        app = app_factory(cfg)  # type: ignore[attr-defined]
+
+        if current_app:
+            # Copy the database connections from the previous app
+            # so we re-use them
+            app.extensions = current_app.extensions
+
+            app.data.mongo.driver = current_app.data.mongo.driver
+            app.data.mongo_async.driver = current_app.data.mongo_async.driver
+            app.data.elastic.es = current_app.data.elastic.es
+            app.data.elastic.elastics = current_app.data.elastic.elastics
+
+            app.data.elastic_async.es_async = current_app.data.elastic_async.es_async
+            app.data.elastic_async.elastics = current_app.data.elastic_async.elastics
+
+            app.async_app.mongo._mongo_clients = current_app.async_app.mongo._mongo_clients
+            app.async_app.mongo._mongo_clients_async = current_app.async_app.mongo._mongo_clients_async
+            app.async_app.elastic._elastic_connections = current_app.async_app.elastic._elastic_connections
+            app.async_app.elastic._elastic_async_connections = current_app.async_app.elastic._elastic_async_connections
+
+        setup.app = app  # type: ignore[attr-defined]
         setup.async_app = setup.app.async_app  # type: ignore[attr-defined]
         setup.reset = reset  # type: ignore[attr-defined]
     app = setup.app  # type: ignore[attr-defined]
@@ -405,10 +447,7 @@ async def setup(context=None, config=None, app_factory=get_app, reset=False, aut
             context.test_context = app.test_request_context("/")
             await context.test_context.push()
 
-    async with app.app_context():
-        await clean_dbs(app, force=bool(config))
-        app.data.elastic.init_index()
-        cache.clean()
+    await clean_dbs(app, init_indexes=True)
 
 
 async def setup_auth_user(context, user=None):
@@ -601,7 +640,6 @@ class AsyncTestCase(IsolatedAsyncioTestCase):
             return
 
         self.setupApp()
-        self.addAsyncCleanup(stop_previous_app)
 
     def get_fixture_path(self, filename):
         rootpath = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -646,20 +684,26 @@ class AsyncFlaskTestCase(AsyncTestCase):
     async_app: SuperdeskAsyncApp
     app: SuperdeskApp
     use_default_apps: bool = False
+    test_client: TestClient
 
-    async def asyncSetUp(self):
-        config = deepcopy(self.app_config)
+    @classmethod
+    async def asyncSetUpClass(cls):
+        "Hook method for setting up class fixture before running tests in the class."
+        config = deepcopy(cls.app_config)
 
-        if self.use_default_apps:
-            await setup(self, config=config, reset=True, auto_add_apps=True)
+        if cls.use_default_apps:
+            await setup(cls, config=config, reset=True, auto_add_apps=True)
         else:
             config.setdefault("CORE_APPS", [])
             config.setdefault("INSTALLED_APPS", [])
-            await setup(self, config=config, reset=True, auto_add_apps=False)
-        self.async_app = self.app.async_app
-        setattr(setup, "async_app", self.async_app)
-        self.app.test_client_class = TestClient
-        self.test_client = self.app.test_client()
+            await setup(cls, config=config, reset=True, auto_add_apps=False)
+        cls.async_app = cls.app.async_app
+        cls.app.test_client_class = TestClient
+        cls.test_client = cls.app.test_client()
+
+    async def asyncSetUp(self):
+        await clean_dbs(self.app, init_indexes=False)
+
         self.ctx = self.app.app_context()
         await self.ctx.push()
 
@@ -671,16 +715,12 @@ class AsyncFlaskTestCase(AsyncTestCase):
                     pass
 
         self.addAsyncCleanup(clean_ctx)
-        self.addAsyncCleanup(stop_previous_app)
-        self.async_app.elastic.init_all_indexes()
 
     async def get_resource_etag(self, resource: str, item_id: str):
         return (await (await self.test_client.get(f"/api/{resource}/{item_id}")).get_json())["_etag"]
 
     async def resetDatabase(self):
-        await clean_dbs(self.app)
-        self.app.data.elastic.init_index()
-        cache.clean()
+        await clean_dbs(self.app, init_indexes=False)
 
 
 class TestCase(AsyncFlaskTestCase):

--- a/superdesk/tests/async_case.py
+++ b/superdesk/tests/async_case.py
@@ -1,0 +1,83 @@
+import asyncio
+
+from unittest import IsolatedAsyncioTestCase as AsyncTestCase
+
+
+def get_loop():
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+
+    asyncio.set_event_loop(loop)
+    loop.set_debug(True)
+
+    return loop
+
+
+def call_async(func, /, *args, **kwargs):
+    loop = get_loop()
+    ret = func(*args, **kwargs)
+    return loop.run_until_complete(ret)
+
+
+class IsolatedAsyncioTestCase(AsyncTestCase):
+    @classmethod
+    def setUpClass(cls):
+        "Hook method for setting up class fixture before running tests in the class."
+        call_async(cls.asyncSetUpClass)
+
+    @classmethod
+    def tearDownClass(cls):
+        "Hook method for deconstructing the class fixture after running all tests in the class."
+        call_async(cls.asyncTearDownClass)
+
+    @classmethod
+    async def asyncSetUpClass(cls):
+        "Hook method for setting up class fixture before running tests in the class."
+        pass
+        # print("\t*** asyncSetUpClass")
+
+    @classmethod
+    async def asyncTearDownClass(cls):
+        "Hook method for setting up class fixture before running tests in the class."
+        pass
+        # print("\t--- asyncTearDownClass")
+
+    def _setupAsyncioLoop(self):
+        loop = get_loop()
+        self._asyncioTestLoop = loop
+        fut = loop.create_future()
+        self._asyncioCallsTask = loop.create_task(self._asyncioLoopRunner(fut))
+        loop.run_until_complete(fut)
+
+    def _tearDownAsyncioLoop(self):
+        assert self._asyncioTestLoop is not None, "asyncio test loop is not initialized"
+        loop = self._asyncioTestLoop
+        self._asyncioTestLoop = None
+        self._asyncioCallsQueue.put_nowait(None)
+        loop.run_until_complete(self._asyncioCallsQueue.join())
+
+        # cancel all tasks
+        to_cancel = asyncio.all_tasks(loop)
+        if not to_cancel:
+            return
+
+        for task in to_cancel:
+            task.cancel()
+
+        loop.run_until_complete(asyncio.gather(*to_cancel, return_exceptions=True))
+
+        for task in to_cancel:
+            if task.cancelled():
+                continue
+            if task.exception() is not None:
+                loop.call_exception_handler(
+                    {
+                        "message": "unhandled exception during test shutdown",
+                        "exception": task.exception(),
+                        "task": task,
+                    }
+                )
+        # shutdown asyncgens
+        loop.run_until_complete(loop.shutdown_asyncgens())

--- a/superdesk/tests/async_case.py
+++ b/superdesk/tests/async_case.py
@@ -36,13 +36,11 @@ class IsolatedAsyncioTestCase(AsyncTestCase):
     async def asyncSetUpClass(cls):
         "Hook method for setting up class fixture before running tests in the class."
         pass
-        # print("\t*** asyncSetUpClass")
 
     @classmethod
     async def asyncTearDownClass(cls):
         "Hook method for setting up class fixture before running tests in the class."
         pass
-        # print("\t--- asyncTearDownClass")
 
     def _setupAsyncioLoop(self):
         loop = get_loop()
@@ -81,3 +79,12 @@ class IsolatedAsyncioTestCase(AsyncTestCase):
                 )
         # shutdown asyncgens
         loop.run_until_complete(loop.shutdown_asyncgens())
+
+    # Python v3.12 changes
+    def _tearDownAsyncioRunner(self):
+        pass
+
+    def _setupAsyncioRunner(self):
+        assert self._asyncioRunner is None, "asyncio runner is already initialized"
+        runner = asyncio.Runner(debug=True, loop_factory=get_loop)
+        self._asyncioRunner = runner

--- a/superdesk/tests/environment.py
+++ b/superdesk/tests/environment.py
@@ -39,11 +39,12 @@ def setup_before_all(context, config, app_factory):
     setup_before_all.app_factory = app_factory
 
 
-async def setup_before_scenario(context, scenario, config, app_factory):
+async def before_scenario_async(context, scenario):
+    current_app = context.app
     if scenario.status != "skipped" and "notesting" in scenario.tags:
-        config["SUPERDESK_TESTING"] = False
+        current_app.config["SUPERDESK_TESTING"] = False
 
-    await tests.setup(context, config, app_factory, bool(config))
+    await tests.clean_dbs(current_app, init_indexes=False)
 
     context.headers = [("Content-Type", "application/json"), ("Origin", "localhost")]
 
@@ -95,7 +96,7 @@ def before_all(context):
 def before_feature(context, feature):
     try:
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(before_scenario_async(context, feature))
+        loop.run_until_complete(before_feature_async(context, feature))
     except Exception as e:
         # Make sure exceptions raised are printed to the console
         logger.exception(e)
@@ -108,8 +109,8 @@ async def before_feature_async(context, feature):
         app_factory = setup_before_all.app_factory
     else:
         # superdesk-aap don't use "setup_before_all" already
-        config = getattr(setup_before_scenario, "config", None)
-        app_factory = getattr(setup_before_scenario, "app_factory", None)
+        config = getattr(before_scenario_async, "config", None)
+        app_factory = getattr(before_scenario_async, "app_factory", None)
     config = deepcopy(config or {})
     app_factory = app_factory or get_app
 
@@ -136,11 +137,6 @@ def before_scenario(context, scenario):
         # Make sure exceptions raised are printed to the console
         logger.exception(e)
         raise e
-
-
-async def before_scenario_async(context, scenario):
-    config = {}
-    await setup_before_scenario(context, scenario, config, app_factory=get_app)
 
 
 def after_scenario(context, scenario):

--- a/superdesk/tests/environment.py
+++ b/superdesk/tests/environment.py
@@ -44,7 +44,8 @@ async def before_scenario_async(context, scenario):
     if scenario.status != "skipped" and "notesting" in scenario.tags:
         current_app.config["SUPERDESK_TESTING"] = False
 
-    await tests.clean_dbs(current_app, init_indexes=False)
+    async with current_app.app_context():
+        await tests.clean_dbs(current_app, init_indexes=False)
 
     context.headers = [("Content-Type", "application/json"), ("Origin", "localhost")]
 

--- a/tests/core/config_test.py
+++ b/tests/core/config_test.py
@@ -68,40 +68,44 @@ class ModuleConfigTestCase(AsyncTestCase):
     app_config = {"MODULES": ["tests.core.modules.module_with_config"]}
     autorun = False
 
-    async def asyncSetUp(self, force: bool = False):
-        self.app_config = {"MODULES": ["tests.core.modules.module_with_config"]}
-        module_with_config.config.load_from_dict({}, freeze=False)
-        module_with_config.module.config_prefix = None
-        module_with_config.module.freeze_config = True
-        await super().asyncSetUp()
+    @classmethod
+    async def asyncSetUpClass(cls):
+        pass
 
-    def test_module_config(self):
-        self.setupApp()
+    async def setupApp(self, config: dict | None = None, config_prefix: str | None = None):
+        ModuleConfigTestCase.app_config = {
+            "MODULES": ["tests.core.modules.module_with_config"],
+            **(config or {}),
+        }
+        # Reset the module config instance
+        module_with_config.config = module_with_config.module.config = module_with_config.ModuleConfig()
+        module_with_config.module.config_prefix = config_prefix
+        await super().asyncSetUpClass()
+
+    async def test_module_config(self):
+        await self.setupApp()
         self.assertEqual(module_with_config.ModuleConfig(), module_with_config.config)
 
-    def test_app_fails_to_start_with_invalid_config(self):
-        self.app_config["DEFAULT_STRING"] = "abcd123"
-        self.setupApp()
+    async def test_app_fails_to_start_with_invalid_config(self):
+        await self.setupApp({"DEFAULT_STRING": "abcd123"})
         self.assertEqual(module_with_config.config.default_string, "abcd123")
 
-    def test_module_config_prefix(self):
-        module_with_config.module.config_prefix = "CUSTOM"
-        self.app_config["CUSTOM_DEFAULT_STRING"] = "abcd123"
-        self.setupApp()
+    async def test_module_config_prefix(self):
+        await self.setupApp({"CUSTOM_DEFAULT_STRING": "abcd123"}, config_prefix="CUSTOM")
         self.assertEqual(module_with_config.config.default_string, "abcd123")
 
     @markers.investigate_cause_of_error
-    def test_module_config_immutability(self):
-        self.setupApp()
+    async def test_module_config_immutability(self):
+        await self.setupApp()
 
         # Test module config immutability
         with self.assertRaises(ValidationError):
             module_with_config.config.default_string = "test-immutability"
         self.assertEqual(module_with_config.config.default_string, "test-default")
 
-    def test_module_config_mutable(self):
+    async def test_module_config_mutable(self):
         module_with_config.module.freeze_config = False
-        self.setupApp()
+        await self.setupApp()
 
         # Test module config is mutable
         module_with_config.config.default_string = "test-immutability"

--- a/tests/core/privilege_rules_test.py
+++ b/tests/core/privilege_rules_test.py
@@ -1,7 +1,7 @@
-from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch, MagicMock
 from superdesk.errors import SuperdeskApiError
 from superdesk.core.auth.privilege_rules import http_method_privilege_based_rules, required_privilege_rule
+from superdesk.tests import IsolatedAsyncioTestCase
 
 
 class TestPrivilegeRules(IsolatedAsyncioTestCase):

--- a/tests/core/resource_service_test.py
+++ b/tests/core/resource_service_test.py
@@ -33,8 +33,9 @@ class TestResourceService(AsyncTestCase):
     service: AsyncResourceService[User]
 
     async def asyncSetUp(self):
+        await super().asyncSetUpClass()
         await super().asyncSetUp()
-        self.app.elastic.init_index("users_async")
+        await self.resetDatabase(True)
         self.service = User.get_service()
 
     @mock.patch("superdesk.core.resources.service.utcnow", return_value=NOW)

--- a/tests/core/signals_test.py
+++ b/tests/core/signals_test.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest import IsolatedAsyncioTestCase, mock
+from unittest import mock
 from unittest.mock import Mock, AsyncMock, ANY
 
 from superdesk.core import AsyncSignal
@@ -11,7 +11,7 @@ from superdesk.utils import format_time
 from superdesk.factory.app import HttpFlaskRequest
 from superdesk.errors import SuperdeskApiError
 
-from superdesk.tests import AsyncTestCase, AsyncFlaskTestCase
+from superdesk.tests import AsyncTestCase, AsyncFlaskTestCase, IsolatedAsyncioTestCase
 
 from .modules.users import User
 from .fixtures.users import john_doe


### PR DESCRIPTION
### Purpose
The `SuperdeskValidationError` exception used `send_response` from Eve lib, which is async. This is invalid and causes issues in Quart/Flask code

### What has changed
* Manually construct the response in the `SuperdeskValidationError`, including CORS headers
* Update usage of `send_response` in other parts of the code base to await the response