### PR TITLE
[SDESK-7641] fix: Use common code to store auth values on session/request

### DIFF
--- a/apps/auth/auth.py
+++ b/apps/auth/auth.py
@@ -13,12 +13,10 @@ from inspect import isawaitable
 
 import superdesk
 
-from datetime import timedelta
 from eve.auth import TokenAuth
 
-from superdesk.core import get_app_config
-from superdesk.resource_fields import LAST_UPDATED
-from superdesk.flask import g, session, request
+from superdesk.core.auth.utils import set_user_request_auth_data, clear_user_request_auth_data
+from superdesk.flask import session, request
 from superdesk.resource import Resource
 from superdesk.errors import SuperdeskApiError
 from superdesk import (
@@ -27,7 +25,6 @@ from superdesk import (
     get_no_resource_privileges,
     get_intrinsic_privileges,
 )
-from superdesk.utc import utcnow
 from quart_babel import gettext as _
 
 logger = logging.getLogger(__name__)
@@ -83,18 +80,17 @@ class SuperdeskTokenAuth(TokenAuth):
 
         1. If there's no user associated with the request or HTTP Method is GET or the Resource is a Flask Blueprint
         then return True.
-        2. Get User's Privileges
-        3. Intrinsic Privileges:
+        2. Intrinsic Privileges:
             Check if resource has intrinsic privileges.
                 If it has then check if HTTP Method is allowed.
                     Return True if `is_authorized()` on the resource service returns True.
                     Otherwise, raise ForbiddenError.
                 HTTP Method not allowed continue
             No intrinsic privileges continue
-        4. User's Privileges
+        3. User's Privileges
             Get Resource Privileges and validate it against user's privileges. Return True if validation is successful.
             Otherwise continue.
-        5. If method didn't return True, then user is not authorized to perform the requested operation on the resource.
+        4. If method didn't return True, then user is not authorized to perform the requested operation on the resource.
         """
 
         # Step 1:
@@ -104,9 +100,6 @@ class SuperdeskTokenAuth(TokenAuth):
         if resource == "_blueprint":
             return True
 
-        # Step 2: Get User's Privileges
-        get_resource_service("users").set_privileges(user, g.role)
-
         try:
             resource_privileges = get_resource_privileges(resource).get(method, None)
         except KeyError:
@@ -115,7 +108,7 @@ class SuperdeskTokenAuth(TokenAuth):
         if method == "GET" and not resource_privileges:
             return True
 
-        # Step 3: Intrinsic Privileges
+        # Step 2: Intrinsic Privileges
         message = _("Insufficient privileges for the requested operation.")
         intrinsic_privileges = get_intrinsic_privileges()
         if intrinsic_privileges.get(resource) and method in intrinsic_privileges[resource]:
@@ -129,7 +122,7 @@ class SuperdeskTokenAuth(TokenAuth):
 
             return authorized
 
-        # Step 4: User's privileges
+        # Step 3: User's privileges
         privileges = user.get("active_privileges", {})
 
         if not resource_privileges and get_no_resource_privileges(resource):
@@ -138,7 +131,7 @@ class SuperdeskTokenAuth(TokenAuth):
         if privileges.get(resource_privileges, False):
             return True
 
-        # Step 5:
+        # Step 4:
         raise SuperdeskApiError.forbiddenError(message=message)
 
     async def check_auth(self, token, allowed_roles, resource, method):
@@ -146,32 +139,17 @@ class SuperdeskTokenAuth(TokenAuth):
 
         If token is valid it updates session and checks permissions.
         """
-        auth_service = get_resource_service("auth")
-        user_service = get_resource_service("users")
-        auth_token = await auth_service.find_one_async(token=token, req=None)
-        if auth_token:
-            if session.get("session_token") != token:
-                session["session_token"] = token
-            user_id = str(auth_token["user"])
-            g.user = await user_service.find_one_async(req=None, _id=user_id)
-            g.role = await user_service.get_role(g.user)
-            g.auth = auth_token
-            g.auth_value = auth_token["user"]
-            if method in ("POST", "PUT", "PATCH") or method == "GET" and not request.args.get("auto"):
-                now = utcnow()
-                auth_updated = False
-                if auth_token[LAST_UPDATED] + timedelta(seconds=get_app_config("SESSION_UPDATE_SECONDS")) < now:
-                    await auth_service.update_session({LAST_UPDATED: now})
-                    auth_updated = True
-                if not g.user.get("last_activity_at") or auth_updated:
-                    await user_service.system_update_async(
-                        g.user["_id"], {"last_activity_at": now, "_updated": now}, g.user
-                    )
 
-            return await self.check_permissions(resource, method, g.user)
+        try:
+            user_dict = await set_user_request_auth_data(token, request)
+            return await self.check_permissions(resource, method, user_dict)
+        except SuperdeskApiError as error:
+            if error.status_code != 401:
+                # If this is not an authentication error, then raise it
+                raise
 
-        # pop invalid session
-        session.pop("session_token", None)
+        # The user is not authenticated, clear the request auth data and return False
+        clear_user_request_auth_data(request)
         return False
 
     async def authorized(self, allowed_roles, resource, method):

--- a/superdesk/core/auth/token_auth.py
+++ b/superdesk/core/auth/token_auth.py
@@ -1,18 +1,12 @@
 import base64
-import arrow
 
-from typing import Any, cast
-from datetime import timedelta
+from typing import Any
 
-from superdesk.utc import utcnow
-from superdesk.core import json, get_app_config
 from superdesk.core.types import Request
-from superdesk import get_resource_service
-from superdesk.types import UsersResourceModel
 from superdesk.errors import SuperdeskApiError
-from superdesk.resource_fields import LAST_UPDATED, ID_FIELD
 
 from .user_auth import UserAuthProtocol
+from .utils import set_user_request_auth_data, clear_user_request_auth_data
 
 
 class TokenAuthorization(UserAuthProtocol):
@@ -35,6 +29,10 @@ class TokenAuthorization(UserAuthProtocol):
             token = token.strip()
             if token.lower().startswith(("token", "bearer", "basic")):
                 token = token.split(" ")[1] if " " in token else ""
+
+            # tokens are no longer decoded internally by flask/quart
+            # so we need to do it ourselves
+            token = self._decode_token(token)
         else:
             token = request.storage.session.get("session_token")
             new_session = False
@@ -43,68 +41,23 @@ class TokenAuthorization(UserAuthProtocol):
             await self.stop_session(request)
             raise SuperdeskApiError.unauthorizedError()
 
-        # Check provided token is valid
-        auth_service = get_resource_service("auth")
-
-        # tokens are no longer decoded internally by flask/quart
-        # so we need to do it ourselves
-        token = self._decode_token(token)
-        auth_token = await auth_service.find_one_async(token=token, req=None)
-
-        if not auth_token:
-            await self.stop_session(request)
-            raise SuperdeskApiError.unauthorizedError()
-
-        user = await UsersResourceModel.get_service().find_by_id_raw(auth_token["user"])
-
-        if not user:
-            await self.stop_session(request)
-            raise SuperdeskApiError.unauthorizedError()
-
         if new_session:
-            await self.start_session(request, user, auth_token=auth_token)
+            await self.start_session(request, {}, token=token)
         else:
-            await self.continue_session(request, user)
-
-    async def start_session(self, request: Request, user: dict[str, Any], **kwargs) -> None:
-        auth_token: str | None = kwargs.pop("auth_token", None)
-        if not auth_token:
-            await self.stop_session(request)
-            raise SuperdeskApiError.unauthorizedError()
-
-        request.storage.session.set("session_token", json.dumps(auth_token))
-        await super().start_session(request, user, **kwargs)
+            await self.continue_session(request, {}, token=token)
 
     async def continue_session(self, request: Request, user: dict[str, Any], **kwargs) -> None:
-        auth_token = request.storage.session.get("session_token")
+        try:
+            user_dict = await set_user_request_auth_data(kwargs.get("token"), request)
+            await super().continue_session(request, user_dict, **kwargs)
+        except SuperdeskApiError as error:
+            if error.status_code == 401:
+                await self.stop_session(request)
+            raise
 
-        if not auth_token:
-            await self.stop_session(request)
-            raise SuperdeskApiError.unauthorizedError()
-
-        if isinstance(auth_token, str):
-            auth_token = json.loads(auth_token)
-
-        user_service = get_resource_service("users")
-        request.storage.request.set("user", user)
-        request.storage.request.set("role", await user_service.get_role(user))
-        request.storage.request.set("auth", auth_token)
-        request.storage.request.set("auth_value", auth_token["user"])
-
-        if request.method in ("POST", "PUT", "PATCH") or (request.method == "GET" and not request.get_url_arg("auto")):
-            now = utcnow()
-            auth_updated = False
-            session_update_seconds = cast(int, get_app_config("SESSION_UPDATE_SECONDS", 30))
-            auth_last_updated = arrow.get(auth_token[LAST_UPDATED])
-
-            if auth_last_updated + timedelta(seconds=session_update_seconds) < now:
-                auth_service = get_resource_service("auth")
-                await auth_service.update_session({LAST_UPDATED: now})
-                auth_updated = True
-            if auth_updated or not request.storage.request.get("last_activity_at"):
-                user_service.system_update(user[ID_FIELD], {"last_activity_at": now, "_updated": now}, user)
-
-        await super().continue_session(request, user, **kwargs)
+    async def stop_session(self, request: Request) -> None:
+        clear_user_request_auth_data(request)
+        await super().stop_session(request)
 
     def get_current_user(self, request: Request) -> dict[str, Any] | None:
         user = request.storage.request.get("user")

--- a/superdesk/core/auth/utils.py
+++ b/superdesk/core/auth/utils.py
@@ -1,0 +1,104 @@
+from datetime import timedelta
+
+import arrow
+from quart import g, session, Request as QuartRequest
+
+from superdesk.core.types import Request as SuperdeskRequest
+from superdesk.core import get_config
+from superdesk import get_resource_service
+from superdesk.utc import utcnow
+from superdesk.resource_fields import LAST_UPDATED
+from superdesk.errors import SuperdeskApiError
+
+
+async def set_user_request_auth_data(auth_token: str | None, request: SuperdeskRequest | QuartRequest) -> dict:
+    """Set user, role and auth data on the request and session storage.
+
+    :param auth_token: Auth token, from the Authorization header or the session cookie.
+    :param request: Superdesk Core or Quart request instance
+    :returns: A dictionary of the ``user`` resource for the current user
+    :raises SuperdeskApiError.unauthorizedError: If the auth token is invalid or the user is not found.
+    """
+
+    if not auth_token:
+        raise SuperdeskApiError.unauthorizedError()
+
+    user_service = get_resource_service("users")
+    auth_service = get_resource_service("auth")
+
+    # Using the supplied token, get the ``auth`` and ``user`` docs
+    auth_data = await auth_service.find_one_async(token=auth_token, req=None)
+    if not auth_data:
+        raise SuperdeskApiError.unauthorizedError()
+
+    user_id = auth_data.get("user")
+    if not user_id:
+        raise SuperdeskApiError.unauthorizedError()
+
+    user_dict = await user_service.find_one_async(req=None, _id=user_id)
+    if not user_dict:
+        raise SuperdeskApiError.unauthorizedError()
+
+    # Get the user role and apply privileges to the user doc
+    user_role = await user_service.get_role(user_dict)
+    user_service.set_privileges(user_dict, user_role)
+
+    # Store user, role and auth data on the request and session storage
+    if isinstance(request, QuartRequest):
+        # Superdesk Core request instance not available, use Quart directly
+        if session.get("session_token") != auth_token:
+            session["session_token"] = auth_token
+
+        # Ignore types here, as quart.g is a proxy object and doesn't support type hints
+        g.user = user_dict  # type: ignore[attr-defined]
+        g.role = user_role  # type: ignore[attr-defined]
+        g.auth = auth_data  # type: ignore[attr-defined]
+        g.auth_value = user_id  # type: ignore[attr-defined]
+    else:
+        # Use a Superdesk Core request instance (which indirectly uses Quart)
+        if request.storage.session.get("session_token") != auth_token:
+            request.storage.session.set("session_token", auth_token)
+
+        request.storage.request.set("user", user_dict)
+        request.storage.request.set("role", user_role)
+        request.storage.request.set("auth", auth_data)
+        request.storage.request.set("auth_value", user_id)
+
+    # Update the user's last activity time if necessary
+    auto = request.args.get("auto") if isinstance(request, QuartRequest) else request.get_url_arg("auto")
+    if request.method in ("POST", "PUT", "PATCH") or (request.method == "GET" and not auto):
+        now = utcnow()
+        auth_updated = False
+        session_update_seconds = get_config(int, "SESSION_UPDATE_SECONDS")
+        auth_last_updated = arrow.get(auth_data[LAST_UPDATED])
+
+        if auth_last_updated + timedelta(seconds=session_update_seconds) < now:
+            await auth_service.update_session({LAST_UPDATED: now})
+            auth_updated = True
+
+        if auth_updated or not user_dict.get("last_activity_at"):
+            user_service.system_update(user_id, {"last_activity_at": now, "_updated": now}, user_dict)
+
+    return user_dict
+
+
+def clear_user_request_auth_data(request: SuperdeskRequest | QuartRequest) -> None:
+    """Clear user, role and auth data from the request and session storage.
+
+    Removes all session and request data stored by ``set_user_request_auth_data``.
+
+    :param request: Superdesk Core or Quart request instance
+    """
+
+    if isinstance(request, QuartRequest):
+        session.pop("session_token", None)
+        g.pop("user", None)
+        g.pop("role", None)
+        g.pop("auth", None)
+        g.pop("auth_value", None)
+    else:
+        request.storage.session.pop("session_token", None)
+        request.storage.request.pop("user", None)
+        request.storage.request.pop("role", None)
+        request.storage.request.pop("auth", None)
+        request.storage.request.pop("auth_value", None)


### PR DESCRIPTION
### Purpose
An authentication issue was discovered with blueprint endpoints, automatically signing the user out.

### What has changed
Create common util functions for use by Eve and new async authentication to store/clear the user session and request information.

Resolves: [SDESK-7641](https://sofab.atlassian.net/browse/SDESK-7641)



[SDESK-7641]: https://sofab.atlassian.net/browse/SDESK-7641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ