### PR TITLE
[SDESK-7623] - Filter condition creation required fields are empty

### DIFF
--- a/superdesk/publish_async/views.py
+++ b/superdesk/publish_async/views.py
@@ -23,7 +23,7 @@ from superdesk.publish_async.publish_cache import PublishCache
 publish_endpoints = EndpointGroup("publish", __name__)
 
 
-@publish_endpoints.endpoint("filter_conditions/parameters", "filter_conditions_parameters", methods=["GET"])
+@publish_endpoints.endpoint("filter_conditions/parameters", "filter_conditions/parameters", methods=["GET"])
 async def content_params_endpoint() -> Response:
     params = await get_available_filter_params()
     return Response(


### PR DESCRIPTION
### Purpose
This PR fixes a small naming issue which was causing the client not to resolve the `filter_conditions/parameters` url.

### What has changed
- Changed name of filter conditions params URL

### Steps to test
1. Go to Superdesk settings. Open Content Filters.
2. Click the Filter Conditions tab and click Add New.
3. Observe that the `Field` dropdown is populated accordingly. 

Resolves: #[SDESK-7623]

[SDESK-7623]: https://sofab.atlassian.net/browse/SDESK-7623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ