### PR TITLE
[STT-105] Allow content api consumer to publish planning and event items

### DIFF
--- a/superdesk/publish_async/consumers/content_api_consumer.py
+++ b/superdesk/publish_async/consumers/content_api_consumer.py
@@ -4,7 +4,14 @@ from superdesk.types import PublishQueueResource, SubscribersResource, PublishCo
 from superdesk.resource_fields import ID_FIELD
 from superdesk import get_resource_service
 from superdesk.publish_async.publish_cache import PublishCache
+from superdesk.metadata.item import ITEM_TYPE
 
+try:
+    from planning.content_api import ContentAPIEventService, ContentAPIPlanningService
+
+    planning_enabled = True
+except ImportError:
+    planning_enabled = False
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +56,13 @@ class ContentApiPublishConsumer(PublishConsumer):
             for subscriber_id in subscriber_ids
             if cache.subscribers.get(subscriber_id)
         ]
+
+        item_type = item.get(ITEM_TYPE)
         try:
+            if planning_enabled and item_type in ("planning", "event"):
+                service = ContentAPIPlanningService() if item_type == "planning" else ContentAPIEventService()
+                return await service.publish_async(item, subscribers)
+
             await get_resource_service("content_api").publish_async(item, subscribers)
         except Exception:
             logger.exception(


### PR DESCRIPTION
This is required in order to register planning and event items into content api after they are published. 

[STT-105]

[STT-105]: https://sofab.atlassian.net/browse/STT-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ