### PR TITLE
Fix celery in eager mode, and pydantic service search where clause

### DIFF
--- a/superdesk/celery_app/context_task.py
+++ b/superdesk/celery_app/context_task.py
@@ -59,17 +59,23 @@ class HybridAppContextTask(Task):
         # We need a wrapper to handle exceptions inside the async function because asyncio
         # does not propagate them in the same way as synchronous exceptions. This ensures that
         # all exceptions are managed and logged regardless of where they occur within the event loop
-        async def wrapper():
+        async def wrapper(with_context: bool = True) -> Any | None:
             try:
-                async with self.get_current_app().app_context():
+                if with_context:
+                    async with self.get_current_app().app_context():
+                        response = self.run(*args, **kwargs)
+                else:
                     response = self.run(*args, **kwargs)
-                    return await response if isawaitable(response) else response
+
+                return await response if isawaitable(response) else response
             except self.app_errors as e:
                 self.handle_exception(e)
                 return None
 
         if is_always_eager:
-            return asyncio.create_task(wrapper())
+            # No need to run it with app_context, as we should already be within an app context
+            # Also no need to create async task, as the callee awaits the response anyway
+            return wrapper(False)
         else:
             background_tasks = set()
             loop = asyncio.get_event_loop()

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -33,6 +33,9 @@ from bson import ObjectId, UuidRepresentation
 from bson.json_util import dumps, DEFAULT_JSON_OPTIONS
 from motor.motor_asyncio import AsyncIOMotorCursor
 
+# TODO-ASYNC: Replace Eve's parser with our own
+from eve.io.mongo.parser import parse, ParseError
+
 from superdesk.core.types import SearchRequest, SortListParam, SortParam, ProjectedFieldArg
 from superdesk.core.errors import ElasticNotConfiguredForResource
 from superdesk.flask import g
@@ -784,16 +787,23 @@ class AsyncResourceService(Generic[ResourceModelType]):
             if sort:
                 kwargs["sort"] = sort
 
-        where = json.loads(req.where or "{}") if isinstance(req.where, str) else req.where or {}
-        where = cast_item(where)
+        where = None
+        if req.where:
+            try:
+                where = json.loads(req.where or "{}") if isinstance(req.where, str) else req.where
+            except ValueError:
+                try:
+                    where = parse(req.where)
+                except ParseError:
+                    raise SuperdeskApiError.badRequestError("Failed to parse the where filter")
 
+        where = cast_item(where or {})
         kwargs["filter"] = where
 
         projection_arg = self._get_mongo_projection_argument(req)
         if projection_arg:
             kwargs["projection"] = projection_arg
 
-        self.mongo.find
         cursor = self.mongo_async.find(**kwargs) if not versioned else self.mongo_versioned_async.find(**kwargs)
 
         return MongoResourceCursorAsync(

--- a/superdesk/core/types/web.py
+++ b/superdesk/core/types/web.py
@@ -186,7 +186,7 @@ class Request(Protocol):
         """Get an HTTP header from the current request"""
         ...
 
-    async def get_json(self) -> Any | None:
+    async def get_json(self, force: bool = False) -> Any | None:
         """Get the body of the current request in JSON format"""
         ...
 

--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -150,8 +150,8 @@ class HttpFlaskRequest(Request):
     def get_header(self, key: str) -> Optional[str]:
         return self.request.headers.get(key)
 
-    async def get_json(self) -> Union[Any, None]:
-        return await self.request.get_json()
+    async def get_json(self, force: bool = False) -> Union[Any, None]:
+        return await self.request.get_json(force=force)
 
     async def get_form(self) -> Mapping:
         return (await self.request.form).deepcopy()

--- a/superdesk/tests/fixtures/content_filters.py
+++ b/superdesk/tests/fixtures/content_filters.py
@@ -1,11 +1,20 @@
 from bson import ObjectId
 from superdesk.types import ContentFiltersResource, ContentFilter, ContentFilterExpression
 
-from .filter_conditions import FILTER_CONDITION_PICTURE_ID, FILTER_CONDITION_VIDEO_ID
+from .filter_conditions import FILTER_CONDITION_TEXT_ID, FILTER_CONDITION_PICTURE_ID, FILTER_CONDITION_VIDEO_ID
 
+CONTENT_FILTER_TEXT_ID = ObjectId()
 CONTENT_FILTER_PICTURES_ID = ObjectId()
 CONTENT_FILTER_VIDEOS_ID = ObjectId()
 CONTENT_FILTER_MEDIA_ID = ObjectId()
+
+
+def content_filter_text() -> ContentFiltersResource:
+    return ContentFiltersResource(
+        id=CONTENT_FILTER_TEXT_ID,
+        name="Text Content Filter",
+        content_filter=[ContentFilter(expression=ContentFilterExpression(fc=[FILTER_CONDITION_TEXT_ID]))],
+    )
 
 
 def content_filter_pictures() -> ContentFiltersResource:

--- a/superdesk/tests/fixtures/filter_conditions.py
+++ b/superdesk/tests/fixtures/filter_conditions.py
@@ -1,8 +1,19 @@
 from bson import ObjectId
 from superdesk.types import FilterConditionsResource, FilterConditionOperator
 
+FILTER_CONDITION_TEXT_ID = ObjectId()
 FILTER_CONDITION_PICTURE_ID = ObjectId()
 FILTER_CONDITION_VIDEO_ID = ObjectId()
+
+
+def filter_condition_text() -> FilterConditionsResource:
+    return FilterConditionsResource(
+        id=FILTER_CONDITION_TEXT_ID,
+        name="All Text",
+        field="type",
+        operator=FilterConditionOperator.EQUALS,
+        value="text",
+    )
 
 
 def filter_condition_picture() -> FilterConditionsResource:

--- a/superdesk/tests/fixtures/products.py
+++ b/superdesk/tests/fixtures/products.py
@@ -1,14 +1,32 @@
 from bson import ObjectId
 from superdesk.types import ProductsResource, ProductTypes, ProductContentFilter, ProductFilterType
 
-from .content_filters import CONTENT_FILTER_MEDIA_ID, CONTENT_FILTER_PICTURES_ID, CONTENT_FILTER_VIDEOS_ID
+from .content_filters import (
+    CONTENT_FILTER_TEXT_ID,
+    CONTENT_FILTER_MEDIA_ID,
+    CONTENT_FILTER_PICTURES_ID,
+    CONTENT_FILTER_VIDEOS_ID,
+)
 
+TEXT_PRODUCT_ID = ObjectId()
 NSW_PRODUCT_ID = ObjectId()
 ABCDEF_PRODUCT_ID = ObjectId()
 XYZ_PRODUCT_ID = ObjectId()
 PICTURE_PRODUCT_ID = ObjectId()
 VIDEO_PRODUCT_ID = ObjectId()
 MEDIA_PRODUCT_ID = ObjectId()
+
+
+def text_product() -> ProductsResource:
+    return ProductsResource(
+        id=TEXT_PRODUCT_ID,
+        name="Text Product",
+        product_type=ProductTypes.BOTH,
+        content_filter=ProductContentFilter(
+            filter_id=CONTENT_FILTER_TEXT_ID,
+            filter_type=ProductFilterType.PERMITTING,
+        ),
+    )
 
 
 def nsw_product() -> ProductsResource:

--- a/superdesk/tests/fixtures/subscribers.py
+++ b/superdesk/tests/fixtures/subscribers.py
@@ -1,13 +1,35 @@
 from bson import ObjectId
 from superdesk.types import SubscribersResource, SubscriberType, SubscriberSequenceSettings, SubscriberDestination
 
-from .products import NSW_PRODUCT_ID, ABCDEF_PRODUCT_ID
+from .products import TEXT_PRODUCT_ID, NSW_PRODUCT_ID, ABCDEF_PRODUCT_ID
 
 SUB1_ID = ObjectId()
 SUB2_ID = ObjectId()
 SUB3_ID = ObjectId()
 SUB4_ID = ObjectId()
 SUB5_ID = ObjectId()
+
+TEXT_SUBSCRIBER_ID = ObjectId()
+
+
+def text_subscriber() -> SubscribersResource:
+    return SubscribersResource(
+        id=TEXT_SUBSCRIBER_ID,
+        name="text",
+        email="text@subscriber.com",
+        is_active=True,
+        subscriber_type=SubscriberType.ALL,
+        sequence_num_settings=SubscriberSequenceSettings(min=1, max=100),
+        products=[TEXT_PRODUCT_ID],
+        destinations=[
+            SubscriberDestination(
+                name="dest1",
+                format="nitf",
+                delivery_type="File",
+                config={"file_path": "/tmp/"},
+            ),
+        ],
+    )
 
 
 def sub1_subscriber() -> SubscribersResource:


### PR DESCRIPTION
### Purpose
Fixes/improvements found during fixing tests in the Planning module


### What has changed:
* Fix celery in tests: Don't wrap task in app context if in eager mode, as the caller is already in an app context when the task is called (was causing issues in tests)
* Fix search in Pydantic services, not supporting eve style where clause (such as `?where=event_id=="abcd123"`
* Support `force` param in the web request's `get_json` method
* Add more test fixtures for configuring publishing (filters, products & subscribers)