### PR TITLE
[SDESK-7578] Upgrade upload, download and attachments resources to async

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -543,6 +543,7 @@ class ArchiveService(BaseService, HighlightsSearchMixin):
 
         for attachment_id in attachment_ids_to_remove:
             lookup = {"_id": attachment_id}
+            # TODO-ASYNC[attachments]: Use ``delete_action_async``
             get_resource_service("attachments").delete_action(lookup)
 
     def on_updated(self, updates, original):

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -543,6 +543,7 @@ def remove_media_files(doc, published=False):
 
     for attachment in doc.get("attachments", []):
         lookup = {"_id": attachment["attachment"]}
+        # TODO-ASYNC[attachments]: Use ``delete_action_async``
         get_resource_service("attachments").delete_action(lookup)
 
 

--- a/apps/export/service.py
+++ b/apps/export/service.py
@@ -1,8 +1,9 @@
 import logging
 import re
+from inspect import isawaitable
 
 from superdesk.core import get_current_app, json
-from superdesk.services import BaseService
+from superdesk.eve_async import AsyncBaseService
 from superdesk import get_resource_service
 from superdesk.errors import FormatterError, SuperdeskApiError
 from superdesk.publish.formatters import get_all_formatters
@@ -15,8 +16,8 @@ from quart_babel import gettext as _
 logger = logging.getLogger(__name__)
 
 
-class ExportService(BaseService):
-    def create(self, docs, **kwargs):
+class ExportService(AsyncBaseService):
+    async def create_async(self, docs, **kwargs):
         doc = docs[0]
         formatter = self._validate_and_get_formatter(doc)
 
@@ -27,6 +28,7 @@ class ExportService(BaseService):
         unsuccessful_exports = 0
 
         for item_id in doc.get("item_ids"):
+            # TODO-ASYNC[archive]: Use ``find_one_async`` when available
             item = archive_service.find_one(req=None, _id=item_id)
             if item:
                 if validate:
@@ -38,6 +40,8 @@ class ExportService(BaseService):
 
                 try:
                     contents = formatter.export(item)
+                    if isawaitable(contents):
+                        contents = await contents
                 except FormatterError as e:
                     logger.exception(e)
                     unsuccessful_exports += 1
@@ -69,7 +73,7 @@ class ExportService(BaseService):
                     zip.writestr(filename, contents.encode("UTF-8"))
 
             app = get_current_app()
-            zip_id = app.media.put(
+            zip_id = await app.media.put_async(
                 in_memory_zip.getvalue(),
                 filename="export_{}.zip".format(get_random_string()),
                 content_type="application/zip",

--- a/superdesk/archive_async/service.py
+++ b/superdesk/archive_async/service.py
@@ -421,7 +421,7 @@ class AsyncArchiveService(AsyncResourceService[ArchiveResourceModel], Highlights
 
         for attachment_id in attachment_ids_to_remove:
             lookup = {"_id": attachment_id}
-            await get_resource_service("attachments").delete_action(lookup)
+            await get_resource_service("attachments").delete_action_async(lookup)
 
     async def on_updated(self, updates: Dict[str, Any], original: ArchiveResourceModel) -> None:
         """Run after an item has been updated.

--- a/superdesk/attachments.py
+++ b/superdesk/attachments.py
@@ -1,9 +1,12 @@
 import os
 from typing import Optional, Dict, Any
-import superdesk
+from werkzeug.utils import secure_filename
+
+from superdesk import get_resource_service, register_resource
+from superdesk.resource import Resource
+from superdesk.eve_async import AsyncBaseService
 from superdesk.logging import logger
 
-from werkzeug.utils import secure_filename
 from superdesk.core import get_current_app
 from superdesk.flask import request
 from apps.auth import get_user_id
@@ -12,7 +15,7 @@ from apps.auth import get_user_id
 RESOURCE = "attachments"
 
 
-class AttachmentsResource(superdesk.Resource):
+class AttachmentsResource(Resource):
     schema = {
         "media": {"type": "media"},
         "mimetype": {"type": "string"},
@@ -24,7 +27,7 @@ class AttachmentsResource(superdesk.Resource):
             "sams": {"field": "name"},
         },
         "description": {"type": "string"},
-        "user": superdesk.Resource.rel("users"),
+        "user": Resource.rel("users"),
         "internal": {
             "type": "boolean",
             "default": False,
@@ -37,8 +40,8 @@ class AttachmentsResource(superdesk.Resource):
     privileges = {"POST": "archive", "PATCH": "archive"}
 
 
-class AttachmentsService(superdesk.Service):
-    def on_create(self, docs):
+class AttachmentsService(AsyncBaseService):
+    async def on_create_async(self, docs):
         current_app = get_current_app()
         for doc in docs:
             doc["user"] = get_user_id()
@@ -54,10 +57,11 @@ class AttachmentsService(superdesk.Service):
                 doc.setdefault("mimetype", getattr(media, "content_type"))
                 doc.setdefault("length", getattr(media, "length"))
 
-    def on_deleted(self, doc):
+    async def on_deleted_async(self, doc):
         get_current_app().media.delete(doc["media"], RESOURCE)
 
 
+# TODO-ASYNC[attachments]: Convert this to async when possible (used by ContentAPI publish function)
 def is_attachment_public(attachment):
     """Retuns true if attachment is public. False if it's internal.
 
@@ -65,12 +69,12 @@ def is_attachment_public(attachment):
     :return: boolean
     """
     if attachment.get("attachment"):  # retrieve object reference
-        attachment = superdesk.get_resource_service("attachments").find_one(req=None, _id=attachment["attachment"])
+        attachment = get_resource_service("attachments").find_one(req=None, _id=attachment["attachment"])
 
     return not attachment.get("internal")
 
 
-def get_attachment_public_url(attachment: Dict[str, Any]) -> Optional[str]:
+async def get_attachment_public_url(attachment: Dict[str, Any]) -> Optional[str]:
     """Returns the file url for the attachment provided
 
     :param dict attachment: The attachment to get the file URL
@@ -79,7 +83,7 @@ def get_attachment_public_url(attachment: Dict[str, Any]) -> Optional[str]:
     """
 
     if attachment.get("attachment"):  # retrieve object reference
-        attachment = superdesk.get_resource_service("attachments").find_one(req=None, _id=attachment["attachment"])
+        attachment = get_resource_service("attachments").find_one_async(req=None, _id=attachment["attachment"])
 
     if attachment.get("internal"):
         return None
@@ -96,6 +100,6 @@ def get_attachment_public_url(attachment: Dict[str, Any]) -> Optional[str]:
 
 
 def init_app(app) -> None:
-    superdesk.register_resource(RESOURCE, AttachmentsResource, AttachmentsService)
+    register_resource(RESOURCE, AttachmentsResource, AttachmentsService)
     app.client_config["attachments_max_files"] = app.config.get("ATTACHMENTS_MAX_FILES", 10)
     app.client_config["attachments_max_size"] = app.config.get("ATTACHMENTS_MAX_SIZE", 2**20 * 8)  # 8MB

--- a/superdesk/commands/clean_images.py
+++ b/superdesk/commands/clean_images.py
@@ -18,7 +18,7 @@ from .async_cli import cli
 
 
 @cli.command("app:clean_images")
-def cli_clean_images():
+async def cli_clean_images():
     """This command will remove all the images from the system which are not referenced by content.
 
     It checks the media type and calls the correspoinding function as s3 and mongo
@@ -31,11 +31,11 @@ def cli_clean_images():
         $ python manage.py app:clean_images
 
     """
-    CleanImages().run()
+    await CleanImages().run()
 
 
 class CleanImages:
-    def run(self):
+    async def run(self):
         print("Starting image cleaning.")
         used_images = set()
         types = ["picture", "video", "audio"]
@@ -50,7 +50,7 @@ class CleanImages:
         ingest_items = superdesk.get_resource_service("ingest").get_from_mongo(None, {"type": {"$in": types}})
         self.__add_existing_files(used_images, ingest_items)
 
-        upload_items = superdesk.get_resource_service("upload").get_from_mongo(req=None, lookup={})
+        upload_items = await superdesk.get_resource_service("upload").get_from_mongo_async(req=None, lookup={})
         self.__add_existing_files(used_images, upload_items)
 
         if get_app_config("LEGAL_ARCHIVE"):

--- a/superdesk/media/renditions.py
+++ b/superdesk/media/renditions.py
@@ -177,6 +177,13 @@ def delete_file_on_error(doc, file_id):
     get_current_app().media.delete(file_id)
 
 
+async def delete_file_on_error_async(doc, file_id):
+    # Don't delete the file if we are on the import from storage flow
+    if doc.get("_import", None):
+        return
+    await get_current_app().media.delete_async(file_id)
+
+
 def _crop_image(content, format, ratio):
     """Crop the image given as a binary stream
 

--- a/superdesk/publish/formatters/imatrics.py
+++ b/superdesk/publish/formatters/imatrics.py
@@ -10,7 +10,7 @@ class IMatricsFormatter(NINJSFormatter):
     def can_format(self, format_type, article):
         return format_type.lower() == "imatrics" and article.get("type") == "text"
 
-    def _transform_to_ninjs(self, article, subscriber, recursive=True):
+    async def _transform_to_ninjs(self, article, subscriber, recursive=True):
         return {
             "uuid": article["guid"],
             "createdTimestamp": format_datetime(article["firstcreated"]),

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -176,12 +176,12 @@ class NINJSFormatter(Formatter):
         try:
             pub_seq_num = await superdesk.get_resource_service("subscribers").generate_sequence_number_async(subscriber)
 
-            ninjs = self._transform_to_ninjs(article, subscriber)
+            ninjs = await self._transform_to_ninjs(article, subscriber)
             return [(pub_seq_num, json.dumps(ninjs, default=json_serialize_datetime_objectId))]
         except Exception as ex:
             raise FormatterError.ninjsFormatterError(ex, subscriber)
 
-    def _transform_to_ninjs(self, article, subscriber, recursive=True):
+    async def _transform_to_ninjs(self, article, subscriber, recursive=True):
         ninjs = {
             "guid": article.get(GUID_FIELD, article.get("uri")),
             "version": str(article.get(VERSION, 1)),
@@ -294,7 +294,7 @@ class NINJSFormatter(Formatter):
             ninjs.setdefault("signal", []).extend([self._format_signal(signal) for signal in article["signal"]])
 
         if article.get("attachments"):
-            ninjs["attachments"] = self._format_attachments(article)
+            ninjs["attachments"] = await self._format_attachments(article)
 
         if ninjs["type"] == CONTENT_TYPE.TEXT and ("body_html" in ninjs or "body_text" in ninjs):
             if "body_html" in ninjs:
@@ -550,12 +550,12 @@ class NINJSFormatter(Formatter):
     def _format_signal_cwarn(self):
         return [{"name": "Content Warning", "code": "cwarn", "scheme": SCHEME_MAP["sig"]}]
 
-    def _format_attachments(self, article):
+    async def _format_attachments(self, article):
         output = []
         attachments_service = superdesk.get_resource_service("attachments")
         for attachment_ref in article["attachments"]:
-            attachment = attachments_service.find_one(req=None, _id=attachment_ref["attachment"])
-            href = get_attachment_public_url(attachment)
+            attachment = attachments_service.find_one_async(req=None, _id=attachment_ref["attachment"])
+            href = await get_attachment_public_url(attachment)
             if href:
                 # If we get a href, the attachment is available for subscriber consumption
                 output.append(
@@ -645,9 +645,9 @@ class NINJSFormatter(Formatter):
             scheme=SCHEME_MAP.get(scheme) or scheme,
         )
 
-    def export(self, item):
+    async def export(self, item):
         if self.can_format(self.type, item):
-            sequence, formatted_doc = self.format(item, {"_id": "0"}, None)[0]
+            sequence, formatted_doc = await self.format(item, {"_id": "0"}, None)[0]
             return formatted_doc.replace("''", "'")
         else:
             raise Exception()

--- a/superdesk/publish/formatters/ninjs_ftp_formatter.py
+++ b/superdesk/publish/formatters/ninjs_ftp_formatter.py
@@ -32,7 +32,7 @@ class FTPNinjsFormatter(NINJSFormatter):
         self.internal_renditions = []
         self.path = None
 
-    def _transform_to_ninjs(self, article, subscriber, recursive=True):
+    async def _transform_to_ninjs(self, article, subscriber, recursive=True):
         """
         Re-wire that href's in the document to be relative to the destination FTP server root, it expects the
         destination to be an FTP server
@@ -52,7 +52,7 @@ class FTPNinjsFormatter(NINJSFormatter):
         if article.get("type") == "text" and recursive:
             self.apply_product_filtering_to_associations(formatted_article, subscriber)
 
-        ninjs = super()._transform_to_ninjs(formatted_article, subscriber, recursive)
+        ninjs = await super()._transform_to_ninjs(formatted_article, subscriber, recursive)
 
         renditions = ninjs.get("renditions")
         if renditions:

--- a/superdesk/publish/formatters/ninjs_newsroom_formatter.py
+++ b/superdesk/publish/formatters/ninjs_newsroom_formatter.py
@@ -44,8 +44,8 @@ class NewsroomNinjsFormatter(NINJSFormatter):
         return getattr(g, cache_id)
 
     @elasticapm.capture_span()
-    def _transform_to_ninjs(self, article, subscriber, recursive=True):
-        ninjs = super()._transform_to_ninjs(article, subscriber, recursive)
+    async def _transform_to_ninjs(self, article, subscriber, recursive=True):
+        ninjs = await super()._transform_to_ninjs(article, subscriber, recursive)
 
         if article.get("ingest_id") and (
             article.get("auto_publish") or (article.get("extra") or {}).get("publish_ingest_id_as_guid")

--- a/superdesk/upload.py
+++ b/superdesk/upload.py
@@ -17,9 +17,9 @@ from superdesk.flask import request, redirect, make_response, jsonify, Blueprint
 import json
 import os
 from superdesk.errors import SuperdeskApiError
-from superdesk.media.renditions import generate_renditions, delete_file_on_error
+from superdesk.media.renditions import generate_renditions, delete_file_on_error_async
 from superdesk.media.media_operations import (
-    download_file_from_url,
+    download_file_from_url_async,
     download_file_from_encoded_str,
     process_file_from_stream,
     crop_image,
@@ -31,16 +31,16 @@ from superdesk.users.services import current_user_has_privilege
 from superdesk.auth.decorator import blueprint_auth
 from superdesk import get_resource_privileges
 from .resource import Resource
-from .services import BaseService
+from superdesk.eve_async import AsyncBaseService
 
 
 bp = Blueprint("upload_raw", __name__)
 logger = logging.getLogger(__name__)
 
 
-def handle_cors():
+async def _handle_cors():
     """Return headers to avoid CORS problems."""
-    response = make_response()
+    response = await make_response()
     response.headers.add("Access-Control-Allow-Origin", "*")
     response.headers.add("Access-Control-Allow-Headers", "*")
     response.headers.add("Access-Control-Allow-Methods", "POST")
@@ -49,9 +49,9 @@ def handle_cors():
 
 @bp.route("/upload/<path:media_id>/raw", methods=["GET", "OPTIONS"])
 @blueprint_auth()
-def get_upload_as_data_uri_bc(media_id):
+async def get_upload_as_data_uri_bc(media_id):
     if request.method == "OPTIONS":
-        return handle_cors()
+        return await _handle_cors()
     """Keep previous url for backward compatibility"""
     return redirect(upload_url(media_id))
 
@@ -62,7 +62,7 @@ async def get_upload_as_data_uri(media_id):
     app = get_current_app()
 
     if request.method == "OPTIONS":
-        response = make_response()
+        response = await make_response()
         response.headers.add("Access-Control-Allow-Origin", "*")
         response.headers.add("Access-Control-Allow-Headers", "*")
         response.headers.add("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
@@ -83,7 +83,7 @@ async def get_upload_as_data_uri(media_id):
 @blueprint_auth()
 async def upload_config_file():
     if request.method == "OPTIONS":
-        return handle_cors()
+        return await _handle_cors()
 
     _resource = request.args.get("resource")
     if not _resource:
@@ -116,8 +116,13 @@ async def upload_config_file():
             file_data = [file_data]
         _items += file_data
 
-    res = superdesk.get_resource_service(_resource).update_data_from_json(_items)
-    response = make_response(jsonify(res))
+    service = superdesk.get_resource_service(_resource)
+    if hasattr(service, "update_data_from_json_async"):
+        res = await service.update_data_from_json_async(_items)
+    else:
+        res = service.update_data_from_json(_items)
+
+    response = await make_response(jsonify(res))
     response.headers.add("Access-Control-Allow-Origin", "*")
     response.headers.add("Access-Control-Expose-Headers", "*")
     return response
@@ -174,8 +179,8 @@ class UploadResource(Resource):
     privileges = {"DELETE": "archive"}
 
 
-class UploadService(BaseService):
-    def on_create(self, docs):
+class UploadService(AsyncBaseService):
+    async def on_create_async(self, docs):
         for doc in docs:
             if doc.get("URL") and doc.get("media"):
                 message = "Uploading file by URL and file stream in the same time is not supported."
@@ -189,11 +194,13 @@ class UploadService(BaseService):
                 filename = content.filename
                 content_type = content.mimetype
             elif doc.get("URL"):
-                content, filename, content_type = self.download_file(doc)
+                content, filename, content_type = await self.download_file(doc)
 
-            self.crop_and_store_file(doc, content, filename, content_type)
+            await self.crop_and_store_file(doc, content, filename, content_type)
 
-    def crop_and_store_file(self, doc, content, filename, content_type):
+    async def crop_and_store_file(self, doc, content, filename, content_type):
+        inserted = []
+
         # retrieve file name and metadata from file
         file_name, content_type, metadata = process_file_from_stream(content, content_type=content_type)
         # crop the file if needed, can change the image size
@@ -206,7 +213,7 @@ class UploadService(BaseService):
         try:
             logger.debug("Going to save media file with %s " % file_name)
             out.seek(0)
-            file_id = get_current_app().media.put(
+            file_id = await get_current_app().media.put_async(
                 out, filename=file_name, content_type=content_type, resource=self.datasource, metadata=metadata
             )
             doc["media"] = file_id
@@ -221,14 +228,14 @@ class UploadService(BaseService):
             doc["renditions"] = renditions
         except Exception as io:
             for file_id in inserted:
-                delete_file_on_error(doc, file_id)
+                await delete_file_on_error_async(doc, file_id)
             raise SuperdeskApiError.internalError("Generating renditions failed", exception=io)
 
-    def download_file(self, doc):
+    async def download_file(self, doc):
         url = doc.get("URL")
         if not url:
             return
         if url.startswith("data"):
             return download_file_from_encoded_str(url)
         else:
-            return download_file_from_url(url)
+            return await download_file_from_url_async(url)

--- a/superdesk/users/async_service.py
+++ b/superdesk/users/async_service.py
@@ -209,7 +209,7 @@ class UsersAsyncService(AsyncResourceService[UsersResourceModel]):
             push_notification("user", updated=1, user_id=str(user_id))
 
     async def get_avatar_renditions(self, doc):
-        renditions = get_resource_service("upload").find_one(req=None, _id=doc)
+        renditions = await get_resource_service("upload").find_one_async(req=None, _id=doc)
         return renditions.get("renditions") if renditions is not None else None
 
     async def handle_user_type_changed(self, updates: dict[str, Any], user: UsersResourceModel):
@@ -233,7 +233,7 @@ class UsersAsyncService(AsyncResourceService[UsersResourceModel]):
             if not doc.role:
                 doc.role = await get_resource_service("roles").get_default_role_id_async()
             if doc.avatar:
-                doc.avatar_renditions = self.get_avatar_renditions(doc.avatar)
+                doc.avatar_renditions = await self.get_avatar_renditions(doc.avatar)
 
             get_resource_service("preferences").set_user_initial_prefs(doc)
 

--- a/superdesk/users/services.py
+++ b/superdesk/users/services.py
@@ -240,9 +240,9 @@ class UsersService(AsyncBaseService):
         else:
             push_notification("user", updated=1, user_id=str(user_id))
 
-    def get_avatar_renditions(self, doc):
+    async def get_avatar_renditions(self, doc):
         # TODO-ASYNC[upload]: Upgrade to async when updating the ``upload`` module
-        renditions = get_resource_service("upload").find_one(req=None, _id=doc)
+        renditions = await get_resource_service("upload").find_one_async(req=None, _id=doc)
         return renditions.get("renditions") if renditions is not None else None
 
     async def handle_user_type_changed_async(self, updates, user):
@@ -262,7 +262,7 @@ class UsersService(AsyncBaseService):
             user_doc.setdefault(SIGN_OFF, set_sign_off(user_doc))
             user_doc.setdefault("role", await get_resource_service("roles").get_default_role_id_async())
             if user_doc.get("avatar"):
-                user_doc.setdefault("avatar_renditions", self.get_avatar_renditions(user_doc["avatar"]))
+                user_doc.setdefault("avatar_renditions", await self.get_avatar_renditions(user_doc["avatar"]))
 
             get_resource_service("preferences").set_user_initial_prefs(user_doc)
 
@@ -296,7 +296,7 @@ class UsersService(AsyncBaseService):
         update_sign_off(updates)
 
         if updates.get("avatar"):
-            updates["avatar_renditions"] = self.get_avatar_renditions(updates["avatar"])
+            updates["avatar_renditions"] = await self.get_avatar_renditions(updates["avatar"])
 
     async def on_updated_async(self, updates, user):
         if "role" in updates or "privileges" in updates:

--- a/tests/content_api_test.py
+++ b/tests/content_api_test.py
@@ -745,7 +745,7 @@ class ContentAPITestCase(TestCase):
         async with self.app.test_request_context("attachments", method="POST", files=files):
             attachment["media"] = (await request.files)["media"]
             await store_media_files(attachment, "attachments")  # this would happen automatically otherwise
-            superdesk.get_resource_service("attachments").post([attachment])
+            await superdesk.get_resource_service("attachments").post_async([attachment])
         self.assertIn("_id", attachment)
         self.assertIsInstance(attachment["media"], ObjectId)
 
@@ -788,7 +788,7 @@ class ContentAPITestCase(TestCase):
             public_attachment["media"] = (await request.files)["media"]
             await store_media_files(internal_attachment, "attachments")
             await store_media_files(public_attachment, "attachments")
-            superdesk.get_resource_service("attachments").post([internal_attachment, public_attachment])
+            await superdesk.get_resource_service("attachments").post_async([internal_attachment, public_attachment])
         self.assertIn("_id", internal_attachment)
         self.assertIn("_id", public_attachment)
         self.assertIsInstance(internal_attachment["media"], ObjectId)


### PR DESCRIPTION
### Purpose
Upgrade the `attachments`, `download`, `upload` and `export` resources to eve async service.

### What has changed:
* Upgrade `ExportService` service to `AsyncBaseService`
* Upgrade `AttachmentsService` service to `AsyncBaseService`
* Upgrade `UploadService` service to `AsyncBaseService`, minor async fixes in upload web endpoints
* Upgrade `app:clean_images` command to async, and use async `upload` resource
* Upgrade some ninjs based formatters to use async `attachments` resource
* Placed comments on code that can't be upgraded right now