### PR TITLE
Fix `context_task.py` so it runs tasks under the app's context

### DIFF
--- a/superdesk/celery_app/context_task.py
+++ b/superdesk/celery_app/context_task.py
@@ -56,6 +56,10 @@ class HybridAppContextTask(Task):
         """
         is_always_eager = self._is_always_eager()
 
+        async def _handle_run_task(func: Any, *func_args, **func_kwargs) -> Any:
+            response = func(*func_args, **func_kwargs)
+            return await response if isawaitable(response) else response
+
         # We need a wrapper to handle exceptions inside the async function because asyncio
         # does not propagate them in the same way as synchronous exceptions. This ensures that
         # all exceptions are managed and logged regardless of where they occur within the event loop
@@ -63,11 +67,10 @@ class HybridAppContextTask(Task):
             try:
                 if with_context:
                     async with self.get_current_app().app_context():
-                        response = self.run(*args, **kwargs)
+                        return await _handle_run_task(self.run, *args, **kwargs)
                 else:
-                    response = self.run(*args, **kwargs)
+                    return await _handle_run_task(self.run, *args, **kwargs)
 
-                return await response if isawaitable(response) else response
             except self.app_errors as e:
                 self.handle_exception(e)
                 return None


### PR DESCRIPTION
### Purpose
Fix `context_task.py` so it runs tasks under the app's context. The intention is to fix an error found on test instances. Look at the traceback below:

### Issue's traceback
```python
Traceback (most recent call last):
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/opt/superdesk/env/lib/python3.10/site-packages/celery/app/trace.py", line 453, in trace_task
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     R = retval = fun(*args, **kwargs)
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/opt/superdesk/env/lib/python3.10/site-packages/superdesk/celery_app/context_task.py", line 42, in __call__
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     return self.run_async(*args, **kwargs)
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/opt/superdesk/env/lib/python3.10/site-packages/superdesk/celery_app/context_task.py", line 85, in run_async
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     return loop.run_until_complete(wrapper())
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     return future.result()
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/usr/lib/python3.10/asyncio/futures.py", line 201, in result
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     raise self._exception.with_traceback(self._exception_tb)
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/usr/lib/python3.10/asyncio/tasks.py", line 232, in __step
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     result = coro.send(None)
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/opt/superdesk/env/lib/python3.10/site-packages/superdesk/celery_app/context_task.py", line 70, in wrapper
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     return await response if isawaitable(response) else response
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/opt/superdesk/env/lib/python3.10/site-packages/superdesk/publish_async/commands.py", line 117, in transmit
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     await get_exchange_factory().process_pending_tasks()
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/opt/superdesk/env/lib/python3.10/site-packages/superdesk/publish_async/exchanges/exchange_factory.py", line 305, in process_pending_tasks
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     if not lock(lock_name, expire=1810):
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/opt/superdesk/env/lib/python3.10/site-packages/superdesk/lock.py", line 69, in lock
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     got_lock = _lock.lock(task, host, expire=expire, timeout=timeout)
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/opt/superdesk/env/lib/python3.10/site-packages/werkzeug/local.py", line 318, in __get__
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     obj = instance._get_current_object()
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/opt/superdesk/env/lib/python3.10/site-packages/werkzeug/local.py", line 526, in _get_current_object
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     return get_name(local())
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/opt/superdesk/env/lib/python3.10/site-packages/superdesk/lock.py", line 46, in _get_lock
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     client_config, dbname = get_mongo_client_config(get_current_app().config)
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/opt/superdesk/env/lib/python3.10/site-packages/werkzeug/local.py", line 318, in __get__
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     obj = instance._get_current_object()
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |   File "/opt/superdesk/env/lib/python3.10/site-packages/werkzeug/local.py", line 519, in _get_current_object
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 |     raise RuntimeError(unbound_message) from None
May 14 18:50:40 sd-async sh[109]: 18:50:40 work.1 | RuntimeError: Not within an app context
```