### PR TITLE
[SDESK-7586] Upgrade system resources to async eve services

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -414,6 +414,8 @@ class ArchiveService(BaseService, HighlightsSearchMixin):
                 msg = 'added new {{ type }} item about "{{ subject }}"'
             else:
                 msg = "added new {{ type }} item with empty header/title"
+
+            # TODO-ASYNC[activity]: Prefix this next line with `await ` when updating this module
             add_activity(ACTIVITY_CREATE, msg, self.datasource, item=doc, type=doc[ITEM_TYPE], subject=subject)
 
             if doc.get("profile"):
@@ -556,6 +558,7 @@ class ArchiveService(BaseService, HighlightsSearchMixin):
         updated.update(updates)
 
         if VERSION in updates:
+            # TODO-ASYNC[activity]: Prefix this next line with `await ` when updating this module
             add_activity(
                 ACTIVITY_UPDATE,
                 'created new version {{ version }} for item {{ type }} about "{{ subject }}"',
@@ -591,6 +594,7 @@ class ArchiveService(BaseService, HighlightsSearchMixin):
 
     def on_replaced(self, document, original):
         get_component(ItemAutosave).clear(original["_id"])
+        # TODO-ASYNC[activity]: Prefix this next line with `await ` when updating this module
         add_activity(
             ACTIVITY_UPDATE,
             "replaced item {{ type }} about {{ subject }}",
@@ -610,6 +614,7 @@ class ArchiveService(BaseService, HighlightsSearchMixin):
         remove_media_files(doc, published=False)
         self._remove_from_translations(doc)
 
+        # TODO-ASYNC[activity]: Prefix this next line with `await ` when updating this module
         add_activity(
             ACTIVITY_DELETE,
             "removed item {{ type }} about {{ subject }}",

--- a/apps/archive/archive_media.py
+++ b/apps/archive/archive_media.py
@@ -72,6 +72,7 @@ class ArchiveMediaService:
                 doc["renditions"] = renditions
                 doc["mimetype"] = content_type
                 set_filemeta(doc, metadata)
+                # TODO-ASYNC[activity]: Prefix this next line with `await ` when updating this module
                 add_activity(
                     "upload",
                     "uploaded media {{ name }}",

--- a/apps/client_config.py
+++ b/apps/client_config.py
@@ -11,6 +11,7 @@ class ClientConfigResource(superdesk.Resource):
     resource_methods = ["GET"]
 
 
+# Not upgrading to async, as there is no I/O to wait for
 class ClientConfigService(superdesk.Service):
     def get(self, req, lookup):
         return ListCursor()

--- a/apps/comments/user_mentions.py
+++ b/apps/comments/user_mentions.py
@@ -68,7 +68,7 @@ async def notify_mentioned_users(docs, origin, item=None):
         if len(mentioned_users) > 0:
             if not item:
                 item = superdesk.get_resource_service("archive").find_one(req=None, _id=doc["item"])
-            add_activity(
+            await add_activity(
                 "user:mention",
                 "",
                 resource=None,
@@ -86,6 +86,7 @@ def notify_mentioned_desks(docs):
         mentioned_desks = doc.get("mentioned_desks", {}).values()
         if len(mentioned_desks) > 0:
             item = superdesk.get_resource_service("archive").find_one(req=None, _id=doc["item"])
+            # TODO-ASYNC[activity]: Prefix this next line with `await ` when updating this module
             add_activity(
                 "desk:mention",
                 "",

--- a/apps/desks.py
+++ b/apps/desks.py
@@ -278,7 +278,7 @@ class DesksService(AsyncBaseService):
 
             for added_user in added:
                 user = await users_service.find_by_id(added_user)
-                activity = add_activity(
+                activity = await add_activity(
                     ACTIVITY_UPDATE,
                     "user {{user}} has been added to desk {{desk}}: Please re-login.",
                     self.datasource,

--- a/apps/desks_async/desks_async_service.py
+++ b/apps/desks_async/desks_async_service.py
@@ -158,7 +158,7 @@ class DesksAsyncService(AsyncResourceService[DesksResourceModel]):
                 if user is None:
                     logger.warning(f"Failed sending notification to user '{added_user}: user not found")
                     continue
-                activity = add_activity(
+                activity = await add_activity(
                     ACTIVITY_UPDATE,
                     "user {{user}} has been added to desk {{desk}}: Please re-login.",
                     self.resource_name,

--- a/apps/languages/service.py
+++ b/apps/languages/service.py
@@ -8,18 +8,13 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-import logging
-import superdesk
-
-from superdesk.services import BaseService
-from superdesk.utils import ListCursor
+from superdesk.types.vocabularies import CVItem
+from superdesk.eve_async import AsyncBaseService, AsyncListCursor
+from superdesk.vocabularies_async import get_languages
 
 
-logger = logging.getLogger(__name__)
-
-
-def view_language(item):
-    language = item.copy()
+def view_language(item: CVItem) -> dict:
+    language = item.to_dict()
     language["_id"] = language["qcode"]
     language["label"] = language["name"]
     language["language"] = language["qcode"]
@@ -31,11 +26,10 @@ def view_language(item):
     return language
 
 
-class LanguagesService(BaseService):
-    def get(self, req, lookup):
+class LanguagesService(AsyncBaseService):
+    async def get_async(self, req, lookup):
         """
         Return the list of languages defined on config file.
         """
-        # TODO-ASYNC[vocabularies]: Use VocabulariesService async service where when upgrading this module
-        languages = superdesk.get_resource_service("vocabularies").get_languages()
-        return ListCursor([view_language(lang) for lang in languages])
+        languages = await get_languages()
+        return AsyncListCursor([view_language(lang) for lang in languages])

--- a/apps/publish/content/correct.py
+++ b/apps/publish/content/correct.py
@@ -38,7 +38,7 @@ async def send_translation_notifications(original):
     if len(user_ids) == 0 or changed_article is None:
         return
 
-    add_activity("translated:changed", "", resource=None, item=changed_article, notify=user_ids)
+    await add_activity("translated:changed", "", resource=None, item=changed_article, notify=user_ids)
 
     recipients = []
     users_service = UsersResourceModel.get_service()

--- a/apps/system_message/service.py
+++ b/apps/system_message/service.py
@@ -10,17 +10,17 @@
 
 
 from superdesk.resource_fields import ID_FIELD
-from superdesk.services import Service
+from superdesk.eve_async import AsyncBaseService
 from superdesk.notification import push_notification
 from apps.auth import get_user_id
 
 
-class SystemMessagesService(Service):
-    def on_create(self, docs):
+class SystemMessagesService(AsyncBaseService):
+    async def on_create_async(self, docs):
         for doc in docs:
             doc["user_id"] = get_user_id()
 
-    def on_created(self, docs):
+    async def on_created_async(self, docs):
         """
         Send notification
         :param docs:
@@ -28,10 +28,10 @@ class SystemMessagesService(Service):
         """
         push_notification("system_message:created", _id=[doc.get(ID_FIELD) for doc in docs])
 
-    def on_update(self, updates, original):
+    async def on_update_async(self, updates, original):
         updates["user_id"] = get_user_id()
 
-    def on_updated(self, updates, original):
+    async def on_updated_async(self, updates, original):
         """
         Send notifification
         :param updates:
@@ -40,7 +40,7 @@ class SystemMessagesService(Service):
         """
         push_notification("system_message:updated", _id=[original.get(ID_FIELD)])
 
-    def on_deleted(self, doc):
+    async def on_deleted_async(self, doc):
         """
         Send a notification
         :param doc:

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -268,6 +268,7 @@ class TasksService(AsyncBaseService):
         for doc in docs:
             insert_into_versions(doc["_id"])
             if is_assigned_to_a_desk(doc):
+                # TODO-ASYNC[activity]: Prefix this next line with `await ` when updating this module
                 add_activity(
                     ACTIVITY_CREATE,
                     "added new task {{ subject }} of type {{ type }}",
@@ -314,6 +315,7 @@ class TasksService(AsyncBaseService):
         if is_assigned_to_a_desk(updated):
             if self.__is_content_assigned_to_new_desk(original, updates) and not self._stage_changed(updates, original):
                 insert_into_versions(doc=updated)
+            # TODO-ASYNC[activity]: Prefix this next line with `await ` when updating this module
             add_activity(
                 ACTIVITY_UPDATE,
                 "updated task {{ subject }} for item {{ type }}",

--- a/superdesk/activity.py
+++ b/superdesk/activity.py
@@ -13,7 +13,7 @@ import logging
 from typing import List
 
 from bson.objectid import ObjectId
-from quart_babel import gettext as _, lazy_gettext
+from quart_babel import lazy_gettext
 
 import superdesk
 from superdesk import get_resource_service
@@ -23,7 +23,7 @@ from superdesk.errors import SuperdeskApiError, add_notifier
 from superdesk.notification import push_notification
 from superdesk.preferences import get_user_notification_preferences
 from superdesk.resource import Resource
-from superdesk.services import BaseService
+from superdesk.eve_async import AsyncBaseService
 from superdesk.types import User, UsersResourceModel, UserTypeEnum
 from superdesk.utc import utcnow
 from eve.utils import ParsedRequest
@@ -103,8 +103,8 @@ class ActivityResource(Resource):
     )
 
 
-class ActivityService(BaseService):
-    def get(self, req, lookup):
+class ActivityService(AsyncBaseService):
+    async def get_async(self, req, lookup):
         """Filter out personal activity on personal items if inquired by another user."""
         if req is None:
             req = ParsedRequest()
@@ -122,9 +122,9 @@ class ActivityService(BaseService):
             where_cond["$or"] = [where_item, {"resource": {"$ne": "archive"}}]
             req.where = json.dumps(where_cond)
 
-        return self.backend.get(self.datasource, req=req, lookup=lookup)
+        return await super().get_async(req, lookup)
 
-    def on_update(self, updates, original):
+    async def on_update_async(self, updates, original):
         """Called on the patch request to mark a activity/notification/comment as read and nothing else
 
         :param updates:
@@ -174,7 +174,7 @@ ACTIVITY_EVENT = "event"
 ACTIVITY_ERROR = "error"
 
 
-def add_activity(
+async def add_activity(
     activity_name, msg, resource=None, item=None, notify=None, notify_desks=None, can_push_notification=True, **data
 ):
     """
@@ -231,7 +231,7 @@ def add_activity(
         if item.get("task") and item["task"].get("desk"):
             activity["desk"] = ObjectId(item["task"]["desk"])
 
-    get_resource_service(ActivityResource.endpoint_name).post([activity])
+    await get_resource_service(ActivityResource.endpoint_name).post_async([activity])
 
     if can_push_notification:
         push_notification(ActivityResource.endpoint_name, _dest=activity["recipients"], activity=activity)
@@ -257,7 +257,7 @@ async def notify_and_add_activity(
         if get_user_notification_preferences(user, notification_name)["desktop"]
     ]
 
-    add_activity(
+    await add_activity(
         activity_name,
         msg=msg,
         resource=resource,
@@ -300,4 +300,7 @@ def get_recipients(user_list: List[User], notification_name=None) -> List[str]:
     return recipients
 
 
-add_notifier(notify_and_add_activity)
+# TODO-ASYNC[activity]: Figure out how to handle this next one
+# it adds an activity and notifies the user when a Publish or Ingest error happens
+# but this code is within the constructor of an Exception class, which can't be async
+# add_notifier(notify_and_add_activity)

--- a/superdesk/archive_async/service.py
+++ b/superdesk/archive_async/service.py
@@ -279,7 +279,7 @@ class AsyncArchiveService(AsyncResourceService[ArchiveResourceModel], Highlights
                 msg = 'added new {{ type }} item about "{{ subject }}"'
             else:
                 msg = "added new {{ type }} item with empty header/title"
-            add_activity(ACTIVITY_CREATE, msg, self.resource_name, item=doc, type=doc.item_type, subject=subject)
+            await add_activity(ACTIVITY_CREATE, msg, self.resource_name, item=doc, type=doc.item_type, subject=subject)
 
             if doc.profile:
                 profiles.add(doc.profile)
@@ -439,7 +439,7 @@ class AsyncArchiveService(AsyncResourceService[ArchiveResourceModel], Highlights
             setattr(updated, k, v)
 
         if VERSION in updates:
-            add_activity(
+            await add_activity(
                 ACTIVITY_UPDATE,
                 'created new version {{ version }} for item {{ type }} about "{{ subject }}"',
                 self.resource_name,
@@ -484,7 +484,7 @@ class AsyncArchiveService(AsyncResourceService[ArchiveResourceModel], Highlights
         :param original: Original document that was replaced
         """
         get_component(ItemAutosave).clear(original["_id"])
-        add_activity(
+        await add_activity(
             ACTIVITY_UPDATE,
             "replaced item {{ type }} about {{ subject }}",
             self.resource_name,
@@ -507,7 +507,7 @@ class AsyncArchiveService(AsyncResourceService[ArchiveResourceModel], Highlights
         await remove_media_files(doc, published=False)
         await self._remove_from_translations(doc)
 
-        add_activity(
+        await add_activity(
             ACTIVITY_DELETE,
             "removed item {{ type }} about {{ subject }}",
             self.resource_name,

--- a/superdesk/audit/__init__.py
+++ b/superdesk/audit/__init__.py
@@ -30,5 +30,5 @@ def init_app(app) -> None:
 
 
 @celery.task(soft_time_limit=600)
-def gc_audit():
-    PurgeAudit().run()
+async def gc_audit():
+    await PurgeAudit().run()

--- a/superdesk/audit/audit.py
+++ b/superdesk/audit/audit.py
@@ -11,7 +11,7 @@
 import logging
 from superdesk.flask import g
 from superdesk.resource import Resource
-from superdesk.services import BaseService
+from superdesk.eve_async import AsyncBaseService
 
 log = logging.getLogger(__name__)
 
@@ -44,8 +44,8 @@ class AuditResource(Resource):
     }
 
 
-class AuditService(BaseService):
-    def on_generic_inserted(self, resource, docs):
+class AuditService(AsyncBaseService):
+    async def on_generic_inserted(self, resource, docs):
         if resource in AuditResource.exclude:
             return
 
@@ -69,9 +69,9 @@ class AuditService(BaseService):
             "audit_id": self._extract_doc_id(docs[0]),
         }
 
-        self.post([audit])
+        await self.post_async([audit])
 
-    def on_generic_updated(self, resource, doc, original):
+    async def on_generic_updated(self, resource, doc, original):
         if resource in AuditResource.exclude:
             return
 
@@ -88,9 +88,9 @@ class AuditService(BaseService):
         }
         if "_id" not in doc:
             audit["extra"]["_id"] = original.get("_id", None)
-        self.post([audit])
+        await self.post_async([audit])
 
-    def on_generic_deleted(self, resource, doc):
+    async def on_generic_deleted(self, resource, doc):
         if resource in AuditResource.exclude:
             return
 
@@ -105,7 +105,7 @@ class AuditService(BaseService):
             "extra": doc,
             "audit_id": self._extract_doc_id(doc),
         }
-        self.post([audit])
+        await self.post_async([audit])
 
     def _extract_doc_id(self, doc):
         """

--- a/superdesk/audit/commands.py
+++ b/superdesk/audit/commands.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 @cli.command("audit:purge")
 @click.option("--expiry_minutes", "-e", required=False, type=int)
-def cli_audit_purge(expiry_minutes: int | None = None):
+async def cli_audit_purge(expiry_minutes: int | None = None):
     """Purge audit collection.
 
     Entries are purged if the related item is no longer in 'Production'.
@@ -41,7 +41,7 @@ def cli_audit_purge(expiry_minutes: int | None = None):
 
     """
 
-    PurgeAudit().run(expiry_minutes)
+    await PurgeAudit().run(expiry_minutes)
 
 
 class PurgeAudit:
@@ -73,7 +73,7 @@ class PurgeAudit:
 
     not_item_entry_query = {"$or": [{"resource": {"$nin": item_resources}}, {"audit_id": {"$in": [None, ""]}}]}
 
-    def run(self, expiry=None):
+    async def run(self, expiry=None):
         if expiry is not None:
             self.expiry = utcnow() - datetime.timedelta(minutes=int(expiry))
         else:
@@ -82,11 +82,11 @@ class PurgeAudit:
                 return
             self.expiry = utcnow() - datetime.timedelta(minutes=get_app_config("AUDIT_EXPIRY_MINUTES"))
         logger.info("Starting audit purge for items older than {}".format(self.expiry))
-        # self.purge_orphaned_item_audits()
-        self.purge_old_entries()
+        # await self.purge_orphaned_item_audits()
+        await self.purge_old_entries()
         logger.info("Completed audit purge")
 
-    def _get_archive_ids(self, ids):
+    async def _get_archive_ids(self, ids):
         """
         Given a set of ids return those that have an entry in the archive collection
         :param ids:
@@ -96,11 +96,12 @@ class PurgeAudit:
         query = {"_id": {"$in": list(ids)}}
         req = ParsedRequest()
         req.projection = '{"_id": 1}'
+        # TODO-ASYNC[archive]: Use `get_from_mongo_async` when available
         archive_ids = service.get_from_mongo(req=req, lookup=query)
         existing = list([item["_id"] for item in archive_ids])
         return set(existing)
 
-    def purge_orphaned_item_audits(self):
+    async def purge_orphaned_item_audits(self):
         """
         Purge the audit items that do not have associated entries existing in archive
         :return:
@@ -119,8 +120,8 @@ class PurgeAudit:
             req.sort = '[("_id", 1)]'
             req.projection = '{"_id": 1, "audit_id":1}'
             req.max_results = 1000
-            audits = service.get_from_mongo(req=req, lookup=query)
-            items = list([(item["_id"], item["audit_id"]) for item in audits])
+            audits = await service.get_from_mongo_async(req=req, lookup=query)
+            items = [(item["_id"], item["audit_id"]) async for item in audits]
             if len(items) == 0:
                 logger.info("Finished purging audit logs of content items not in archive at {}".format(utcnow()))
                 return
@@ -128,18 +129,18 @@ class PurgeAudit:
             current_id = items[len(items) - 1][0]
 
             batch_ids = set([i[1] for i in items])
-            archive_ids = self._get_archive_ids(batch_ids)
+            archive_ids = await self._get_archive_ids(batch_ids)
             ids = batch_ids - archive_ids
             audit_ids = [i[0] for i in items if i[1] in ids]
             logger.info("Deleting {} orphaned audit items at {}".format(len(audit_ids), utcnow()))
-            service.delete_ids_from_mongo(audit_ids)
+            await service.delete_ids_from_mongo_async(audit_ids)
 
-    def purge_old_entries(self):
+    async def purge_old_entries(self):
         """Purge entries older than the expiry"""
 
         logger.info("Starting to purge audit logs at {}".format(utcnow()))
         service = superdesk.get_resource_service("audit")
         time_start = time()
-        service.delete_from_mongo({"_id": {"$lt": ObjectId.from_datetime(self.expiry)}})
+        await service.delete_from_mongo_async({"_id": {"$lt": ObjectId.from_datetime(self.expiry)}})
         time_diff = time() - time_start
         logger.info(f"Finished purging audit logs. Took {time_diff:.4f} seconds")

--- a/superdesk/backend_meta/backend_meta.py
+++ b/superdesk/backend_meta/backend_meta.py
@@ -41,6 +41,8 @@ class BackendMetaResource(Resource):
     pass
 
 
+# Not upgrading to async, as local file I/O should not add much delay
+# and this endpoint is not used that often
 class BackendMetaService(BaseService):
     """Service givin metadata on backend itself"""
 

--- a/superdesk/data_updates.py
+++ b/superdesk/data_updates.py
@@ -21,6 +21,7 @@ class DataUpdatesResource(Resource):
     item_url = superdesk.metadata.utils.item_url
 
 
+# Not updating to async, as this is only used by backend commands
 class DataUpdatesService(BaseService):
     def on_create(self, docs):
         for doc in docs:

--- a/superdesk/eve_async/cursors.py
+++ b/superdesk/eve_async/cursors.py
@@ -47,7 +47,7 @@ class AsyncListCursor:
         raise StopAsyncIteration
 
     async def next(self) -> dict | None:
-        if self._index >= self._limit:
+        if self._limit >= 0 and self._index >= self._limit:
             return None
 
         try:

--- a/superdesk/roles/roles.py
+++ b/superdesk/roles/roles.py
@@ -105,7 +105,7 @@ class RolesService(AsyncBaseService):
                 push_notification("role_privileges_revoked", updated=1, role_id=str(role_id))
                 privileges_updated = True
             if len(added) > 0 or (0, 1) in modified.values():
-                activity = add_activity(
+                activity = await add_activity(
                     ACTIVITY_UPDATE,
                     "role {{role}} has been granted new privileges: Please re-login.",
                     self.datasource,

--- a/superdesk/server_config.py
+++ b/superdesk/server_config.py
@@ -1,5 +1,7 @@
-import superdesk
+from motor.motor_asyncio import AsyncIOMotorCollection
 
+import superdesk
+from superdesk.eve_async import AsyncBaseService
 from superdesk.core import get_current_app
 from apps.auth import is_current_user_admin
 from superdesk.utc import utcnow
@@ -18,32 +20,34 @@ class ConfigResource(superdesk.Resource):
     public_item_methods = ["GET"]
 
 
-class ConfigService(superdesk.Service):
-    def find_one(self, req, **lookup):
-        item = super().find_one(req, **lookup)
+class ConfigService(AsyncBaseService):
+    async def find_one_async(self, req, **lookup):
+        item = await super().find_one_async(req, **lookup)
         if item:
             return item
         else:
             return {"_id": lookup["_id"], "val": None}
 
-    def create(self, docs, **kwargs):
+    async def create_async(self, docs, **kwargs):
         ids = []
         for doc in docs:
-            self.set(doc["_id"], doc.get("val"))
+            await self.set(doc["_id"], doc.get("val"))
             ids.append(doc["_id"])
         return ids
 
-    def set(self, key, val, namespace="superdesk"):
-        coll = get_current_app().data.mongo.get_collection_with_write_concern("config", "config")
+    async def set(self, key, val, namespace="superdesk"):
+        coll: AsyncIOMotorCollection = get_current_app().data.mongo_async.get_collection_with_write_concern(
+            "config", "config"
+        )
         if isinstance(val, dict):
             updates = {f"val.{k}": v for k, v in val.items()} if val else {}
         else:
             updates = {"val": val}
         updates["_updated"] = utcnow()
-        coll.update_one({"_id": key}, {"$set": dict(_id=key, **updates)}, upsert=True)
+        await coll.update_one({"_id": key}, {"$set": dict(_id=key, **updates)}, upsert=True)
 
-    def get(self, key, namespace="superdesk"):
-        return self.find_one(req=None, _id=key).get("val")
+    async def get_async(self, key, namespace="superdesk"):
+        return (await self.find_one_async(req=None, _id=key)).get("val")
 
     def is_authorizes(self, user):
         return is_current_user_admin()

--- a/superdesk/types/vocabularies.py
+++ b/superdesk/types/vocabularies.py
@@ -32,6 +32,7 @@ class CVItem(Dataclass):
     qcode: str | int
     is_active: bool = True
     translations: dict[str, dict[str, Any]] | None = None
+    scheme: str | None = None
 
 
 class DateShortcut(Dataclass):

--- a/superdesk/users/async_service.py
+++ b/superdesk/users/async_service.py
@@ -187,7 +187,7 @@ class UsersAsyncService(AsyncResourceService[UsersResourceModel]):
             if len(removed) > 0 or (1, 0) in modified.values():
                 push_notification("user_privileges_revoked", updated=1, user_id=str(user_id))
             if len(added) > 0:
-                add_activity(
+                await add_activity(
                     ACTIVITY_UPDATE,
                     "user {{user}} has been granted new privileges: Please re-login.",
                     self.resource_name,
@@ -198,7 +198,7 @@ class UsersAsyncService(AsyncResourceService[UsersResourceModel]):
             if not is_admin(updates):
                 push_notification("user_type_changed", updated=1, user_id=str(user_id))
             else:
-                add_activity(
+                await add_activity(
                     ACTIVITY_UPDATE,
                     "user {{user}} is updated to administrator: Please re-login.",
                     self.resource_name,
@@ -240,7 +240,7 @@ class UsersAsyncService(AsyncResourceService[UsersResourceModel]):
     async def on_created(self, docs: list[UsersResourceModel]) -> None:
         for doc in docs:
             await self.__update_user_defaults(doc)
-            add_activity(
+            await add_activity(
                 ACTIVITY_CREATE,
                 "created user {{user}}",
                 self.resource_name,
@@ -322,7 +322,7 @@ class UsersAsyncService(AsyncResourceService[UsersResourceModel]):
         3. Reset Password Tokens
         """
 
-        add_activity(
+        await add_activity(
             ACTIVITY_UPDATE,
             "disabled user {{user}}",
             self.resource_name,

--- a/superdesk/users/services.py
+++ b/superdesk/users/services.py
@@ -205,7 +205,7 @@ class UsersService(AsyncBaseService):
             if can_send_mail:
                 await send_user_status_changed_email([user.get("email")], status)
 
-    def __send_notification(self, updates, user):
+    async def __send_notification(self, updates, user):
         user_id = user["_id"]
 
         if "is_enabled" in updates and not updates["is_enabled"]:
@@ -219,7 +219,7 @@ class UsersService(AsyncBaseService):
             if len(removed) > 0 or (1, 0) in modified.values():
                 push_notification("user_privileges_revoked", updated=1, user_id=str(user_id))
             if len(added) > 0:
-                add_activity(
+                await add_activity(
                     ACTIVITY_UPDATE,
                     "user {{user}} has been granted new privileges: Please re-login.",
                     self.datasource,
@@ -230,7 +230,7 @@ class UsersService(AsyncBaseService):
             if not is_admin(updates):
                 push_notification("user_type_changed", updated=1, user_id=str(user_id))
             else:
-                add_activity(
+                await add_activity(
                     ACTIVITY_UPDATE,
                     "user {{user}} is updated to administrator: Please re-login.",
                     self.datasource,
@@ -269,7 +269,7 @@ class UsersService(AsyncBaseService):
     async def on_created_async(self, docs):
         for user_doc in docs:
             self.__update_user_defaults(user_doc)
-            add_activity(
+            await add_activity(
                 ACTIVITY_CREATE,
                 "created user {{user}}",
                 self.datasource,
@@ -303,7 +303,7 @@ class UsersService(AsyncBaseService):
             await get_resource_service("preferences").on_update_async(updates, user)
         await self.__handle_status_changed_async(updates, user)
         await self.handle_user_type_changed_async(updates, user)
-        self.__send_notification(updates, user)
+        await self.__send_notification(updates, user)
 
     async def on_delete_async(self, user):
         """Overriding the method to prevent user from the below:
@@ -360,7 +360,7 @@ class UsersService(AsyncBaseService):
         3. Reset Password Tokens
         """
 
-        add_activity(
+        await add_activity(
             ACTIVITY_UPDATE,
             "disabled user {{user}}",
             self.datasource,

--- a/superdesk/vocabularies_async/__init__.py
+++ b/superdesk/vocabularies_async/__init__.py
@@ -1,7 +1,8 @@
 from superdesk.core.module import Module
 from .service import VocabulariesService
 from .module import vocabularies_resource_config
+from .utils import get_cv_items, get_languages
 
-__all__ = ["VocabulariesService"]
+__all__ = ["VocabulariesService", "get_cv_items", "get_languages"]
 
 module = Module(name="superdesk.vocabularies_async", resources=[vocabularies_resource_config])

--- a/superdesk/vocabularies_async/service.py
+++ b/superdesk/vocabularies_async/service.py
@@ -18,7 +18,6 @@ from quart_babel import gettext, lazy_gettext
 from superdesk import privilege
 from superdesk.cache import cache
 from superdesk.core.resources import ResourceModel, AsyncResourceService
-from superdesk.core.types import SearchRequest
 from superdesk.default_schema import DEFAULT_EDITOR, DEFAULT_SCHEMA
 from superdesk.errors import SuperdeskApiError
 from superdesk.notification import push_notification
@@ -280,82 +279,6 @@ class VocabulariesService(AsyncResourceService[VocabulariesResourceModel]):
         article_item.update({"scheme": scheme})
         return article_item
 
-    async def get_items(
-        self,
-        _id: str,
-        qcode: Optional[str] = None,
-        is_active: bool = True,
-        name: Optional[str] = None,
-        lang: Optional[str] = None,
-    ) -> List[CVItem]:
-        """
-        Return `items` with specified filters from the CV with specified `_id`.
-        If `lang` is provided then `name` is looked in `items.translations.name.{lang}`,
-        otherwise `name` is looked in `items.name`.
-
-        :param _id: custom vocabulary _id
-        :param qcode: items.qcode filter
-        :param is_active: items.is_active filter
-        :param name: items.name filter
-        :param lang: items.lang filter
-        :return: items list
-        """
-
-        projection: dict[str, Any] = {}
-        lookup = {"_id": _id}
-
-        if qcode:
-            elem_match = projection.setdefault("items", {}).setdefault("$elemMatch", {})
-            elem_match["qcode"] = qcode
-
-        # if `lang` is provided `name` is looked in `translations.name.{lang}`
-        if name and lang:
-            elem_match = projection.setdefault("items", {}).setdefault("$elemMatch", {})
-            elem_match[f"translations.name.{lang}"] = {
-                "$regex": r"^{}$".format(name),
-                # case-insensitive
-                "$options": "i",
-            }
-        elif name:
-            elem_match = projection.setdefault("items", {}).setdefault("$elemMatch", {})
-            elem_match["name"] = {
-                "$regex": r"^{}$".format(name),
-                # case-insensitive
-                "$options": "i",
-            }
-
-        cursor = await self.find(SearchRequest(where=lookup, projection=projection))
-
-        try:
-            voc = await cursor.next()
-            if voc is None:
-                raise StopIteration
-        except StopIteration:
-            return []
-        else:
-            items = voc.items
-
-        # $elemMatch projection contains only the first element matching the condition,
-        # that"s why `is_active` filter is filtered via python
-        if is_active is not None:
-            items = [i for i in items if i.is_active == is_active]
-
-        def format_item(item: CVItem) -> CVItem:
-            try:
-                del item.is_active
-            except KeyError:
-                pass
-            # FIXME
-            item.scheme = _id  # type: ignore
-            return item
-
-        items = list(map(format_item, items))
-
-        return items
-
-    async def get_languages(self) -> list[CVItem]:
-        return await self.get_items(_id="languages")
-
     async def get_field_options(self, field) -> dict[str, Any]:
         cv = await self.find_by_id(field)
         return cv.field_options if cv else {}
@@ -365,7 +288,8 @@ class VocabulariesService(AsyncResourceService[VocabulariesResourceModel]):
 async def get_related_field_ids():
     service = VocabulariesService()
     cursor = await service.find(
-        req=SearchRequest(where={"field_type": "related_content"}, projection={"field_type": 1})
+        {"field_type": "related_content"},
+        projection={"field_type": 1},
     )
     return await cursor.to_list()
 

--- a/superdesk/vocabularies_async/utils.py
+++ b/superdesk/vocabularies_async/utils.py
@@ -1,0 +1,73 @@
+from superdesk.types.vocabularies import CVItem, VocabulariesResourceModel
+
+
+async def get_cv_items(
+    cv_id: str,
+    qcode: str | None = None,
+    is_active: bool = True,
+    name: str | None = None,
+    lang: str | None = None,
+) -> list[CVItem]:
+    """
+    Return `items` with specified filters from the CV with specified `cv_id`.
+    If `lang` is provided then `name` is looked in `items.translations.name.{lang}`,
+    otherwise `name` is looked in `items.name`.
+
+    :param cv_id: custom vocabulary cv_id
+    :param qcode: items.qcode filter
+    :param is_active: items.is_active filter
+    :param name: items.name filter
+    :param lang: items.lang filter
+    :return: items list
+    """
+
+    projection: dict = {}
+    lookup = {"_id": cv_id}
+
+    if qcode:
+        elem_match = projection.setdefault("items", {}).setdefault("$elemMatch", {})
+        elem_match["qcode"] = qcode
+
+    # if `lang` is provided `name` is looked in `translations.name.{lang}`
+    if name and lang:
+        elem_match = projection.setdefault("items", {}).setdefault("$elemMatch", {})
+        elem_match[f"translations.name.{lang}"] = {
+            "$regex": r"^{}$".format(name),
+            # case-insensitive
+            "$options": "i",
+        }
+    elif name:
+        elem_match = projection.setdefault("items", {}).setdefault("$elemMatch", {})
+        elem_match["name"] = {
+            "$regex": r"^{}$".format(name),
+            # case-insensitive
+            "$options": "i",
+        }
+
+    cursor = await VocabulariesResourceModel.get_service().find(lookup, projection=projection)
+    voc = await cursor.next()
+    if voc is None:
+        return []
+
+    items = voc.items
+
+    # $elemMatch projection contains only the first element matching the condition,
+    # that"s why `is_active` filter is filtered via python
+    if is_active is not None:
+        items = [i for i in items if i.is_active == is_active]
+
+    def format_item(item: CVItem) -> CVItem:
+        try:
+            del item.is_active
+        except KeyError:
+            pass
+        item.scheme = cv_id
+        return item
+
+    items = list(map(format_item, items))
+
+    return items
+
+
+async def get_languages() -> list[CVItem]:
+    return await get_cv_items("languages")


### PR DESCRIPTION
### Purpose
Upgrade system based resources to use async eve services

### What has changed
* Upgraded `languages` resource to async eve
* Upgraded `system_messages` resource to async eve
* Upgraded `activity` resource to async eve
* Upgraded `audit` resource to async eve
* Upgraded `config` resource to async eve
* Fixed `limit` attribute of the AsyncListCursor
* Moved `get_items` and `get_languages` out of the Pydantic service to a util file

### What was **not** changed
* `client_config` - no I/O to wait for
* `backend_meta` - uses local file input, endpoint not used often
* `data_updates` - only used by backend commands

**Note:** Commented out notifier on Ingest/Publish error, due to requiring async but the code runs inside an Exception constructor. Will do this task in a separate ticket, as it will be much bigger of a change. (see usage of [update_notifiers](https://github.com/superdesk/superdesk-core/blob/develop/superdesk/errors.py#L31))