### PR TITLE
[SDESK-7619] Update Ingest/Publish exceptions to support async notifications

### DIFF
--- a/apps/archive/__init__.py
+++ b/apps/archive/__init__.py
@@ -149,5 +149,5 @@ def init_app(app) -> None:
 
 
 @celery.task(soft_time_limit=LOCK_EXPIRY - 300)  # should finish before the lock is gone
-def content_expiry():
-    RemoveExpiredContent().run()
+async def content_expiry():
+    await RemoveExpiredContent().run()

--- a/apps/io/feeding_services/reuters.py
+++ b/apps/io/feeding_services/reuters.py
@@ -134,16 +134,16 @@ class ReutersHTTPFeedingService(HTTPFeedingService):
                     logger.warn("Reuters API timeout retrying, retries {}".format(retries))
                     retries += 1
                     continue
-                raise IngestApiError.apiTimeoutError(ex, self.provider)
+                raise await IngestApiError.apiTimeoutError(ex, self.provider).send_notifications()
             except requests.exceptions.TooManyRedirects as ex:
                 # Tell the user their URL was bad and try a different one
-                raise IngestApiError.apiRedirectError(ex, self.provider)
+                raise await IngestApiError.apiRedirectError(ex, self.provider).send_notifications()
             except requests.exceptions.RequestException as ex:
                 # catastrophic error. bail.
-                raise IngestApiError.apiRequestError(ex, self.provider)
+                raise await IngestApiError.apiRequestError(ex, self.provider).send_notifications()
             except Exception as error:
                 traceback.print_exc()
-                raise IngestApiError.apiGeneralError(error, self.provider)
+                raise await IngestApiError.apiGeneralError(error, self.provider).send_notifications()
 
             if response.status_code == 404:
                 raise LookupError(_("Not found {payload}").format(payload=payload))
@@ -154,13 +154,13 @@ class ReutersHTTPFeedingService(HTTPFeedingService):
             return etree.fromstring(response.content)  # workaround for http mock lib
         except UnicodeEncodeError as error:
             traceback.print_exc()
-            raise IngestApiError.apiUnicodeError(error, self.provider)
+            raise await IngestApiError.apiUnicodeError(error, self.provider).send_notifications()
         except ParseError as error:
             traceback.print_exc()
-            raise IngestApiError.apiParseError(error, self.provider)
+            raise await IngestApiError.apiParseError(error, self.provider).send_notifications()
         except Exception as error:
             traceback.print_exc()
-            raise IngestApiError.apiGeneralError(error, self.provider)
+            raise await IngestApiError.apiGeneralError(error, self.provider).send_notifications()
 
     def _get_absolute_url(self, endpoint):
         """
@@ -236,7 +236,7 @@ class ReutersHTTPFeedingService(HTTPFeedingService):
         """
         # get the provider in case it has been updated by another channel
         ingest_provider_service = superdesk.get_resource_service("ingest_providers")
-        provider = await ingest_provider_service.find_one_asnc(req=None, _id=self.provider[ID_FIELD])
+        provider = await ingest_provider_service.find_one_async(req=None, _id=self.provider[ID_FIELD])
         provider_token = provider.get("tokens")
         if "poll_tokens" not in provider_token:
             provider_token["poll_tokens"] = {channel: poll_token}
@@ -280,8 +280,8 @@ class ReutersHTTPFeedingService(HTTPFeedingService):
         payload = {"id": id}
         tree = await self._get_tree("item", payload)
 
-        parser = self.get_feed_parser(self.provider, tree)
-        items = parser.parse(tree, self.provider)
+        parser = await self.get_feed_parser(self.provider, tree)
+        items = await parser.parse(tree, self.provider)
 
         return items
 

--- a/apps/io/feeding_services/wufoo.py
+++ b/apps/io/feeding_services/wufoo.py
@@ -54,7 +54,7 @@ class WufooFeedingService(FeedingService):
         super().__init__()
         self.fields_cache = {}
 
-    def _update(self, provider, update):
+    async def _update(self, provider, update):
         user = provider["config"]["wufoo_username"]
         wufoo_data = {
             "url": WUFOO_URL.format(subdomain=user),
@@ -64,17 +64,17 @@ class WufooFeedingService(FeedingService):
             "update": update,
         }
         try:
-            parser = self.get_feed_parser(provider, None)
+            parser = await self.get_feed_parser(provider, None)
         except requests.exceptions.Timeout as ex:
-            raise IngestApiError.apiTimeoutError(ex, provider)
+            raise await IngestApiError.apiTimeoutError(ex, provider).send_notifications()
         except requests.exceptions.TooManyRedirects as ex:
-            raise IngestApiError.apiRedirectError(ex, provider)
+            raise await IngestApiError.apiRedirectError(ex, provider).send_notifications()
         except requests.exceptions.RequestException as ex:
-            raise IngestApiError.apiRequestError(ex, provider)
+            raise await IngestApiError.apiRequestError(ex, provider).send_notifications()
         except Exception as error:
             traceback.print_exc()
-            raise IngestApiError.apiGeneralError(error, self.provider)
-        items = parser.parse(wufoo_data, provider)
+            raise await IngestApiError.apiGeneralError(error, self.provider).send_notifications()
+        items = await parser.parse(wufoo_data, provider)
         return [items]
 
 

--- a/apps/io/search_ingest.py
+++ b/apps/io/search_ingest.py
@@ -66,7 +66,7 @@ class SearchIngestService(AsyncBaseService):
             try:
                 archived_doc = self.fetch(doc["guid"])
             except FileNotFoundError as ex:
-                raise ProviderError.externalProviderError(ex, provider)
+                raise await ProviderError.externalProviderError(ex, provider).send_notifications()
 
             dest_doc = await fetch_item(archived_doc, doc.get("desk"), doc.get("stage"), state=doc.get("state"))
             new_guids.append(dest_doc["guid"])
@@ -145,7 +145,7 @@ class SearchIngestServiceAsync(AsyncBaseService):
             try:
                 archived_doc = await self.fetch_async(doc["guid"])
             except FileNotFoundError as ex:
-                raise ProviderError.externalProviderError(ex, provider)
+                raise await ProviderError.externalProviderError(ex, provider).send_notifications()
 
             dest_doc = await fetch_item(archived_doc, doc.get("desk"), doc.get("stage"), state=doc.get("state"))
             new_guids.append(dest_doc["guid"])

--- a/apps/legal_archive/commands.py
+++ b/apps/legal_archive/commands.py
@@ -121,7 +121,7 @@ class LegalArchiveImport:
                     doc.get(ITEM_STATE), self.log_msg_format.format(**doc)
                 )
                 logger.error(msg)
-                update_notifiers(ACTIVITY_ERROR, msg=msg, resource=ARCHIVE)
+                await update_notifiers(ACTIVITY_ERROR, msg=msg, resource=ARCHIVE)
 
             # required for behave test.
             legal_archive_doc = deepcopy(doc)

--- a/superdesk/activity.py
+++ b/superdesk/activity.py
@@ -301,7 +301,4 @@ def get_recipients(user_list: List[User], notification_name=None) -> List[str]:
     return recipients
 
 
-# TODO-ASYNC[activity]: Figure out how to handle this next one
-# it adds an activity and notifies the user when a Publish or Ingest error happens
-# but this code is within the constructor of an Exception class, which can't be async
-# add_notifier(notify_and_add_activity)
+add_notifier(notify_and_add_activity)

--- a/superdesk/celery_app/serializer.py
+++ b/superdesk/celery_app/serializer.py
@@ -38,7 +38,7 @@ class ContextAwareSerializerFactory:
         Returns:
             Any: The casted value, or the original value if no casting was possible.
         """
-        if value is None or isinstance(value, bool) or value == 0:
+        if value is None or isinstance(value, (bool, int)) or value == 0:
             return value
 
         try:

--- a/superdesk/core/utils.py
+++ b/superdesk/core/utils.py
@@ -8,8 +8,9 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from typing import TypeVar, cast
+from typing import TypeVar, cast, AsyncGenerator
 from typing_extensions import Self
+from inspect import isgenerator
 from importlib import import_module
 from datetime import datetime
 from uuid import uuid4
@@ -152,3 +153,11 @@ class SingletonInstance(object):
             cls._set_instance(instance)
 
         return instance
+
+
+LIST_ITEM_TYPE = TypeVar("LIST_ITEM_TYPE")
+
+
+async def list_to_async_generator(items: list[LIST_ITEM_TYPE]) -> AsyncGenerator[LIST_ITEM_TYPE, None]:
+    for item in items:
+        yield item

--- a/superdesk/errors.py
+++ b/superdesk/errors.py
@@ -31,9 +31,9 @@ def add_notifier(notifier):
 
 async def update_notifiers(*args, **kwargs):
     for notifier in notifiers:
-        resposne = notifier(*args, **kwargs)
-        if isawaitable(resposne):
-            await resposne
+        response = notifier(*args, **kwargs)
+        if isawaitable(response):
+            await response
 
 
 def get_registered_errors(self):

--- a/superdesk/errors.py
+++ b/superdesk/errors.py
@@ -8,6 +8,8 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from typing_extensions import Self
+from inspect import isawaitable
 import logging
 
 from cerberus import DocumentError
@@ -27,9 +29,11 @@ def add_notifier(notifier):
         notifiers.append(notifier)
 
 
-def update_notifiers(*args, **kwargs):
+async def update_notifiers(*args, **kwargs):
     for notifier in notifiers:
-        notifier(*args, **kwargs)
+        resposne = notifier(*args, **kwargs)
+        if isawaitable(resposne):
+            await resposne
 
 
 def get_registered_errors(self):
@@ -215,7 +219,27 @@ class InvalidStateTransitionError(SuperdeskApiError):
         super().__init__(message, status_code)
 
 
-class SuperdeskIngestError(SuperdeskError):
+class SuperdeskErrorWithNotifications(SuperdeskError):
+    def _set_notification_args(self, *args, **kwargs):
+        self._notification_args = dict(args=args, kwargs=kwargs)
+
+    async def send_notifications(self) -> Self:
+        args = getattr(self, "_notification_args", {})
+        if args:
+            try:
+                await update_notifiers(*args["args"], **args["kwargs"])
+            except KeyError:
+                # this might not be working during tests
+                # and should be probably avoided in the first place
+                pass
+
+            # Make sure multiple notifications won't be sent for this one exception
+            self._notification_args = {}
+
+        return self
+
+
+class SuperdeskIngestError(SuperdeskErrorWithNotifications):
     _codes = {
         2000: "Configured Feed Parser either not found or not registered with the application",
         2001: "Configuration of the feeding service is missing or incomplete",
@@ -238,18 +262,14 @@ class SuperdeskIngestError(SuperdeskError):
                     message += '\nitem="{}" name="{}"'.format(
                         item.get("guid", ""), item.get("headline", item.get("slugline", ""))
                     )
-                try:
-                    update_notifiers(
-                        "error",
-                        message,
+                self._set_notification_args(
+                    ["error", message],
+                    dict(
                         resource="ingest_providers" if provider else None,
                         name=self.provider_name,
                         provider_id=provider.get("_id", ""),
-                    )
-                except KeyError:
-                    # this might not be working during tests
-                    # and should be probably avoided in the first place
-                    pass
+                    ),
+                )
 
             if provider:
                 message = "{}: {} on channel {}".format(self, exception, self.provider_name)
@@ -531,7 +551,7 @@ class IngestTwitterError(SuperdeskIngestError):
         return IngestTwitterError(6400, exception, provider)
 
 
-class SuperdeskPublishError(SuperdeskError):
+class SuperdeskPublishError(SuperdeskErrorWithNotifications):
     def __init__(self, code, exception, destination=None):
         super().__init__(code)
         self.system_exception = exception
@@ -541,12 +561,16 @@ class SuperdeskPublishError(SuperdeskError):
         if exception:
             exception_msg = str(exception)[-200:]
             if notifications_enabled():
-                update_notifiers(
-                    "error",
-                    "Error [%s] on a Subscriber" "s destination {{name}}: %s" % (code, exception_msg),
-                    resource="subscribers" if destination else None,
-                    name=self.destination_name,
-                    provider_id=destination.get("_id", ""),
+                self._set_notification_args(
+                    [
+                        "error",
+                        "Error [%s] on a Subscriber" "s destination {{name}}: %s" % (code, exception_msg),
+                    ],
+                    dict(
+                        resource="subscribers" if destination else None,
+                        name=self.destination_name,
+                        provider_id=destination.get("_id", ""),
+                    ),
                 )
 
             extra = {}

--- a/superdesk/ftp.py
+++ b/superdesk/ftp.py
@@ -1,14 +1,14 @@
 import socket
 import ftplib
 
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from superdesk.core import get_app_config
 
 from superdesk.errors import IngestFtpError
 
 
-@contextmanager
-def ftp_connect(config):
+@asynccontextmanager
+async def ftp_connect(config):
     """Get ftp connection for given config.
 
     use with `with`
@@ -19,24 +19,24 @@ def ftp_connect(config):
         try:
             ftp = ftplib.FTP_TLS(config.get("host"), timeout=get_app_config("FTP_TIMEOUT", 300))
         except socket.gaierror as e:
-            raise IngestFtpError.ftpHostError(exception=e)
+            raise await IngestFtpError.ftpHostError(exception=e).send_notifications()
 
         try:
             ftp.auth()
         except ftplib.error_perm as ae:
             ftp.close()
-            raise IngestFtpError.ftpAuthError(exception=ae)
+            raise await IngestFtpError.ftpAuthError(exception=ae).send_notifications()
     else:
         try:
             ftp = ftplib.FTP(config.get("host"), timeout=get_app_config("FTP_TIMEOUT", 300))
         except socket.gaierror as e:
-            raise IngestFtpError.ftpHostError(exception=e)
+            raise await IngestFtpError.ftpHostError(exception=e).send_notifications()
 
     if config.get("username"):
         try:
             ftp.login(config.get("username"), config.get("password"))
         except ftplib.error_perm as e:
-            raise IngestFtpError.ftpAuthError(exception=e)
+            raise await IngestFtpError.ftpAuthError(exception=e).send_notifications()
 
     # set encryption on data channel if able
     if hasattr(ftp, "prot_p"):

--- a/superdesk/io/commands/add_provider.py
+++ b/superdesk/io/commands/add_provider.py
@@ -48,6 +48,6 @@ async def cli_add_provider(provider: str):
             ex = Exception(
                 "Failed to add Provider as the data provided is invalid. Errors: {}".format(str(validator.errors))
             )
-            raise ProviderError.providerAddError(exception=ex, provider=data)
+            raise await ProviderError.providerAddError(exception=ex, provider=data).send_notifications()
     except Exception as ex:
-        raise ProviderError.providerAddError(ex, data)
+        raise await ProviderError.providerAddError(ex, data).send_notifications()

--- a/superdesk/io/commands/remove_expired_content.py
+++ b/superdesk/io/commands/remove_expired_content.py
@@ -44,12 +44,12 @@ class RemoveExpiredContent:
         providers = await (
             await superdesk.get_resource_service("ingest_providers").get_async(req=None, lookup={})
         ).to_list()
-        self.remove_expired({"exclude": [str(p.get("_id")) for p in providers]})
+        await self.remove_expired({"exclude": [str(p.get("_id")) for p in providers]})
         for provider in providers:
             if not provider_name or provider_name == provider.get("name"):
-                self.remove_expired(provider)
+                await self.remove_expired(provider)
 
-    def remove_expired(self, provider):
+    async def remove_expired(self, provider):
         lock_name = "ingest:gc"
 
         if not lock(lock_name, expire=300):
@@ -60,7 +60,7 @@ class RemoveExpiredContent:
             push_notification("ingest:cleaned")
         except Exception as err:
             logger.exception(err)
-            raise ProviderError.expiredContentError(err, provider)
+            raise await ProviderError.expiredContentError(err, provider).send_notifications()
         finally:
             unlock(lock_name)
 

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -128,7 +128,7 @@ def is_not_expired(item, delta):
     return False
 
 
-def filter_expired_items(provider, items):
+async def filter_expired_items(provider, items):
     """Filter out expired items from the list of articles to be ingested.
 
     Filte both expired and `item['type'] not in provider['content_types']`.
@@ -170,7 +170,7 @@ def filter_expired_items(provider, items):
 
         return filtered_items
     except Exception as ex:
-        raise ProviderError.providerFilterExpiredContentError(ex, provider)
+        raise await ProviderError.providerFilterExpiredContentError(ex, provider).send_notifications()
 
 
 async def get_provider_rule_set(provider):
@@ -208,7 +208,7 @@ async def get_provider_routing_scheme(provider):
     rules_filters = ((rule, str(rule["filter"])) for rule in scheme["rules"] if rule.get("filter"))
 
     for rule, filter_id in rules_filters:
-        content_filter = await filters_service.find_by_id(filter_id)
+        content_filter = await filters_service.find_by_id_raw(filter_id)
         rule["filter"] = content_filter
 
     return scheme
@@ -317,23 +317,21 @@ async def update_provider(provider, rule_set=None, routing_scheme=None, sync=Fal
         if sync:
             provider[LAST_UPDATED] = utcnow() - timedelta(days=9999)  # import everything again
 
-        generator = feeding_service.update(provider, update)
-        if isinstance(generator, list):
-            generator = (items for items in generator)
+        generator = await feeding_service.update(provider, update)
         failed = None
         while True:
             try:
                 if not touch(lock_name, expire=UPDATE_TTL):
                     logger.warning("lock expired while updating provider %s", provider[ID_FIELD])
                     return
-                items = generator.send(failed)
+                items = await generator.asend(failed)
                 failed = await ingest_items(items, provider, feeding_service, rule_set, routing_scheme)
                 update_last_item_updated(update, items)
 
                 if not update.get(LAST_ITEM_ARRIVED) or update[LAST_ITEM_ARRIVED] < datetime.now(tz=pytz.utc):
                     update[LAST_ITEM_ARRIVED] = datetime.now(tz=pytz.utc)
 
-            except StopIteration:
+            except StopAsyncIteration:
                 break
 
         # Some Feeding Services update the collection and by this time the _etag might have been changed.
@@ -359,7 +357,7 @@ async def update_provider(provider, rule_set=None, routing_scheme=None, sync=Fal
             push_notification("ingest:update", provider_id=str(provider[ID_FIELD]))
     except Exception as e:
         logger.error("Failed to ingest file: {error}".format(error=e))
-        raise IngestFileError(3000, e, provider)
+        raise await IngestFileError(3000, e, provider).send_notifications()
     finally:
         unlock(lock_name)
 
@@ -388,7 +386,7 @@ async def _process_anpa_category(item, provider):
                             set_subject_name_translation(item_category, item["language"])
 
     except Exception as ex:
-        raise ProviderError.anpaError(ex, provider)
+        raise await ProviderError.anpaError(ex, provider).send_notifications()
 
 
 async def _derive_category(item, provider):
@@ -413,7 +411,7 @@ async def _derive_category(item, provider):
         logger.exception(ex)
 
 
-def process_iptc_codes(item, provider):
+async def process_iptc_codes(item, provider):
     """Ensures that the higher level IPTC codes are present by inserting them if missing.
 
     For example if given 15039001 (Formula One) make sure that 15039000 (motor racing) and 15000000 (sport)
@@ -448,7 +446,7 @@ def process_iptc_codes(item, provider):
                         logger.warning("missing qcode in subject_codes: {qcode}".format(qcode=mid_qcode))
                         continue
     except Exception as ex:
-        raise ProviderError.iptcError(ex, provider)
+        raise await ProviderError.iptcError(ex, provider).send_notifications()
 
 
 async def _derive_subject(item):
@@ -499,7 +497,7 @@ async def apply_rule_set(item, provider, rule_set=None):
 
         return item
     except Exception as ex:
-        raise ProviderError.ruleError(ex, provider)
+        raise await ProviderError.ruleError(ex, provider).send_notifications()
 
 
 def ingest_cancel(item, feeding_service):
@@ -522,7 +520,7 @@ def ingest_cancel(item, feeding_service):
 
 
 async def ingest_items(items, provider, feeding_service, rule_set=None, routing_scheme=None):
-    all_items = filter_expired_items(provider, items)
+    all_items = await filter_expired_items(provider, items)
     items_dict = {doc[GUID_FIELD]: doc for doc in all_items}
     items_in_package = []
     failed_items = set()
@@ -595,7 +593,7 @@ async def ingest_item(item, provider, feeding_service, rule_set=None, routing_sc
             _ingest_cancel = ingest_cancel
 
         # determine if we already have this item
-        old_item = ingest_service.find_one(guid=item[GUID_FIELD], req=None)
+        old_item = await ingest_service.find_one_async(guid=item[GUID_FIELD], req=None)
 
         if not old_item:
             item.setdefault(ID_FIELD, generate_guid(type=GUID_NEWSML))
@@ -635,7 +633,7 @@ async def ingest_item(item, provider, feeding_service, rule_set=None, routing_sc
         if "subject" in item:
             if not get_app_config("INGEST_SKIP_IPTC_CODES", False):
                 # FIXME: temporary fix for SDNTB-344, need to be removed once SDESK-439 is implemented
-                process_iptc_codes(item, provider)
+                await process_iptc_codes(item, provider)
             if "anpa_category" not in item:
                 await _derive_category(item, provider)
         elif "anpa_category" in item:
@@ -664,12 +662,12 @@ async def ingest_item(item, provider, feeding_service, rule_set=None, routing_sc
             guid = assoc.get("guid")
             assoc_name = assoc.get("headline") or assoc.get("slugline") or guid
             if guid:
-                ingested = ingest_service.find_one(req=None, guid=guid)
+                ingested = await ingest_service.find_one_async(req=None, guid=guid)
                 if ingested is not None:
                     logger.info("assoc ingested before %s", assoc_name)
                     assoc["_id"] = ingested["_id"]
                     # update expiry so assoc will stay as long as the item using it
-                    ingest_service.system_update(ingested["_id"], {"expiry": item["expiry"]}, ingested)
+                    await ingest_service.system_update_async(ingested["_id"], {"expiry": item["expiry"]}, ingested)
                     if _is_new_version(assoc, ingested) and assoc.get("renditions"):  # new version
                         logger.info("new assoc version - re-transfer renditions for %s", assoc_name)
                         try:
@@ -702,7 +700,7 @@ async def ingest_item(item, provider, feeding_service, rule_set=None, routing_sc
                     if status:
                         assoc["_id"] = ids[0]
                         items_ids.extend(ids)
-                        ingested = ingest_service.find_one(req=None, _id=ids[0])
+                        ingested = await ingest_service.find_one_async(req=None, _id=ids[0])
                         update_assoc_renditions(assoc, ingested)
             elif assoc.get("residRef"):
                 item["associations"][key] = resolve_ref(assoc)
@@ -712,10 +710,7 @@ async def ingest_item(item, provider, feeding_service, rule_set=None, routing_sc
             new_version = _is_new_version(item, old_item)
             updates = deepcopy(item)
             if new_version:
-                if hasattr(ingest_service, "patch_in_mongo_async"):
-                    await ingest_service.patch_in_mongo_async(old_item[ID_FIELD], updates, old_item)
-                else:
-                    ingest_service.patch_in_mongo(old_item[ID_FIELD], updates, old_item)
+                await ingest_service.patch_in_mongo(old_item[ID_FIELD], updates, old_item)
                 item.update(old_item)
                 item.update(updates)
                 items_ids.append(item["_id"])
@@ -728,23 +723,20 @@ async def ingest_item(item, provider, feeding_service, rule_set=None, routing_sc
                 else:
                     ingest_service.set_ingest_provider_sequence(item, provider)
             try:
-                if hasattr(ingest_service, "post_in_mongo_async"):
-                    items_ids.extend(await ingest_service.post_in_mongo_async([item]))
-                else:
-                    items_ids.extend(ingest_service.post_in_mongo([item]))
+                items_ids.extend(await ingest_service.post_in_mongo([item]))
             except HTTPException as e:
                 logger.error("Exception while persisting item in %s collection: %s", ingest_collection, e)
                 raise e
 
         if routing_scheme and new_version:
-            routed = ingest_service.find_one(_id=item[ID_FIELD], req=None)
+            routed = await ingest_service.find_one_async(_id=item[ID_FIELD], req=None)
             await superdesk.get_resource_service("routing_schemes").apply_routing_scheme(
                 routed, provider, routing_scheme
             )
 
     except Exception as ex:
         logger.exception(ex)
-        ProviderError.ingestItemError(ex, provider, item=item)
+        await ProviderError.ingestItemError(ex, provider, item=item).send_notifications()
         return False, []
     return True, items_ids
 

--- a/superdesk/io/feed_parsers/__init__.py
+++ b/superdesk/io/feed_parsers/__init__.py
@@ -42,7 +42,7 @@ class FeedParser(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def parse(self, article, provider=None):
+    async def parse(self, article, provider=None):
         """Parse the given article and extracts the relevant elements/attributes values from the given article.
 
         :param article: XML String to parse

--- a/superdesk/io/feed_parsers/afp_newsml_1_2.py
+++ b/superdesk/io/feed_parsers/afp_newsml_1_2.py
@@ -25,8 +25,8 @@ class AFPNewsMLOneFeedParser(NewsMLOneFeedParser):
 
     label = "AFP News ML 1.2 Parser"
 
-    def parse(self, xml, provider=None):
-        item = super().parse(xml, provider)
+    async def parse(self, xml, provider=None):
+        item = await super().parse(xml, provider)
         item["firstcreated"] = utc.localize(item["firstcreated"]) if item.get("firstcreated") else utcnow()
         item["versioncreated"] = utc.localize(item["versioncreated"]) if item.get("versioncreated") else utcnow()
         return item

--- a/superdesk/io/feed_parsers/ana_mpe_newsml.py
+++ b/superdesk/io/feed_parsers/ana_mpe_newsml.py
@@ -33,7 +33,7 @@ class ANANewsMLOneFeedParser(NewsMLOneFeedParser):
     def can_parse(self, xml):
         return xml.tag == "NewsML"
 
-    def parse(self, xml, provider=None):
+    async def parse(self, xml, provider=None):
         item = {}
         try:
             self.root = xml
@@ -113,7 +113,7 @@ class ANANewsMLOneFeedParser(NewsMLOneFeedParser):
                 )
             return self.populate_fields(item)
         except Exception as ex:
-            raise ParserError.newsmlOneParserError(ex, provider)
+            raise await ParserError.newsmlOneParserError(ex, provider).send_notifications()
 
     def parse_newslines(self, item, tree):
         parsed_el = self.parse_elements(tree.find("NewsItem/NewsComponent/NewsLines"))

--- a/superdesk/io/feed_parsers/anpa.py
+++ b/superdesk/io/feed_parsers/anpa.py
@@ -36,7 +36,7 @@ class ANPAFeedParser(FileFeedParser):
         except Exception:
             return False
 
-    def parse(self, file_path, provider=None):
+    async def parse(self, file_path, provider=None):
         try:
             item = {ITEM_TYPE: CONTENT_TYPE.TEXT, GUID_FIELD: generate_guid(type=GUID_TAG), FORMAT: FORMATS.HTML}
 
@@ -112,7 +112,7 @@ class ANPAFeedParser(FileFeedParser):
 
             return item
         except Exception as ex:
-            raise ParserError.anpaParseFileError(file_path, ex)
+            raise await ParserError.anpaParseFileError(file_path, ex).send_notifications()
 
     def _parse_ednote(self, header_lines, item):
         for line in header_lines:

--- a/superdesk/io/feed_parsers/ap_anpa.py
+++ b/superdesk/io/feed_parsers/ap_anpa.py
@@ -73,8 +73,8 @@ class AP_ANPAFeedParser(ANPAFeedParser):
         "RGL-": "15048000",
     }
 
-    def parse(self, file_path, provider=None):
-        item = super().parse(file_path, provider)
+    async def parse(self, file_path, provider=None):
+        item = await super().parse(file_path, provider)
         self.ap_derive_dateline(item)
         self.map_category_codes(item)
         self.map_sluglines_to_subjects(item)

--- a/superdesk/io/feed_parsers/ap_media.py
+++ b/superdesk/io/feed_parsers/ap_media.py
@@ -167,7 +167,7 @@ class APMediaFeedParser(FeedParser):
                 except KeyError:
                     logger.debug("Subject code '%s' not found" % qcode)
 
-    def parse(self, s_json, provider=None):
+    async def parse(self, s_json, provider=None):
         in_item = s_json.get("data", {}).get("item")
         nitf_item = s_json.get("nitf", {})
         item = {"guid": in_item.get("altids", {}).get("itemid") + ":" + str(in_item.get("version"))}
@@ -267,16 +267,16 @@ class APMediaFeedParser(FeedParser):
                 item["body_html"] = nitf_item.get("body_html").replace('<block id="Main">', "").replace("</block>", "")
 
         if s_json.get("associations"):
-            self._parse_associations(s_json["associations"], item, provider)
+            await self._parse_associations(s_json["associations"], item, provider)
 
         return item
 
-    def _parse_associations(self, associations, item, provider=None):
+    async def _parse_associations(self, associations, item, provider=None):
         related_id = getattr(self, "RELATED_ID", get_app_config("INGEST_AP_RELATED_ID"))
         if related_id:
             item["associations"] = {}
             for key, raw in associations.items():
-                item["associations"]["{}--{}".format(related_id, key)] = self.parse(raw, provider)
+                item["associations"]["{}--{}".format(related_id, key)] = await self.parse(raw, provider)
 
     def _parse_renditions(self, renditions, item):
         try:

--- a/superdesk/io/feed_parsers/bbc_ninjs.py
+++ b/superdesk/io/feed_parsers/bbc_ninjs.py
@@ -95,7 +95,7 @@ class BBCNINJSFeedParser(FeedParser):
 
         return False
 
-    def parse(self, s_json, provider=None):
+    async def parse(self, s_json, provider=None):
         parsed = []
         json_items = json.loads(s_json).get("item", [])
 

--- a/superdesk/io/feed_parsers/dpa_iptc7901.py
+++ b/superdesk/io/feed_parsers/dpa_iptc7901.py
@@ -18,8 +18,8 @@ class DPAIPTC7901FeedParser(IPTC7901FeedParser):
 
     label = "DPA IPTC 7901 Parser"
 
-    def parse(self, file_path, provider=None):
-        item = super().parse(file_path, provider)
+    async def parse(self, file_path, provider=None):
+        item = await super().parse(file_path, provider)
         item = self.dpa_derive_dateline(item)
         self.dpa_parse_header(item)
         # Markup the text and set the content type

--- a/superdesk/io/feed_parsers/dpa_newsml.py
+++ b/superdesk/io/feed_parsers/dpa_newsml.py
@@ -30,8 +30,8 @@ class DPAFeedParser(NewsMLTwoFeedParser):
     def can_parse(self, xml):
         return super().can_parse(xml)
 
-    def parse(self, xml, provider=None):
-        items = super().parse(xml, provider)
+    async def parse(self, xml, provider=None):
+        items = await super().parse(xml, provider)
         for item in items:
             if "versioncreated" in item:
                 item["versioncreated"] = item["versioncreated"].astimezone(utc)

--- a/superdesk/io/feed_parsers/efe_nitf.py
+++ b/superdesk/io/feed_parsers/efe_nitf.py
@@ -76,8 +76,8 @@ class EFEFeedParser(NITFFeedParser):
         super().__init__()
         self.default_mapping = {}
 
-    def parse(self, xml, provider=None):
-        item = super().parse(xml, provider)
+    async def parse(self, xml, provider=None):
+        item = await super().parse(xml, provider)
         self.derive_dateline(item)
         return item
 

--- a/superdesk/io/feed_parsers/image_iptc.py
+++ b/superdesk/io/feed_parsers/image_iptc.py
@@ -60,13 +60,13 @@ class ImageIPTCFeedParser(FileFeedParser):
             return False
         return mimetypes.guess_type(image_path)[0] == "image/jpeg"
 
-    def parse(self, image_path, provider=None):
+    async def parse(self, image_path, provider=None):
         try:
             item = self.parse_item(image_path)
             return item
         except Exception as ex:
             logger.exception(ex)
-            raise ParserError.parseFileError(exception=ex, provider=provider)
+            raise await ParserError.parseFileError(exception=ex, provider=provider).send_notifications()
 
     def parse_item(self, image_path):
         filename = os.path.basename(image_path)

--- a/superdesk/io/feed_parsers/iptc7901.py
+++ b/superdesk/io/feed_parsers/iptc7901.py
@@ -41,7 +41,7 @@ class IPTC7901FeedParser(FileFeedParser):
         except Exception:
             return False
 
-    def parse(self, file_path, provider=None):
+    async def parse(self, file_path, provider=None):
         try:
             item = {ITEM_TYPE: CONTENT_TYPE.TEXT, "guid": generate_guid(type=GUID_TAG), "versioncreated": utcnow()}
 
@@ -95,7 +95,7 @@ class IPTC7901FeedParser(FileFeedParser):
 
             return item
         except Exception as ex:
-            raise ParserError.IPTC7901ParserError(exception=ex, provider=provider)
+            raise await ParserError.IPTC7901ParserError(exception=ex, provider=provider).send_notifications()
 
     def map_category(self, source_category):
         if source_category.lower() == "u" or source_category.lower() == "x":

--- a/superdesk/io/feed_parsers/newsml_1_2.py
+++ b/superdesk/io/feed_parsers/newsml_1_2.py
@@ -32,7 +32,7 @@ class NewsMLOneFeedParser(XMLFeedParser):
     def can_parse(self, xml):
         return xml.tag == "NewsML" and xml.get("Version", "") == "1.2"
 
-    def parse(self, xml, provider=None):
+    async def parse(self, xml, provider=None):
         item = {}
         try:
             self.root = xml
@@ -88,7 +88,7 @@ class NewsMLOneFeedParser(XMLFeedParser):
 
             return self.populate_fields(item)
         except Exception as ex:
-            raise ParserError.newsmlOneParserError(ex, provider)
+            raise await ParserError.newsmlOneParserError(ex, provider).send_notifications()
 
     def parse_content(self, item, xml):
         item["body_html"] = (

--- a/superdesk/io/feed_parsers/newsml_2_0.py
+++ b/superdesk/io/feed_parsers/newsml_2_0.py
@@ -56,7 +56,7 @@ class NewsMLTwoFeedParser(XMLFeedParser):
     def can_parse(self, xml):
         return any([xml.tag.endswith(tag) for tag in ["newsMessage", "newsItem", "packageItem"]])
 
-    def parse(self, xml, provider=None):
+    async def parse(self, xml, provider=None):
         self.root = xml
         items = []
         try:
@@ -73,7 +73,7 @@ class NewsMLTwoFeedParser(XMLFeedParser):
                     items.append(item)
             return items
         except Exception as ex:
-            raise ParserError.newsmlTwoParserError(ex, provider)
+            raise await ParserError.newsmlTwoParserError(ex, provider).send_notifications()
 
     def parse_item(self, tree):
         # config is not accessible during __init__, so we check it here

--- a/superdesk/io/feed_parsers/ninjs.py
+++ b/superdesk/io/feed_parsers/ninjs.py
@@ -69,7 +69,7 @@ class NINJSFeedParser(FeedParser):
             pass
         return False
 
-    def parse(self, file_path, provider=None):
+    async def parse(self, file_path, provider=None):
         self.items = []
         with open(file_path, "r") as f:
             ninjs = json.load(f)

--- a/superdesk/io/feed_parsers/nitf.py
+++ b/superdesk/io/feed_parsers/nitf.py
@@ -108,7 +108,7 @@ class NITFFeedParser(XMLFeedParser):
     def can_parse(self, xml):
         return xml.tag == "nitf"
 
-    def parse(self, xml, provider=None):
+    async def parse(self, xml, provider=None):
         item = {
             ITEM_TYPE: CONTENT_TYPE.TEXT,  # set the default type.
         }
@@ -120,7 +120,7 @@ class NITFFeedParser(XMLFeedParser):
 
             item.setdefault("word_count", get_word_count(item["body_html"], no_html=True))
         except Exception as ex:
-            raise ParserError.nitfParserError(ex, provider)
+            raise await ParserError.nitfParserError(ex, provider).send_notifications()
         return item
 
     def get_norm_datetime(self, tree):

--- a/superdesk/io/feed_parsers/pa_nitf.py
+++ b/superdesk/io/feed_parsers/pa_nitf.py
@@ -109,9 +109,9 @@ class PAFeedParser(NITFFeedParser):
         }
         super().__init__()
 
-    def parse(self, xml, provider=None):
+    async def parse(self, xml, provider=None):
         self.xml = xml
-        return super().parse(xml, provider=provider)
+        return await super().parse(xml, provider=provider)
 
 
 register_feed_parser(PAFeedParser.NAME, PAFeedParser())

--- a/superdesk/io/feed_parsers/rfc822.py
+++ b/superdesk/io/feed_parsers/rfc822.py
@@ -60,11 +60,11 @@ class EMailRFC822FeedParser(EmailFeedParser):
 
         return False
 
-    def parse(self, data, provider=None):
+    async def parse(self, data, provider=None):
         config = provider.get("config", {})
         # If the channel is configured to process structured email generated from a google form
         if config.get("formatted", False):
-            return self._parse_formatted_email(data, provider)
+            return await self._parse_formatted_email(data, provider)
         try:
             new_items = []
             # create an item for the body text of the email
@@ -241,7 +241,7 @@ class EMailRFC822FeedParser(EmailFeedParser):
             new_items.append(item)
             return new_items
         except Exception as ex:
-            raise IngestEmailError.emailParseError(ex, provider)
+            raise await IngestEmailError.emailParseError(ex, provider).send_notifications()
 
     def parse_header(self, field):
         try:
@@ -299,7 +299,7 @@ class EMailRFC822FeedParser(EmailFeedParser):
                             )
                         break
 
-    def _parse_formatted_email(self, data, provider):
+    async def _parse_formatted_email(self, data, provider):
         """Construct an item from an email that was constructed as a notification from a google form submission.
 
         The google form submits to a google sheet, this sheet creates the email as a notification
@@ -430,7 +430,7 @@ class EMailRFC822FeedParser(EmailFeedParser):
 
             return [item]
         except Exception as ex:
-            raise IngestEmailError.emailParseError(ex, provider)
+            raise await IngestEmailError.emailParseError(ex, provider).send_notifications()
 
 
 register_feed_parser(EMailRFC822FeedParser.NAME, EMailRFC822FeedParser())

--- a/superdesk/io/feed_parsers/ritzau.py
+++ b/superdesk/io/feed_parsers/ritzau.py
@@ -82,14 +82,14 @@ class RitzauFeedParser(XMLFeedParser):
     def can_parse(self, xml):
         return xml.tag.endswith("RBNews")
 
-    def parse(self, xml, provider=None):
+    async def parse(self, xml, provider=None):
         item = {
             ITEM_TYPE: CONTENT_TYPE.TEXT,  # set the default type.
         }
         try:
             self.do_mapping(item, xml, namespaces=NS)
         except Exception as ex:
-            raise ParserError.parseMessageError(ex, provider)
+            raise await ParserError.parseMessageError(ex, provider).send_notifications()
         return item
 
     def get_datetime(self, value):

--- a/superdesk/io/feed_parsers/scoop_newsml_2_0.py
+++ b/superdesk/io/feed_parsers/scoop_newsml_2_0.py
@@ -39,7 +39,7 @@ class ScoopNewsMLTwoFeedParser(NewsMLTwoFeedParser):
                 return False
         return False
 
-    def parse(self, xml, provider=None):
+    async def parse(self, xml, provider=None):
         self.root = xml
         items = []
         try:
@@ -91,7 +91,7 @@ class ScoopNewsMLTwoFeedParser(NewsMLTwoFeedParser):
                         items.append(item)
             return items
         except Exception as ex:
-            raise ParserError.newsmlTwoParserError(ex, provider)
+            raise await ParserError.newsmlTwoParserError(ex, provider).send_notifications()
 
     def parse_header(self, tree):
         """Parse header element, it seems that the header tag is in camel case

--- a/superdesk/io/feed_parsers/stt_newsml.py
+++ b/superdesk/io/feed_parsers/stt_newsml.py
@@ -46,7 +46,7 @@ class STTNewsMLFeedParser(NewsMLTwoFeedParser):
     def can_parse(self, xml):
         return xml.tag.endswith("newsItem")
 
-    def parse(self, xml, provider=None):
+    async def parse(self, xml, provider=None):
         self.root = xml
         try:
             item = self.parse_item(xml)
@@ -153,7 +153,7 @@ class STTNewsMLFeedParser(NewsMLTwoFeedParser):
 
             return [item]
         except Exception as ex:
-            raise ParserError.newsmlTwoParserError(ex, provider)
+            raise await ParserError.newsmlTwoParserError(ex, provider).send_notifications()
 
     def parse_inline_content(self, tree, item):
         html_elt = tree.find(self.qname("html"))

--- a/superdesk/io/feed_parsers/wenn_parser.py
+++ b/superdesk/io/feed_parsers/wenn_parser.py
@@ -39,7 +39,7 @@ class WENNFeedParser(XMLFeedParser):
             and len(xml.findall(self.qname("NewsManagement", self.WENN_NM_NS))) > 0
         )
 
-    def parse(self, xml, provider=None):
+    async def parse(self, xml, provider=None):
         itemList = []
         try:
             for entry in xml.findall(self.qname("entry", self.ATOM_NS)):
@@ -54,7 +54,7 @@ class WENNFeedParser(XMLFeedParser):
             return itemList
 
         except Exception as ex:
-            raise ParserError.wennParserError(ex, provider)
+            raise await ParserError.wennParserError(ex, provider).send_notifications()
 
     def set_item_defaults(self, item):
         item[ITEM_TYPE] = CONTENT_TYPE.TEXT

--- a/superdesk/io/feed_parsers/wordpress_wxr.py
+++ b/superdesk/io/feed_parsers/wordpress_wxr.py
@@ -103,7 +103,7 @@ class WPWXRFeedParser(XMLFeedParser):
     def can_parse(self, xml):
         return xml.tag == "rss"
 
-    def parse(self, xml, provider=None):
+    async def parse(self, xml, provider=None):
         return list(self.parse_items(xml))
 
     def parse_items(self, xml):

--- a/superdesk/io/feeding_services/__init__.py
+++ b/superdesk/io/feeding_services/__init__.py
@@ -8,6 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from typing import AsyncGenerator
 import logging
 import warnings
 from inspect import isawaitable
@@ -16,6 +17,7 @@ from datetime import timedelta, datetime
 from pytz import utc
 
 from superdesk.core import get_app_config
+from superdesk.core.utils import list_to_async_generator
 from superdesk.resource_fields import ID_FIELD
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError, SuperdeskIngestError
@@ -86,7 +88,7 @@ class FeedingService(metaclass=ABCMeta):
         self._provider = None
 
     @abstractmethod
-    def _update(self, provider, update):
+    async def _update(self, provider, update) -> AsyncGenerator[dict, None] | list[dict] | None:
         """
         Subclasses must override this method and get items from the provider as per the configuration.
 
@@ -99,7 +101,7 @@ class FeedingService(metaclass=ABCMeta):
         """
         raise NotImplementedError()
 
-    def _test_feed_parser(self, provider):
+    async def _test_feed_parser(self, provider):
         """
         Checks if the feed_parser value was in the restricted values list.
 
@@ -114,9 +116,9 @@ class FeedingService(metaclass=ABCMeta):
             and restricted_feeding_service_parsers.get(feeding_service)
             and not restricted_feeding_service_parsers.get(feeding_service).get(feed_parser)
         ):
-            raise SuperdeskIngestError.invalidFeedParserValue(provider=provider)
+            raise await SuperdeskIngestError.invalidFeedParserValue(provider=provider).send_notifications()
 
-    def _test(self, provider):
+    async def _test(self, provider):
         """
         Subclasses should override this method and do specific config test.
 
@@ -124,7 +126,7 @@ class FeedingService(metaclass=ABCMeta):
         """
         return
 
-    def config_test(self, provider=None):
+    async def config_test(self, provider=None):
         """Test provider configuration.
 
         :param provider: provider data
@@ -133,8 +135,8 @@ class FeedingService(metaclass=ABCMeta):
             return
         if self._is_closed(provider):
             return
-        self._test_feed_parser(provider)
-        return self._test(provider)
+        await self._test_feed_parser(provider)
+        return await self._test(provider)
 
     def _is_closed(self, provider):
         """Test if provider is closed.
@@ -152,7 +154,7 @@ class FeedingService(metaclass=ABCMeta):
     def _log_msg(self, msg, level="info"):
         getattr(logger, level)("Ingest:{} '{}': {}".format(self._provider["_id"], self._provider["name"], msg))
 
-    async def update(self, provider, update):
+    async def update(self, provider, update) -> AsyncGenerator[dict, None] | None:
         """
         Clients consuming Ingest Services should invoke this to get items from the provider.
 
@@ -166,23 +168,31 @@ class FeedingService(metaclass=ABCMeta):
         """
         if self._is_closed(provider):
             raise SuperdeskApiError.internalError("Ingest Provider is closed")
-        else:
-            try:
-                self._provider = provider
-                self._log_msg("Start update execution.")
-                self._timer.start("update")
 
-                response = self._update(provider, update) or []
-                if isawaitable(response):
-                    response = await response
-                return response
-            except SuperdeskIngestError as error:
-                await self.close_provider(provider, error)
-                raise error
-            finally:
-                self._log_msg("Stop update execution. Exec time: {:.4f} secs.".format(self._timer.stop("update")))
-                # just in case stop all timers
-                self._timer.stop_all()
+        try:
+            self._provider = provider
+            self._log_msg("Start update execution.")
+            self._timer.start("update")
+
+            response = self._update(provider, update)
+
+            # Feeds that return a list or None are awaitable, async generators are not.
+            # So check if the response is awaitable first and then await if needed.
+            items = await response if isawaitable(response) else response
+
+            if items is None:
+                return None
+            elif isinstance(items, list):
+                return list_to_async_generator(items)
+            else:
+                return items
+        except SuperdeskIngestError as error:
+            await self.close_provider(provider, error)
+            raise error
+        finally:
+            self._log_msg("Stop update execution. Exec time: {:.4f} secs.".format(self._timer.stop("update")))
+            # just in case stop all timers
+            self._timer.stop_all()
 
     async def close_provider(self, provider, error, force=False):
         """Closes the provider and uses error as reason for closing.
@@ -252,7 +262,7 @@ class FeedingService(metaclass=ABCMeta):
         """
         return href
 
-    def get_feed_parser(self, provider, article=None):
+    async def get_feed_parser(self, provider, article=None):
         """
         Returns instance of configured feed parser for the given provider.
 
@@ -268,10 +278,10 @@ class FeedingService(metaclass=ABCMeta):
 
         parser = registered_feed_parsers.get(provider.get("feed_parser", ""))
         if not parser:
-            raise SuperdeskIngestError.parserNotFoundError(provider=provider)
+            raise await SuperdeskIngestError.parserNotFoundError(provider=provider).send_notifications()
 
         if article is not None and not parser.can_parse(article):
-            raise SuperdeskIngestError.parserNotFoundError(provider=provider)
+            raise await SuperdeskIngestError.parserNotFoundError(provider=provider).send_notifications()
 
         if article is not None:
             parser = parser.__class__()

--- a/superdesk/io/feeding_services/ap.py
+++ b/superdesk/io/feeding_services/ap.py
@@ -54,10 +54,10 @@ class APFeedingService(HTTPFeedingServiceBase):
     ]
     HTTP_URL = "https://syndication.ap.org/AP.Distro.Feed/GetFeed.aspx"
 
-    def config_test(self, provider=None):
-        super().config_test(provider)
+    async def config_test(self, provider=None):
+        await super().config_test(provider)
 
-    def _update(self, provider, update):
+    async def _update(self, provider, update):
         try:
             config = provider["config"]
             id_list = config["idList"]
@@ -66,7 +66,7 @@ class APFeedingService(HTTPFeedingServiceBase):
             if not id_list.strip():
                 raise KeyError
         except KeyError:
-            raise SuperdeskIngestError.notConfiguredError(Exception("idList is needed"))
+            raise await SuperdeskIngestError.notConfiguredError(Exception("idList is needed")).send_notifications()
 
         # we check if the provider has been closed since the last update
         try:
@@ -102,15 +102,15 @@ class APFeedingService(HTTPFeedingServiceBase):
             params["sortOrder"] = "chronological"
             chronological = True
 
-        r = self.get_url(params=params)
+        r = await self.get_url(params=params)
 
         try:
             root_elt = etree.fromstring(r.content)
         except Exception:
-            raise IngestApiError.apiRequestError(Exception("error while doing the request"))
+            raise await IngestApiError.apiRequestError(Exception("error while doing the request")).send_notifications()
 
-        parser = self.get_feed_parser(provider)
-        items = parser.parse(root_elt, provider)
+        parser = await self.get_feed_parser(provider)
+        items = await parser.parse(root_elt, provider)
         if not chronological:
             items.reverse()
 
@@ -118,7 +118,9 @@ class APFeedingService(HTTPFeedingServiceBase):
             min_date_time = root_elt.xpath('//iptc:timestamp[@role="minDateTime"]/text()', namespaces=NS)[0].strip()
             sequence_number = root_elt.xpath("//iptc:transmitId/text()", namespaces=NS)[0].strip()
         except IndexError:
-            raise IngestApiError.apiRequestError(Exception("missing minDateTime or transmitId"))
+            raise await IngestApiError.apiRequestError(
+                Exception("missing minDateTime or transmitId")
+            ).send_notifications()
         else:
             update.setdefault("private", {})
             update["private"]["min_date_time"] = min_date_time

--- a/superdesk/io/feeding_services/ap_media.py
+++ b/superdesk/io/feeding_services/ap_media.py
@@ -84,7 +84,7 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
 
     HTTP_TIMEOUT = 40
 
-    async def config_test_async(self, provider=None):
+    async def config_test(self, provider=None):
         self.provider = provider
         self._get_products(provider)
         original = await superdesk.get_resource_service("ingest_providers").find_one_async(
@@ -116,13 +116,13 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
                 productList.append("{}".format(entitlement.get("id")))
         provider["config"]["availableProducts"] = ",".join(productList)
 
-    def _update(self, provider, update):
+    async def _update(self, provider, update):
         self.HTTP_URL = provider.get("config", {}).get("api_url", "")
         self.provider = provider
 
         # Use the next link if one is available in the config
         if provider.get("config", {}).get("next_link"):
-            r = self.get_url(url=provider.get("config", {}).get("next_link"))
+            r = await self.get_url(url=provider.get("config", {}).get("next_link"))
             r.raise_for_status()
         else:
             params = dict()
@@ -144,12 +144,12 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
             params["versions"] = "all"
 
             logger.info("AP Media Start/Recovery time: {} params {}".format(recovery_time, params))
-            r = self.get_url(params=params)
+            r = await self.get_url(params=params)
             r.raise_for_status()
         try:
             response = json.loads(r.text)
         except Exception:
-            raise IngestApiError.apiRequestError(Exception("error parsing response"))
+            raise await IngestApiError.apiRequestError(Exception("error parsing response")).send_notifications()
 
         nextLink = response.get("data", {}).get("next_page")
         # Got the same next link as last time so nothing new
@@ -157,7 +157,7 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
             logger.info("Nothing new from AP Media")
             return []
 
-        parser = self.get_feed_parser(provider)
+        parser = await self.get_feed_parser(provider)
         parsed_items = []
         for item in response.get("data", {}).get("items", []):
             try:
@@ -167,7 +167,7 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
                         item.get("item", {}).get("headline"), item.get("item", {}).get("uri")
                     )
                 )
-                r = self.api_get(item.get("item", {}).get("uri"))
+                r = await self.api_get(item.get("item", {}).get("uri"))
                 complete_item = json.loads(r.text)
 
                 # Get the nitf rendition of the item
@@ -176,7 +176,7 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
                 )
                 if nitf_ref:
                     logger.info("Get AP nitf : {}".format(nitf_ref))
-                    r = self.api_get(nitf_ref)
+                    r = await self.api_get(nitf_ref)
                     root_elt = etree.fromstring(r.content)
 
                     # If the default namespace definition is the nitf namespace then remove it
@@ -186,7 +186,7 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
                                 elem.tag = elem.tag.replace("{" + nitf_namespace["nitf"] + "}", "")
                         etree.cleanup_namespaces(root_elt)
 
-                    nitf_item = nitf.NITFFeedParser().parse(root_elt)
+                    nitf_item = await nitf.NITFFeedParser().parse(root_elt)
                     complete_item["nitf"] = nitf_item
                 else:
                     if item.get("item", {}).get("type") == "text":
@@ -198,12 +198,12 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
                     for key, assoc in associations.items():
                         logger.info('Get AP association "%s"', assoc.get("headline"))
                         try:
-                            related_json = self.api_get(assoc["uri"]).json()
+                            related_json = (await self.api_get(assoc["uri"])).json()
                             complete_item["associations"][key] = related_json
                         except IngestApiError:
                             logger.warning("Could not fetch AP association", extra=assoc)
 
-                parsed_items.append(parser.parse(complete_item, provider))
+                parsed_items.append(await parser.parse(complete_item, provider))
 
             # Any exception processing an indivisual item is swallowed
             except Exception as ex:
@@ -217,8 +217,8 @@ class APMediaFeedingService(HTTPFeedingServiceBase):
 
         return [parsed_items]
 
-    def api_get(self, url):
-        resp = self.get_url(url=url)
+    async def api_get(self, url):
+        resp = await self.get_url(url=url)
         resp.raise_for_status()
         return resp
 

--- a/superdesk/io/feeding_services/bbc_ldrs.py
+++ b/superdesk/io/feeding_services/bbc_ldrs.py
@@ -54,7 +54,7 @@ class BBCLDRSFeedingService(HTTPFeedingServiceBase):
     def __init__(self):
         super().__init__()
 
-    def _test(self, provider):
+    async def _test(self, provider):
         config = self.config
         url = config["url"]
         api_key = config["api_key"]
@@ -64,22 +64,22 @@ class BBCLDRSFeedingService(HTTPFeedingServiceBase):
         params = {"limit": 1, "fields": "id"}
         headers = {"apikey": api_key}
 
-        self.get_url(url, params=params, headers=headers)
+        await self.get_url(url, params=params, headers=headers)
 
-    def _update(self, provider, update):
-        json_items = self._fetch_data()
+    async def _update(self, provider, update):
+        json_items = await self._fetch_data()
         parsed_items = []
 
         for item in json_items:
             try:
-                parser = self.get_feed_parser(provider, item)
-                parsed_items.append(parser.parse(item))
+                parser = await self.get_feed_parser(provider, item)
+                parsed_items.append(await parser.parse(item))
             except Exception as ex:
-                raise ParserError.parseMessageError(ex, provider, data=item)
+                raise await ParserError.parseMessageError(ex, provider, data=item).send_notifications()
 
         return parsed_items
 
-    def _fetch_data(self):
+    async def _fetch_data(self):
         url = self.config["url"]
         api_key = self.config["api_key"]
 
@@ -97,7 +97,7 @@ class BBCLDRSFeedingService(HTTPFeedingServiceBase):
         while True:
             params["offset"] = offset
 
-            response = self.get_url(url, params=params, headers=headers)
+            response = await self.get_url(url, params=params, headers=headers)
             # The total number of results are given to us in json, get them
             # via a regex to read the field so we don't have to convert the
             # whole thing to json pointlessly
@@ -105,7 +105,7 @@ class BBCLDRSFeedingService(HTTPFeedingServiceBase):
             results_str = re.search("[0-9]+", item_ident).group()
 
             if results_str is None:
-                raise IngestApiError.apiGeneralError(Exception(response.text), self.provider)
+                raise await IngestApiError.apiGeneralError(Exception(response.text), self.provider).send_notifications()
 
             num_results = int(results_str)
 

--- a/superdesk/io/feeding_services/email.py
+++ b/superdesk/io/feeding_services/email.py
@@ -73,22 +73,22 @@ class EmailFeedingService(FeedingService):
         {"id": "filter", "type": "text", "label": l_("Filter"), "placeholder": "Filter", "required": False},
     ]
 
-    def _test(self, provider):
-        self._update(provider, update=None, test=True)
+    async def _test(self, provider):
+        await self._update(provider, update=None, test=True)
 
-    def authenticate(self, provider: dict, config: dict) -> imaplib.IMAP4_SSL:
+    async def authenticate(self, provider: dict, config: dict) -> imaplib.IMAP4_SSL:
         server = config.get("server", "")
         port = int(config.get("port", 993))
         try:
             socket.setdefaulttimeout(get_app_config("EMAIL_TIMEOUT", 10))
             imap = imaplib.IMAP4_SSL(host=server, port=port)
         except (socket.gaierror, OSError) as e:
-            raise IngestEmailError.emailHostError(exception=e, provider=provider)
+            raise await IngestEmailError.emailHostError(exception=e, provider=provider).send_notifications()
 
         try:
             imap.login(config.get("user", None), config.get("password", None))
         except imaplib.IMAP4.error:
-            raise IngestEmailError.emailLoginError(imaplib.IMAP4.error, provider)
+            raise await IngestEmailError.emailLoginError(imaplib.IMAP4.error, provider).send_notifications()
 
         return imap
 
@@ -99,29 +99,29 @@ class EmailFeedingService(FeedingService):
         """
         pass
 
-    def _update(self, provider, update, test=False):
+    async def _update(self, provider, update, test=False):
         config = provider.get("config", {})
         new_items = []
 
         try:
-            imap = self.authenticate(provider, config)
+            imap = await self.authenticate(provider, config)
 
             try:
                 rv, data = imap.select(config.get("mailbox", None), readonly=False)
                 if rv != "OK":
-                    raise IngestEmailError.emailMailboxError()
+                    raise await IngestEmailError.emailMailboxError().send_notifications()
                 try:
                     # at least one criterion must be set
                     # (see file:///usr/share/doc/python/html/library/imaplib.html#imaplib.IMAP4.search)
                     rv, data = imap.search(None, config.get("filter") or "(UNSEEN)")
                     if rv != "OK":
-                        raise IngestEmailError.emailFilterError()
+                        raise await IngestEmailError.emailFilterError().send_notifications()
                     for num in data[0].split():
                         rv, data = imap.fetch(num, "(RFC822)")
                         if rv == "OK" and not test:
                             try:
-                                parser = self.get_feed_parser(provider, data)
-                                parsed_items = parser.parse(data, provider)
+                                parser = await self.get_feed_parser(provider, data)
+                                parsed_items = await parser.parse(data, provider)
                                 self.parse_extra(imap, num, parsed_items)
                                 new_items.append(parsed_items)
                                 rv, data = imap.store(num, "+FLAGS", "\\Seen")
@@ -134,7 +134,7 @@ class EmailFeedingService(FeedingService):
         except IngestEmailError:
             raise
         except Exception as ex:
-            raise IngestEmailError.emailError(ex, provider)
+            raise await IngestEmailError.emailError(ex, provider).send_notifications()
         return new_items
 
     def prepare_href(self, href, mimetype=None):

--- a/superdesk/io/feeding_services/file_service.py
+++ b/superdesk/io/feeding_services/file_service.py
@@ -54,14 +54,14 @@ class FileFeedingService(FeedingService):
         }
     ]
 
-    def _test(self, provider):
+    async def _test(self, provider):
         path = provider.get("config", {}).get("path", None)
         if not os.path.exists(path):
-            raise IngestFileError.notExistsError()
+            raise await IngestFileError.notExistsError().send_notifications()
         if not os.path.isdir(path):
-            raise IngestFileError.isNotDirError()
+            raise await IngestFileError.isNotDirError().send_notifications()
 
-    def _update(self, provider, update):
+    async def _update(self, provider, update):
         # check if deprecated FILE_INGEST_OLD_CONTENT_MINUTES setting is still used
         app = get_current_app()
         if "FILE_INGEST_OLD_CONTENT_MINUTES" in app.config:
@@ -84,9 +84,9 @@ class FileFeedingService(FeedingService):
                     provider["name"]
                 )
             )
-            return []
+            return
 
-        registered_parser = self.get_feed_parser(provider)
+        registered_parser = await self.get_feed_parser(provider)
         for filename in get_sorted_files(self.path, sort_by=FileSortAttributes.created):
             try:
                 last_updated = None
@@ -101,11 +101,11 @@ class FileFeedingService(FeedingService):
                         if isinstance(registered_parser, XMLFeedParser):
                             with open(file_path, "rb") as f:
                                 xml = etree.parse(f)
-                                parser = self.get_feed_parser(provider, xml.getroot())
-                                item = parser.parse(xml.getroot(), provider)
+                                parser = await self.get_feed_parser(provider, xml.getroot())
+                                item = await parser.parse(xml.getroot(), provider)
                         else:
-                            parser = self.get_feed_parser(provider, file_path)
-                            item = parser.parse(file_path, provider)
+                            parser = await self.get_feed_parser(provider, file_path)
+                            item = await parser.parse(file_path, provider)
 
                         self.after_extracting(item, provider)
 
@@ -114,13 +114,15 @@ class FileFeedingService(FeedingService):
                         else:
                             failed = yield [item]
 
-                        self.move_file(self.path, filename, provider=provider, success=not failed)
+                        await self.move_file(self.path, filename, provider=provider, success=not failed)
                     else:
-                        self.move_file(self.path, filename, provider=provider, success=False)
+                        await self.move_file(self.path, filename, provider=provider, success=False)
             except Exception as ex:
                 if last_updated and self.is_old_content(last_updated):
-                    self.move_file(self.path, filename, provider=provider, success=False)
-                raise ParserError.parseFileError("{}-{}".format(provider["name"], self.NAME), filename, ex, provider)
+                    await self.move_file(self.path, filename, provider=provider, success=False)
+                raise await ParserError.parseFileError(
+                    "{}-{}".format(provider["name"], self.NAME), filename, ex, provider
+                ).send_notifications()
 
         push_notification("ingest:update")
 
@@ -139,7 +141,7 @@ class FileFeedingService(FeedingService):
         """
         pass
 
-    def move_file(self, file_path, filename, provider, success=True):
+    async def move_file(self, file_path, filename, provider, success=True):
         """Move the files from the current directory to the _Processed if successful, else _Error if unsuccessful.
 
         Creates _Processed and _Error directories within current directory if they don't exist.
@@ -158,7 +160,7 @@ class FileFeedingService(FeedingService):
             if not os.path.exists(os.path.join(file_path, "_ERROR/")):
                 os.makedirs(os.path.join(file_path, "_ERROR/"))
         except Exception as ex:
-            raise IngestFileError.folderCreateError(ex, provider)
+            raise await IngestFileError.folderCreateError(ex, provider).send_notifications()
 
         try:
             if success:
@@ -166,7 +168,7 @@ class FileFeedingService(FeedingService):
             else:
                 shutil.copy2(os.path.join(file_path, filename), os.path.join(file_path, "_ERROR/"))
         except Exception as ex:
-            raise IngestFileError.fileMoveError(ex, provider)
+            raise await IngestFileError.fileMoveError(ex, provider).send_notifications()
         finally:
             os.remove(os.path.join(file_path, filename))
 

--- a/superdesk/io/feeding_services/ftp.py
+++ b/superdesk/io/feeding_services/ftp.py
@@ -130,10 +130,10 @@ class FTPFeedingService(FeedingService):
             "path": url_parts.path.lstrip("/"),
         }
 
-    def _test(self, provider):
+    async def _test(self, provider):
         config = provider.get("config", {})
         try:
-            with ftp_connect(config) as ftp:
+            async with ftp_connect(config) as ftp:
                 ftp.mlsd()
         except IngestFtpError:
             raise
@@ -141,7 +141,7 @@ class FTPFeedingService(FeedingService):
             if "500" in str(ex):
                 ftp.nlst()
             else:
-                raise IngestFtpError.ftpError(ex, provider)
+                raise await IngestFtpError.ftpError(ex, provider).send_notifications()
 
     def _move(self, ftp, src, dest, file_modify, failed):
         """Move distant file
@@ -226,16 +226,18 @@ class FTPFeedingService(FeedingService):
         """Test if given file path is empty, return True if a file is empty"""
         return not (os.path.isfile(file_path) and os.path.getsize(file_path) > 0)
 
-    def _list_files(self, ftp, provider):
+    async def _list_files(self, ftp, provider):
         self._timer.start("ftp_list")
         try:
-            return [(filename, facts["modify"]) for filename, facts in ftp.mlsd() if facts.get("type") == "file"]
+            data = ftp.mlsd()
+            print(data)
+            return [(filename, facts["modify"]) for filename, facts in data if facts.get("type") == "file"]
         except Exception as ex:
             if "500" in str(ex):
                 now = utcnow()
                 return [(file_name, now) for file_name in ftp.nlst()]
             else:
-                raise IngestFtpError.ftpError(ex, provider)
+                raise await IngestFtpError.ftpError(ex, provider).send_notifications()
         finally:
             self._log_msg("FTP list files. Exec time: {:.4f} secs.".format(self._timer.stop("ftp_list")))
 
@@ -245,7 +247,7 @@ class FTPFeedingService(FeedingService):
         self._log_msg("Sort {} files. Exec time: {:.4f} secs.".format(len(files), self._timer.stop("sort_files")))
         return files
 
-    def _retrieve_and_parse(self, ftp, config, filename, provider, registered_parser):
+    async def _retrieve_and_parse(self, ftp, config, filename, provider, registered_parser):
         self._timer.start("retrieve_parse")
 
         if "dest_path" not in config:
@@ -260,7 +262,7 @@ class FTPFeedingService(FeedingService):
                         self._timer.split("retrieve_parse"), os.path.getsize(local_file_path), filename
                     )
                 )
-            except ftplib.all_errors:
+            except ftplib.all_errors as err:
                 self._log_msg(
                     "Download failed. Exec time: {:.4f} secs. File: {}.".format(
                         self._timer.stop("retrieve_parse"), filename
@@ -275,11 +277,11 @@ class FTPFeedingService(FeedingService):
 
         if isinstance(registered_parser, XMLFeedParser):
             xml = etree.parse(local_file_path).getroot()
-            parser = self.get_feed_parser(provider, xml)
-            parsed = parser.parse(xml, provider)
+            parser = await self.get_feed_parser(provider, xml)
+            parsed = await parser.parse(xml, provider)
         else:
-            parser = self.get_feed_parser(provider, local_file_path)
-            parsed = parser.parse(local_file_path, provider)
+            parser = await self.get_feed_parser(provider, local_file_path)
+            parsed = await parser.parse(local_file_path, provider)
 
         self._log_msg(
             "Parsing finished. Exec time: {:.4f} secs. File: {}.".format(self._timer.stop("retrieve_parse"), filename)
@@ -287,25 +289,25 @@ class FTPFeedingService(FeedingService):
 
         return [parsed] if isinstance(parsed, dict) else parsed
 
-    def _update(self, provider, update):
+    async def _update(self, provider, update):
         config = provider.get("config", {})
         do_move = config.get("move", False)
         last_processed_file_modify = provider.get("private", {}).get("last_processed_file_modify")
         limit = get_app_config("FTP_INGEST_FILES_LIST_LIMIT", 100)
-        registered_parser = self.get_feed_parser(provider)
+        registered_parser = await self.get_feed_parser(provider)
         allowed_ext = getattr(registered_parser, "ALLOWED_EXT", self.ALLOWED_EXT_DEFAULT)
         if config.get(ALLOWED_EXTENSIONS_CONFIG):
             allowed_ext = set(map(_format_extension, config.get(ALLOWED_EXTENSIONS_CONFIG).split(",")))
 
         try:
             self._timer.start("ftp_connect")
-            with ftp_connect(config) as ftp:
+            async with ftp_connect(config) as ftp:
                 ftp.encoding = "UTF-8"
                 self._log_msg(
                     "Connected to FTP server. Exec time: {:.4f} secs.".format(self._timer.stop("ftp_connect"))
                 )
                 files_to_process = []
-                files = self._sort_files(self._list_files(ftp, provider))
+                files = self._sort_files(await self._list_files(ftp, provider))
 
                 if do_move:
                     move_path, move_path_error = self._create_move_folders(config, ftp)
@@ -353,7 +355,9 @@ class FTPFeedingService(FeedingService):
                 for filename, file_modify in files_to_process:
                     try:
                         update["private"] = {"last_processed_file_modify": file_modify}
-                        failed = yield self._retrieve_and_parse(ftp, config, filename, provider, registered_parser)
+                        failed = yield await self._retrieve_and_parse(
+                            ftp, config, filename, provider, registered_parser
+                        )
 
                         if do_move:
                             move_dest_file_path = os.path.join(move_path if not failed else move_path_error, filename)
@@ -371,10 +375,11 @@ class FTPFeedingService(FeedingService):
                     "Processing finished. Exec time: {:.4f} secs.".format(self._timer.stop("start_processing"))
                 )
 
-        except IngestFtpError:
-            raise
+        except IngestFtpError as ex:
+            await ex.send_notifications()
+            raise ex
         except Exception as ex:
-            raise IngestFtpError.ftpError(ex, provider)
+            raise await IngestFtpError.ftpError(ex, provider).send_notifications()
 
 
 register_feeding_service(FTPFeedingService)

--- a/superdesk/io/feeding_services/gmail.py
+++ b/superdesk/io/feeding_services/gmail.py
@@ -83,14 +83,16 @@ class GMailFeedingService(EmailFeedingService):
         field = next(f for f in cls.fields if f["id"] == "log_out_url")
         field["url"] = join(app.config["SERVER_URL"], "logout", "google", "{PROVIDER_ID}")
 
-    def _test(self, provider):
-        self._update(provider, update=None, test=True)
+    async def _test(self, provider):
+        await self._update(provider, update=None, test=True)
 
-    def authenticate(self, provider: dict, config: dict) -> imaplib.IMAP4_SSL:
+    async def authenticate(self, provider: dict, config: dict) -> imaplib.IMAP4_SSL:
         oauth2_token_service = superdesk.get_resource_service("oauth2_token")
         token = oauth2_token_service.find_one(req=None, _id=ObjectId(provider["_id"]))
         if token is None:
-            raise IngestEmailError.notConfiguredError(ValueError(l_("You need to log in first")), provider=provider)
+            raise await IngestEmailError.notConfiguredError(
+                ValueError(l_("You need to log in first")), provider=provider
+            ).send_notifications()
         imap = imaplib.IMAP4_SSL("imap.gmail.com")
 
         if token["expires_at"].replace(tzinfo=None).timestamp() < time.time() + 600:

--- a/superdesk/io/feeding_services/http_base_service.py
+++ b/superdesk/io/feeding_services/http_base_service.py
@@ -128,7 +128,7 @@ class HTTPFeedingServiceBase(FeedingService):
     def config(self):
         return self.provider.setdefault("config", {})
 
-    def validate_config(self):
+    async def validate_config(self):
         """
         Validate provider config according to `cls.fields`
 
@@ -139,19 +139,21 @@ class HTTPFeedingServiceBase(FeedingService):
         # validate required config fields
         required_keys = [field["id"] for field in self.fields if field.get("required", False)]
         if not set(self.config.keys()).issuperset(required_keys):
-            raise SuperdeskIngestError.notConfiguredError(
+            raise await SuperdeskIngestError.notConfiguredError(
                 Exception("{} are required.".format(", ".join(required_keys)))
-            )
+            ).send_notifications()
 
         # validate url
         url = self.config.get("url")
         if url and not url.strip().startswith("http"):
-            raise SuperdeskIngestError.notConfiguredError(Exception("URL must be a valid HTTP link."))
+            raise await SuperdeskIngestError.notConfiguredError(
+                Exception("URL must be a valid HTTP link.")
+            ).send_notifications()
 
     def get_request_kwargs(self) -> Dict[str, Any]:
         return {}
 
-    def get_url(self, url=None, **kwargs):
+    async def get_url(self, url=None, **kwargs):
         """Do an HTTP Get on URL
 
         :param string url: url to use (None to use self.HTTP_URL)
@@ -177,9 +179,9 @@ class HTTPFeedingServiceBase(FeedingService):
 
         if auth_required:
             if not user:
-                raise SuperdeskIngestError.notConfiguredError("user is not configured")
+                raise await SuperdeskIngestError.notConfiguredError("user is not configured").send_notifications()
             if not password:
-                raise SuperdeskIngestError.notConfiguredError("password is not configured")
+                raise await SuperdeskIngestError.notConfiguredError("password is not configured").send_notifications()
             kwargs.setdefault("auth", (user, password))
 
         params = kwargs.pop("params", {})
@@ -198,23 +200,23 @@ class HTTPFeedingServiceBase(FeedingService):
         try:
             response = self.session.get(url, **request_kwargs)
         except requests.exceptions.Timeout as exception:
-            raise IngestApiError.apiTimeoutError(exception, self.provider)
+            raise await IngestApiError.apiTimeoutError(exception, self.provider).send_notifications()
         except requests.exceptions.ConnectionError as exception:
-            raise IngestApiError.apiConnectionError(exception, self.provider)
+            raise await IngestApiError.apiConnectionError(exception, self.provider).send_notifications()
         except requests.exceptions.RequestException as exception:
-            raise IngestApiError.apiRequestError(exception, self.provider)
+            raise await IngestApiError.apiRequestError(exception, self.provider).send_notifications()
         except Exception as exception:
             traceback.print_exc()
-            raise IngestApiError.apiGeneralError(exception, self.provider)
+            raise await IngestApiError.apiGeneralError(exception, self.provider).send_notifications()
 
         if not response.ok:
             exc = Exception(response.reason)
             if response.status_code in (401, 403):
-                raise IngestApiError.apiAuthError(exc, self.provider)
+                raise await IngestApiError.apiAuthError(exc, self.provider).send_notifications()
             elif response.status_code == 404:
-                raise IngestApiError.apiNotFoundError(exc, self.provider)
+                raise await IngestApiError.apiNotFoundError(exc, self.provider).send_notifications()
             else:
-                raise IngestApiError.apiGeneralError(exc, self.provider)
+                raise await IngestApiError.apiGeneralError(exc, self.provider).send_notifications()
 
         return response
 
@@ -224,7 +226,7 @@ class HTTPFeedingServiceBase(FeedingService):
         request_kwargs.setdefault("timeout", self.HTTP_TIMEOUT)
         return download_file_from_url(url, request_kwargs, self.session)
 
-    def update(self, provider, update):
+    async def update(self, provider, update):
         self.provider = provider
-        self.validate_config()
-        return super().update(provider, update)
+        await self.validate_config()
+        return await super().update(provider, update)

--- a/superdesk/io/feeding_services/http_service.py
+++ b/superdesk/io/feeding_services/http_service.py
@@ -72,7 +72,7 @@ class HTTPFeedingService(FeedingService, metaclass=ABCMeta):
 
         auth_url = provider.get("config", {}).get("auth_url", None)
         if not auth_url:
-            raise IngestApiError.apiGeneralError(
+            raise await IngestApiError.apiGeneralError(
                 provider=provider,
                 exception=KeyError(
                     """
@@ -82,7 +82,7 @@ class HTTPFeedingService(FeedingService, metaclass=ABCMeta):
                         provider["name"]
                     )
                 ),
-            )
+            ).send_notifications()
 
         payload = {
             "username": provider.get("config", {}).get("username", ""),
@@ -96,6 +96,7 @@ class HTTPFeedingService(FeedingService, metaclass=ABCMeta):
             except Exception:
                 err = IngestApiError.apiAuthError(provider=provider)
                 await self.close_provider(provider, err, force=True)
+                await err.send_notifications()
                 raise err
 
         tree = etree.fromstring(response.content)  # workaround for http mock lib

--- a/superdesk/io/feeding_services/ritzau.py
+++ b/superdesk/io/feeding_services/ritzau.py
@@ -48,48 +48,60 @@ class RitzauFeedingService(HTTPFeedingServiceBase):
     # auth is done with params
     HTTP_AUTH = False
 
-    def _update(self, provider, update):
+    async def _update(self, provider, update):
         config = self.config
         try:
             user, password = self.config["username"], self.config["password"]
         except KeyError:
-            SuperdeskIngestError.notConfiguredError(Exception("username and password are needed"))
+            raise await SuperdeskIngestError.notConfiguredError(
+                Exception("username and password are needed")
+            ).send_notifications()
 
         url_override = config.get("url", "").strip()
-        if not url_override.startswith("http"):
-            SuperdeskIngestError.notConfiguredError(Exception("if URL is set, it must be a valid http link"))
+        if url_override and not url_override.startswith("http"):
+            raise await SuperdeskIngestError.notConfiguredError(
+                Exception("if URL is set, it must be a valid http link")
+            ).send_notifications()
 
         if url_override:
             params = {"user": user, "password": password, "maksAntal": 50}
         else:
             params = {"user": user, "password": password, "maksAntal": 50, "waitAcknowledge": "true"}
 
-        r = self.get_url(url_override, params=params)
+        r = await self.get_url(url_override, params=params)
 
         try:
             root_elt = etree.fromstring(r.text)
         except Exception:
-            raise IngestApiError.apiRequestError(Exception("error while parsing the request answer"))
+            raise await IngestApiError.apiRequestError(
+                Exception("error while parsing the request answer")
+            ).send_notifications()
 
         try:
             if root_elt.xpath("(//error/text())[1]")[0] != "0":
                 err_msg = root_elt.xpath("(//errormsg/text())[1]")[0]
-                raise IngestApiError.apiRequestError(Exception("error code returned by API: {msg}".format(msg=err_msg)))
+                raise await IngestApiError.apiRequestError(
+                    Exception("error code returned by API: {msg}".format(msg=err_msg))
+                ).send_notifications()
         except IndexError:
-            raise IngestApiError.apiRequestError(Exception("Invalid XML, <error> element not found"))
+            raise await IngestApiError.apiRequestError(
+                Exception("Invalid XML, <error> element not found")
+            ).send_notifications()
 
-        parser = self.get_feed_parser(provider)
+        parser = await self.get_feed_parser(provider)
         items = []
         for elt in root_elt.xpath("//RBNews"):
-            item = parser.parse(elt, provider)
+            item = await parser.parse(elt, provider)
             items.append(item)
             if not url_override:
                 try:
                     queue_id = elt.xpath(".//ServiceQueueId/text()")[0]
                 except IndexError:
-                    raise IngestApiError.apiRequestError(Exception("missing ServiceQueueId element"))
+                    raise await IngestApiError.apiRequestError(
+                        Exception("missing ServiceQueueId element")
+                    ).send_notifications()
                 ack_params = {"user": user, "password": password, "servicequeueid": queue_id}
-                self.get_url(URL_ACK, params=ack_params)
+                await self.get_url(URL_ACK, params=ack_params)
 
         return [items]
 

--- a/superdesk/io/feeding_services/rss.py
+++ b/superdesk/io/feeding_services/rss.py
@@ -146,15 +146,15 @@ class RSSFeedingService(HTTPFeedingServiceBase):
 
         return url
 
-    def _test(self, provider):
+    async def _test(self, provider):
         """Test connection."""
         self.provider = provider
-        xml = self._fetch_data()
+        xml = await self._fetch_data()
         data = feedparser.parse(xml)
         if data.bozo:
-            raise ParserError.parseMessageError(data.bozo_exception, provider)
+            raise await ParserError.parseMessageError(data.bozo_exception, provider).send_notifications()
 
-    def _update(self, provider, update):
+    async def _update(self, provider, update):
         """
         Check data provider for data updates and returns new items (if any).
 
@@ -165,12 +165,12 @@ class RSSFeedingService(HTTPFeedingServiceBase):
         :raises IngestApiError: if data retrieval error occurs
         :raises ParserError: if retrieved RSS data cannot be parsed
         """
-        xml_data = self._fetch_data()
+        xml_data = await self._fetch_data()
 
         try:
             data = feedparser.parse(xml_data)
         except Exception as ex:
-            raise ParserError.parseMessageError(ex, provider, data=xml_data)
+            raise await ParserError.parseMessageError(ex, provider, data=xml_data).send_notifications()
 
         # If provider last updated time is not available, set it to 1.1.1970
         # so that it will be recognized as "not up to date".
@@ -209,7 +209,7 @@ class RSSFeedingService(HTTPFeedingServiceBase):
 
         return [new_items]
 
-    def _fetch_data(self):
+    async def _fetch_data(self):
         """Fetch the latest feed data.
 
         :return: fetched RSS data
@@ -220,7 +220,7 @@ class RSSFeedingService(HTTPFeedingServiceBase):
         """
         url = self.config["url"]
 
-        response = self.get_url(url)
+        response = await self.get_url(url)
 
         return response.content
 

--- a/superdesk/io/feeding_services/twitter.py
+++ b/superdesk/io/feeding_services/twitter.py
@@ -64,10 +64,10 @@ class TwitterFeedingService(FeedingService):
         IngestTwitterError.TwitterAPIGeneralError().get_error_description(),
     ]
 
-    def _test(self, provider):
-        self._update(provider, update=None, test=True)
+    async def _test(self, provider):
+        await self._update(provider, update=None, test=True)
 
-    def _update(self, provider, update, test=False):
+    async def _update(self, provider, update, test=False):
         config = provider.get("config", {})
         consumer_key = config.get("consumer_key", "")
         consumer_secret = config.get("consumer_secret", "")
@@ -80,10 +80,10 @@ class TwitterFeedingService(FeedingService):
         try:
             screen_names = screen_names.split(",")
         except Exception as ex:
-            raise IngestTwitterError.TwitterNoScreenNamesError(ex, provider)
+            raise await IngestTwitterError.TwitterNoScreenNamesError(ex, provider).send_notifications()
 
         if not screen_names:
-            raise IngestTwitterError.TwitterNoScreenNamesError(provider)
+            raise await IngestTwitterError.TwitterNoScreenNamesError(provider).send_notifications()
         for screen_name in screen_names:
             screen_name = screen_name.replace(" ", "")
             try:
@@ -96,18 +96,18 @@ class TwitterFeedingService(FeedingService):
             except twitter.error.TwitterError as exc:
                 # in some case python twitter error will return dict
                 if isinstance(exc.args[0], dict):
-                    raise IngestTwitterError.TwitterAPIGeneralError(exc, provider)
+                    raise await IngestTwitterError.TwitterAPIGeneralError(exc, provider).send_notifications()
                 if exc.message[0].get("code") == 34:
                     # that page does not exist
                     continue
                 elif exc.message[0].get("code") == 32:
                     # invalid credentials
-                    raise IngestTwitterError.TwitterLoginError(exc, provider)
+                    raise await IngestTwitterError.TwitterLoginError(exc, provider).send_notifications()
                 elif exc.message[0].get("code") == 88:
                     # rate limit exceeded
-                    raise IngestTwitterError.TwitterRateLimitError(exc, provider)
+                    raise await IngestTwitterError.TwitterRateLimitError(exc, provider).send_notifications()
                 else:
-                    raise IngestTwitterError.TwitterAPIGeneralError(exc, provider)
+                    raise await IngestTwitterError.TwitterAPIGeneralError(exc, provider).send_notifications()
 
             for status in statuses:
                 d = parser.parse(status.created_at)

--- a/superdesk/io/importers/__init__.py
+++ b/superdesk/io/importers/__init__.py
@@ -66,7 +66,7 @@ class ImportCommand:
             buf = buf.replace(b"\r", b"&#13;")
             xml_parser = etree.XMLParser(recover=True)
             parsed = etree.fromstring(buf, xml_parser)
-        articles = feed_parser.parse(parsed)
+        articles = await feed_parser.parse(parsed)
         updates = {ITEM_STATE: "published"}
         if profile is not None:
             updates["profile"] = profile_id

--- a/superdesk/io/ingest.py
+++ b/superdesk/io/ingest.py
@@ -41,7 +41,7 @@ class IngestResource(Resource):
 
 
 class IngestService(AsyncBaseService):
-    async def post_in_mongo_async(self, docs, **kwargs):
+    async def post_in_mongo(self, docs, **kwargs):
         for doc in docs:
             self._resolve_defaults(doc)
         await self.on_create_async(docs)
@@ -50,7 +50,7 @@ class IngestService(AsyncBaseService):
         await self.on_created_async(docs)
         return ids
 
-    async def patch_in_mongo_async(self, id, document, original):
+    async def patch_in_mongo(self, id, document, original):
         res = await self.backend.update_in_mongo_async(self.datasource, id, document, original)
         return res
 

--- a/superdesk/io/ingest_provider_model.py
+++ b/superdesk/io/ingest_provider_model.py
@@ -308,10 +308,7 @@ class IngestProviderService(AsyncBaseService):
         except KeyError:
             return
 
-        if hasattr(service, "config_test_async"):
-            await service.config_test_async(provider)
-        else:
-            service.config_test(provider)
+        await service.config_test(provider)
 
 
 superdesk.workflow_state(CONTENT_STATE.INGESTED)

--- a/superdesk/publish/formatters/email_formatter.py
+++ b/superdesk/publish/formatters/email_formatter.py
@@ -77,7 +77,7 @@ class EmailFormatter(Formatter):
                 "renditions"
             )
         except Exception as ex:
-            raise FormatterError.EmailFormatterError(ex, FormatterError)
+            raise await FormatterError.EmailFormatterError(ex, FormatterError).send_notifications()
         return [(pub_seq_num, json.dumps(doc))]
 
     def can_format(self, format_type, article):

--- a/superdesk/publish/formatters/idml_formatter/__init__.py
+++ b/superdesk/publish/formatters/idml_formatter/__init__.py
@@ -28,7 +28,7 @@ class IDMLFormatter(Formatter):
             publish_seq_num = await generate_sequence_number(subscriber)
             idml_bytes = Converter().create_idml(article)
         except Exception as e:
-            raise FormatterError.IDMLFormatterError(e, subscriber)
+            raise await FormatterError.IDMLFormatterError(e, subscriber).send_notifications()
 
         return [
             {

--- a/superdesk/publish/formatters/newsml_1_2_formatter.py
+++ b/superdesk/publish/formatters/newsml_1_2_formatter.py
@@ -80,7 +80,7 @@ class NewsML12Formatter(Formatter):
 
             return [(pub_seq_num, self.XML_ROOT + etree.tostring(newsml, encoding=self.ENCODING).decode(self.ENCODING))]
         except Exception as ex:
-            raise FormatterError.newml12FormatterError(ex, subscriber)
+            raise await FormatterError.newml12FormatterError(ex, subscriber).send_notifications()
 
     def _format_news_envelope(self, article, news_envelope, pub_seq_num):
         """

--- a/superdesk/publish/formatters/newsml_g2_formatter.py
+++ b/superdesk/publish/formatters/newsml_g2_formatter.py
@@ -110,7 +110,7 @@ class NewsMLG2Formatter(Formatter):
                 )
             ]
         except Exception as ex:
-            raise FormatterError.newmsmlG2FormatterError(ex, subscriber)
+            raise await FormatterError.newmsmlG2FormatterError(ex, subscriber).send_notifications()
 
     def _is_package(self, article):
         """Given an article returns if it is a none takes package or not

--- a/superdesk/publish/formatters/ninjs_formatter.py
+++ b/superdesk/publish/formatters/ninjs_formatter.py
@@ -182,7 +182,7 @@ class NINJSFormatter(Formatter):
             ninjs = await self._transform_to_ninjs(article, subscriber)
             return [(pub_seq_num, json.dumps(ninjs, default=json_serialize_datetime_objectId))]
         except Exception as ex:
-            raise FormatterError.ninjsFormatterError(ex, subscriber)
+            raise await FormatterError.ninjsFormatterError(ex, subscriber).send_notifications()
 
     async def _transform_to_ninjs(self, article, subscriber, recursive=True):
         ninjs = {

--- a/superdesk/publish/formatters/nitf_formatter.py
+++ b/superdesk/publish/formatters/nitf_formatter.py
@@ -151,7 +151,7 @@ class NITFFormatter(Formatter):
                 )
             ]
         except Exception as ex:
-            raise FormatterError.nitfFormatterError(ex, subscriber)
+            raise await FormatterError.nitfFormatterError(ex, subscriber).send_notifications()
 
     def get_nitf(self, article, destination, pub_seq_num):
         if get_app_config("NITF_INCLUDE_SCHEMA", False):

--- a/superdesk/publish/publish_service.py
+++ b/superdesk/publish/publish_service.py
@@ -47,7 +47,9 @@ class PublishServiceBase:
         subscriber = await SubscribersResource.get_service().find_by_id(queue_item["subscriber_id"])
 
         if not subscriber.is_active:
-            raise SubscriberError.subscriber_inactive_error(Exception("Subscriber inactive"), subscriber)
+            raise await SubscriberError.subscriber_inactive_error(
+                Exception("Subscriber inactive"), subscriber
+            ).send_notifications()
         else:
             try:
                 # "formatted_item" is the item as str
@@ -117,7 +119,7 @@ class PublishServiceBase:
 
             await PublishQueueResource.get_service().update(queue_item_id, item_update)
         except Exception as ex:
-            raise PublishQueueError.item_update_error(ex)
+            raise await PublishQueueError.item_update_error(ex).send_notifications()
 
     @classmethod
     def get_file_extension(cls, queue_item):

--- a/superdesk/publish/transmitters/amazon_sqs_fifo.py
+++ b/superdesk/publish/transmitters/amazon_sqs_fifo.py
@@ -30,7 +30,7 @@ class AmazonSQSFIFOPublishService(publish_service.PublishService):
 
     NAME = "Amazon SQS FIFO"
 
-    def _transmit(self, queue_item, subscriber):
+    async def _transmit(self, queue_item, subscriber):
         destination = queue_item.get("destination") or {}
         config = destination.get("config") or {}
 
@@ -49,11 +49,11 @@ class AmazonSQSFIFOPublishService(publish_service.PublishService):
                 MessageGroupId=config.get("message_group_id"),
             )
         except (EndpointConnectionError, ConnectionClosedError, NewConnectionError) as error:
-            raise PublishAmazonSQSError.connectionError(error, destination)
+            raise await PublishAmazonSQSError.connectionError(error, destination).send_notifications()
         except ClientError as error:
-            raise PublishAmazonSQSError.clientError(error, destination)
+            raise await PublishAmazonSQSError.clientError(error, destination).sendMessageError()
         except Exception as error:
-            raise PublishAmazonSQSError.sendMessageError(error, destination)
+            raise await PublishAmazonSQSError.sendMessageError(error, destination).send_notifications()
 
     def _transmit_media(self, media, destination):
         # Not supported

--- a/superdesk/publish/transmitters/email.py
+++ b/superdesk/publish/transmitters/email.py
@@ -36,7 +36,7 @@ class EmailPublishService(PublishService):
 
     NAME = "Email"
 
-    def _transmit(self, queue_item, subscriber):
+    async def _transmit(self, queue_item, subscriber):
         config = queue_item.get("destination", {}).get("config", {})
 
         try:
@@ -52,7 +52,9 @@ class EmailPublishService(PublishService):
             recipients = [r.strip() for r in config.get("recipients", "").split(";") if r.strip()]
             bcc = [r.strip() for r in config.get("recipients_bcc", "").split(";") if r.strip()]
             if not recipients and not bcc:
-                raise PublishEmailError.recipientNotFoundError(LookupError("recipient and bcc fields are empty!"))
+                raise await PublishEmailError.recipientNotFoundError(
+                    LookupError("recipient and bcc fields are empty!")
+                ).send_notifications()
 
             subject = item.get("message_subject", "Story: {}".format(queue_item["item_id"]))
             text_body = item.get("message_text", queue_item["formatted_item"])
@@ -96,7 +98,7 @@ class EmailPublishService(PublishService):
             )
 
         except Exception as ex:
-            raise PublishEmailError.emailError(ex, queue_item.get("destination"))
+            raise await PublishEmailError.emailError(ex, queue_item.get("destination")).send_notifications()
 
 
 register_transmitter("email", EmailPublishService(), errors)

--- a/superdesk/publish/transmitters/file_output.py
+++ b/superdesk/publish/transmitters/file_output.py
@@ -24,7 +24,7 @@ class FilePublishService(publish_service.PublishService):
 
     NAME = "File"
 
-    def _transmit(self, queue_item, subscriber):
+    async def _transmit(self, queue_item, subscriber):
         try:
             config = queue_item["destination"]["config"]
             file_path = config["file_path"]
@@ -33,7 +33,7 @@ class FilePublishService(publish_service.PublishService):
             with open(path.join(file_path, publish_service.get_publish_service().get_filename(queue_item)), "wb") as f:
                 f.write(queue_item["encoded_item"])
         except Exception as ex:
-            raise PublishFileError.fileSaveError(ex, config)
+            raise await PublishFileError.fileSaveError(ex, config).send_notifications()
 
 
 register_transmitter("File", FilePublishService(), errors)

--- a/superdesk/publish/transmitters/ftp.py
+++ b/superdesk/publish/transmitters/ftp.py
@@ -67,7 +67,7 @@ class FTPPublishService(PublishService):
         config = queue_item.get("destination", {}).get("config", {})
 
         try:
-            with ftp_connect(config) as ftp:
+            async with ftp_connect(config) as ftp:
                 if config.get("push_associated", False):
                     # Set the working directory for the associated files
                     if "associated_path" in config and config.get("associated_path"):
@@ -87,7 +87,7 @@ class FTPPublishService(PublishService):
         except PublishFtpError:
             raise
         except Exception as ex:
-            raise PublishFtpError.ftpError(ex, queue_item.get("destination"))
+            raise await PublishFtpError.ftpError(ex, queue_item.get("destination")).send_notifications()
 
     def _copy_published_media_files(self, item, ftp):
         media = {}

--- a/superdesk/publish/transmitters/http_push.py
+++ b/superdesk/publish/transmitters/http_push.py
@@ -200,13 +200,13 @@ class HTTPPushService(PublishService):
     def _get_resource_url(self, destination):
         return destination.get("config", {}).get("resource_url")
 
-    def _raise_publish_error(self, status_code, e, destination=None):
+    async def _raise_publish_error(self, status_code, e, destination=None):
         if status_code >= 400 and status_code < 500:
-            raise PublishHTTPPushClientError.httpPushError(e, destination)
+            raise await PublishHTTPPushClientError.httpPushError(e, destination).send_notifications()
         elif status_code >= 500 and status_code < 600:
-            raise PublishHTTPPushServerError.httpPushError(e, destination)
+            raise await PublishHTTPPushServerError.httpPushError(e, destination).send_notifications()
         else:
-            raise PublishHTTPPushError.httpPushError(e, destination)
+            raise await PublishHTTPPushError.httpPushError(e, destination).send_notifications()
 
 
 register_transmitter("http_push", HTTPPushService(), errors)

--- a/superdesk/publish/transmitters/odbc.py
+++ b/superdesk/publish/transmitters/odbc.py
@@ -36,7 +36,7 @@ class ODBCPublishService(PublishService):
 
     NAME = "ODBC"
 
-    def _transmit(self, queue_item, subscriber):
+    async def _transmit(self, queue_item, subscriber):
         """
         Transmit the given formatted item to the configured ODBC output.
 
@@ -44,7 +44,7 @@ class ODBCPublishService(PublishService):
         """
 
         if not get_app_config("ODBC_PUBLISH") or not pyodbc_available:
-            raise PublishODBCError()
+            raise await PublishODBCError().send_notifications()
 
         config = queue_item.get("destination", {}).get("config", {})
 
@@ -56,7 +56,7 @@ class ODBCPublishService(PublishService):
                 conn.commit()
             return ret
         except Exception as ex:
-            raise PublishODBCError.odbcError(ex, config)
+            raise await PublishODBCError.odbcError(ex, config).send_notifications()
 
     def _CallStoredProc(self, conn, procName, paramDict):
         params = ""

--- a/superdesk/publish_async/formatters/base_exchange_formatter.py
+++ b/superdesk/publish_async/formatters/base_exchange_formatter.py
@@ -372,6 +372,6 @@ class BasePublishExchangeFormatter(PublishExchangeFormatter):
                     msg = gettext("Can not find package {package} published item {item}").format(
                         package=package["item_id"], item=ref["residRef"]
                     )
-                    raise SuperdeskPublishError(500, msg)
+                    raise await SuperdeskPublishError(500, msg).send_notifications()
                 package_item[ID_FIELD] = package_item["item_id"]
                 ref["package_item"] = package_item

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -797,21 +797,21 @@ async def fetch_from_provider(context, provider_name, guid, routing_scheme=None,
             file_path = os.path.join(provider.get("config", {}).get("path_fixtures", ""), guid)
         else:
             file_path = os.path.join(provider.get("config", {}).get("path", ""), guid)
-        feeding_parser = provider_service.get_feed_parser(provider)
+        feeding_parser = await provider_service.get_feed_parser(provider)
         if isinstance(feeding_parser, STTNewsMLFeedParser):
             with open(file_path, "rb") as f:
                 xml_string = etree.etree.fromstring(f.read())
-                items = feeding_parser.parse(xml_string, provider)
+                items = await feeding_parser.parse(xml_string, provider)
         elif isinstance(feeding_parser, XMLFeedParser):
             with open(file_path, "rb") as f:
                 xml_string = etree.etree.fromstring(f.read())
-                items = [feeding_parser.parse(xml_string, provider)]
+                items = [await feeding_parser.parse(xml_string, provider)]
         elif isinstance(feeding_parser, EMailRFC822FeedParser):
             with open(file_path, "rb") as f:
                 data = f.read()
-                items = feeding_parser.parse([(1, data)], provider)
+                items = await feeding_parser.parse([(1, data)], provider)
         else:
-            parsed = feeding_parser.parse(file_path, provider)
+            parsed = await feeding_parser.parse(file_path, provider)
             items = [parsed] if not isinstance(parsed, list) else parsed
     else:
         provider_service.provider = provider
@@ -3097,10 +3097,11 @@ async def setp_impl_when_we_init_data(context, entity):
 
 
 @when('we run task "{name}"')
-def when_we_run_task(context, name):
+@async_run_until_complete
+async def when_we_run_task(context, name):
     task = celery.signature(name)
     assert task is not None
-    task.apply()
+    await task.apply()
 
 
 @when('the lock expires "{url}"')

--- a/tests/audit_purge_test.py
+++ b/tests/audit_purge_test.py
@@ -29,5 +29,5 @@ class AuditTestCase(TestCase):
             ],
         )
         self.app.config["AUDIT_EXPIRY_MINUTES"] = 5
-        PurgeAudit().run()
+        await PurgeAudit().run()
         self.assertEqual(get_resource_service("audit").find({}).count(), 1)

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -399,13 +399,13 @@ class ErrorsTestCase(TestCase):
             "Testing nitfParserError on channel TestProvider",
         )
 
-    def test_raise_providerAddError(self):
+    async def test_raise_providerAddError(self):
         with self.assertRaises(ProviderError) as error_context:
             try:
                 ex = Exception("Testing providerAddError")
                 raise ex
             except Exception:
-                raise ProviderError.providerAddError(ex, self.provider)
+                raise await ProviderError.providerAddError(ex, self.provider).send_notifications()
         exception = error_context.exception
         self.assertTrue(exception.code == 2001)
         self.assertTrue(exception.message == "Provider could not be saved")
@@ -418,13 +418,13 @@ class ErrorsTestCase(TestCase):
             "Testing providerAddError on channel TestProvider",
         )
 
-    def test_raise_expiredContentError(self):
+    async def test_raise_expiredContentError(self):
         with self.assertRaises(ProviderError) as error_context:
             try:
                 ex = Exception("Testing expiredContentError")
                 raise ex
             except Exception:
-                raise ProviderError.expiredContentError(ex, self.provider)
+                raise await ProviderError.expiredContentError(ex, self.provider).send_notifications()
         exception = error_context.exception
         self.assertTrue(exception.code == 2002)
         self.assertTrue(exception.message == "Expired content could not be removed")
@@ -437,13 +437,13 @@ class ErrorsTestCase(TestCase):
             "Testing expiredContentError on channel TestProvider",
         )
 
-    def test_raise_ruleError(self):
+    async def test_raise_ruleError(self):
         with self.assertRaises(ProviderError) as error_context:
             try:
                 ex = Exception("Testing ruleError")
                 raise ex
             except Exception:
-                raise ProviderError.ruleError(ex, self.provider)
+                raise await ProviderError.ruleError(ex, self.provider).send_notifications()
         exception = error_context.exception
         self.assertTrue(exception.code == 2003)
         self.assertTrue(exception.message == "Rule could not be applied")
@@ -455,13 +455,13 @@ class ErrorsTestCase(TestCase):
             "ProviderError Error 2003 - Rule could not be applied: " "Testing ruleError on channel TestProvider",
         )
 
-    def test_raise_ingestError(self):
+    async def test_raise_ingestError(self):
         with self.assertRaises(ProviderError) as error_context:
             try:
                 ex = Exception("Testing ingestError")
                 raise ex
             except Exception:
-                raise ProviderError.ingestError(ex, self.provider)
+                raise await ProviderError.ingestError(ex, self.provider).send_notifications()
         exception = error_context.exception
         self.assertTrue(exception.code == 2004)
         self.assertTrue(exception.message == "Ingest error")
@@ -474,13 +474,13 @@ class ErrorsTestCase(TestCase):
             "ProviderError Error 2004 - Ingest error: " "Testing ingestError on channel TestProvider",
         )
 
-    def test_raise_anpaError(self):
+    async def test_raise_anpaError(self):
         with self.assertRaises(ProviderError) as error_context:
             try:
                 ex = Exception("Testing anpaError")
                 raise ex
             except Exception:
-                raise ProviderError.anpaError(ex, self.provider)
+                raise await ProviderError.anpaError(ex, self.provider).send_notifications()
         exception = error_context.exception
         self.assertTrue(exception.code == 2005)
         self.assertTrue(exception.message == "Anpa category error")
@@ -492,13 +492,13 @@ class ErrorsTestCase(TestCase):
             "ProviderError Error 2005 - Anpa category error: " "Testing anpaError on channel TestProvider",
         )
 
-    def test_raise_providerFilterExpiredContentError(self):
+    async def test_raise_providerFilterExpiredContentError(self):
         with self.assertRaises(ProviderError) as error_context:
             try:
                 ex = Exception("Testing providerFilterExpiredContentError")
                 raise ex
             except Exception:
-                raise ProviderError.providerFilterExpiredContentError(ex, self.provider)
+                raise await ProviderError.providerFilterExpiredContentError(ex, self.provider).send_notifications()
         exception = error_context.exception
         self.assertTrue(exception.code == 2006)
         self.assertTrue(exception.message == "Expired content could not be filtered")

--- a/tests/io/feed_parsers/afpnewsml12_test.py
+++ b/tests/io/feed_parsers/afpnewsml12_test.py
@@ -10,20 +10,20 @@
 
 import datetime
 import os
-import unittest
 from pytz import utc
 
+from superdesk.tests import IsolatedAsyncioTestCase
 from superdesk.etree import etree
 from superdesk.io.feed_parsers.afp_newsml_1_2 import AFPNewsMLOneFeedParser
 
 
-class TestCase(unittest.TestCase):
-    def setUp(self):
+class TestCase(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.join(dirname, "../fixtures", "afp.xml")
         provider = {"name": "Test"}
         with open(fixture, "rb") as f:
-            self.item = AFPNewsMLOneFeedParser().parse(etree.fromstring(f.read()), provider)
+            self.item = await AFPNewsMLOneFeedParser().parse(etree.fromstring(f.read()), provider)
 
     def test_headline(self):
         self.assertEqual(self.item.get("headline"), "Sweden court accepts receivership for Saab carmaker")

--- a/tests/io/feed_parsers/afpnewsmlnew_test.py
+++ b/tests/io/feed_parsers/afpnewsmlnew_test.py
@@ -12,21 +12,21 @@
 import os
 import re
 import datetime
-import unittest
 from pytz import utc
 
+from superdesk.tests import IsolatedAsyncioTestCase
 from superdesk.etree import etree
 from superdesk.io.feed_parsers.afp_newsml_1_2_new import AFPNewsMLFeedParser
 
 
-class TestCase(unittest.TestCase):
-    def setUp(self):
+class TestCase(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.join(dirname, "../fixtures", "afp20.xml")
         provider = {"name": "Test"}
         with open(fixture, "r") as f:
             xml_content = f.read().encode("iso-8859-1")
-            self.item = AFPNewsMLFeedParser().parse(etree.fromstring(xml_content), provider)
+            self.item = await AFPNewsMLFeedParser().parse(etree.fromstring(xml_content), provider)
 
     def test_headline(self):
         self.assertEqual(

--- a/tests/io/feed_parsers/ana_mpe_nitf_test.py
+++ b/tests/io/feed_parsers/ana_mpe_nitf_test.py
@@ -21,7 +21,7 @@ class TestANACase(TestCase):
         fixture = os.path.normpath(os.path.join(dirname, "../fixtures", "ana1.xml"))
         provider = {"name": "Test", "source": "ANA"}
         with open(fixture, "rb") as f:
-            self.item = ANANewsMLOneFeedParser().parse(etree.fromstring(f.read()), provider)
+            self.item = await ANANewsMLOneFeedParser().parse(etree.fromstring(f.read()), provider)
 
     def test_headline(self):
         self.assertEqual(self.item["headline"], "Wage employment balance positive in Jan-March")

--- a/tests/io/feed_parsers/anpa_tests.py
+++ b/tests/io/feed_parsers/anpa_tests.py
@@ -23,12 +23,12 @@ def fixture(filename):
 class ANPATestCase(TestCase):
     parser = ANPAFeedParser()
 
-    def open(self, filename):
+    async def open(self, filename):
         provider = {"name": "Test"}
-        return self.parser.parse(fixture(filename), provider)
+        return await self.parser.parse(fixture(filename), provider)
 
-    def test_open_anpa_file(self):
-        item = self.open("anpa-1.tst")
+    async def test_open_anpa_file(self):
+        item = await self.open("anpa-1.tst")
         self.assertEqual("text", item["type"])
         self.assertEqual("2870", item["provider_sequence"])
         self.assertEqual(1, item["priority"])
@@ -41,19 +41,19 @@ class ANPATestCase(TestCase):
         self.assertEqual("Argentina-Cancer", item["slugline"])
         self.assertEqual("2013-11-13T15:09:00+00:00", item["firstcreated"].isoformat())
 
-    def test_ed_note(self):
-        item = self.open("anpa-2.tst")
+    async def test_ed_note(self):
+        item = await self.open("anpa-2.tst")
         self.assertEqual(
             "This is part of an Associated Press investigation into the hidden costs of green energy.", item["ednote"]
         )
         self.assertEqual("1stLd-Writethru", item["anpa_take_key"])
 
-    def test_tab_content(self):
-        item = self.open("anpa-3.tst")
+    async def test_tab_content(self):
+        item = await self.open("anpa-3.tst")
         self.assertEqual("preserved", item["format"])
 
-    def test_header_lines_only(self):
-        item = self.open("anpa-4.tst")
+    async def test_header_lines_only(self):
+        item = await self.open("anpa-4.tst")
         self.assertEqual("text", item["type"])
         self.assertEqual("HTML", item["format"])
         self.assertRegex(item["body_html"], "<p>Ex-bodyguard testifies about lewd messages sent to Paltrow")

--- a/tests/io/feed_parsers/ap_anpa_test.py
+++ b/tests/io/feed_parsers/ap_anpa_test.py
@@ -44,12 +44,12 @@ class ANPATestCase(TestCase):
         ]
         self.app.data.insert("vocabularies", vocab)
 
-    def open(self, filename):
+    async def open(self, filename):
         provider = {"name": "Test"}
-        return self.parser.parse(fixture(filename), provider)
+        return await self.parser.parse(fixture(filename), provider)
 
     async def test_ed_note(self):
-        item = self.open("anpa-2.tst")
+        item = await self.open("anpa-2.tst")
         self.assertEqual(
             "This is part of an Associated Press investigation into the hidden costs of green energy.", item["ednote"]
         )
@@ -57,23 +57,23 @@ class ANPATestCase(TestCase):
         self.assertEqual("i", item["anpa_category"][0]["qcode"])
 
     async def test_subject_expansion(self):
-        item = self.open("ap_anpa-1.tst")
+        item = await self.open("ap_anpa-1.tst")
         self.assertEqual(item["subject"][0]["qcode"], "15008000")
         self.assertEqual(item["dateline"]["text"], "ATLANTA, Feb 19 AP -")
         self.assertEqual(item["anpa_category"][0]["qcode"], "s")
 
     async def test_table_story(self):
-        item = self.open("ap_anpa-2.tst")
+        item = await self.open("ap_anpa-2.tst")
         self.assertEqual(item["slugline"], "BBO--BaseballExpanded")
         self.assertEqual(item["format"], "preserved")
         self.assertGreater(item["body_html"].find("%08Baltimore;23;13;.639;_;_;8-2;L-1;16-6;7-7"), 0)
 
     async def test_unknown_category_defaults_to_i(self):
-        item = self.open("ap_anpa-3.tst")
+        item = await self.open("ap_anpa-3.tst")
         self.assertEqual(item["anpa_category"][0]["qcode"], "i")
 
     async def test_ed_note_with_parentesis(self):
-        item = self.open("ap_anpa-4.tst")
+        item = await self.open("ap_anpa-4.tst")
         self.assertEqual(
             item["ednote"],
             "(Minor edits. A longer version of this story is available. "
@@ -81,7 +81,7 @@ class ANPATestCase(TestCase):
         )
 
     async def test_alert(self):
-        item = self.open("ap_anpa-5.tst")
+        item = await self.open("ap_anpa-5.tst")
         self.assertTrue(
             item["headline"],
             "Hawaii files court challenge to Trump administration"
@@ -90,10 +90,10 @@ class ANPATestCase(TestCase):
         )
 
     async def test_no_word_count(self):
-        item = self.open("ap_anpa-6.tst")
+        item = await self.open("ap_anpa-6.tst")
         self.assertEqual(item["slugline"], "BBO--WildCardGlance")
         self.assertEqual(item["anpa_category"], [{"qcode": "s"}])
 
     async def test_number_in_slugline(self):
-        item = self.open("ap_anpa-7.tst")
+        item = await self.open("ap_anpa-7.tst")
         self.assertEqual(item["slugline"], "10ThingstoKnow-Today")

--- a/tests/io/feed_parsers/ap_media_test.py
+++ b/tests/io/feed_parsers/ap_media_test.py
@@ -25,7 +25,7 @@ class APMediaTestCase(TestCase):
         fixture = os.path.normpath(os.path.join(dirname, "../fixtures", self.filename))
         provider = {"name": "Test"}
         with open(fixture) as fp:
-            self.item = APMediaFeedParser().parse(json.load(fp), provider)
+            self.item = await APMediaFeedParser().parse(json.load(fp), provider)
 
 
 class SimpleTestCase(APMediaTestCase):

--- a/tests/io/feed_parsers/ap_test.py
+++ b/tests/io/feed_parsers/ap_test.py
@@ -26,7 +26,7 @@ class BaseAPTestCase(TestCase):
         provider = {"name": "Test"}
         with open(fixture, "rb") as f:
             self.root_elt = etree.fromstring(f.read())
-            self.items = NewsMLTwoFeedParser().parse(self.root_elt, provider)
+            self.items = await NewsMLTwoFeedParser().parse(self.root_elt, provider)
 
 
 class APTestCase(BaseAPTestCase):

--- a/tests/io/feed_parsers/bbc_ninjs_test.py
+++ b/tests/io/feed_parsers/bbc_ninjs_test.py
@@ -26,7 +26,7 @@ class BBCNINJSTestCase(TestCase):
         with open(fixture, "r") as json_file:
             data = json_file.read()
 
-        self.items = BBCNINJSFeedParser().parse(data, provider)
+        self.items = await BBCNINJSFeedParser().parse(data, provider)
 
 
 class SimpleTestCase(BBCNINJSTestCase):

--- a/tests/io/feed_parsers/dpa_test.py
+++ b/tests/io/feed_parsers/dpa_test.py
@@ -23,12 +23,12 @@ def fixture(filename):
 class DPAIptcTestCase(TestCase):
     parser = DPAIPTC7901FeedParser()
 
-    def open(self, filename):
+    async def open(self, filename):
         provider = {"name": "Test"}
-        return self.parser.parse(fixture(filename), provider)
+        return await self.parser.parse(fixture(filename), provider)
 
     async def test_open_iptc7901_file(self):
-        item = self.open("IPTC7901.txt")
+        item = await self.open("IPTC7901.txt")
         self.assertEqual("text", item["type"])
         self.assertEqual("062", item["ingest_provider_sequence"])
         self.assertEqual("i", item["anpa_category"][0]["qcode"])
@@ -43,7 +43,7 @@ class DPAIptcTestCase(TestCase):
         self.assertEqual(item["dateline"]["located"]["city"], "Berlin")
 
     async def test_open_dpa_copyright(self):
-        item = self.open("dpa_copyright.txt")
+        item = await self.open("dpa_copyright.txt")
         self.assertEqual("text", item["type"])
         self.assertEqual("rs", item["anpa_category"][0]["qcode"])
         self.assertEqual("Impressum", item["headline"])
@@ -51,18 +51,18 @@ class DPAIptcTestCase(TestCase):
         self.assertEqual("(Achtung)", item["anpa_take_key"])
 
     async def test_four_line_header(self):
-        item = self.open("dpa_four_line.txt")
+        item = await self.open("dpa_four_line.txt")
         self.assertEqual("Switzerland joins list of countries resisting UN migration pact", item["headline"])
         self.assertEqual("Switzerland/migration/UN", item["slugline"])
         self.assertEqual("REFILE 1ST LEAD", item["anpa_take_key"])
 
     async def test_two_line_header(self):
-        item = self.open("dpa_two_line.txt")
+        item = await self.open("dpa_two_line.txt")
         self.assertEqual("Peace talks on Yemen to take place in Sweden next month, Mattis says", item["headline"])
         self.assertEqual("Yemen/conflict", item["slugline"])
         self.assertEqual("EXTRA", item["anpa_take_key"])
 
     async def test_two_by_line_header(self):
-        item = self.open("dpa_two_by_line.txt")
+        item = await self.open("dpa_two_by_line.txt")
         self.assertEqual("Chiefs-Rams 2.0? Would be a fun Super Bowl, but don't count on it", item["headline"])
         self.assertEqual("American Football/NFL", item["slugline"])

--- a/tests/io/feed_parsers/dpanewsml_test.py
+++ b/tests/io/feed_parsers/dpanewsml_test.py
@@ -29,7 +29,7 @@ class DPANewsMLTestCase(TestCase):
         provider = {"name": "Test"}
         with open(fixture, "rb") as f:
             self.nitf = f.read()
-            self.item = self.parser.parse(etree.fromstring(self.nitf), provider)[0]
+            self.item = (await self.parser.parse(etree.fromstring(self.nitf), provider))[0]
 
     def test_headline(self):
         self.assertEqual(self.item.get("headline"), "Eintracht in London: Hintereggers Tränen und Attacke auf Reporter")

--- a/tests/io/feed_parsers/efe_nitf_tests.py
+++ b/tests/io/feed_parsers/efe_nitf_tests.py
@@ -24,7 +24,7 @@ class EFENITFTestCase(TestCase):
         provider = {"name": "Test"}
         with open(fixture) as f:
             self.nitf = f.read()
-            self.item = EFEFeedParser().parse(etree.fromstring(self.nitf), provider)
+            self.item = await EFEFeedParser().parse(etree.fromstring(self.nitf), provider)
 
     def test_item(self):
         self.assertEqual(self.item.get("headline"), "Honduran president announces Cabinet changes")

--- a/tests/io/feed_parsers/image_iptc_test.py
+++ b/tests/io/feed_parsers/image_iptc_test.py
@@ -23,7 +23,7 @@ class BaseImageIPTCTestCase(TestCase):
         self.image_path = os.path.normpath(os.path.join(dirname, "../fixtures", self.filename))
         provider = {"name": "Test"}
         parser = ImageIPTCFeedParser()
-        self.item = parser.parse(self.image_path, provider)
+        self.item = await parser.parse(self.image_path, provider)
 
 
 class ImageIPTCTestCase(BaseImageIPTCTestCase):

--- a/tests/io/feed_parsers/iptc7901_tests.py
+++ b/tests/io/feed_parsers/iptc7901_tests.py
@@ -23,12 +23,12 @@ def fixture(filename):
 class IptcTestCase(TestCase):
     parser = IPTC7901FeedParser()
 
-    def open(self, filename):
+    async def open(self, filename):
         provider = {"name": "Test"}
-        return self.parser.parse(fixture(filename), provider)
+        return await self.parser.parse(fixture(filename), provider)
 
     async def test_open_iptc7901_file(self):
-        item = self.open("IPTC7901.txt")
+        item = await self.open("IPTC7901.txt")
         self.assertEqual("text", item["type"])
         self.assertEqual("062", item["ingest_provider_sequence"])
         self.assertEqual("i", item["anpa_category"][0]["qcode"])
@@ -41,7 +41,7 @@ class IptcTestCase(TestCase):
         self.assertTrue(item["ednote"].find("## Editorial contacts"))
 
     async def test_open_iptc7901_file_odd_charset(self):
-        item = self.open("IPTC7901_odd_charset.txt")
+        item = await self.open("IPTC7901_odd_charset.txt")
         self.assertTrue(item["body_html"].find("Müller"))
         self.assertTrue(item["ednote"].find("## Editorial contacts"))
 

--- a/tests/io/feed_parsers/newsml2_parser_test.py
+++ b/tests/io/feed_parsers/newsml2_parser_test.py
@@ -31,7 +31,7 @@ class BaseNewMLTwoTestCase(unittest.TestCase):
             self.parser = NewsMLTwoFeedParser()
             self.xml = ElementTree.parse(f)
             async with app.app_context():
-                self.item = self.parser.parse(self.xml.getroot(), provider)
+                self.item = await self.parser.parse(self.xml.getroot(), provider)
 
 
 class ReutersTestCase(BaseNewMLTwoTestCase):

--- a/tests/io/feed_parsers/ninjs_test.py
+++ b/tests/io/feed_parsers/ninjs_test.py
@@ -35,7 +35,7 @@ class NINJSTestCase(TestCase):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.normpath(os.path.join(dirname, "../fixtures", self.filename))
         provider = {"name": "Test"}
-        self.items = NINJSFeedParser().parse(fixture, provider)
+        self.items = await NINJSFeedParser().parse(fixture, provider)
 
 
 class SimpleTestCase(NINJSTestCase):

--- a/tests/io/feed_parsers/nitf_tests.py
+++ b/tests/io/feed_parsers/nitf_tests.py
@@ -28,7 +28,7 @@ class NITFTestCase(TestCase):
         provider = {"name": "Test"}
         with open(fixture, "rb") as f:
             self.nitf = f.read()
-            self.item = NITFFeedParser().parse(etree.fromstring(self.nitf), provider)
+            self.item = await NITFFeedParser().parse(etree.fromstring(self.nitf), provider)
 
 
 class AAPTestCase(NITFTestCase):
@@ -240,7 +240,7 @@ class MappingTestCase(TestCase):
         provider = {"name": "Test"}
         with open(fixture, "rb") as f:
             self.nitf = f.read()
-            self.item = NITFFeedParser().parse(etree.fromstring(self.nitf), provider)
+            self.item = await NITFFeedParser().parse(etree.fromstring(self.nitf), provider)
 
     def test_update_and_hook(self):
         subjects = self.item.get("subject")

--- a/tests/io/feed_parsers/pa_nitf_test.py
+++ b/tests/io/feed_parsers/pa_nitf_test.py
@@ -26,7 +26,7 @@ class PANITFFileTestCase(TestCase):
         provider = {"name": "Test"}
         with open(fixture, "rb") as f:
             xml = etree.parse(f)
-            self.item = PAFeedParser().parse(xml.getroot(), provider)
+            self.item = await PAFeedParser().parse(xml.getroot(), provider)
 
 
 class PAFileWithNoSubjects(PANITFFileTestCase):

--- a/tests/io/feed_parsers/rfc822_parser_test.py
+++ b/tests/io/feed_parsers/rfc822_parser_test.py
@@ -35,7 +35,7 @@ class RFC822TestCase(TestCase):
         with open(fixture, mode="rb") as f:
             bytes = f.read()
         parser = EMailRFC822FeedParser()
-        self.items = parser.parse([(1, bytes)], provider)
+        self.items = await parser.parse([(1, bytes)], provider)
 
     def test_headline(self):
         self.assertEqual(self.items[0]["headline"], "Test message 1234")
@@ -61,7 +61,7 @@ class RFC822ComplexTestCase(TestCase):
         with open(fixture, mode="rb") as f:
             bytes = f.read()
         parser = EMailRFC822FeedParser()
-        self.items = parser.parse([(1, bytes)], provider)
+        self.items = await parser.parse([(1, bytes)], provider)
 
     def test_composite(self):
         self.assertEqual(len(self.items), 3)
@@ -86,7 +86,7 @@ class RFC822OddCharSetTestCase(TestCase):
         with open(fixture, mode="rb") as f:
             bytes = f.read()
         parser = EMailRFC822FeedParser()
-        self.items = parser.parse([(1, bytes)], provider)
+        self.items = await parser.parse([(1, bytes)], provider)
 
     def test_headline(self):
         # This tests a subject that fails to decode but we just try a string conversion
@@ -107,7 +107,7 @@ class RFC822CharSetInSubjectTestCase(TestCase):
         with open(fixture, mode="rb") as f:
             bytes = f.read()
         parser = EMailRFC822FeedParser()
-        self.items = parser.parse([(1, bytes)], provider)
+        self.items = await parser.parse([(1, bytes)], provider)
 
     def test_headline(self):
         # This test a subject that has a charset that decodes correctly
@@ -148,7 +148,7 @@ class RFC822FormattedEmailTestCase(TestCase):
             bytes = f.read()
         parser = EMailRFC822FeedParser()
 
-        self.items = parser.parse([(1, bytes)], self.provider)
+        self.items = await parser.parse([(1, bytes)], self.provider)
         self.assertEqual(self.items[0]["headline"], "TEST NZ HEADER")
         self.assertEqual(self.items[0]["task"]["desk"], 1)
         self.assertEqual(self.items[0]["original_creator"], 123)
@@ -166,7 +166,7 @@ class RFC822FormattedEmailTestCase(TestCase):
         with open(fixture, mode="rb") as f:
             bytes = f.read()
         parser = EMailRFC822FeedParser()
-        self.items = parser.parse([(1, bytes)], self.provider)
+        self.items = await parser.parse([(1, bytes)], self.provider)
         self.assertEqual(self.items[0]["headline"], "Arnold 'worried' about maroon-clad Roar")
         self.assertEqual(self.items[0]["task"]["desk"], 1)
         self.assertEqual(self.items[0]["original_creator"], 123)
@@ -194,7 +194,7 @@ class RFC822JsonEmailTestCase(TestCase):
         with open(fixture, mode="rb") as f:
             bytes = f.read()
         parser = EMailRFC822FeedParser()
-        self.items = parser.parse([(1, bytes)], self.provider)
+        self.items = await parser.parse([(1, bytes)], self.provider)
 
         self.assertEqual(self.items[0]["priority"], 5)
         self.assertEqual(self.items[0]["sign_off"], "TA")
@@ -221,7 +221,7 @@ class RFC822JsonEmailTestCase(TestCase):
 
         try:
             with self.assertRaises(IngestEmailError) as exc_context:
-                self.items = parser.parse([(1, bytes)], self.provider)
+                self.items = await parser.parse([(1, bytes)], self.provider)
         except Exception:
             self.fail("Expected exception type was not raised.")
 

--- a/tests/io/feed_parsers/ritzau_test.py
+++ b/tests/io/feed_parsers/ritzau_test.py
@@ -21,22 +21,22 @@ class BaseRitzauTestCase(TestCase):
         await super().asyncSetUp()
         self.app.data.insert("vocabularies", self.vocab)
 
-    def _parse_file(self, filename):
+    async def _parse_file(self, filename):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.normpath(os.path.join(dirname, "../fixtures", filename))
         provider = {"name": "Test"}
         with open(fixture, "rb") as f:
             self.root_elt = etree.fromstring(f.read())
-            self.item = RitzauFeedParser().parse(self.root_elt, provider)
+            self.item = await RitzauFeedParser().parse(self.root_elt, provider)
 
 
 class RitzauTestCase(BaseRitzauTestCase):
-    def test_can_parse(self):
-        self._parse_file("ritzau_news.xml")
+    async def test_can_parse(self):
+        await self._parse_file("ritzau_news.xml")
         self.assertTrue(RitzauFeedParser().can_parse(self.root_elt))
 
-    def test_content(self):
-        self._parse_file("ritzau_news.xml")
+    async def test_content(self):
+        await self._parse_file("ritzau_news.xml")
         item = self.item
         self.assertEqual(item["version"], 1)
         self.assertEqual(item["byline"], "/ritzau/")
@@ -59,8 +59,8 @@ class RitzauTestCase(BaseRitzauTestCase):
         self.assertEqual(item["priority"], 3)
         self.assertEqual(item["priority"], item["urgency"])
 
-    def test_ednote(self):
-        self._parse_file("ritzau_news_test_ednote.xml")
+    async def test_ednote(self):
+        await self._parse_file("ritzau_news_test_ednote.xml")
         self.assertEqual(
             self.item["ednote"],
             "Lasse Norman Hansen skifter til Corendon-Circus.\n"

--- a/tests/io/feed_parsers/scoop_parser_test.py
+++ b/tests/io/feed_parsers/scoop_parser_test.py
@@ -43,7 +43,7 @@ class ScoopTestCase(TestCase):
         with open(fixture, "rb") as f:
             parser = ScoopNewsMLTwoFeedParser()
             self.xml = etree.parse(f)
-            self.item = parser.parse(self.xml.getroot(), provider)
+            self.item = await parser.parse(self.xml.getroot(), provider)
 
     def test_content(self):
         self.assertEqual(

--- a/tests/io/feed_parsers/stt_newsml_test.py
+++ b/tests/io/feed_parsers/stt_newsml_test.py
@@ -24,7 +24,7 @@ class BaseSTTNewsMLTestCase(TestCase):
         with open(fixture, "rb") as f:
             parser = STTNewsMLFeedParser()
             self.xml_root = etree.parse(f).getroot()
-            self.item = parser.parse(self.xml_root, provider)
+            self.item = await parser.parse(self.xml_root, provider)
 
 
 class STTTestCase(BaseSTTNewsMLTestCase):

--- a/tests/io/feed_parsers/wenn_parser_test.py
+++ b/tests/io/feed_parsers/wenn_parser_test.py
@@ -11,24 +11,24 @@
 
 import datetime
 import os
-import unittest
 
+from superdesk.tests import IsolatedAsyncioTestCase
 from superdesk.etree import etree
 from superdesk.io.feed_parsers.wenn_parser import WENNFeedParser
 from superdesk.utc import utc
 
 
-class WENNTestCase(unittest.TestCase):
+class WENNTestCase(IsolatedAsyncioTestCase):
     filename = "wenn.xml"
 
-    def setUp(self):
+    async def asyncSetUp(self):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.normpath(os.path.join(dirname, "../fixtures", self.filename))
         provider = {"name": "Wenn"}
         with open(fixture, "rb") as f:
             self.file = f.read()
             etree.fromstring(self.file)
-            self.items = WENNFeedParser().parse(etree.fromstring(self.file), provider)
+            self.items = await WENNFeedParser().parse(etree.fromstring(self.file), provider)
 
     def test_items_counts(self):
         self.assertEqual(len(self.items), 2)

--- a/tests/io/feed_parsers/wordpress_wxr_test.py
+++ b/tests/io/feed_parsers/wordpress_wxr_test.py
@@ -13,7 +13,7 @@ import os
 import datetime
 
 from unittest import TestCase, mock
-
+from superdesk.tests import IsolatedAsyncioTestCase
 from superdesk.etree import etree
 from superdesk.io.feed_parsers import wordpress_wxr
 
@@ -82,12 +82,11 @@ def fake_update_renditions(item, url, _):
     item.update(update)
 
 
-class WPWXRTestBase(TestCase):
+class WPWXRTestBase(IsolatedAsyncioTestCase):
     filename = None
 
     @mock.patch.object(wordpress_wxr, "update_renditions", fake_update_renditions)
-    def __init__(self, methodname):
-        super().__init__(methodname)
+    async def asyncSetUp(self):
         if self.filename is None:
             return
         dirname = os.path.dirname(os.path.realpath(__file__))
@@ -98,7 +97,7 @@ class WPWXRTestBase(TestCase):
         self.ori_file = buf
         parser = etree.XMLParser(recover=True)
         parsed = etree.fromstring(buf, parser)
-        self.articles = wordpress_wxr.WPWXRFeedParser().parse(parsed, provider)
+        self.articles = await wordpress_wxr.WPWXRFeedParser().parse(parsed, provider)
 
 
 class WPWXRTestCase(WPWXRTestBase):

--- a/tests/io/feeding_service_tests.py
+++ b/tests/io/feeding_service_tests.py
@@ -16,13 +16,13 @@ class TestFeedingService(FeedingService):
 
 
 class FeedingServiceParserTestCase(TestCase):
-    def test_restricted_parser(self):
+    async def test_restricted_parser(self):
         feeding_service = TestFeedingService()
         with patch.dict(
             "superdesk.io.feeding_services.restricted_feeding_service_parsers", {"test_feeding": {"ninjs": True}}
         ):
             with self.assertRaises(SuperdeskIngestError):
-                feeding_service.config_test({"feed_parser": "foo", "feeding_service": "test_feeding"})
+                await feeding_service.config_test({"feed_parser": "foo", "feeding_service": "test_feeding"})
 
     def test_add_timestamps_warning(self):
         item = {}

--- a/tests/io/feeding_services/ap_media_test.py
+++ b/tests/io/feeding_services/ap_media_test.py
@@ -72,7 +72,7 @@ class APTestCase(TestCase):
         provider["config"]["api_url"] = "https://a.b.c/media/v/content/feed"
         service = APMediaFeedingService()
         service.provider = provider
-        items = service._update(provider, {})[0]
+        items = (await service._update(provider, {}))[0]
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].get("headline"), "headline")
 
@@ -108,7 +108,7 @@ class APTestCase(TestCase):
         provider["config"]["next_link"] = ""
         service = APMediaFeedingService()
         service.provider = provider
-        items = service._update(provider, {})[0]
+        items = (await service._update(provider, {}))[0]
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].get("headline"), "BC-BBN--Top Ten")
         self.assertEqual(items[0].get("slugline"), "BBN--Top Ten")

--- a/tests/io/feeding_services/ap_test.py
+++ b/tests/io/feeding_services/ap_test.py
@@ -49,7 +49,7 @@ class APTestCase(TestCase):
         service.provider = provider
         mock_get = service.session.get.return_value
         mock_get.content = self.feed_raw
-        items = service._update(provider, {})[0]
+        items = (await service._update(provider, {}))[0]
         self.assertEqual(len(items), 3)
 
     @mock.patch.object(http_base_service, "requests")
@@ -73,7 +73,7 @@ class APTestCase(TestCase):
         self.assertNotIn("private", provider)
         with mock.patch.object(feed_parser, "parse"):
             update = {}
-            items = service._update(provider, update)[0]
+            items = (await service._update(provider, update))[0]
             items.reverse.assert_called_once_with()
             provider.update(update)
 
@@ -81,5 +81,5 @@ class APTestCase(TestCase):
         # private data must now be present
         self.assertIn("private", provider)
         with mock.patch.object(feed_parser, "parse"):
-            items = service._update(provider, {})[0]
+            items = (await service._update(provider, {}))[0]
             items.reverse.assert_not_called()

--- a/tests/io/feeding_services/ftp_tests.py
+++ b/tests/io/feeding_services/ftp_tests.py
@@ -22,6 +22,7 @@ from superdesk.tests import setup
 from superdesk.tests import TestCase as CoreTestCase
 from superdesk.io.feeding_services import ftp
 from superdesk.utc import utcnow, utc
+from superdesk.default_settings import FTP_INGEST_FILES_LIST_LIMIT
 
 PREFIX = "test_superdesk_"
 PROVIDER = {
@@ -51,13 +52,13 @@ def ftp_file(filename, modify):
     return [filename, facts]
 
 
-def ingest_items(generator, ingest_status=True):
+async def ingest_items(generator, ingest_status=True):
     failed = None
     while True:
         try:
-            item = generator.send(failed)
+            item = await generator.asend(failed)
             failed = set([item["guid"]]) if not ingest_status else set()
-        except StopIteration:
+        except StopAsyncIteration:
             break
 
 
@@ -88,6 +89,20 @@ class FakeFTP(mock.MagicMock):
         pass
 
 
+def mock_ftp_connect(ftp_class: type[FakeFTP] = FakeFTP):
+    class FakeFTPContext:
+        def __init__(self):
+            self.ftp = ftp_class()
+
+        async def __aenter__(self):
+            return self.ftp
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    return FakeFTPContext()
+
+
 class FakeFTPRecentFiles(FakeFTP):
     files = [
         ftp_file("old_file.xml", "20170517164756"),
@@ -97,10 +112,8 @@ class FakeFTPRecentFiles(FakeFTP):
     ]
 
 
-class FakeFeedParser(mock.MagicMock):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        del self.ALLOWED_EXT
+class FakeFeedParser(mock.AsyncMock):
+    ALLOWED_EXT = ftp.FTPFeedingService.ALLOWED_EXT_DEFAULT
 
 
 class FailingFakeFeedParser(FakeFeedParser):
@@ -123,6 +136,10 @@ class TestCase(CoreTestCase):
 
 
 class FTPTestCase(TestCase):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.app.config["FTP_INGEST_FILES_LIST_LIMIT"] = FTP_INGEST_FILES_LIST_LIMIT
+
     def test_it_can_connect(self):
         service = ftp.FTPFeedingService()
 
@@ -150,10 +167,10 @@ class FTPTestCase(TestCase):
             shutil.rmtree(folder)
 
     @mock.patch.object(os.path, "getsize", return_value=3)
-    @mock.patch.object(ftp, "ftp_connect", new_callable=FakeFTP)
-    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", FakeFeedParser())
+    @mock.patch.object(ftp, "ftp_connect", return_value=mock_ftp_connect())
+    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", return_value=FakeFeedParser())
     @mock.patch("builtins.open", mock.mock_open())
-    def test_move_ingested(self, ftp_connect, *args):
+    async def test_move_ingested(self, feed_parser, ftp_connect, *args):
         """Check that ingested file is moved if "move" is set
 
         feature requested in SDESK-468
@@ -161,19 +178,19 @@ class FTPTestCase(TestCase):
         provider = copy.deepcopy(PROVIDER)
         service = ftp.FTPFeedingService()
         service._is_empty = mock.MagicMock(return_value=False)
-        ingest_items(service.update(provider, {}))
+        await ingest_items(await service.update(provider, {}))
 
-        mock_ftp = ftp_connect.return_value.__enter__.return_value
+        mock_ftp = ftp_connect.return_value.ftp
 
         self.assertEqual(mock_ftp.rename.call_count, len(FakeFTP.files))
         for i, call in enumerate(mock_ftp.rename.call_args_list):
             self.assertEqual(call[0], (FakeFTP.files[i][0], "dest_move/{}".format(FakeFTP.files[i][0])))
 
     @mock.patch.object(os.path, "getsize", return_value=3)
-    @mock.patch.object(ftp, "ftp_connect", new_callable=FakeFTP)
-    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", FakeFeedParser())
+    @mock.patch.object(ftp, "ftp_connect", return_value=mock_ftp_connect())
+    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", return_value=FakeFeedParser())
     @mock.patch("builtins.open", mock.mock_open())
-    def test_move_ingested_default(self, ftp_connect, *args):
+    async def test_move_ingested_default(self, feed_parser, ftp_connect, get_size, *args):
         """Check that ingested file is moved to default path if "move" is empty string
 
         feature requested in SDESK-1452
@@ -182,8 +199,10 @@ class FTPTestCase(TestCase):
         provider["config"]["ftp_move_path"] = ""
         service = ftp.FTPFeedingService()
         service._is_empty = mock.MagicMock(return_value=False)
-        ingest_items(service.update(provider, {}))
-        mock_ftp = ftp_connect.return_value.__enter__.return_value
+        await ingest_items(await service.update(provider, {}))
+
+        print("ftp_connect.return_value = ", ftp_connect.return_value)
+        mock_ftp = ftp_connect.return_value.ftp
 
         self.assertEqual(mock_ftp.rename.call_count, len(FakeFTP.files))
         for i, call in enumerate(mock_ftp.rename.call_args_list):
@@ -192,26 +211,26 @@ class FTPTestCase(TestCase):
             )
 
     @mock.patch.object(os.path, "getsize", return_value=3)
-    @mock.patch.object(ftp, "ftp_connect", new_callable=FakeFTP)
-    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", FakeFeedParser())
+    @mock.patch.object(ftp, "ftp_connect", return_value=mock_ftp_connect())
+    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", return_value=FakeFeedParser())
     @mock.patch("builtins.open", mock.mock_open())
-    def test_move_ingested_error(self, ftp_connect, *args):
+    async def test_move_ingested_error(self, feed_parser, ftp_connect, *args):
         """Check that ingested file is moved to error path if ingest fails"""
         provider = copy.deepcopy(PROVIDER)
         provider["config"]["ftp_move_path"] = ""
         service = ftp.FTPFeedingService()
         service._is_empty = mock.MagicMock(return_value=False)
-        ingest_items(service.update(provider, {}), False)
-        mock_ftp = ftp_connect.return_value.__enter__.return_value
+        await ingest_items(await service.update(provider, {}), False)
+        mock_ftp = ftp_connect.return_value.ftp
 
         self.assertEqual(mock_ftp.rename.call_count, len(FakeFTP.files))
         for i, call in enumerate(mock_ftp.rename.call_args_list):
             self.assertEqual(call[0], (FakeFTP.files[i][0], "{}/{}".format("error", FakeFTP.files[i][0])))
 
-    @mock.patch.object(ftp, "ftp_connect", new_callable=FakeFTP)
-    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", FakeFeedParser())
+    @mock.patch.object(ftp, "ftp_connect", return_value=mock_ftp_connect())
+    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", return_value=FakeFeedParser())
     @mock.patch("builtins.open", mock.mock_open())
-    def test_move_ingested_no_move(self, ftp_connect):
+    async def test_move_ingested_no_move(self, ftp_connect, feed_parser):
         """Check that ingested file is not moved if "move" is not set
 
         feature requested in SDESK-468
@@ -219,20 +238,20 @@ class FTPTestCase(TestCase):
         provider = copy.deepcopy(PROVIDER)
         provider["config"]["move"] = False
         service = ftp.FTPFeedingService()
-        ingest_items(service.update(provider, {}))
-        mock_ftp = ftp_connect.return_value.__enter__.return_value
+        await ingest_items(await service.update(provider, {}))
+        mock_ftp = ftp_connect.return_value.ftp
         mock_ftp.rename.assert_not_called()
 
-    @mock.patch.object(ftp, "ftp_connect", new_callable=FakeFTPRecentFiles)
-    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", FakeFeedParser())
+    @mock.patch.object(ftp, "ftp_connect", return_value=mock_ftp_connect(FakeFTPRecentFiles))
+    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", return_value=FakeFeedParser())
     @mock.patch("builtins.open", mock.mock_open())
-    def test_move_backstop(self, ftp_connect):
+    async def test_move_backstop(self, feed_parser, ftp_connect):
         """Check that failing file is not moved if it's more recent thant INGEST_OLD_CONTENT_MINUTES"""
         provider = copy.deepcopy(PROVIDER)
         service = ftp.FTPFeedingService()
         service._is_empty = mock.MagicMock(return_value=False)
-        ingest_items(service.update(provider, {}))
-        mock_ftp = ftp_connect.return_value.__enter__.return_value
+        await ingest_items(await service.update(provider, {}))
+        mock_ftp = ftp_connect.return_value.ftp
 
         # recent_file must not have been ingested
         self.assertEqual(mock_ftp.rename.call_count, len(FakeFTPRecentFiles.files) - 1)
@@ -242,10 +261,10 @@ class FTPTestCase(TestCase):
                 "recent_file.xml",
             )
 
-    @mock.patch.object(ftp, "ftp_connect", new_callable=FakeFTP)
-    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", FailingFakeFeedParser())
+    @mock.patch.object(ftp, "ftp_connect", return_value=mock_ftp_connect())
+    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", return_value=FailingFakeFeedParser())
     @mock.patch("builtins.open", mock.mock_open())
-    def test_move_error(self, ftp_connect):
+    async def test_move_error(self, feed_parser, ftp_connect):
         """Check that error on ingestion moves item if "move_path_error" is set
 
         feature requested in SDESK-1452
@@ -253,17 +272,17 @@ class FTPTestCase(TestCase):
         provider = copy.deepcopy(PROVIDER)
         service = ftp.FTPFeedingService()
         service._is_empty = mock.MagicMock(return_value=False)
-        ingest_items(service.update(provider, {}))
-        mock_ftp = ftp_connect.return_value.__enter__.return_value
+        await ingest_items(await service.update(provider, {}))
+        mock_ftp = ftp_connect.return_value.ftp
 
         self.assertEqual(mock_ftp.rename.call_count, len(FakeFTP.files))
         for i, call in enumerate(mock_ftp.rename.call_args_list):
             self.assertEqual(call[0], (FakeFTP.files[i][0], "error/{}".format(FakeFTP.files[i][0])))
 
-    @mock.patch.object(ftp, "ftp_connect", new_callable=FakeFTP)
-    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", FailingFakeFeedParser())
+    @mock.patch.object(ftp, "ftp_connect", return_value=mock_ftp_connect())
+    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", return_value=FailingFakeFeedParser())
     @mock.patch("builtins.open", mock.mock_open())
-    def test_move_error_default(self, ftp_connect):
+    async def test_move_error_default(self, feed_parser, ftp_connect):
         """Check that error on ingestion use default path if "move_path_error" is empty string
 
         feature requested in SDESK-1452
@@ -272,8 +291,8 @@ class FTPTestCase(TestCase):
         provider["config"]["move_path_error"] = ""
         service = ftp.FTPFeedingService()
         service._is_empty = mock.MagicMock(return_value=False)
-        ingest_items(service.update(provider, {}))
-        mock_ftp = ftp_connect.return_value.__enter__.return_value
+        await ingest_items(await service.update(provider, {}))
+        mock_ftp = ftp_connect.return_value.ftp
 
         self.assertEqual(mock_ftp.rename.call_count, len(FakeFTP.files))
         for i, call in enumerate(mock_ftp.rename.call_args_list):
@@ -292,10 +311,10 @@ class FTPTestCase(TestCase):
         self.assertFalse(service._is_allowed("foojson", allowed))
         self.assertFalse(service._is_allowed("foo.json.tar.gz", allowed))
 
-    @mock.patch.object(ftp, "ftp_connect", new_callable=FakeFTP)
-    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", FakeFeedParser())
+    @mock.patch.object(ftp, "ftp_connect", return_value=mock_ftp_connect())
+    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", return_value=FakeFeedParser())
     @mock.patch.object(ftp.FTPFeedingService, "_retrieve_and_parse")
-    def test_files_limit_no_move(self, *mocks):
+    async def test_files_limit_no_move(self, *mocks):
         """Test file limits when move is off
 
         feature requested in SDESK-3815
@@ -303,14 +322,14 @@ class FTPTestCase(TestCase):
         update = {}
         self.app.config["FTP_INGEST_FILES_LIST_LIMIT"] = 3
 
-        retrieve_and_parse, ftp_connect = mocks
+        retrieve_and_parse, feed_parser, ftp_connect = mocks
         provider = copy.deepcopy(PROVIDER)
         provider["config"]["move"] = False
         service = ftp.FTPFeedingService()
         service._is_empty = mock.MagicMock(return_value=False)
-        mock_ftp = ftp_connect.return_value.__enter__.return_value
+        mock_ftp = ftp_connect.return_value.ftp
 
-        ingest_items(service.update(provider, update))
+        await ingest_items(await service.update(provider, update))
         provider.update(update)
         self.assertEqual(retrieve_and_parse.call_count, 3)
         self.assertEqual(
@@ -318,7 +337,7 @@ class FTPTestCase(TestCase):
             datetime.datetime.strptime("20170517164739", "%Y%m%d%H%M%S").replace(tzinfo=utc),
         )
 
-        ingest_items(service.update(provider, update))
+        await ingest_items(await service.update(provider, update))
         provider.update(update)
         self.assertEqual(retrieve_and_parse.call_count, 8)
         self.assertEqual(
@@ -326,7 +345,7 @@ class FTPTestCase(TestCase):
             datetime.datetime.strptime("20170517164745", "%Y%m%d%H%M%S").replace(tzinfo=utc),
         )
 
-        ingest_items(service.update(provider, update))
+        await ingest_items(await service.update(provider, update))
         provider.update(update)
         self.assertEqual(retrieve_and_parse.call_count, 13)
         self.assertEqual(
@@ -334,7 +353,7 @@ class FTPTestCase(TestCase):
             datetime.datetime.strptime("20170517164746", "%Y%m%d%H%M%S").replace(tzinfo=utc),
         )
 
-        ingest_items(service.update(provider, update))
+        await ingest_items(await service.update(provider, update))
         provider.update(update)
         self.assertEqual(retrieve_and_parse.call_count, 16)
         self.assertEqual(
@@ -342,7 +361,7 @@ class FTPTestCase(TestCase):
             datetime.datetime.strptime("20170517164748", "%Y%m%d%H%M%S").replace(tzinfo=utc),
         )
 
-        ingest_items(service.update(provider, update))
+        await ingest_items(await service.update(provider, update))
         provider.update(update)
         self.assertEqual(retrieve_and_parse.call_count, 22)
         self.assertEqual(
@@ -350,7 +369,7 @@ class FTPTestCase(TestCase):
             datetime.datetime.strptime("20170517164755", "%Y%m%d%H%M%S").replace(tzinfo=utc),
         )
 
-        ingest_items(service.update(provider, update))
+        await ingest_items(await service.update(provider, update))
         provider.update(update)
         self.assertEqual(retrieve_and_parse.call_count, 24)
         self.assertEqual(
@@ -360,10 +379,10 @@ class FTPTestCase(TestCase):
 
         self.assertEqual(mock_ftp.rename.call_count, 0)
 
-    @mock.patch.object(ftp, "ftp_connect", new_callable=FakeFTP)
-    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", FakeFeedParser())
+    @mock.patch.object(ftp, "ftp_connect", return_value=mock_ftp_connect())
+    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", return_value=FakeFeedParser())
     @mock.patch.object(ftp.FTPFeedingService, "_retrieve_and_parse")
-    def test_files_limit_move(self, *mocks):
+    async def test_files_limit_move(self, *mocks):
         """Test file limits when move is on
 
         feature requested in SDESK-3815
@@ -371,17 +390,17 @@ class FTPTestCase(TestCase):
         update = {}
         self.app.config["FTP_INGEST_FILES_LIST_LIMIT"] = 3
 
-        retrieve_and_parse, ftp_connect = mocks
+        retrieve_and_parse, get_feed_parser, ftp_connect = mocks
         provider = copy.deepcopy(PROVIDER)
         service = ftp.FTPFeedingService()
         service._is_empty = mock.MagicMock(return_value=False)
-        mock_ftp = ftp_connect.return_value.__enter__.return_value
+        mock_ftp = ftp_connect.return_value.ftp
 
-        ingest_items(service.update(provider, update))
+        await ingest_items(await service.update(provider, update))
         provider.update(update)
         # emulate moving files by reducing list
-        ftp_connect().__enter__().mlsd = mock.Mock()
-        ftp_connect().__enter__().mlsd.return_value = iter(FakeFTP.files[3:])
+        mock_ftp.mlsd = mock.Mock()
+        mock_ftp.mlsd.return_value = iter(FakeFTP.files[3:])
 
         self.assertEqual(retrieve_and_parse.call_count, 3)
         self.assertEqual(
@@ -389,11 +408,11 @@ class FTPTestCase(TestCase):
             datetime.datetime.strptime("20170517164739", "%Y%m%d%H%M%S").replace(tzinfo=utc),
         )
 
-        ingest_items(service.update(provider, update))
+        await ingest_items(await service.update(provider, update))
         provider.update(update)
         # emulate moving files by reducing list
-        ftp_connect().__enter__().mlsd = mock.Mock()
-        ftp_connect().__enter__().mlsd.return_value = iter(FakeFTP.files[6:])
+        mock_ftp.mlsd = mock.Mock()
+        mock_ftp.mlsd.return_value = iter(FakeFTP.files[6:])
 
         self.assertEqual(retrieve_and_parse.call_count, 6)
         self.assertEqual(
@@ -401,11 +420,11 @@ class FTPTestCase(TestCase):
             datetime.datetime.strptime("20170517164745", "%Y%m%d%H%M%S").replace(tzinfo=utc),
         )
 
-        ingest_items(service.update(provider, update))
+        await ingest_items(await service.update(provider, update))
         provider.update(update)
         # emulate moving files by reducing list
-        ftp_connect().__enter__().mlsd = mock.Mock()
-        ftp_connect().__enter__().mlsd.return_value = iter(FakeFTP.files[9:])
+        mock_ftp.mlsd = mock.Mock()
+        mock_ftp.mlsd.return_value = iter(FakeFTP.files[9:])
 
         self.assertEqual(retrieve_and_parse.call_count, 9)
         self.assertEqual(
@@ -413,11 +432,11 @@ class FTPTestCase(TestCase):
             datetime.datetime.strptime("20170517164746", "%Y%m%d%H%M%S").replace(tzinfo=utc),
         )
 
-        ingest_items(service.update(provider, update))
+        await ingest_items(await service.update(provider, update))
         provider.update(update)
         # emulate moving files by reducing list
-        ftp_connect().__enter__().mlsd = mock.Mock()
-        ftp_connect().__enter__().mlsd.return_value = iter(FakeFTP.files[12:])
+        mock_ftp.mlsd = mock.Mock()
+        mock_ftp.mlsd.return_value = iter(FakeFTP.files[12:])
 
         self.assertEqual(retrieve_and_parse.call_count, 12)
         self.assertEqual(
@@ -425,11 +444,11 @@ class FTPTestCase(TestCase):
             datetime.datetime.strptime("20170517164748", "%Y%m%d%H%M%S").replace(tzinfo=utc),
         )
 
-        ingest_items(service.update(provider, update))
+        await ingest_items(await service.update(provider, update))
         provider.update(update)
         # emulate moving files by reducing list
-        ftp_connect().__enter__().mlsd = mock.Mock()
-        ftp_connect().__enter__().mlsd.return_value = iter(FakeFTP.files[15:])
+        mock_ftp.mlsd = mock.Mock()
+        mock_ftp.mlsd.return_value = iter(FakeFTP.files[15:])
 
         self.assertEqual(retrieve_and_parse.call_count, 15)
         self.assertEqual(
@@ -437,11 +456,11 @@ class FTPTestCase(TestCase):
             datetime.datetime.strptime("20170517164755", "%Y%m%d%H%M%S").replace(tzinfo=utc),
         )
 
-        ingest_items(service.update(provider, update))
+        await ingest_items(await service.update(provider, update))
         provider.update(update)
         # emulate moving files by reducing list
-        ftp_connect().__enter__().mlsd = mock.Mock()
-        ftp_connect().__enter__().mlsd.return_value = iter(FakeFTP.files[16:])
+        mock_ftp.mlsd = mock.Mock()
+        mock_ftp.mlsd.return_value = iter(FakeFTP.files[16:])
 
         self.assertEqual(retrieve_and_parse.call_count, 16)
         self.assertEqual(
@@ -451,17 +470,17 @@ class FTPTestCase(TestCase):
 
         self.assertEqual(mock_ftp.rename.call_count, 16)
 
-    @mock.patch.object(ftp, "ftp_connect", new_callable=FakeFTP)
-    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", FakeFeedParser())
+    @mock.patch.object(ftp, "ftp_connect", return_value=mock_ftp_connect())
+    @mock.patch.object(ftp.FTPFeedingService, "get_feed_parser", return_value=FakeFeedParser())
     @mock.patch.object(ftp.FTPFeedingService, "_retrieve_and_parse")
-    def test_allowed_extension_config(self, ftp_connect, *mocks):
+    async def test_allowed_extension_config(self, ftp_connect, *mocks):
         provider = copy.deepcopy(PROVIDER)
         service = ftp.FTPFeedingService()
         with mock.patch.object(service, "_retrieve_and_parse", return_value=True) as mock_retrieve_and_parse:
             provider["config"]["allowed_extension"] = "json"
-            ingest_items(service.update(provider, {}))
+            await ingest_items(await service.update(provider, {}))
             mock_retrieve_and_parse.assert_not_called()
 
             provider["config"]["allowed_extension"] = "json,XML"
-            ingest_items(service.update(provider, {}))
+            await ingest_items(await service.update(provider, {}))
             mock_retrieve_and_parse.assert_called()

--- a/tests/io/feeding_services/http_tests.py
+++ b/tests/io/feeding_services/http_tests.py
@@ -86,7 +86,7 @@ class GetTokenTestCase(TestCase):
         # Tests shouldn't depends on some external settings
         # this block should be run always or must be removed %)
         if provider["config"]["username"]:
-            token = TestFeedingService()._generate_auth_token(provider, update=True)
+            token = await TestFeedingService()._generate_auth_token(provider, update=True)
             self.assertNotEquals("", token)
             self.assertEqual(token, provider["tokens"]["auth_token"])
 

--- a/tests/io/feeding_services/ritzau_tests.py
+++ b/tests/io/feeding_services/ritzau_tests.py
@@ -26,8 +26,6 @@ PROVIDER = {
 class RitzauTestCase(TestCase):
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        vocab = [{}]
-        self.app.data.insert("vocabularies", vocab)
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.normpath(os.path.join(dirname, "../fixtures", "ritzau_feed.xml"))
         with open(fixture) as f:
@@ -42,5 +40,5 @@ class RitzauTestCase(TestCase):
         service.provider = provider
         mock_get = service.session.get.return_value
         mock_get.text = self.feed_raw
-        items = service._update(provider, {})[0]
+        items = (await service._update(provider, {}))[0]
         self.assertEqual(len(items), 2)

--- a/tests/io/feeding_services/rss_test.py
+++ b/tests/io/feeding_services/rss_test.py
@@ -12,7 +12,7 @@
 from datetime import datetime
 from time import struct_time
 from unittest import mock
-from unittest.mock import call, MagicMock
+from unittest.mock import call, MagicMock, AsyncMock
 
 from superdesk.tests import TestCase
 from superdesk.io.commands.update_ingest import LAST_ITEM_UPDATE
@@ -52,6 +52,9 @@ class RssError(Exception):
         self.orig_ex = orig_ex
         self.provider = provider
 
+    async def send_notifications(self):
+        return self
+
 
 class FakeIngestApiError(Exception):
     """Mocked factory for ingest API errors."""
@@ -73,6 +76,9 @@ class FakeParseError(Exception):
     @classmethod
     def parseMessageError(cls, exception=None, provider=None, data=None):
         return FakeParseError(exception)
+
+    async def send_notifications(self):
+        return self
 
 
 class RssIngestServiceTest(TestCase):
@@ -136,26 +142,26 @@ class UpdateMethodTestCase(RssIngestServiceTest):
     async def asyncSetUp(self):
         await super().asyncSetUp()
         self._hard_reset_mock(feed_parse)
-        self.instance._fetch_data = MagicMock(return_value="<rss>foo</rss>")
+        self.instance._fetch_data = AsyncMock(return_value="<rss>foo</rss>")
         self.instance._create_item = MagicMock(return_value={})
         self.instance._extract_image_links = MagicMock(return_value=[])
         self.instance._fetch_images = MagicMock()
         self.instance._wrap_into_package = MagicMock()
 
-    def test_raises_ingest_error_if_fetching_data_fails(self):
+    async def test_raises_ingest_error_if_fetching_data_fails(self):
         self.instance._fetch_data.side_effect = FakeIngestApiError
         try:
             with self.assertRaises(FakeIngestApiError):
-                self.instance._update({}, {})
+                await self.instance._update({}, {})
         except Exception:
             self.fail("Expected exception type was not raised.")
 
-    def test_raises_ingest_error_on_parse_error(self):
+    async def test_raises_ingest_error_on_parse_error(self):
         feed_parse.side_effect = Exception("Parse error!")
         with self.assertRaises(FakeParseError):
-            self.instance._update({}, {})
+            await self.instance._update({}, {})
 
-    def test_returns_items_built_from_retrieved_data(self):
+    async def test_returns_items_built_from_retrieved_data(self):
         feed_parse.return_value = MagicMock(
             entries=[
                 MagicMock(updated_parsed=struct_time([2015, 2, 25, 17, 11, 11, 2, 56, 0])),
@@ -175,13 +181,13 @@ class UpdateMethodTestCase(RssIngestServiceTest):
         )
         self.instance._create_item.side_effect = [item_1, item_2]
 
-        returned = self.instance._update({"last_updated": datetime(2015, 2, 25, 14, 0, 0)}, {})
+        returned = await self.instance._update({"last_updated": datetime(2015, 2, 25, 14, 0, 0)}, {})
 
         self.assertEqual(len(returned), 1)
         items = returned[0]
         self.assertEqual(items, [item_1, item_2])
 
-    def test_does_not_return_old_items(self):
+    async def test_does_not_return_old_items(self):
         feed_parse.return_value = MagicMock(
             entries=[
                 MagicMock(updated_parsed=struct_time([2015, 2, 25, 11, 11, 11, 2, 56, 0])),
@@ -195,13 +201,13 @@ class UpdateMethodTestCase(RssIngestServiceTest):
         )
         self.instance._create_item.return_value = item
 
-        returned = self.instance._update({LAST_ITEM_UPDATE: datetime(2015, 2, 25, 15, 0, 0)}, {})
+        returned = await self.instance._update({LAST_ITEM_UPDATE: datetime(2015, 2, 25, 15, 0, 0)}, {})
 
         self.assertEqual(len(returned), 1)
         items = returned[0]
         self.assertEqual(len(items), 0)
 
-    def test_returns_items_and_package_list_if_entry_contains_image_urls(self):
+    async def test_returns_items_and_package_list_if_entry_contains_image_urls(self):
         feed_parse.return_value = MagicMock(
             entries=[
                 MagicMock(updated_parsed=struct_time([2015, 2, 25, 17, 11, 11, 0, 0, 0])),
@@ -225,7 +231,7 @@ class UpdateMethodTestCase(RssIngestServiceTest):
         self.instance._create_image_items = MagicMock(return_value=fake_image_items)
         self.instance._create_package = MagicMock(return_value=fake_package)
 
-        returned = self.instance._update({"last_updated": datetime(1965, 2, 24)}, {})
+        returned = await self.instance._update({"last_updated": datetime(1965, 2, 24)}, {})
 
         self.instance._create_package.assert_called_with(fake_text_item, fake_image_items)
 
@@ -253,16 +259,16 @@ class FetchDataMethodTestCase(RssIngestServiceTest):
         self.fake_provider.__getitem__.return_value = self.config
         self.fake_provider.setdefault.return_value = self.config
 
-    def test_retrieves_feed_from_correct_url(self):
+    async def test_retrieves_feed_from_correct_url(self):
         self.instance.session.get.return_value = MagicMock(ok=True)
         self.config.update(dict(url="http://news.com/rss"))
 
-        self.instance._fetch_data()
+        await self.instance._fetch_data()
 
         call_args = self.instance.session.get.call_args[0]
         self.assertEqual(call_args[0], "http://news.com/rss")
 
-    def test_stores_auth_info_in_instance_if_auth_required(self):
+    async def test_stores_auth_info_in_instance_if_auth_required(self):
         self.fake_provider["config"].update(
             {
                 "url": "foo",
@@ -275,36 +281,36 @@ class FetchDataMethodTestCase(RssIngestServiceTest):
         self.instance.session.get.return_value = MagicMock(ok=False)
 
         try:
-            self.instance._update(self.fake_provider, {})
+            await self.instance._update(self.fake_provider, {})
         except Exception:
             pass
 
         self.assertEqual(self.instance.auth_info, {"username": "james", "password": "bond+007"})
 
-    def test_provides_auth_info_if_required(self):
+    async def test_provides_auth_info_if_required(self):
         self.instance.session.get.return_value = MagicMock(ok=True)
         self.config.update(dict(url="http://news.com/rss", auth_required=True, username="johndoe", password="secret"))
 
-        self.instance._fetch_data()
+        await self.instance._fetch_data()
 
         kw_call_args = self.instance.session.get.call_args[1]
         self.assertEqual(kw_call_args.get("auth"), ("johndoe", "secret"))
 
-    def test_returns_fetched_data_on_success(self):
+    async def test_returns_fetched_data_on_success(self):
         self.instance.session.get.return_value = MagicMock(ok=True, content="<rss>X</rss>")
         self.config.update(dict(url="http://news.com/rss"))
 
-        response = self.instance._fetch_data()
+        response = await self.instance._fetch_data()
 
         self.assertEqual(response, "<rss>X</rss>")
 
-    def test_raises_auth_error_on_401(self):
+    async def test_raises_auth_error_on_401(self):
         self.instance.session.get.return_value = MagicMock(ok=False, status_code=401, reason="invalid credentials")
         self.config.update(dict(url="http://news.com/rss"))
 
         try:
             with self.assertRaises(RssError) as exc_context:
-                self.instance._fetch_data()
+                await self.instance._fetch_data()
         except Exception:
             self.fail("Expected exception type was not raised.")
 
@@ -313,13 +319,13 @@ class FetchDataMethodTestCase(RssIngestServiceTest):
         self.assertEqual(ex.orig_ex.args[0], "invalid credentials")
         self.assertIs(ex.provider, self.fake_provider)
 
-    def test_raises_auth_error_on_403(self):
+    async def test_raises_auth_error_on_403(self):
         self.instance.session.get.return_value = MagicMock(ok=False, status_code=403, reason="access forbidden")
         self.config.update(dict(url="http://news.com/rss"))
 
         try:
             with self.assertRaises(RssError) as exc_context:
-                self.instance._fetch_data()
+                await self.instance._fetch_data()
         except Exception:
             self.fail("Expected exception type was not raised.")
 
@@ -328,13 +334,13 @@ class FetchDataMethodTestCase(RssIngestServiceTest):
         self.assertEqual(ex.orig_ex.args[0], "access forbidden")
         self.assertIs(ex.provider, self.fake_provider)
 
-    def test_raises_not_found_error_on_404(self):
+    async def test_raises_not_found_error_on_404(self):
         self.instance.session.get.return_value = MagicMock(ok=False, status_code=404, reason="resource not found")
         self.config.update(dict(url="http://news.com/rss"))
 
         try:
             with self.assertRaises(RssError) as exc_context:
-                self.instance._fetch_data()
+                await self.instance._fetch_data()
         except Exception:
             self.fail("Expected exception type was not raised.")
 
@@ -343,13 +349,13 @@ class FetchDataMethodTestCase(RssIngestServiceTest):
         self.assertEqual(ex.orig_ex.args[0], "resource not found")
         self.assertIs(ex.provider, self.fake_provider)
 
-    def test_raises_general_error_on_unknown_error(self):
+    async def test_raises_general_error_on_unknown_error(self):
         self.instance.session.get.return_value = MagicMock(ok=False, status_code=500, reason="server down")
         self.config.update(dict(url="http://news.com/rss"))
 
         try:
             with self.assertRaises(RssError) as exc_context:
-                self.instance._fetch_data()
+                await self.instance._fetch_data()
         except Exception:
             self.fail("Expected exception type was not raised.")
 
@@ -642,23 +648,23 @@ class CreateItemMethodTestCase(RssIngestServiceTest):
 
         self.assertEqual(item.get("abstract"), "http://news.com/1234abcd")
 
-    def test_guid_not_permalink(self):
+    async def test_guid_not_permalink(self):
         self.instance.provider = provider = {"config": {"url": "http://example.com/rss"}}
         self.instance.session.get = MagicMock()
         self.instance.session.get.return_value = RssResponse()
-        items = self.instance._update(provider, None)[0]
+        items = (await self.instance._update(provider, None))[0]
         self.assertEqual(1, len(items))
         self.assertEqual("https://www.nrk.no/finnmark/stanset-ikke-for-fotgjenger-1.13362571", items[0]["uri"])
         self.assertEqual("tag:www.nrk.no:1.13362571", items[0]["guid"])
         self.assertIn(items[0]["uri"], items[0]["body_html"])
 
-    def test_guid_not_set(self):
+    async def test_guid_not_set(self):
         self.instance.provider = provider = {"config": {"url": "http://example.com/rss"}}
         response = RssResponse()
         response.content = nrk_xml.replace('<guid isPermaLink="false">1.13362571</guid>', "")
         self.instance.session.get = MagicMock()
         self.instance.session.get.return_value = response
-        items = self.instance._update(provider, None)[0]
+        items = (await self.instance._update(provider, None))[0]
         self.assertEqual("tag:www.nrk.no:finnmark:stanset-ikke-for-fotgjenger-1.13362571", items[0]["guid"])
 
 

--- a/tests/io/get_provider_routing_test.py
+++ b/tests/io/get_provider_routing_test.py
@@ -9,7 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock
 
 from superdesk.tests import TestCase
 
@@ -38,8 +38,8 @@ class GetProviderRoutingSchemeTestCase(TestCase):
             self.funcToTest = get_provider_routing_scheme
 
         fake_superdesk.services = {
-            "routing_schemes": MagicMock(name="routing_schemes"),
-            "content_filters": MagicMock(name="content_filters"),
+            "routing_schemes": AsyncMock(name="routing_schemes"),
+            "content_filters": AsyncMock(name="content_filters"),
         }
 
     async def test_returns_none_if_no_provider_scheme_defined(self):
@@ -50,18 +50,19 @@ class GetProviderRoutingSchemeTestCase(TestCase):
     async def test_returns_scheme_config_from_db_if_scheme_defined(self):
         fake_scheme = {"_id": "abc123", "rules": []}
         schemes_service = fake_superdesk.services["routing_schemes"]
-        schemes_service.find_one.return_value = fake_scheme
+        schemes_service.find_one_async.return_value = fake_scheme
 
         fake_provider = {"routing_scheme": "abc123"}
         result = await self.funcToTest(fake_provider)
 
         # check that correct scheme has been fetched and returned
-        self.assertTrue(schemes_service.find_one.called)
-        args, kwargs = schemes_service.find_one.call_args
+        self.assertTrue(schemes_service.find_one_async.called)
+        args, kwargs = schemes_service.find_one_async.call_args
         self.assertEqual(kwargs.get("_id"), "abc123")
         self.assertEqual(result, fake_scheme)
 
-    async def test_includes_content_filters_in_returned_scheme(self):
+    @mock.patch("superdesk.io.commands.update_ingest.ContentFiltersResource.get_service")
+    async def test_includes_content_filters_in_returned_scheme(self, content_filters_service):
         fake_scheme = {
             "_id": "abc123",
             "rules": [
@@ -70,13 +71,12 @@ class GetProviderRoutingSchemeTestCase(TestCase):
             ],
         }
         schemes_service = fake_superdesk.services["routing_schemes"]
-        schemes_service.find_one.return_value = fake_scheme
+        schemes_service.find_one_async.return_value = fake_scheme
 
-        filters_service = fake_superdesk.services["content_filters"]
-        filters_service.find_one.side_effect = [
-            {"_id": "filter_id_4"},
-            {"_id": "filter_id_8"},
-        ]
+        async def get_filters_mock(filter_id):
+            return {"_id": filter_id}
+
+        content_filters_service().find_by_id_raw.side_effect = get_filters_mock
 
         fake_provider = {"routing_scheme": "abc123"}
         result = await self.funcToTest(fake_provider)

--- a/tests/io/io_tests.py
+++ b/tests/io/io_tests.py
@@ -58,20 +58,22 @@ class UtilsTest(AsyncTestCase):
             ),
         )
 
-    def test_get_xml_parser_newsmlg2(self):
+    async def test_get_xml_parser_newsmlg2(self):
         etree = get_etree("snep.xml")
         self.assertIsInstance(
-            FileFeedingService().get_feed_parser({"feed_parser": "newsml2"}, etree), NewsMLTwoFeedParser
+            await FileFeedingService().get_feed_parser({"feed_parser": "newsml2"}, etree), NewsMLTwoFeedParser
         )
 
-    def test_get_xml_parser_nitf(self):
+    async def test_get_xml_parser_nitf(self):
         etree = get_etree("nitf-fishing.xml")
-        self.assertIsInstance(FileFeedingService().get_feed_parser({"feed_parser": "nitf"}, etree), NITFFeedParser)
+        self.assertIsInstance(
+            await FileFeedingService().get_feed_parser({"feed_parser": "nitf"}, etree), NITFFeedParser
+        )
 
-    def test_get_xml_parser_newsml12(self):
+    async def test_get_xml_parser_newsml12(self):
         etree = get_etree("afp.xml")
         self.assertIsInstance(
-            FileFeedingService().get_feed_parser({"feed_parser": "newsml12"}, etree), NewsMLOneFeedParser
+            await FileFeedingService().get_feed_parser({"feed_parser": "newsml12"}, etree), NewsMLOneFeedParser
         )
 
     def test_is_old_content(self):
@@ -81,19 +83,19 @@ class UtilsTest(AsyncTestCase):
 
 
 class ItemTest(TestCase):
-    def setUpFixture(self, filename):
+    async def setUpFixture(self, filename):
         self.tree = get_etree(filename)
         provider = {"name": "Test"}
 
         for parser in registered_feed_parsers.values():
             if parser.can_parse(self.tree):
-                self.item = parser.parse(self.tree, provider)[0]
+                self.item = (await parser.parse(self.tree, provider))[0]
 
 
 class TextParserTest(ItemTest):
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        self.setUpFixture("text.xml")
+        await self.setUpFixture("text.xml")
 
     def test_instance(self):
         self.assertTrue(self.item)
@@ -138,7 +140,7 @@ class TextParserTest(ItemTest):
 class PictureParserTest(ItemTest):
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        self.setUpFixture("picture.xml")
+        await self.setUpFixture("picture.xml")
 
     def test_type(self):
         self.assertEqual("picture", self.item.get("type"))
@@ -184,7 +186,7 @@ class PictureParserTest(ItemTest):
 class SNEPParserTest(ItemTest):
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        self.setUpFixture("snep.xml")
+        await self.setUpFixture("snep.xml")
 
     def test_content_set(self):
         self.assertEqual(4, self.item.get("priority"))

--- a/tests/io/update_ingest_tests.py
+++ b/tests/io/update_ingest_tests.py
@@ -21,7 +21,7 @@ from superdesk.flask import g
 from superdesk import get_resource_service, etree
 from superdesk.utc import utcnow
 from superdesk.errors import SuperdeskApiError, ProviderError
-from superdesk.tests import TestCase, markers, utils as test_utils
+from superdesk.tests import TestCase, utils as test_utils, fixtures
 from superdesk.tests.setup_teardown import setup_providers, teardown_providers
 from superdesk.io import get_feeding_service
 from superdesk.io.commands.remove_expired_content import RemoveExpiredContent, get_expired_items
@@ -159,8 +159,8 @@ class UpdateIngestTest(TestCase):
             "and run eventually",
         )
 
-    @markers.requires_async_celery
-    async def test_change_last_updated(self):
+    @patch("superdesk.io.feeding_services.file_service.FileFeedingService._test")
+    async def test_change_last_updated(self, *mocks):
         ingest_provider = {"name": "test", "feeding_service": "file", "feed_parser": "nitf", "_etag": "test"}
         await test_utils.post_items("ingest_providers", [ingest_provider])
         await update_provider(ingest_provider)
@@ -173,12 +173,12 @@ class UpdateIngestTest(TestCase):
         items = await provider_service.fetch_ingest(reuters_guid)
         for item in items[:4]:
             item["expiry"] = utcnow() + timedelta(minutes=11)
-        self.assertEqual(4, len(filter_expired_items(provider, items)))
+        self.assertEqual(4, len(await filter_expired_items(provider, items)))
 
     async def test_filter_expired_items_with_no_expiry(self):
         provider, provider_service = await self.setup_reuters_provider()
         items = await provider_service.fetch_ingest(reuters_guid)
-        self.assertEqual(0, len(filter_expired_items(provider, items)))
+        self.assertEqual(0, len(await filter_expired_items(provider, items)))
 
     async def test_query_getting_expired_content(self):
         provider, provider_service = await self.setup_reuters_provider()
@@ -342,8 +342,8 @@ class UpdateIngestTest(TestCase):
         provider = await test_utils.find_one("ingest_providers", name=provider_name)
         file_path = os.path.join(provider.get("config", {}).get("path", ""), "IPTC7901_odd_charset.txt")
         provider_service = self._get_provider_service(provider)
-        feeding_parser = provider_service.get_feed_parser(provider)
-        items = [feeding_parser.parse(file_path, provider)]
+        feeding_parser = await provider_service.get_feed_parser(provider)
+        items = [await feeding_parser.parse(file_path, provider)]
 
         # ingest the items and check the subject code has been derived
         await self.ingest_items(items, provider, provider_service)
@@ -362,8 +362,8 @@ class UpdateIngestTest(TestCase):
         provider = await test_utils.find_one("ingest_providers", name=provider_name)
         file_path = os.path.join(provider.get("config", {}).get("path", ""), "IPTC7901_odd_charset.txt")
         provider_service = self._get_provider_service(provider)
-        feeding_parser = provider_service.get_feed_parser(provider)
-        items = [feeding_parser.parse(file_path, provider)]
+        feeding_parser = await provider_service.get_feed_parser(provider)
+        items = [await feeding_parser.parse(file_path, provider)]
 
         # ingest the items and check the subject code has been derived
         await self.ingest_items(items, provider, provider_service)
@@ -396,10 +396,10 @@ class UpdateIngestTest(TestCase):
         provider = await test_utils.find_one("ingest_providers", name=provider_name)
         file_path = os.path.join(provider.get("config", {}).get("path", ""), "nitf-fishing.xml")
         provider_service = self._get_provider_service(provider)
-        feeding_parser = provider_service.get_feed_parser(provider)
+        feeding_parser = await provider_service.get_feed_parser(provider)
         with open(file_path, "r") as f:
             xml_string = etree.etree.fromstring(f.read())
-            items = [feeding_parser.parse(xml_string, provider)]
+            items = [await feeding_parser.parse(xml_string, provider)]
             for item in items:
                 item["ingest_provider"] = provider["_id"]
                 item["expiry"] = utcnow() + timedelta(hours=11)
@@ -429,10 +429,10 @@ class UpdateIngestTest(TestCase):
         provider = await test_utils.find_one("ingest_providers", name=provider_name)
         file_path = os.path.join(provider.get("config", {}).get("path", ""), "nitf-fishing.xml")
         provider_service = self._get_provider_service(provider)
-        feeding_parser = provider_service.get_feed_parser(provider)
+        feeding_parser = await provider_service.get_feed_parser(provider)
         with open(file_path, "r") as f:
             xml_string = etree.etree.fromstring(f.read())
-            items = [feeding_parser.parse(xml_string, provider)]
+            items = [await feeding_parser.parse(xml_string, provider)]
             for item in items:
                 item["ingest_provider"] = provider["_id"]
                 item["expiry"] = utcnow() + timedelta(hours=11)
@@ -494,7 +494,7 @@ class UpdateIngestTest(TestCase):
     async def test_get_article_ids(self):
         provider_name = "reuters"
         provider, provider_service = await self.setup_reuters_provider()
-        ids = provider_service._get_article_ids("channel1", utcnow(), utcnow() + timedelta(minutes=-10))
+        ids = await provider_service._get_article_ids("channel1", utcnow(), utcnow() + timedelta(minutes=-10))
         self.assertEqual(len(ids), 3)
         provider = await test_utils.find_one("ingest_providers", name=provider_name)
         self.assertEqual(provider["tokens"]["poll_tokens"]["channel1"], "ExwaY31kfnR2Z2J1cWZ2YnxoYH9kfw==")
@@ -516,8 +516,8 @@ class UpdateIngestTest(TestCase):
         provider = await test_utils.find_one("ingest_providers", name=provider_name)
         file_path = os.path.join(provider.get("config", {}).get("path", ""), "ap_anpa-3.tst")
         provider_service = self._get_provider_service(provider)
-        feeding_parser = provider_service.get_feed_parser(provider)
-        items = [feeding_parser.parse(file_path, provider)]
+        feeding_parser = await provider_service.get_feed_parser(provider)
+        items = [await feeding_parser.parse(file_path, provider)]
 
         # ingest the items and check the subject code has been derived
         items[0]["versioncreated"] = utcnow()
@@ -667,7 +667,6 @@ class UpdateIngestTest(TestCase):
         await ingest_item(items[1], provider, provider_service)
         self.assertEqual("story", items[1].get("profile"))
 
-    @markers.requires_async_celery
     async def test_edited_planning_item_is_not_update(self):
         item = {
             "guid": "urn:onclusive:4112034",
@@ -689,7 +688,8 @@ class UpdateIngestTest(TestCase):
                 "all_day": True,
             },
         }
-        g.user = {"_id": "current_user_id"}
+        await test_utils.post_items("users", [fixtures.users.admin()])
+        g.user = {"_id": fixtures.users.ADMIN_USER_ID}
 
         provider = {
             "_id": "asdnjsandkajsdnjkasnd",
@@ -705,22 +705,21 @@ class UpdateIngestTest(TestCase):
         self.assertTrue(ingested)
         self.assertIn(item["guid"], ids)
 
-        dest = list(event_service.get_from_mongo(req=None, lookup={"guid": item["guid"]}))[0]
+        dest = await (await event_service.get_from_mongo_async(req=None, lookup={"guid": item["guid"]})).next()
         self.assertEqual(dest["name"], "Annual Forum on Anti-Money Laundering and Financial Crime")
         self.assertEqual(dest["state"], "ingested")
         self.assertEqual(dest.get("version_creator"), None)
 
         # edit event
-        event_service.patch(dest["_id"], {"name": "Edit event Name", "update_method": "single"})
-        dest = list(event_service.get_from_mongo(req=None, lookup={"guid": item["guid"]}))[0]
-        self.assertEqual(dest.get("version_creator"), "current_user_id")
+        await event_service.patch_async(dest["_id"], {"name": "Edit event Name", "update_method": "single"})
+        dest = await (await event_service.get_from_mongo_async(req=None, lookup={"guid": item["guid"]})).next()
+        self.assertEqual(dest.get("version_creator"), fixtures.users.ADMIN_USER_ID)
 
         # update event
         ingested, ids = await ingest_item(item, provider=provider, feeding_service={})
         self.assertFalse(ingested)
         self.assertEqual([], ids)
 
-    @markers.requires_async_celery
     async def test_unpublished_event_is_not_update(self):
         item = {
             "guid": "urn:onclusive:411202222",
@@ -742,7 +741,8 @@ class UpdateIngestTest(TestCase):
                 "all_day": True,
             },
         }
-        g.user = {"_id": "current_user_id"}
+        await test_utils.post_items("users", [fixtures.users.admin()])
+        g.user = {"_id": fixtures.users.ADMIN_USER_ID}
 
         provider = {
             "_id": "asdnjsandkajsdnjkasnd",


### PR DESCRIPTION
### Purpose
Original when an exception was raised during an Ingest or Publish cycle, a document would be added to the `activity` resource and email(s) would be sent off. This happened inside the constructor of the Exceptions.

Now that we have async `activity` and emails, we can no longer create these activity docs or send emails in the constructor, where async code is not supported.

### What has changed
* Add a new method for these Exceptions that creates the `activity` resource and sends email notifications
* Update ingest code where these exceptions are raised to send the notifications
* Update publish code where these exceptions are raised to send the notifications
* Update tests