### PR TITLE
[SDESK-7585] Upgrade desk and workflow based resources to async eve

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -858,20 +858,19 @@ class ArchiveService(AsyncBaseService, HighlightsSearchMixin):
         :param updates: item updates
         """
 
-        def abort_if_readonly_stage(stage_id):
-            # TODO-ASYNC[stage]: Upgrade to async
-            stage = superdesk.get_resource_service("stages").find_one(req=None, _id=stage_id)
+        async def abort_if_readonly_stage(stage_id):
+            stage = await superdesk.get_resource_service("stages").find_one_async(req=None, _id=stage_id)
             if stage.get("local_readonly"):
                 abort(403, response={"readonly": True})
 
         orig_stage_id = item.get("task", {}).get("stage")
         if orig_stage_id and get_user() and not item.get(INGEST_ID):
-            abort_if_readonly_stage(orig_stage_id)
+            await abort_if_readonly_stage(orig_stage_id)
 
         if updates:
             dest_stage_id = updates.get("task", {}).get("stage")
             if dest_stage_id and get_user() and not item.get(INGEST_ID):
-                abort_if_readonly_stage(dest_stage_id)
+                await abort_if_readonly_stage(dest_stage_id)
 
     async def _validate_updates(self, original, updates, user):
         """Validates updates to the article for the below conditions.

--- a/apps/archive/commands.py
+++ b/apps/archive/commands.py
@@ -435,7 +435,9 @@ class RemoveExpiredContent:
         archive_service = get_resource_service("archive")
         item_id = item.get(ID_FIELD)
         moved_to_archived = self._conforms_to_archived_filter(item, filter_conditions)
-        published_items = await published_service.get_from_mongo_async(req=None, lookup={"item_id": item_id}).to_list()
+        published_items = await (
+            await published_service.get_from_mongo_async(req=None, lookup={"item_id": item_id})
+        ).to_list()
 
         try:
             if published_items:

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -635,8 +635,7 @@ async def get_expiry(desk_id, stage_id, offset=None):
             raise SuperdeskApiError.notFoundError(_("Invalid desk identifier {desk_id}").format(desk_id=desk_id))
 
     if stage_id:
-        # TODO-ASYNC[stages]: update this code when StagesService is async
-        stage = get_resource_service("stages").find_one(req=None, _id=stage_id)
+        stage = await get_resource_service("stages").find_one_async(req=None, _id=stage_id)
 
         if not stage:
             raise SuperdeskApiError.notFoundError(_("Invalid stage identifier {stage_id}").format(stage_id=stage_id))

--- a/apps/desk_routing.py
+++ b/apps/desk_routing.py
@@ -1,6 +1,7 @@
 from quart_babel import lazy_gettext
-import superdesk
 
+import superdesk
+from superdesk.eve_async import AsyncBaseService
 from superdesk.notification import push_notification
 from apps.content import push_content_notification
 from superdesk import get_resource_service
@@ -31,25 +32,27 @@ class ClosedDeskResource(superdesk.Resource):
     item_methods = ["PATCH"]
 
 
-class ClosedDeskService(superdesk.Service):
-    def on_updated(self, updates, original):
+class ClosedDeskService(AsyncBaseService):
+    async def on_updated_async(self, updates, original):
         is_closed = updates.get("is_closed", False)
         if not is_closed and original.get("is_closed"):
             desk_id = updates["_id"]
-            self.remove_marks(desk_id)
+            await self.remove_marks(desk_id)
         push_notification("desks:closed", is_closed=is_closed, _id=original.get("_id"), _etag=updates.get("_etag"))
 
-    def remove_marks(self, desk_id):
+    async def remove_marks(self, desk_id):
         """Remove "mark for desk" attribute
 
         :param ObjectId desk_id: id of the desk being re-opened
         """
         for service_name in ("archive", "published"):
             service = get_resource_service(service_name)
-            marked_items = service.find({"task.desk": desk_id, "marked_desks": {"$exists": True, "$ne": []}})
-            for item in marked_items:
+            marked_items = await service.find_async(
+                {"task.desk": desk_id, "marked_desks": {"$exists": True, "$ne": []}}
+            )
+            async for item in marked_items:
                 marked_desks = [m for m in item["marked_desks"] if "user_marked" in m]
-                service.system_update(item["_id"], {"marked_desks": marked_desks}, item)
+                await service.system_update_async(item["_id"], {"marked_desks": marked_desks}, item)
                 push_content_notification([item])
 
 

--- a/apps/desks.py
+++ b/apps/desks.py
@@ -149,18 +149,18 @@ class DesksService(AsyncBaseService):
 
             if "working_stage" not in desk:
                 stages_to_be_linked_with_desk.append("working_stage")
-                stage_id = stage_service.create_working_stage()
+                stage_id = await stage_service.create_working_stage()
                 desk["working_stage"] = stage_id[0]
 
             if "incoming_stage" not in desk:
                 stages_to_be_linked_with_desk.append("incoming_stage")
-                stage_id = stage_service.create_incoming_stage()
+                stage_id = await stage_service.create_incoming_stage()
                 desk["incoming_stage"] = stage_id[0]
 
             desk.setdefault("desk_type", DeskTypes.authoring.value)
             await super().create_async([desk], **kwargs)
             for stage_type in stages_to_be_linked_with_desk:
-                stage_service.patch(desk[stage_type], {"desk": desk[ID_FIELD]})
+                await stage_service.patch_async(desk[stage_type], {"desk": desk[ID_FIELD]})
 
             # make the desk available in default content template
             content_templates = get_resource_service("content_templates")
@@ -226,7 +226,7 @@ class DesksService(AsyncBaseService):
                 {"rules.actions.publish.desk": desk[ID_FIELD]},
             ]
         }
-        routing_rule_count = await superdesk.get_resource_service("routing_schemes").count(routing_rules_query)
+        routing_rule_count = await superdesk.get_resource_service("routing_schemes").count_async(routing_rules_query)
         if routing_rule_count > 0:
             raise SuperdeskApiError.preconditionFailedError(
                 message=_("Cannot delete desk as routing scheme(s) are associated with the desk")
@@ -251,7 +251,7 @@ class DesksService(AsyncBaseService):
         Overriding to delete stages before deleting a desk
         """
 
-        superdesk.get_resource_service("stages").delete(lookup={"desk": lookup.get(ID_FIELD)})
+        await superdesk.get_resource_service("stages").delete_async(lookup={"desk": lookup.get(ID_FIELD)})
         await super().delete_async(lookup)
 
     async def on_deleted_async(self, doc):

--- a/apps/desks_async/desks_async_service.py
+++ b/apps/desks_async/desks_async_service.py
@@ -39,12 +39,12 @@ class DesksAsyncService(AsyncResourceService[DesksResourceModel]):
 
             if desk.working_stage is None:
                 stages_to_be_linked_with_desk.append("working_stage")
-                stage_id = stage_service.create_working_stage()
+                stage_id = await stage_service.create_working_stage()
                 desk.working_stage = stage_id[0]
 
             if desk.incoming_stage is None:
                 stages_to_be_linked_with_desk.append("incoming_stage")
-                stage_id = stage_service.create_incoming_stage()
+                stage_id = await stage_service.create_incoming_stage()
                 desk.incoming_stage = stage_id[0]
 
             desk.desk_type = DeskTypeEnum.AUTHORING
@@ -56,7 +56,7 @@ class DesksAsyncService(AsyncResourceService[DesksResourceModel]):
                 docs_entry.update(desk.to_dict())
 
             for stage_type in stages_to_be_linked_with_desk:
-                stage_service.patch(desk.to_dict()[stage_type], {"desk": desk.id})
+                await stage_service.patch_async(desk.to_dict()[stage_type], {"desk": desk.id})
 
             # make the desk available in default content template
             content_templates = get_resource_service("content_templates")
@@ -116,7 +116,7 @@ class DesksAsyncService(AsyncResourceService[DesksResourceModel]):
                 {"rules.actions.publish.desk": doc.id},
             ]
         }
-        routing_rule_count = await get_resource_service("routing_schemes").count(routing_rules_query)
+        routing_rule_count = await get_resource_service("routing_schemes").count_async(routing_rules_query)
         if routing_rule_count > 0:
             raise SuperdeskApiError.preconditionFailedError(
                 message=_("Cannot delete desk as routing scheme(s) are associated with the desk")
@@ -141,7 +141,7 @@ class DesksAsyncService(AsyncResourceService[DesksResourceModel]):
         Overriding to delete stages before deleting a desk
         """
 
-        get_resource_service("stages").delete(lookup={"desk": lookup.get(ID_FIELD)})
+        await get_resource_service("stages").delete_async(lookup={"desk": lookup.get(ID_FIELD)})
         return await super().delete_many(lookup)
 
     async def on_deleted(self, doc: DesksResourceModel):

--- a/apps/highlights/generate.py
+++ b/apps/highlights/generate.py
@@ -2,6 +2,7 @@ import superdesk
 from superdesk.metadata.item import CONTENT_TYPE, CONTENT_STATE, get_schema
 
 from superdesk.core import get_current_app
+from superdesk.eve_async import AsyncBaseService
 from superdesk.resource_fields import (
     ID_FIELD,
     DATE_CREATED,
@@ -45,39 +46,39 @@ PACKAGE_FIELDS = {
 }
 
 
-def get_template(highlightId):
+async def get_template(highlight_id):
     """Return the string template associated with highlightId or none"""
-    if not highlightId:
+    if not highlight_id:
         return None
-    highlightService = superdesk.get_resource_service("highlights")
-    highlight = highlightService.find_one(req=None, _id=highlightId)
+    highlight_service = superdesk.get_resource_service("highlights")
+    highlight = await highlight_service.find_one_async(req=None, _id=highlight_id)
     if not highlight or not highlight.get("template"):
         return None
 
-    # TODO-ASYNC[ContentTemplatesService]: Use find_one_async where when upgrading this module
-    templateService = superdesk.get_resource_service("content_templates")
-    template = templateService.find_one(req=None, _id=highlight.get("template"))
+    template_service = superdesk.get_resource_service("content_templates")
+    template = await template_service.find_one_async(req=None, _id=highlight.get("template"))
     return template
 
 
-class GenerateHighlightsService(superdesk.Service):
-    def create(self, docs, **kwargs):
+class GenerateHighlightsService(AsyncBaseService):
+    async def create_async(self, docs, **kwargs):
         """Generate highlights text item for given package.
 
         If doc.preview is True it won't save the item, only return.
         """
         service = superdesk.get_resource_service("archive")
         app = get_current_app().as_any()
+        preview = False
         for doc in docs:
             preview = doc.get("preview", False)
-            package = service.find_one(req=None, _id=doc["package"])
+            package = await service.find_one_async(req=None, _id=doc["package"])
             if not package:
                 abort(404)
             export = doc.get("export")
-            template = get_template(package.get("highlight"))
-            stringTemplate = None
+            template = await get_template(package.get("highlight"))
+            string_template = None
             if template and template.get("data") and template["data"].get("body_html"):
-                stringTemplate = template["data"]["body_html"]
+                string_template = template["data"]["body_html"]
 
             doc.clear()
             doc[ITEM_TYPE] = CONTENT_TYPE.TEXT
@@ -93,7 +94,7 @@ class GenerateHighlightsService(superdesk.Service):
             for group in package.get("groups", []):
                 for ref in group.get("refs", []):
                     if "residRef" in ref:
-                        item = service.find_one(req=None, _id=ref.get("residRef"))
+                        item = await service.find_one_async(req=None, _id=ref.get("residRef"))
                         if item:
                             if not (export or preview) and (
                                 item.get("lock_session") or item.get("state") != "published"
@@ -103,32 +104,30 @@ class GenerateHighlightsService(superdesk.Service):
 
                             items.append(item)
                             if not preview:
-                                app.on_archive_item_updated(
+                                await app.on_archive_item_updated.call_async(
                                     {
                                         "highlight_id": package.get("highlight"),
-                                        "highlight_name": get_highlight_name(package.get("highlight")),
+                                        "highlight_name": await get_highlight_name(package.get("highlight")),
                                     },
                                     item,
                                     ITEM_EXPORT_HIGHLIGHT,
                                 )
 
-            if stringTemplate:
-                # TODO-ASYNC: Support async (see superdesk.tests.markers.requires_eve_resource_async_event)
-                doc["body_html"] = render_template_string(stringTemplate, package=package, items=items)
+            if string_template:
+                doc["body_html"] = await render_template_string(string_template, package=package, items=items)
             else:
-                # TODO-ASYNC: Support async (see superdesk.tests.markers.requires_eve_resource_async_event)
-                doc["body_html"] = render_template("default_highlight_template.txt", package=package, items=items)
+                doc["body_html"] = await render_template("default_highlight_template.txt", package=package, items=items)
         if preview:
             return ["" for doc in docs]
         else:
-            ids = service.post(docs, **kwargs)
-            for id in ids:
-                app.on_archive_item_updated(
+            ids = await service.post_async(docs, **kwargs)
+            for item_id in ids:
+                await app.on_archive_item_updated.call_async(
                     {
                         "highlight_id": package.get("highlight"),
-                        "highlight_name": get_highlight_name(package.get("highlight")),
+                        "highlight_name": await get_highlight_name(package.get("highlight")),
                     },
-                    {"_id": id},
+                    {"_id": item_id},
                     ITEM_CREATE_HIGHLIGHT,
                 )
             return ids

--- a/apps/highlights/service.py
+++ b/apps/highlights/service.py
@@ -10,7 +10,7 @@ import apps.archive  # NOQA
 from superdesk.core import get_current_app, get_app_config
 import apps.packages.package_service as package
 from superdesk import get_resource_service
-from superdesk.services import BaseService
+from superdesk.eve_async import AsyncBaseService
 from eve.utils import ParsedRequest
 from superdesk.notification import push_notification
 from superdesk.utc import get_timezone_offset, utcnow
@@ -24,9 +24,9 @@ def init_parsed_request(elastic_query):
     return parsed_request
 
 
-def get_highlighted_items(highlights_id):
+async def get_highlighted_items(highlights_id):
     """Get items marked for given highlight and passing date range query."""
-    highlight = get_resource_service("highlights").find_one(req=None, _id=highlights_id)
+    highlight = await get_resource_service("highlights").find_one_async(req=None, _id=highlights_id)
     query = {
         "query": {
             "filtered": {
@@ -52,74 +52,74 @@ def get_highlighted_items(highlights_id):
     }
     request = ParsedRequest()
     request.args = {"source": json.dumps(query), "repo": "archive,published"}
-    # TODO-ASYNC[search]: Use `get_async` when upgrading this module
-    return list(get_resource_service("search").get(req=request, lookup=None))
+    return await get_resource_service("search").get_async(req=request, lookup=None)
 
 
-def init_highlight_package(doc):
+async def init_highlight_package(doc):
     """Add to package items marked for doc highlight."""
     main_group = doc.get("groups")[1]
-    items = get_highlighted_items(doc.get("highlight"))
+    items = await get_highlighted_items(doc.get("highlight"))
     used_items = []
-    for item in items:
+    async for item in items:
         if item["_id"] not in used_items:
             main_group["refs"].append(package.get_item_ref(item))
             used_items.append(item["_id"])
 
 
-def init_default_content_profile(doc):
+async def init_default_content_profile(doc):
     if not doc.get("profile"):
         desk_id = doc.get("task", {}).get("desk")
-        # TODO-ASYNC[desks]: Use DesksResourceModel async service where when upgrading this module
-        desk = get_resource_service("desks").find_one(req=None, _id=desk_id)
+        desk = await get_resource_service("desks").find_one_async(req=None, _id=desk_id)
         doc["profile"] = desk.get("default_content_profile")
 
 
-def on_create_package(sender, docs):
+async def on_create_package(docs: list[dict]) -> None:
     """Call init_highlight_package for each package with highlight reference."""
     for doc in docs:
         if doc.get("highlight"):
-            init_highlight_package(doc)
-            init_default_content_profile(doc)
+            await init_highlight_package(doc)
+            await init_default_content_profile(doc)
 
 
-def get_highlight_name(highlights_id):
+async def get_highlight_name(highlights_id):
     """
     Given the id of a highlight it will return the name.
     :param hightlight_id:
     :return:
     """
-    highlight = get_resource_service("highlights").find_one(req=None, _id=highlights_id)
+    highlight = await get_resource_service("highlights").find_one_async(req=None, _id=highlights_id)
     if highlight and "name" in highlight:
         return highlight.get("name", None)
     return None
 
 
-class HighlightsService(BaseService):
-    def on_delete(self, doc):
+class HighlightsService(AsyncBaseService):
+    async def on_delete_async(self, doc):
         service = get_resource_service("archive")
         highlights_id = str(doc["_id"])
         query = {"query": {"filtered": {"filter": {"term": {"highlights": highlights_id}}}}}
         req = init_parsed_request(query)
-        proposedItems = service.get(req=req, lookup=None)
+        proposed_items = await service.get_async(req=req, lookup=None)
         app = get_current_app().as_any()
-        for item in proposedItems:
-            app.on_archive_item_updated(
-                {"highlight_id": highlights_id, "highlight_name": get_highlight_name(highlights_id)}, item, ITEM_UNMARK
+        async for item in proposed_items:
+            await app.on_archive_item_updated.call_async(
+                {"highlight_id": highlights_id, "highlight_name": await get_highlight_name(highlights_id)},
+                item,
+                ITEM_UNMARK,
             )
             highlights = [h for h in item.get("highlights") if h != highlights_id]
-            service.update(item["_id"], {"highlights": highlights}, item)
+            await service.update_async(item["_id"], {"highlights": highlights}, item)
 
 
-class MarkedForHighlightsService(BaseService):
-    def create(self, docs, **kwargs):
+class MarkedForHighlightsService(AsyncBaseService):
+    async def create_async(self, docs, **kwargs):
         """Toggle highlight status for given highlight and item."""
         service = get_resource_service("archive")
-        publishedService = get_resource_service("published")
+        published_service = get_resource_service("published")
         ids = []
         app = get_current_app().as_any()
         for doc in docs:
-            item = service.find_one(req=None, _id=doc["marked_item"])
+            item = await service.find_one_async(req=None, _id=doc["marked_item"])
             if not item:
                 ids.append(None)
                 continue
@@ -139,23 +139,21 @@ class MarkedForHighlightsService(BaseService):
                     status[str(highlight)] = ITEM_UNMARK
 
             updates = {"highlights": highlights, "_etag": item["_etag"]}
-            service.update(item["_id"], updates, item)
+            await service.update_async(item["_id"], updates, item)
 
-            # TODO-ASYNC[published]: Use ``await service.find_async`` when updating this module
-            publishedItems = publishedService.find({"item_id": item["_id"]})
-            for publishedItem in publishedItems:
-                if publishedItem["_current_version"] == item["_current_version"]:
+            published_items = await published_service.find_async({"item_id": item["_id"]})
+            async for published_item in published_items:
+                if published_item["_current_version"] == item["_current_version"]:
                     updates = {
                         "highlights": highlights,
-                        "_updated": publishedItem["_updated"],
-                        "_etag": publishedItem["_etag"],
+                        "_updated": published_item["_updated"],
+                        "_etag": published_item["_etag"],
                     }
-                    # TODO-ASYNC[published]: Use ``await service.update`` when updating this module
-                    publishedService.update(publishedItem["_id"], updates, publishedItem)
+                    await published_service.update_async(published_item["_id"], updates, published_item)
 
             for highlight in doc_highlights:
-                app.on_archive_item_updated(
-                    {"highlight_id": highlight, "highlight_name": get_highlight_name(highlight)},
+                await app.on_archive_item_updated.call_async(
+                    {"highlight_id": highlight, "highlight_name": await get_highlight_name(highlight)},
                     item,
                     status[str(highlight)],
                 )

--- a/apps/legal_archive/commands.py
+++ b/apps/legal_archive/commands.py
@@ -157,7 +157,7 @@ class LegalArchiveImport:
                 return
 
             # Step 2 - De-normalizing the legal archive doc
-            self._denormalize_user_desk(legal_archive_doc, log_msg)
+            await self._denormalize_user_desk(legal_archive_doc, log_msg)
             logger.info("De-normalized article {}".format(log_msg))
 
             # Step 3 - Upserting Legal Archive
@@ -211,7 +211,7 @@ class LegalArchiveImport:
                 versions_to_insert.append(versioned_doc)
 
             for version_doc in versions_to_insert:
-                self._denormalize_user_desk(
+                await self._denormalize_user_desk(
                     version_doc,
                     self.log_msg_format.format(
                         _id=version_doc[version_id_field],
@@ -227,7 +227,7 @@ class LegalArchiveImport:
                 logger.info("Inserted de-normalized versions for article {}".format(log_msg))
 
             for history_doc in history_to_insert:
-                self._denormalize_history(history_doc)
+                await self._denormalize_history(history_doc)
                 history_doc.pop(ETAG, None)
 
             if history_to_insert:
@@ -242,7 +242,7 @@ class LegalArchiveImport:
             logger.exception("Failed to import into legal archive {}.".format(item_id))
             raise
 
-    def _denormalize_history(self, history_item):
+    async def _denormalize_history(self, history_item):
         """
         De-normalizes history items
         """
@@ -264,7 +264,9 @@ class LegalArchiveImport:
                     logger.info("Desk Details Not Found: {}. {}".format(history_update["task"].get("desk"), msg))
 
             if history_update.get("task") and history_update["task"].get("stage"):
-                stage = get_resource_service("stages").find_one(req=None, _id=str(history_update["task"]["stage"]))
+                stage = await get_resource_service("stages").find_one_async(
+                    req=None, _id=str(history_update["task"]["stage"])
+                )
                 if stage:
                     history_update["task"]["stage"] = stage.get("name")
                     logger.info("De-normalized Stage Details for article {}".format(msg))
@@ -276,7 +278,7 @@ class LegalArchiveImport:
 
             history_item["update"] = history_update
 
-    def _denormalize_user_desk(self, legal_archive_doc, log_msg):
+    async def _denormalize_user_desk(self, legal_archive_doc, log_msg):
         """
         De-normalizes user, desk and stage details in legal_archive_doc.
         """
@@ -299,7 +301,9 @@ class LegalArchiveImport:
                     logger.info("Desk Details Not Found: {}. {}".format(legal_archive_doc["task"].get("desk"), log_msg))
 
             if legal_archive_doc["task"].get("stage"):
-                stage = get_resource_service("stages").find_one(req=None, _id=str(legal_archive_doc["task"]["stage"]))
+                stage = await get_resource_service("stages").find_one_async(
+                    req=None, _id=str(legal_archive_doc["task"]["stage"])
+                )
                 if stage:
                     legal_archive_doc["task"]["stage"] = stage.get("name")
                     logger.info("De-normalized Stage Details for article {}".format(log_msg))

--- a/apps/marked_desks/service.py
+++ b/apps/marked_desks/service.py
@@ -14,15 +14,14 @@ from eve.utils import ParsedRequest
 from superdesk.core import get_current_app
 from superdesk.resource_fields import ID_FIELD
 from superdesk import get_resource_service
-from superdesk.services import BaseService
+from superdesk.eve_async import AsyncBaseService
 from superdesk.notification import push_notification
 from apps.archive.common import get_user
 from superdesk.utc import utcnow
 from apps.archive.common import ITEM_MARK, ITEM_UNMARK
 
 
-# TODO-ASYNC[search]: Is this used anywhere?
-def get_marked_items(desk_id):
+async def get_marked_items(desk_id):
     """Get items marked for given desk"""
     query = {
         "query": {"filtered": {"filter": {"term": {"marked_desks.desk_id": str(desk_id)}}}},
@@ -31,19 +30,18 @@ def get_marked_items(desk_id):
     }
     request = ParsedRequest()
     request.args = {"source": json.dumps(query), "repo": "archive,published"}
-    # TODO-ASYNC[search]: Use `get_async` when upgrading this module
-    return list(get_resource_service("search").get(req=request, lookup=None))
+    return await (await get_resource_service("search").get_async(req=request, lookup=None)).to_list()
 
 
-class MarkedForDesksService(BaseService):
-    def create(self, docs, **kwargs):
+class MarkedForDesksService(AsyncBaseService):
+    async def create_async(self, docs, **kwargs):
         """Toggle marked desk status for given desk and item."""
 
         service = get_resource_service("archive")
         published_service = get_resource_service("published")
         ids = []
         for doc in docs:
-            item = service.find_one(req=None, _id=doc["marked_item"])
+            item = await service.find_one_async(req=None, _id=doc["marked_item"])
             if not item:
                 ids.append(None)
                 continue
@@ -69,15 +67,13 @@ class MarkedForDesksService(BaseService):
                 marked_desks_on = True
 
             updates = {"marked_desks": marked_desks}
-            service.system_update(item["_id"], updates, item)
+            await service.system_update_async(item["_id"], updates, item)
 
-            # TODO-ASYNC[published] Use ``await service.find_async`` when updating this module
-            publishedItems = published_service.find({"item_id": item["_id"]})
-            for publishedItem in publishedItems:
-                if publishedItem["_current_version"] == item["_current_version"] or not marked_desks_on:
+            published_items = await published_service.find_async({"item_id": item["_id"]})
+            async for published_item in published_items:
+                if published_item["_current_version"] == item["_current_version"] or not marked_desks_on:
                     updates = {"marked_desks": marked_desks}
-                    # TODO-ASYNC[published] Use ``await service.system_update_async`` when updating this module
-                    published_service.system_update(publishedItem["_id"], updates, publishedItem)
+                    await published_service.system_update_async(published_item["_id"], updates, published_item)
 
             push_notification(
                 "item:marked_desks", marked=int(marked_desks_on), item_id=item["_id"], mark_id=str(doc["marked_desk"])
@@ -85,8 +81,8 @@ class MarkedForDesksService(BaseService):
 
             app = get_current_app().as_any()
             if marked_desks_on:
-                app.on_archive_item_updated({"desk_id": doc["marked_desk"]}, item, ITEM_MARK)
+                await app.on_archive_item_updated.call_async({"desk_id": doc["marked_desk"]}, item, ITEM_MARK)
             else:
-                app.on_archive_item_updated({"desk_id": doc["marked_desk"]}, item, ITEM_UNMARK)
+                await app.on_archive_item_updated.call_async({"desk_id": doc["marked_desk"]}, item, ITEM_UNMARK)
 
         return ids

--- a/apps/packages/package_service.py
+++ b/apps/packages/package_service.py
@@ -11,7 +11,7 @@
 import logging
 from eve.versioning import resolve_document_version
 
-from superdesk.core import get_current_app, get_app_config
+from superdesk.core import get_current_app, get_app_config, AsyncSignal
 from superdesk.resource_fields import ID_FIELD, LAST_UPDATED
 import superdesk
 from collections import Counter
@@ -37,12 +37,11 @@ from apps.archive.common import ITEM_UNLINK, insert_into_versions_async
 from superdesk.utc import utcnow
 from superdesk.default_settings import VERSION
 from quart_babel import gettext as _
-from superdesk.signals import signals
 from superdesk.validation import ValidationError
 
 
 logger = logging.getLogger(__name__)
-package_create_signal = signals.signal("package.create")  # @UndefinedVariable
+package_create_signal: AsyncSignal[list[dict]] = AsyncSignal("package.create")
 ARCHIVE = "archive"
 
 
@@ -83,7 +82,7 @@ async def copy_metadata_from_highlight_template(doc):
     """
     highlight_id = doc.get("highlight", None)
     if highlight_id:
-        highlight = superdesk.get_resource_service("highlights").find_one(req=None, _id=highlight_id)
+        highlight = await superdesk.get_resource_service("highlights").find_one_async(req=None, _id=highlight_id)
         if highlight and "template" in highlight:
             from apps.templates.content_templates import render_content_template_by_id
 
@@ -107,7 +106,7 @@ class PackageService:
             if "highlight" in doc:
                 await copy_metadata_from_highlight_template(doc)
 
-        package_create_signal.send(self, docs=docs)
+        await package_create_signal.send(docs)
 
     async def on_created_async(self, docs):
         for doc, assoc in [(doc, assoc) for doc in docs for assoc in self._get_associations(doc)]:

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -15,7 +15,6 @@ from eve.versioning import resolve_document_version
 from eve.methods.common import resolve_document_etag
 from quart_babel import gettext as _
 
-from superdesk.core import get_config
 from superdesk.types import PublishRequest, PublishSenderType, SubscriberType, DesksResourceModel
 from superdesk.publish_async.commands import publish_item
 from superdesk.publish_async.utils import get_utc_publish_schedule, SCHEDULE_SETTINGS, PUBLISH_SCHEDULE
@@ -40,6 +39,7 @@ from apps.archive.common import (
     validate_schedule,
 )
 from apps.archive.usage import track_usage, update_refs
+from apps.legal_archive.commands import import_into_legal_archive
 from apps.common.components.utils import get_component
 from apps.content import push_content_notification
 from apps.content_types.content_types import DEFAULT_SCHEMA
@@ -802,9 +802,8 @@ class BasePublishService(AsyncBaseService):
 
         if is_legal_archive_enabled() and doc.get(ITEM_STATE) != CONTENT_STATE.SCHEDULED:
             kwargs = {"item_id": doc.get(ID_FIELD)}
-            # TODO-ASYNC: Disabled for now until this module is upgraded to async
             # countdown=3 is for elasticsearch to be refreshed with archive and published changes
-            # await import_into_legal_archive.apply_async(countdown=3, kwargs=kwargs)  # @UndefinedVariable
+            await import_into_legal_archive.apply_async(countdown=3, kwargs=kwargs)  # @UndefinedVariable
 
     def _set_updates_for_media_items(self, doc, updates):
         if doc.get("type") not in MEDIA_TYPES or updates.get("operation") != "publish":

--- a/apps/rundowns/shows.py
+++ b/apps/rundowns/shows.py
@@ -1,5 +1,5 @@
 import superdesk
-import superdesk.utils as utils
+from superdesk.flask import abort
 
 from quart_babel import gettext
 
@@ -32,7 +32,7 @@ class ShowsResource(superdesk.Resource):
 class ShowsService(superdesk.Service):
     def on_delete(self, doc):
         if rundowns_service.find_one(req=None, show=doc["_id"]) is not None:
-            utils.abort(409, gettext("Can't remove show if there are rundowns."))
+            abort(409, gettext("Can't remove show if there are rundowns."))
         return super().on_delete(doc)
 
     def on_deleted(self, doc):

--- a/apps/stages.py
+++ b/apps/stages.py
@@ -9,10 +9,11 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import superdesk
+from superdesk.core.types import ItemId
 from superdesk.resource_fields import ID_FIELD
 from superdesk.notification import push_notification
 from superdesk.resource import Resource
-from superdesk.services import BaseService
+from superdesk.eve_async import AsyncBaseService
 from superdesk.errors import SuperdeskApiError
 from superdesk import get_resource_service
 from superdesk.types import DesksResourceModel, UsersResourceModel
@@ -58,10 +59,10 @@ class StagesResource(Resource):
     }
 
 
-class StagesService(BaseService):
+class StagesService(AsyncBaseService):
     notification_key = "stage"
 
-    def on_create(self, docs):
+    async def on_create_async(self, docs):
         """Runs on stage create.
 
         Overriding this to set desk_order and expiry settings. Also, if this stage is defined as either working or
@@ -78,24 +79,24 @@ class StagesService(BaseService):
             req = ParsedRequest()
             req.sort = "-desk_order"
             req.max_results = 1
-            prev_stage = self.get(req=req, lookup={"desk": doc["desk"]})
+            prev_stage = await (await self.get_async(req=req, lookup={"desk": doc["desk"]})).next()
 
             if doc.get("content_expiry") == 0:
                 doc["content_expiry"] = None
 
-            if prev_stage.count() == 0:
+            if not prev_stage:
                 doc["desk_order"] = 1
             else:
-                doc["desk_order"] = prev_stage[0].get("desk_order", 1) + 1
+                doc["desk_order"] = prev_stage.get("desk_order", 1) + 1
 
             # if this new one is default then remove the old default
             if doc.get("working_stage", False):
-                self.remove_old_default(desk, "working_stage")
+                await self.remove_old_default(desk, "working_stage")
 
             if doc.get("default_incoming", False):
-                self.remove_old_default(desk, "default_incoming")
+                await self.remove_old_default(desk, "default_incoming")
 
-    async def on_created(self, docs):
+    async def on_created_async(self, docs):
         users_service = UsersResourceModel.get_service()
         for doc in docs:
             if "desk" in doc:
@@ -116,7 +117,7 @@ class StagesService(BaseService):
             if not doc.get("is_visible", True):
                 await users_service.update_stage_visibility_for_users()
 
-    async def on_delete(self, doc):
+    async def on_delete_async(self, doc):
         """
         Checks if deleting the stage would not violate data integrity, raises an exception if it does.
 
@@ -139,34 +140,34 @@ class StagesService(BaseService):
                 raise SuperdeskApiError.preconditionFailedError(message=_("Cannot delete a Incoming Stage."))
 
         archive_versions_query = {"task.stage": str(doc[ID_FIELD])}
-        items = superdesk.get_resource_service("archive_versions").get(req=None, lookup=archive_versions_query)
-        if items and items.count():
+        items_count = await superdesk.get_resource_service("archive_versions").count_async(archive_versions_query)
+        if items_count > 0:
             raise SuperdeskApiError.preconditionFailedError(
                 message=_("Cannot delete stage as it has article(s) or referenced by versions of the article(s).")
             )
 
         # check if the stage is referred to in a ingest routing rule
         rules = await self._stage_in_rule(doc[ID_FIELD])
-        if rules.count() > 0:
-            rule_names = ", ".join(rule.get("name") for rule in rules)
+        if await rules.count() > 0:
+            rule_names = ", ".join([rule.get("name") async for rule in rules])
             raise SuperdeskApiError.preconditionFailedError(
                 message=_("Stage is referred by Ingest Routing Schemes : {rule_names}").format(rule_names=rule_names)
             )
 
-    def on_deleted(self, doc):
+    async def on_deleted_async(self, doc):
         push_notification(
             self.notification_key, deleted=1, stage_id=str(doc.get(ID_FIELD)), desk_id=str(doc.get("desk"))
         )
 
-    async def on_update(self, updates, original):
+    async def on_update_async(self, updates, original):
         if updates.get("content_expiry") == 0:
             updates["content_expiry"] = None
 
-        super().on_update(updates, original)
+        await super().on_update_async(updates, original)
 
         if updates.get("working_stage", False):
             if not original.get("working_stage"):
-                self.remove_old_default(original.get("desk"), "working_stage")
+                await self.remove_old_default(original.get("desk"), "working_stage")
                 await self.set_desk_ref(original, "working_stage")
         else:
             if original.get("working_stage") and "working_stage" in updates:
@@ -174,13 +175,13 @@ class StagesService(BaseService):
 
         if updates.get("default_incoming", False):
             if not original.get("default_incoming"):
-                self.remove_old_default(original.get("desk"), "default_incoming")
+                await self.remove_old_default(original.get("desk"), "default_incoming")
                 await self.set_desk_ref(original, "incoming_stage")
         else:
             if original.get("default_incoming") and "default_incoming" in updates:
                 raise SuperdeskApiError.forbiddenError(message=_("Must have one incoming stage in a desk"))
 
-    async def on_updated(self, updates, original):
+    async def on_updated_async(self, updates, original):
         if "is_visible" in updates and updates["is_visible"] != original.get("is_visible", True):
             push_notification(
                 "stage_visibility_updated",
@@ -198,7 +199,7 @@ class StagesService(BaseService):
                 desk_id=str(original.get("desk")),
             )
 
-    def _get_unspiked_stage_documents(self, stage_id):
+    async def _get_unspiked_stage_documents(self, stage_id):
         """Returns the documents that are on the stage and not spiked.
 
         :param stage_id:
@@ -214,13 +215,13 @@ class StagesService(BaseService):
         )
         req = ParsedRequest()
         req.args = {"filter": query_filter}
-        return superdesk.get_resource_service(ARCHIVE).get(req, None)
+        return await superdesk.get_resource_service(ARCHIVE).get_async(req, None)
 
-    def get_stage_documents(self, stage_id):
+    async def get_stage_documents(self, stage_id):
         query_filter = superdesk.json.dumps({"term": {"task.stage": stage_id}})
         req = ParsedRequest()
         req.args = {"filter": query_filter}
-        return superdesk.get_resource_service(ARCHIVE).get(req, None)
+        return await superdesk.get_resource_service(ARCHIVE).get_async(req, None)
 
     async def _stage_in_rule(self, stage_id):
         """Returns the ingest routing rules that refer to the passed stage.
@@ -248,6 +249,21 @@ class StagesService(BaseService):
 
         return list(self.get(req=None, lookup=lookup))
 
+    async def get_stages_by_visibility_async(self, is_visible=False, user_desk_ids=None):
+        """Returns a list of stages for a user."""
+        if user_desk_ids is None:
+            user_desk_ids = []
+        if is_visible:
+            lookup = {"$or": [{"is_visible": True}]}
+            if user_desk_ids:
+                lookup["$or"].append({"desk": {"$in": user_desk_ids}})
+        else:
+            lookup = {"is_visible": False}
+            if user_desk_ids:
+                lookup["desk"] = {"$nin": user_desk_ids}
+
+        return await (await self.get_async(req=None, lookup=lookup)).to_list()
+
     async def set_desk_ref(self, doc, field):
         service = DesksResourceModel.get_service()
         desk = await service.find_by_id_raw(doc.get("desk"))
@@ -260,13 +276,13 @@ class StagesService(BaseService):
         if desk:
             await service.update(doc.get("desk"), {field: None})
 
-    def remove_old_default(self, desk, field):
+    async def remove_old_default(self, desk, field):
         lookup = {"$and": [{field: True}, {"desk": str(desk)}]}
-        stages = self.get(req=None, lookup=lookup)
-        for stage in stages:
-            get_resource_service("stages").update(stage.get("_id"), {field: False}, stage)
+        stages = await self.get_async(req=None, lookup=lookup)
+        async for stage in stages:
+            await get_resource_service("stages").update_async(stage.get("_id"), {field: False}, stage)
 
-    def create_working_stage(self):
+    async def create_working_stage(self):
         """Creates a Working stage and returns it's identifier
 
         :return: identifier of Working Stage
@@ -274,16 +290,16 @@ class StagesService(BaseService):
 
         stage = {"name": "Working Stage", "working_stage": True, "desk_order": 1, "content_expiry": None}
         self._resolve_defaults(stage)
-        return self.create([stage])
+        return await self.create_async([stage])
 
-    def create_incoming_stage(self):
+    async def create_incoming_stage(self):
         """Creates a Incoming stage and returns it's identifier
 
         :return: identifier of Incoming Stage
         """
         stage = {"name": "Incoming Stage", "default_incoming": True, "desk_order": 2, "content_expiry": None}
         self._resolve_defaults(stage)
-        return self.create([stage])
+        return await self.create_async([stage])
 
 
 class StagesOrderResource(Resource):
@@ -297,16 +313,16 @@ class StagesOrderResource(Resource):
     privileges = {"POST": "desks"}
 
 
-class StagesOrderService(BaseService):
-    def create(self, docs):
+class StagesOrderService(AsyncBaseService):
+    async def create_async(self, docs: list[dict], **kwargs) -> list[ItemId]:
         # TODO-ASYNC[desks]: Use DesksResourceModel async service where when upgrading this module
         desks_service = superdesk.get_resource_service("desks")
         stages_service = superdesk.get_resource_service("stages")
         for doc in docs:
-            desk = desks_service.find_one(req=None, _id=doc["desk"])
+            desk = await desks_service.find_one_async(req=None, _id=doc["desk"])
             assert desk, {"desk": 1}
             for index, stage_id in enumerate(doc["stages"]):
-                stage = stages_service.find_one(req=None, _id=stage_id)
+                stage = await stages_service.find_one_async(req=None, _id=stage_id)
                 assert stage, {"stage": stage_id}
-                stages_service.system_update(stage["_id"], {"desk_order": index + 1}, stage)
+                await stages_service.system_update_async(stage["_id"], {"desk_order": index + 1}, stage)
         return [doc["desk"] for doc in docs]

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -86,7 +86,7 @@ async def send_to(doc, update=None, desk_id=None, stage_id=None, user_id=None, d
     original_task = doc.setdefault("task", {})
     current_stage = None
     if original_task.get("stage"):
-        current_stage = get_resource_service("stages").find_one(req=None, _id=original_task.get("stage"))
+        current_stage = await get_resource_service("stages").find_one_async(req=None, _id=original_task.get("stage"))
     desk = destination_stage = None
     task = {"desk": desk_id, "stage": stage_id, "user": original_task.get("user") if user_id is None else user_id}
 
@@ -107,10 +107,12 @@ async def send_to(doc, update=None, desk_id=None, stage_id=None, user_id=None, d
         task["desk"] = desk_id
         if not stage_id:
             task["stage"] = desk.get(default_stage)
-            destination_stage = get_resource_service("stages").find_one(req=None, _id=desk.get(default_stage))
+            destination_stage = await get_resource_service("stages").find_one_async(
+                req=None, _id=desk.get(default_stage)
+            )
 
     if stage_id:
-        destination_stage = get_resource_service("stages").find_one(req=None, _id=stage_id)
+        destination_stage = await get_resource_service("stages").find_one_async(req=None, _id=stage_id)
         if not destination_stage:
             raise SuperdeskApiError.notFoundError(_("Invalid stage identifier {stage_id}").format(stage_id=stage_id))
 
@@ -167,7 +169,7 @@ async def apply_onstage_rule(doc, _id):
     :return:
     """
     doc[ID_FIELD] = _id
-    stage = get_resource_service("stages").find_one(req=None, _id=doc.get("task", {}).get("stage"))
+    stage = await get_resource_service("stages").find_one_async(req=None, _id=doc.get("task", {}).get("stage"))
     if stage:
         await apply_stage_rule(doc, None, stage, "onstage")
 

--- a/apps/workqueue/workqueue.py
+++ b/apps/workqueue/workqueue.py
@@ -9,7 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import superdesk
-
+from superdesk.eve_async import AsyncBaseService
 from superdesk.metadata.item import get_schema
 
 
@@ -30,5 +30,5 @@ class WorkqueueResource(superdesk.Resource):
     item_methods = ["GET"]
 
 
-class WorkqueueService(superdesk.Service):
+class WorkqueueService(AsyncBaseService):
     pass

--- a/features/steps/highlights_steps.py
+++ b/features/steps/highlights_steps.py
@@ -11,11 +11,11 @@ from features.steps.steps import apply_placeholders
 @given("highlights")
 @async_run_until_complete
 async def given_highlights(context):
-    with context.app.app_context():
+    async with context.app.app_context():
         context.desks = {"name": "test"}
         await get_resource_service("desks").post_async([context.desks])
         context.highlights = {"name": "highlight", "desks": [context.desks["_id"]], "auto_insert": "now-12h"}
-        get_resource_service("highlights").post([context.highlights])
+        await get_resource_service("highlights").post_async([context.highlights])
         task = {"desk": context.desks["_id"]}
         context.items = [
             {
@@ -32,10 +32,10 @@ async def given_highlights(context):
             },
             {"headline": "old", "state": "in_progress", "task": task, "versioncreated": utcnow() - timedelta(days=2)},
         ]
-        get_resource_service("archive").post(context.items)
+        await get_resource_service("archive").post_async(context.items)
         for item in context.items:
             marks = [{"highlights": context.highlights["_id"], "marked_item": item["_id"]}]
-            get_resource_service("marked_for_highlights").post(marks)
+            await get_resource_service("marked_for_highlights").post_async(marks)
 
 
 @when("we create highlights package")

--- a/features/steps/template_steps.py
+++ b/features/steps/template_steps.py
@@ -13,15 +13,16 @@ async def when_we_run_create_content_task(context):
     from apps.templates import create_scheduled_content
 
     now = utcnow() + timedelta(days=8)
-    with context.app.app_context():
+    async with context.app.app_context():
         items = await create_scheduled_content(now)
         for item in items:
             set_placeholder(context, "ITEM_ID", str(item["_id"]))
 
 
 @then('next run is on monday "{time}"')
-def then_next_run_is_on_monday(context, time):
-    data = get_json_data(context.response)
+@async_run_until_complete
+async def then_next_run_is_on_monday(context, time):
+    data = await get_json_data(context.response)
     next_run = parse_date(data.get("next_run"))
     fmt = "%H:%M:%S"
 

--- a/superdesk/archive_async/service.py
+++ b/superdesk/archive_async/service.py
@@ -963,19 +963,19 @@ class AsyncArchiveService(AsyncResourceService[ArchiveResourceModel], Highlights
         :param updates: Item updates
         """
 
-        def abort_if_readonly_stage(stage_id):
-            stage = superdesk.get_resource_service("stages").find_one(req=None, _id=stage_id)
+        async def abort_if_readonly_stage(stage_id):
+            stage = await superdesk.get_resource_service("stages").find_one_async(req=None, _id=stage_id)
             if stage.get("local_readonly"):
                 abort(403, response={"readonly": True})
 
         orig_stage_id = item.task.stage if getattr(item, "task", None) else None
         if orig_stage_id and get_user() and not item.get(INGEST_ID):
-            abort_if_readonly_stage(orig_stage_id)
+            await abort_if_readonly_stage(orig_stage_id)
 
         if updates:
             dest_stage_id = updates.get("task", {}).get("stage")
             if dest_stage_id and get_user() and not item.get(INGEST_ID):
-                abort_if_readonly_stage(dest_stage_id)
+                await abort_if_readonly_stage(dest_stage_id)
 
     async def _validate_updates(self, original, updates, user):
         """Validate updates to the article.

--- a/superdesk/internal_destinations.py
+++ b/superdesk/internal_destinations.py
@@ -47,7 +47,7 @@ class InternalDestinationsService(AsyncBaseService):
     pass
 
 
-async def handle_item_published(sender, item, desk=None, **extra):
+async def handle_item_published(item, desk=None, **extra):
     macros_service = get_resource_service("macros")
     archive_service = get_resource_service("archive")
     filters_service = ContentFiltersResource.get_service()
@@ -103,7 +103,7 @@ async def handle_item_published(sender, item, desk=None, **extra):
         extra_fields = [PUBLISH_SCHEDULE, SCHEDULE_SETTINGS]
         next_id = await archive_service.duplicate_item(new_item, state="routed", extra_fields=extra_fields)
         next_item = await archive_service.find_one_async(req=None, _id=next_id)
-        item_routed.send(sender, item=next_item)
+        item_routed.send(None, item=next_item)
 
 
 def init_app(app) -> None:

--- a/superdesk/publish_async/utils/content_filters.py
+++ b/superdesk/publish_async/utils/content_filters.py
@@ -36,10 +36,15 @@ async def _get_referenced_content_filters(
     return pf_list
 
 
-def item_matches_content_filter(item: dict, content_filter: ContentFiltersResource | None) -> bool:
+def item_matches_content_filter(item: dict, content_filter: ContentFiltersResource | dict | None) -> bool:
     """Returns boolean if the supplied item matches the content_filter
 
     Note: Make sure to initialise the PublishCache before running this function
     """
+
+    if content_filter is None:
+        return True
+    elif isinstance(content_filter, dict):
+        content_filter = ContentFiltersResource.from_dict(content_filter)
 
     return BasePublishExchangeFilter().content_filter_matches_item(get_publish_request_from_item(item), content_filter)

--- a/superdesk/publish_async/utils/filter_conditions.py
+++ b/superdesk/publish_async/utils/filter_conditions.py
@@ -381,8 +381,7 @@ async def _get_field_values() -> dict[str, list[str] | list[dict]]:
 
 
 async def _get_stage_field_values(desks: list[dict]) -> list[dict]:
-    # TODO-ASYNC: Convert this to use async stages service
-    stages = list(get_resource_service("stages").get(None, {}))
+    stages = await (await get_resource_service("stages").get_async(None, {})).to_list()
     for i, stage in enumerate(stages):
         try:
             desk = next(filter(lambda d: d["_id"] == stage["desk"], desks))

--- a/superdesk/tests/__init__.py
+++ b/superdesk/tests/__init__.py
@@ -290,12 +290,14 @@ async def clean_dbs(app=None, async_app: SuperdeskAsyncApp | None = None, force=
                         es.elastic(resource).delete_by_query(
                             index=alias,
                             body={"query": {"match_all": {}}},
-                            refresh="wait_for",
+                            refresh=True,
                         )
                     except elasticsearch.exceptions.NotFoundError:
                         pass
 
-                resources_processed.add(resource)
+                # TODO-ASYNC: Figure out what's going on here, uncommenting this line causes
+                # some resources to not be wiped before running tests
+                # resources_processed.add(resource)
 
             await drop_mongo(app)
 

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -64,7 +64,7 @@ from apps.prepopulate.app_initialize import app_initialize_data_handler
 from authlib.jose import jwt
 from authlib.jose.errors import BadSignatureError
 
-from .utils import find_one, post_items, patch_item, system_update, delete_items, find_many
+from .utils import find_one, post_items, patch_item, system_update, delete_items, find_many, find_by_id
 
 external_url = "http://thumbs.dreamstime.com/z/digital-nature-10485007.jpg"
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
@@ -510,9 +510,6 @@ async def step_impl_given_empty(context, resource):
 async def step_impl_given_(context, resource):
     data = apply_placeholders(context, context.text)
     async with context.app.test_request_context(context.app.config["URL_PREFIX"]):
-        if not is_user_resource(resource):
-            await delete_items(resource)
-
         items = [parse(item, resource) for item in json.loads(data)]
         if is_user_resource(resource):
             for item in items:
@@ -564,7 +561,7 @@ async def step_impl_given_resource_with_provider(context, provider):
     async with context.app.test_request_context(context.app.config["URL_PREFIX"]):
         await delete_items(resource)
         items = [parse(item, resource) for item in json.loads(context.text)]
-        ingest_provider = await find_one("ingest_providers", _id=context.providers[provider])
+        ingest_provider = await find_by_id("ingest_providers", context.providers[provider])
         for item in items:
             item["ingest_provider"] = context.providers[provider]
             item["source"] = ingest_provider.get("source")
@@ -739,7 +736,7 @@ async def embed_routing_scheme_rules(scheme):
     rules_filters = ((rule, str(rule["filter"])) for rule in scheme["rules"] if rule.get("filter"))
 
     for rule, filter_id in rules_filters:
-        content_filter = await find_one("content_filters", _id=filter_id)
+        content_filter = await find_by_id("content_filters", filter_id)
         rule["filter"] = content_filter
 
 
@@ -748,7 +745,7 @@ async def embed_routing_scheme_rules(scheme):
 async def step_impl_fetch_from_provider_ingest_using_routing(context, provider_name, guid):
     async with context.app.test_request_context(context.app.config["URL_PREFIX"]):
         _id = apply_placeholders(context, context.text)
-        routing_scheme = await find_one("routing_schemes", _id=_id)
+        routing_scheme = await find_by_id("routing_schemes", _id)
         await embed_routing_scheme_rules(routing_scheme)
         await fetch_from_provider(context, provider_name, guid, routing_scheme)
 
@@ -760,7 +757,7 @@ async def step_impl_fetch_from_provider_ingest_using_routing_with_desk(context, 
         _id = apply_placeholders(context, context.text)
         desk_id = apply_placeholders(context, desk)
         stage_id = apply_placeholders(context, stage)
-        routing_scheme = await find_one("routing_schemes", _id=_id)
+        routing_scheme = await find_by_id("routing_schemes", _id)
         await embed_routing_scheme_rules(routing_scheme)
         await fetch_from_provider(context, provider_name, guid, routing_scheme, desk_id, stage_id)
 
@@ -770,7 +767,7 @@ async def step_impl_fetch_from_provider_ingest_using_routing_with_desk(context, 
 async def step_impl_ingest_with_routing_scheme(context, provider_name, guid):
     async with context.app.test_request_context(context.app.config["URL_PREFIX"]):
         _id = apply_placeholders(context, context.text)
-        routing_scheme = await find_one("routing_schemes", _id=_id)
+        routing_scheme = await find_by_id("routing_schemes", _id)
         await embed_routing_scheme_rules(routing_scheme)
         await fetch_from_provider(context, provider_name, guid, routing_scheme)
 
@@ -786,7 +783,7 @@ async def fetch_from_provider(context, provider_name, guid, routing_scheme=None,
     provider = await find_one("ingest_providers", name=provider_name)
     provider["routing_scheme"] = routing_scheme
     if "rule_set" in provider:
-        rule_set = await find_one("rule_sets", _id=provider["rule_set"])
+        rule_set = await find_by_id("rule_sets", provider["rule_set"])
     else:
         rule_set = None
 
@@ -2532,7 +2529,7 @@ async def validate_routed_item(context, rule_name, is_routed, is_transformed=Fal
             else:
                 assert len(item) == 0
 
-    scheme = await find_one("routing_schemes", _id=data["routing_scheme"])
+    scheme = await find_by_id("routing_schemes", data["routing_scheme"])
     rule = next((rule for rule in scheme["rules"] if rule["name"].lower() == rule_name.lower()), {})
     await validate_rule("fetch", "routed")
     await validate_rule("publish", "published")
@@ -2578,7 +2575,7 @@ async def get_published_items(query):
     req = ParsedRequest()
     req.max_results = 100
     req.args = {"filter": json.dumps(query)}
-    return await get_resource_service("published").get_async(lookup=None, req=req).to_list()
+    return await (await get_resource_service("published").get_async(lookup=None, req=req)).to_list()
 
 
 def assert_items_in_package(item, state, desk, stage):
@@ -2755,7 +2752,7 @@ async def expire_content(context):
         ids = json.loads(apply_placeholders(context, context.text))
         expiry = utcnow() - timedelta(minutes=5)
         for item_id in ids:
-            original = await find_one("archive", _id=item_id)
+            original = await find_by_id("archive", item_id)
             await system_update("archive", item_id, {"expiry": expiry}, original)
             await get_resource_service("published").update_published_items(item_id, "expiry", expiry)
 
@@ -2777,7 +2774,7 @@ async def run_overdue_schedule_jobs(context):
 
         published_service = get_resource_service("published")
         for item_id in ids:
-            original = await find_one("archive", _id=item_id)
+            original = await find_by_id("archive", item_id)
             await system_update("archive", item_id, updates, original)
             await published_service.update_published_items(item_id, "publish_schedule", lapse_time)
             await published_service.update_published_items(
@@ -3109,7 +3106,7 @@ async def when_lock_expires(context, url):
     url = apply_placeholders(context, url).encode("ascii").decode("unicode-escape")
     resource, _id = url.lstrip("/").rstrip("/").split("/")
     async with context.app.app_context():
-        orig = context.app.data.find_one(resource, req=None, _id=_id)
+        orig = await find_by_id(resource, _id)
         assert orig is not None, "could not find {}/{}".format(resource, _id)
         context.app.data.update(resource, orig["_id"], {"_lock_time": utcnow() - timedelta(hours=48)}, orig)
 
@@ -3129,7 +3126,7 @@ async def then_we_get_picture_metadta(context, media):
 @then('we check "{resource}" db item "{item_id}"')
 @async_run_until_complete
 async def check_resource_db_item(context, resource: str, item_id: str):
-    item = await find_one(resource, _id=item_id)
+    item = await find_by_id(resource, item_id)
     assert item is not None, "Item not found"
 
     context_data = json.loads(apply_placeholders(context, context.text))

--- a/superdesk/tests/utils.py
+++ b/superdesk/tests/utils.py
@@ -1,3 +1,4 @@
+from typing import Any
 from bson import ObjectId
 
 from superdesk.core import get_current_async_app
@@ -5,122 +6,145 @@ from superdesk.core.resources import ResourceModel
 from superdesk import get_resource_service
 
 
-async def find_one(resource: str, **kwargs) -> dict | None:
+def _get_eve_service(resource: str) -> Any | None:
+    try:
+        return get_resource_service(resource)
+    except KeyError:
+        return None
+
+
+async def find_one(resource: str, use_eve: bool = True, **kwargs) -> dict | None:
     async_app = get_current_async_app()
+    eve_service = _get_eve_service(resource)
 
     try:
-        model_instance = await async_app.resources.get_resource_service(resource).find_one(**kwargs)
-        return model_instance.to_dict(context={"use_objectid": True}) if model_instance else None
+        if not eve_service or not use_eve:
+            model_instance = await async_app.resources.get_resource_service(resource).find_one(**kwargs)
+            return model_instance.to_dict(context={"use_objectid": True}) if model_instance else None
     except KeyError:
         pass
 
-    service = get_resource_service(resource)
-    if hasattr(service, "find_one_async"):
-        return await service.find_one_async(req=None, **kwargs)
+    if not eve_service:
+        raise RuntimeError(f"Resource {resource} not found")
+    elif hasattr(eve_service, "find_one_async"):
+        return await eve_service.find_one_async(req=None, **kwargs)
     else:
-        return service.find_one(req=None, **kwargs)
+        return eve_service.find_one(req=None, **kwargs)
 
 
-async def find_by_id(resource: str, item_id: str | ObjectId, **kwargs) -> dict | None:
+async def find_by_id(resource: str, item_id: str | ObjectId, use_eve: bool = True, **kwargs) -> dict | None:
     async_app = get_current_async_app()
+    eve_service = _get_eve_service(resource)
 
     try:
-        model_instance = await async_app.resources.get_resource_service(resource).find_by_id(**kwargs)
-        return model_instance.to_dict(context={"use_objectid": True}) if model_instance else None
+        if not eve_service or not use_eve:
+            model_instance = await async_app.resources.get_resource_service(resource).find_by_id(item_id, **kwargs)
+            return model_instance.to_dict(context={"use_objectid": True}) if model_instance else None
     except KeyError:
         pass
 
-    service = get_resource_service(resource)
-    if hasattr(service, "find_one_async"):
-        return await service.find_one_async(req=None, _id=item_id, **kwargs)
+    if not eve_service:
+        raise RuntimeError(f"Resource {resource} not found")
+    elif hasattr(eve_service, "find_one_async"):
+        return await eve_service.find_one_async(req=None, _id=item_id, **kwargs)
     else:
-        return service.find_one(req=None, _id=item_id, **kwargs)
+        return eve_service.find_one(req=None, _id=item_id, **kwargs)
 
 
-async def find_many(resource: str, lookup: dict | None = None, **kwargs) -> list[dict]:
+async def find_many(resource: str, lookup: dict | None = None, use_eve: bool = True, **kwargs) -> list[dict]:
     async_app = get_current_async_app()
+    eve_service = _get_eve_service(resource)
 
     try:
-        cursor = await async_app.resources.get_resource_service(resource).search(lookup or {}, **kwargs)
-        return await cursor.to_list_raw()
+        if not eve_service or not use_eve:
+            cursor = await async_app.resources.get_resource_service(resource).search(lookup or {}, **kwargs)
+            return await cursor.to_list_raw()
     except KeyError:
         pass
 
-    service = get_resource_service(resource)
-    if hasattr(service, "find_one_async"):
-        return await (await service.get_async(req=None, lookup=lookup, **kwargs)).to_list()
+    if not eve_service:
+        raise RuntimeError(f"Resource {resource} not found")
+    elif hasattr(eve_service, "find_one_async"):
+        return await (await eve_service.get_async(req=None, lookup=lookup, **kwargs)).to_list()
     else:
-        return list(service.get(req=None, lookup=lookup, **kwargs))
+        return list(eve_service.get(req=None, lookup=lookup, **kwargs))
 
 
 async def post_items(
-    resource: str, items: list[dict] | list[ResourceModel], use_eve: bool = False
+    resource: str, items: list[dict] | list[ResourceModel], use_eve: bool = True
 ) -> list[str | ObjectId]:
     async_app = get_current_async_app()
+    eve_service = _get_eve_service(resource)
 
     try:
-        eve_service = get_resource_service(resource)
-    except KeyError:
-        eve_service = None
-
-    try:
-        if eve_service is None or not use_eve:
+        if not eve_service or not use_eve:
             new_items = await async_app.resources.get_resource_service(resource).create(items)
             return [item.id for item in new_items]
     except KeyError:
         pass
 
-    if hasattr(eve_service, "post_async"):
+    if not eve_service:
+        raise RuntimeError(f"Resource {resource} not found")
+    elif hasattr(eve_service, "post_async"):
         return await eve_service.post_async(items)
     else:
         return eve_service.post(items)
 
 
-async def patch_item(resource: str, item_id: str | ObjectId, updates: dict) -> None:
+async def patch_item(resource: str, item_id: str | ObjectId, updates: dict, use_eve: bool = True) -> None:
     async_app = get_current_async_app()
+    eve_service = _get_eve_service(resource)
 
     try:
-        await async_app.resources.get_resource_service(resource).update(item_id, updates)
-        return
+        if not eve_service or not use_eve:
+            await async_app.resources.get_resource_service(resource).update(item_id, updates)
+            return
     except KeyError:
         pass
 
-    service = get_resource_service(resource)
-    if hasattr(service, "patch_async"):
-        await service.patch_async(item_id, updates)
+    if not eve_service:
+        raise RuntimeError(f"Resource {resource} not found")
+    elif hasattr(eve_service, "patch_async"):
+        await eve_service.patch_async(item_id, updates)
     else:
-        return service.patch(item_id, updates)
+        return eve_service.patch(item_id, updates)
 
 
-async def system_update(resource: str, item_id: str | ObjectId, updates: dict, original: dict) -> None:
+async def system_update(resource: str, item_id: str | ObjectId, updates: dict, original: dict, use_eve=True) -> None:
     async_app = get_current_async_app()
+    eve_service = _get_eve_service(resource)
 
     try:
-        await async_app.resources.get_resource_service(resource).system_update(item_id, updates)
-        return
+        if not eve_service or not use_eve:
+            await async_app.resources.get_resource_service(resource).system_update(item_id, updates)
+            return
     except KeyError:
         pass
 
-    service = get_resource_service(resource)
-    if hasattr(service, "system_update_async"):
-        await service.system_update_async(item_id, updates, original)
+    if not eve_service:
+        raise RuntimeError(f"Resource {resource} not found")
+    elif hasattr(eve_service, "system_update_async"):
+        await eve_service.system_update_async(item_id, updates, original)
     else:
-        return service.system_update(item_id, updates, original)
+        return eve_service.system_update(item_id, updates, original)
 
 
-async def delete_items(resource: str, lookup: dict | None = None) -> None:
+async def delete_items(resource: str, lookup: dict | None = None, use_eve: bool = True) -> None:
     if lookup is None:
         lookup = {}
     async_app = get_current_async_app()
+    eve_service = _get_eve_service(resource)
 
     try:
-        await async_app.resources.get_resource_service(resource).delete_many(lookup)
-        return
+        if not eve_service or not use_eve:
+            await async_app.resources.get_resource_service(resource).delete_many(lookup)
+            return
     except KeyError:
         pass
 
-    service = get_resource_service(resource)
-    if hasattr(service, "delete_action_async"):
-        await service.delete_action_async(lookup)
+    if not eve_service:
+        raise RuntimeError(f"Resource {resource} not found")
+    elif hasattr(eve_service, "delete_action_async"):
+        await eve_service.delete_action_async(lookup)
     else:
-        return service.delete_action(lookup)
+        return eve_service.delete_action(lookup)

--- a/superdesk/users/services.py
+++ b/superdesk/users/services.py
@@ -105,8 +105,7 @@ async def get_invisible_stages_async(user_id):
     user_desk_ids = await DesksResourceModel.get_service().mongo_async.distinct(
         "_id", {"members.user": [ObjectId(user_id)]}
     )
-    # TODO-ASYNC[stages]: Upgrade to async when updating the ``stages`` module
-    return get_resource_service("stages").get_stages_by_visibility(False, user_desk_ids)
+    return await get_resource_service("stages").get_stages_by_visibility_async(False, user_desk_ids)
 
 
 def set_sign_off(user):

--- a/tests/highlights/service_tests.py
+++ b/tests/highlights/service_tests.py
@@ -9,7 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock
 
 from apps.highlights import init_app
 from superdesk.tests import TestCase
@@ -46,12 +46,12 @@ class CreateMethodTestCase(TestCase):
         self.db_items = {"tag:item_1": db_item_1, "tag:item_2": db_item_2}
 
     async def test_pushes_notifications_for_newly_highlighted_items(self, fake_get_service, fake_push_notify):
-        def fake_find_one(**kwargs):
+        async def fake_find_one(**kwargs):
             item_id = kwargs.get("_id")
             return self.db_items.get(item_id)
 
-        fake_archive_service = MagicMock()
-        fake_archive_service.find_one = fake_find_one
+        fake_archive_service = AsyncMock()
+        fake_archive_service.find_one_async = fake_find_one
 
         fake_get_service.return_value = fake_archive_service
 
@@ -59,7 +59,7 @@ class CreateMethodTestCase(TestCase):
         req_item_1 = {"marked_item": "tag:item_1", "highlights": ["highlight_X"]}
         req_item_2 = {"marked_item": "tag:item_2", "highlights": ["highlight_Y"]}
 
-        self.instance.create([req_item_1, req_item_2])
+        await self.instance.create_async([req_item_1, req_item_2])
 
         # notifications should have been pushed, one for each highlighted item
         self.assertEqual(fake_push_notify.call_count, 2)
@@ -71,12 +71,12 @@ class CreateMethodTestCase(TestCase):
         self.db_items["tag:item_1"]["highlights"] = ["highlight_X"]
         self.db_items["tag:item_2"]["highlights"] = ["highlight_Y"]
 
-        def fake_find_one(**kwargs):
+        async def fake_find_one(**kwargs):
             item_id = kwargs.get("_id")
             return self.db_items.get(item_id)
 
-        fake_archive_service = MagicMock()
-        fake_archive_service.find_one = fake_find_one
+        fake_archive_service = AsyncMock()
+        fake_archive_service.find_one_async = fake_find_one
 
         fake_get_service.return_value = fake_archive_service
 
@@ -84,7 +84,7 @@ class CreateMethodTestCase(TestCase):
         req_item_1 = {"marked_item": "tag:item_1", "highlights": ["highlight_X"]}
         req_item_2 = {"marked_item": "tag:item_2", "highlights": ["highlight_Y"]}
 
-        self.instance.create([req_item_1, req_item_2])
+        await self.instance.create_async([req_item_1, req_item_2])
 
         # notifications should have been pushed, one for each highlighted item
         self.assertEqual(fake_push_notify.call_count, 2)


### PR DESCRIPTION
### Purpose
Update desk and workflow based resources to async.

### What has changed
Updated the following eve resource services to async (including their usage in other code):
* ClosedDeskService
* GenerateHighlightsService
* HighlightsService
* MarkedForHighlightsService
* MarkedForDesksService
* StagesService
* StagesOrderService
* WorkqueueService

### Other changes
In tests, prefer the use of eve resources over Pydantic based ones (we're not ready for full Pydantic resources yet, and we should replace resource by resource entirely to Pydantic - preferring async eve in the meantime)