### PR TITLE
[SDESK-7630] fix: Killing of archived items

### DIFF
--- a/apps/archive/archive_media.py
+++ b/apps/archive/archive_media.py
@@ -74,7 +74,6 @@ class ArchiveMediaService:
                 doc["renditions"] = renditions
                 doc["mimetype"] = content_type
                 set_filemeta(doc, metadata)
-                # TODO-ASYNC[activity]: Prefix this next line with `await ` when updating this module
                 await add_activity(
                     "upload",
                     "uploaded media {{ name }}",

--- a/apps/archived/archived.py
+++ b/apps/archived/archived.py
@@ -18,7 +18,7 @@ from eve.versioning import resolve_document_version
 from superdesk.core import get_current_app
 from superdesk.flask import request
 from superdesk.resource_fields import ID_FIELD, VERSION, ETAG, LAST_UPDATED
-from superdesk.types import SubscribersResource
+from superdesk.types import SubscribersResource, ContentState
 from apps.legal_archive.commands import import_into_legal_archive
 from apps.legal_archive.resource import LEGAL_PUBLISH_QUEUE_NAME
 from apps.publish.content.common import ITEM_KILL
@@ -275,9 +275,6 @@ class ArchivedService(AsyncBaseService):
                 get_resource_service(LEGAL_PUBLISH_QUEUE_NAME).get(req=None, lookup={"item_id": article["item_id"]})
             )
 
-            if transmission_details:
-                await self.enqueue_archived_kill_item(article, transmission_details)
-
             article[ID_FIELD] = article.pop("item_id", article["item_id"])
 
             # Step 3(iv)
@@ -293,6 +290,9 @@ class ArchivedService(AsyncBaseService):
             await get_resource_service("published").post_async([published_doc])
             logger.info("Insert into archive and published for article: {}".format(article[ID_FIELD]))
 
+            if transmission_details:
+                await self.enqueue_archived_kill_item(article, transmission_details, updates.get(ITEM_OPERATION))
+
             # Step 3(iii)
             await import_into_legal_archive.apply_async(countdown=3, kwargs={"item_id": article[ID_FIELD]})
             logger.info("Legal Archive import for article: {}".format(article[ID_FIELD]))
@@ -301,34 +301,22 @@ class ArchivedService(AsyncBaseService):
             await kill_service.broadcast_kill_email(article, updates_copy)
             logger.info("Broadcast kill email for article: {}".format(article[ID_FIELD]))
 
-    async def enqueue_archived_kill_item(self, item: dict, transmission_details) -> None:
+    async def enqueue_archived_kill_item(self, item: dict, transmission_details, operation: str) -> None:
         """Enqueue items that are killed from dusty archive.
 
         :param dict item: item from the archived collection.
         :param list transmission_details: list of legal publish queue entries
         """
         subscriber_ids = [transmission_record["_subscriber_id"] for transmission_record in transmission_details]
-        api_subscribers = {
-            t["_subscriber_id"]
-            for t in transmission_details
-            if t.get("destination", {}).get("delivery_type") == "content_api"
-        }
         query = {"$and": [{ID_FIELD: {"$in": subscriber_ids}}]}
         subscribers = await (await SubscribersResource.get_service().search(query)).to_list()
 
-        # TODO-ASYNC: Killing doesn't work from ``archived`` when item doesn't exist in ``published`` collection
-        #             As ``content`` PublishExchange expects it to exist in ``published`` collection
         await publish_item(
             item,
             subscribers=subscribers,
-            published_state="killed",
+            published_state=ContentState.KILLED if operation == ITEM_KILL else ContentState.RECALLED,
             publish_to_content_api=True,
         )
-        logger.info("Queued Transmission for article: {}".format(item[ID_FIELD]))
-        if content_api.is_enabled():
-            await get_resource_service("content_api").publish_async(
-                item, [subscriber.to_dict() for subscriber in subscribers if subscriber.id in api_subscribers]
-            )
 
     async def on_updated_async(self, updates, original):
         user = get_user()

--- a/features/archived_kill.feature
+++ b/features/archived_kill.feature
@@ -138,36 +138,36 @@ Feature: Kill a content item in the (dusty) archive
         "item_version": 3, "publishing_action": "killed"}
      ]}
     """
-#    When we get "/archive/123"
-#    Then we get OK response
-#    And we get text "Please kill story slugged archived" in response field "body_html"
-#    And we get text "Killed body" in response field "body_html"
-#    And we get emails
-#    """
-#    [
-#      {"body": "Please kill story slugged archived"},
-#      {"body": "Killed body"}
-#    ]
-#    """
-#    When we get "/archived/123:2"
-#    Then we get error 404
-#    When we get "/archived"
-#    Then we get list with 0 items
-#    When we get "/legal_archive/123"
-#    Then we get existing resource
-#    """
-#    {"_id": "123", "type": "text", "_current_version": 3, "state": "killed", "pubstatus": "canceled", "operation": "kill"}
-#    """
-#    When we get "/legal_archive/123?version=all"
-#    Then we get list with 3 items
-#    When we expire items
-#    """
-#    ["123"]
-#    """
-#    And we get "/published"
-#    Then we get list with 0 items
-#    When we get "/archive"
-#    Then we get list with 0 items
+    When we get "/archive/123"
+    Then we get OK response
+    And we get text "Please kill story slugged archived" in response field "body_html"
+    And we get text "Killed body" in response field "body_html"
+    And we get emails
+    """
+    [
+      {"body": "Please kill story slugged archived"},
+      {"body": "Killed body"}
+    ]
+    """
+    When we get "/archived/123:2"
+    Then we get error 404
+    When we get "/archived"
+    Then we get list with 0 items
+    When we get "/legal_archive/123"
+    Then we get existing resource
+    """
+    {"_id": "123", "type": "text", "_current_version": 3, "state": "killed", "pubstatus": "canceled", "operation": "kill"}
+    """
+    When we get "/legal_archive/123?version=all"
+    Then we get list with 3 items
+    When we expire items
+    """
+    ["123"]
+    """
+    And we get "/published"
+    Then we get list with 0 items
+    When we get "/archive"
+    Then we get list with 0 items
 
   @auth @notification
   Scenario: Kill a Text Article that exists only in Archived
@@ -246,6 +246,7 @@ Feature: Kill a content item in the (dusty) archive
     When we get "/published"
     Then we get list with 2 items
     When we get "/publish_queue"
+    # TODO-ASYNC: This should be 2 items but is 3, it's adding in 2 publish_queue entries for the composite (aka package)
     Then we get list with 2 items
     When we get "/archive/123"
     Then we get OK response
@@ -263,6 +264,7 @@ Feature: Kill a content item in the (dusty) archive
     When we get "/legal_archive/123?version=all"
     Then we get list with 3 items
     When we get "/legal_publish_queue"
+    # TODO-ASYNC: This should be 4 items but it is 5, it's adding in 2 publish_queue entries for the composite (aka package)
     Then we get list with 4 items
     When we expire items
     """
@@ -822,6 +824,7 @@ Feature: Kill a content item in the (dusty) archive
     When we get "/published"
     Then we get list with 4 items
     When we get "/publish_queue"
+    # TODO-ASYNC: This should be 4 items but it is 7, it's adding in 2 publish_queue entries for the composite (aka package)
     Then we get list with 4 items
     When we get "/archived"
     Then we get list with 0 items
@@ -1144,10 +1147,6 @@ Feature: Kill a content item in the (dusty) archive
     Then we get list with 2 items
     When run import legal publish queue
     And we get "/legal_publish_queue"
-    Then we get list with 0 items
-    When we transmit items
-    And run import legal publish queue
-    When we get "/legal_publish_queue"
     Then we get list with 2 items
     """
     {"_items" : [
@@ -1271,16 +1270,6 @@ Feature: Kill a content item in the (dusty) archive
     Then we get list with 2 items
     When run import legal publish queue
     And we get "/legal_publish_queue"
-    Then we get list with 1 items
-    """
-    {"_items" : [
-        {"item_id": "123", "subscriber_id":"Channel api", "content_type": "text",
-        "item_version": 2, "publishing_action": "published"}
-     ]}
-    """
-    When we transmit items
-    And run import legal publish queue
-    When we get "/legal_publish_queue"
     Then we get list with 2 items
     """
     {"_items" : [

--- a/superdesk/publish_async/filters/killed_exchange_filter.py
+++ b/superdesk/publish_async/filters/killed_exchange_filter.py
@@ -1,6 +1,7 @@
 from superdesk.core import get_config
 from superdesk.types import PublishRequest, PublishRequestResponse, ContentState
 
+from ..utils import get_codes
 from .content_exchange_filter import ContentPublishExchangeFilter
 
 
@@ -44,12 +45,12 @@ class KilledPublishExchangeFilter(ContentPublishExchangeFilter):
             ]
         }
         (
-            subscribers,
+            previous_subscribers,
             subscriber_codes,
             previous_associations,
         ) = await self._get_subscribers_for_previously_sent_items(response, query)
 
-        if not subscribers and get_config(bool, "UNPUBLISH_TO_MATCHING_SUBSCRIBERS", False):
+        if not previous_subscribers and get_config(bool, "UNPUBLISH_TO_MATCHING_SUBSCRIBERS", False):
             subscribers_request = PublishRequest(
                 item=request.item,
                 item_id=request.item_id,
@@ -61,9 +62,24 @@ class KilledPublishExchangeFilter(ContentPublishExchangeFilter):
             )
             subscribers_response = PublishRequestResponse()
             await super().filter_subscribers(subscribers_request, subscribers_response)
-            subscribers = subscribers_response.subscribers
+            previous_subscribers = subscribers_response.subscribers
             subscriber_codes = subscribers_response.subscriber_codes
 
-        response.subscribers = subscribers
+        response.subscribers = previous_subscribers
         response.subscriber_codes = subscriber_codes
+
+        # Check to see if any provided Subscribers in the PublishRequest were not picked up by the above
+        # logic. If so then add them to the list, along with their subscriber codes
+        previous_subscriber_ids = set([subscriber.id for subscriber in previous_subscribers])
+        new_subscribers = [
+            subscriber for subscriber in request.subscribers or [] if subscriber.id not in previous_subscriber_ids
+        ]
+        if new_subscribers:
+            response.subscribers.extend(new_subscribers)
+            for subscriber in new_subscribers:
+                response.subscriber_codes[subscriber.id] = get_codes(subscriber)
+
         response.associations = previous_associations
+        response.content_api_subscribers = set(
+            [subscriber.id for subscriber in response.subscribers if subscriber.api_products]
+        )


### PR DESCRIPTION
### Purpose
Killing (or Takedown) actions on items from the `archived` resource was not gathering the correct subscribers (including for ContentAPI)

### What has changed
Fix logic in `KilledPublishExchangeFilter` to also use the supplied list of subscribers to kill for.

**Note:** There are still some tests failing in archived feature, but that is due to another bug in publishing of packages and their items. Will be fixed in my next PR

