### PR TITLE
[SDESK-7630] Fix publishing of package items

### DIFF
--- a/apps/archive/archive_media.py
+++ b/apps/archive/archive_media.py
@@ -74,7 +74,6 @@ class ArchiveMediaService:
                 doc["renditions"] = renditions
                 doc["mimetype"] = content_type
                 set_filemeta(doc, metadata)
-                # TODO-ASYNC[activity]: Prefix this next line with `await ` when updating this module
                 await add_activity(
                     "upload",
                     "uploaded media {{ name }}",

--- a/apps/archive/commands.py
+++ b/apps/archive/commands.py
@@ -40,7 +40,7 @@ from werkzeug.exceptions import Conflict
 from .common import remove_media_files
 from celery.exceptions import SoftTimeLimitExceeded
 from superdesk.publish_async.publish_cache import PublishCache
-from superdesk.publish_async.utils import item_matches_content_filter
+from superdesk.publish_async.utils import item_matches_content_filter, get_residrefs
 
 logger = logging.getLogger(__name__)
 
@@ -323,7 +323,7 @@ class RemoveExpiredContent:
 
         if item.get(ITEM_TYPE) == CONTENT_TYPE.COMPOSITE:
             # Get the item references for is package
-            item_refs = package_service.get_residrefs(item)
+            item_refs = get_residrefs(item)
 
         if item.get(ITEM_TYPE) in [CONTENT_TYPE.TEXT, CONTENT_TYPE.PREFORMATTED] and get_app_config(
             "BROADCAST_ENABLED", True

--- a/apps/archived/archived.py
+++ b/apps/archived/archived.py
@@ -18,7 +18,7 @@ from eve.versioning import resolve_document_version
 from superdesk.core import get_current_app
 from superdesk.flask import request
 from superdesk.resource_fields import ID_FIELD, VERSION, ETAG, LAST_UPDATED
-from superdesk.types import SubscribersResource
+from superdesk.types import SubscribersResource, ContentState
 from apps.legal_archive.commands import import_into_legal_archive
 from apps.legal_archive.resource import LEGAL_PUBLISH_QUEUE_NAME
 from apps.publish.content.common import ITEM_KILL
@@ -275,9 +275,6 @@ class ArchivedService(AsyncBaseService):
                 get_resource_service(LEGAL_PUBLISH_QUEUE_NAME).get(req=None, lookup={"item_id": article["item_id"]})
             )
 
-            if transmission_details:
-                await self.enqueue_archived_kill_item(article, transmission_details)
-
             article[ID_FIELD] = article.pop("item_id", article["item_id"])
 
             # Step 3(iv)
@@ -293,6 +290,9 @@ class ArchivedService(AsyncBaseService):
             await get_resource_service("published").post_async([published_doc])
             logger.info("Insert into archive and published for article: {}".format(article[ID_FIELD]))
 
+            if transmission_details:
+                await self.enqueue_archived_kill_item(article, transmission_details, updates.get(ITEM_OPERATION))
+
             # Step 3(iii)
             await import_into_legal_archive.apply_async(countdown=3, kwargs={"item_id": article[ID_FIELD]})
             logger.info("Legal Archive import for article: {}".format(article[ID_FIELD]))
@@ -301,34 +301,22 @@ class ArchivedService(AsyncBaseService):
             await kill_service.broadcast_kill_email(article, updates_copy)
             logger.info("Broadcast kill email for article: {}".format(article[ID_FIELD]))
 
-    async def enqueue_archived_kill_item(self, item: dict, transmission_details) -> None:
+    async def enqueue_archived_kill_item(self, item: dict, transmission_details, operation: str) -> None:
         """Enqueue items that are killed from dusty archive.
 
         :param dict item: item from the archived collection.
         :param list transmission_details: list of legal publish queue entries
         """
         subscriber_ids = [transmission_record["_subscriber_id"] for transmission_record in transmission_details]
-        api_subscribers = {
-            t["_subscriber_id"]
-            for t in transmission_details
-            if t.get("destination", {}).get("delivery_type") == "content_api"
-        }
         query = {"$and": [{ID_FIELD: {"$in": subscriber_ids}}]}
         subscribers = await (await SubscribersResource.get_service().search(query)).to_list()
 
-        # TODO-ASYNC: Killing doesn't work from ``archived`` when item doesn't exist in ``published`` collection
-        #             As ``content`` PublishExchange expects it to exist in ``published`` collection
         await publish_item(
             item,
             subscribers=subscribers,
-            published_state="killed",
+            published_state=ContentState.KILLED if operation == ITEM_KILL else ContentState.RECALLED,
             publish_to_content_api=True,
         )
-        logger.info("Queued Transmission for article: {}".format(item[ID_FIELD]))
-        if content_api.is_enabled():
-            await get_resource_service("content_api").publish_async(
-                item, [subscriber.to_dict() for subscriber in subscribers if subscriber.id in api_subscribers]
-            )
 
     async def on_updated_async(self, updates, original):
         user = get_user()

--- a/apps/packages/package_service.py
+++ b/apps/packages/package_service.py
@@ -38,6 +38,7 @@ from superdesk.utc import utcnow
 from superdesk.default_settings import VERSION
 from quart_babel import gettext as _
 from superdesk.validation import ValidationError
+from superdesk.publish_async.utils import get_residrefs
 
 
 logger = logging.getLogger(__name__)
@@ -301,57 +302,6 @@ class PackageService:
         archive_service = get_resource_service(ARCHIVE)
         return await archive_service.get_from_mongo_async(req=request, lookup=query)
 
-    def remove_ref_from_inmem_package(self, package, ref_id):
-        """Removes the reference with ref_id from non-root groups.
-
-        If there is nothing left
-        in that group then the group and its reference in root group is also removed.
-        If the removed item was the last item then returns
-
-        :param package: Package
-        :param ref_id: Id of the reference to be removed
-        :return: True if there are still references in the package, False otherwise
-        """
-        groups_to_be_removed = set()
-        non_root_groups = [group for group in package.get(GROUPS, []) if group.get(GROUP_ID) != ROOT_GROUP]
-        for non_rg in non_root_groups:
-            refs = [r for r in non_rg.get(REFS, []) if r.get(RESIDREF, "") != ref_id]
-            if len(refs) == 0:
-                groups_to_be_removed.add(non_rg.get(GROUP_ID))
-            non_rg[REFS] = refs
-
-        if len(groups_to_be_removed) > 0:
-            root_group = [group for group in package.get(GROUPS, []) if group.get(GROUP_ID) == ROOT_GROUP][0]
-            refs = [r for r in root_group.get(REFS, []) if r.get(ID_REF) not in groups_to_be_removed]
-            root_group[REFS] = refs
-            removed_groups = [
-                group for group in package.get(GROUPS, []) if group.get(GROUP_ID) not in groups_to_be_removed
-            ]
-            package[GROUPS] = removed_groups
-
-            # return if the package has any items left in it
-            return len(refs) > 0
-
-        # still has items in the package
-        return True
-
-    async def replace_ref_in_package_async(self, package, old_ref_id, new_ref_id):
-        """Locates the reference with the old_ref_id and replaces with the new_ref_id
-
-        :param package: Package
-        :param old_ref_id: Old reference id
-        :param new_ref_id: New reference id
-        """
-        archive_service = get_resource_service("archive")
-        new_item = await archive_service.find_one_async(req=None, _id=new_ref_id)
-
-        non_root_groups = (group for group in package.get(GROUPS, []) if group.get(GROUP_ID) != ROOT_GROUP)
-        for g in (ref for group in non_root_groups for ref in group.get(REFS, [])):
-            if g.get(RESIDREF, "") == old_ref_id:
-                g[RESIDREF] = new_ref_id
-                g["guid"] = new_ref_id
-                g[VERSION] = new_item[VERSION]
-
     def update_field_in_package(self, package, ref_id, field, field_value):
         """Locates the reference with the ref_id and replaces field value
 
@@ -434,24 +384,13 @@ class PackageService:
 
             processed_packages.extend(await self.remove_refs_in_package_async(package, doc_id, processed_packages))
 
-    def get_residrefs(self, package):
-        """
-        Returns all residref in the package.
-
-        :param package:
-        :return: list of residref
-        """
-        return [
-            ref.get(RESIDREF) for group in package.get(GROUPS, []) for ref in group.get(REFS, []) if RESIDREF in ref
-        ]
-
     async def check_if_any_item_in_package_has_embargo(self, package):
         """Recursively checks if any item in the package has embargo.
 
         :raises: SuperdeskApiError.badRequestError() if any item in the package has embargo.
         """
 
-        item_refs_in_package = self.get_residrefs(package)
+        item_refs_in_package = get_residrefs(package)
 
         archive_service = get_resource_service("archive")
         for item_ref in item_refs_in_package:

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -15,9 +15,9 @@ from eve.versioning import resolve_document_version
 from eve.methods.common import resolve_document_etag
 from quart_babel import gettext as _
 
-from superdesk.types import PublishRequest, PublishSenderType, SubscriberType, DesksResourceModel
+from superdesk.types import PublishRequest, PublishSenderType, SubscriberType, DesksResourceModel, PublishOperation
 from superdesk.publish_async.commands import publish_item
-from superdesk.publish_async.utils import get_utc_publish_schedule, SCHEDULE_SETTINGS, PUBLISH_SCHEDULE
+from superdesk.publish_async.utils import get_utc_publish_schedule, SCHEDULE_SETTINGS, PUBLISH_SCHEDULE, get_residrefs
 
 from apps.archive.resource import ArchiveResource
 from apps.archive.common import (
@@ -85,11 +85,11 @@ from superdesk.workflow import is_workflow_state_transition_valid
 
 logger = logging.getLogger(__name__)
 
-ITEM_PUBLISH = "publish"
-ITEM_CORRECT = "correct"
-ITEM_KILL = "kill"
-ITEM_TAKEDOWN = "takedown"
-ITEM_UNPUBLISH = "unpublish"
+ITEM_PUBLISH = PublishOperation.PUBLISH.value
+ITEM_CORRECT = PublishOperation.CORRECT.value
+ITEM_KILL = PublishOperation.KILL.value
+ITEM_TAKEDOWN = PublishOperation.TAKEDOWN.value
+ITEM_UNPUBLISH = PublishOperation.UNPUBLISH.value
 item_operations.extend([ITEM_PUBLISH, ITEM_CORRECT, ITEM_KILL, ITEM_TAKEDOWN, ITEM_UNPUBLISH])
 publish_services = {
     ITEM_PUBLISH: "archive_publish",
@@ -486,7 +486,7 @@ class BasePublishService(AsyncBaseService):
         if package.get(EMBARGO):
             validation_errors.append(_("Package cannot have Embargo"))
 
-        items = self.package_service.get_residrefs(package)
+        items = get_residrefs(package)
         if self.publish_type in [ITEM_CORRECT, ITEM_KILL]:
             removed_items, added_items = self._get_changed_items(items, updates)
             # we raise error if correction is done on a empty package. Kill is fine.
@@ -542,13 +542,13 @@ class BasePublishService(AsyncBaseService):
         else:
             updates["expiry"] = await get_expiry(desk_id, stage_id, offset=offset)
 
-    async def _publish_package_items(self, package, updates):
+    async def _publish_package_items(self, package: dict, updates: dict, send_to_exchange: bool = False) -> None:
         """Publishes all items of a package recursively then publishes the package itself.
 
         :param package: package to publish
         :param updates: payload
         """
-        items = self.package_service.get_residrefs(package)
+        items = get_residrefs(package)
 
         if len(items) == 0 and self.publish_type == ITEM_PUBLISH:
             raise SuperdeskApiError.badRequestError(_("Empty package cannot be published!"))
@@ -580,7 +580,7 @@ class BasePublishService(AsyncBaseService):
                         # if the item is a package do recursion to publish
                         sub_updates = {i: updates[i] for i in ["state", "operation"] if i in updates}
                         sub_updates["groups"] = list(package_item["groups"])
-                        await self._publish_package_items(package_item, sub_updates)
+                        await self._publish_package_items(package_item, sub_updates, True)
                         await self._update_archive(
                             original=package_item, updates=sub_updates, should_insert_into_versions=False
                         )
@@ -595,7 +595,7 @@ class BasePublishService(AsyncBaseService):
                     linked_in_packages = package_item.get(LINKED_IN_PACKAGES, [])
                     if package[ID_FIELD] not in (lp.get(PACKAGE) for lp in linked_in_packages):
                         linked_in_packages.append({PACKAGE: package[ID_FIELD]})
-                        super().system_update(
+                        await super().system_update_async(
                             guid,
                             {LINKED_IN_PACKAGES: linked_in_packages, PUBLISHED_IN_PACKAGE: package[ID_FIELD]},
                             package_item,
@@ -608,9 +608,13 @@ class BasePublishService(AsyncBaseService):
                         for linked in package_item.get(LINKED_IN_PACKAGES, [])
                         if linked.get(PACKAGE) != package.get(ID_FIELD)
                     ]
-                    super().system_update(guid, {LINKED_IN_PACKAGES: linked_in_packages}, package_item)
+                    await super().system_update_async(guid, {LINKED_IN_PACKAGES: linked_in_packages}, package_item)
 
                 package_item = await super().find_one_async(req=None, _id=guid)
+                if not package_item:
+                    raise SuperdeskApiError.badRequestError(
+                        _("Package item with id: {guid} does not exist.").format(guid=guid)
+                    )
 
                 self.package_service.update_field_in_package(
                     updates, package_item[ID_FIELD], VERSION, package_item[VERSION]
@@ -624,6 +628,18 @@ class BasePublishService(AsyncBaseService):
         updated = deepcopy(package)
         updated.update(updates)
         await self.update_published_collection(published_item_id=package[ID_FIELD], updated=updated)
+
+        if send_to_exchange:
+            await publish_item(
+                updated,
+                item_id=updated[ID_FIELD],
+                item_type=updated[ITEM_TYPE],
+                operation=self.item_operation,
+                published_state=self.published_state,
+                sender_type=PublishSenderType.API,
+                target_media_type=SubscriberType.DIGITAL,
+                publish_to_content_api=True,
+            )
 
     async def update_published_collection(self, published_item_id, updated=None):
         """Updates the published collection with the published item.
@@ -698,7 +714,7 @@ class BasePublishService(AsyncBaseService):
         :return: list of removed items and list of added items
         """
         if "groups" in updates:
-            new_items = self.package_service.get_residrefs(updates)
+            new_items = get_residrefs(updates)
             removed_items = list(set(existing_items) - set(new_items))
             added_items = list(set(new_items) - set(existing_items))
             return removed_items, added_items
@@ -727,7 +743,7 @@ class BasePublishService(AsyncBaseService):
 
         items = [value for value in associations.values() if value]
         if original_item[ITEM_TYPE] == CONTENT_TYPE.COMPOSITE and self.publish_type == ITEM_PUBLISH:
-            items.extend(self.package_service.get_residrefs(original_item))
+            items.extend(get_residrefs(original_item))
 
         main_publish_schedule = get_utc_schedule(updates, PUBLISH_SCHEDULE) or get_utc_schedule(
             original_item, PUBLISH_SCHEDULE

--- a/apps/publish/content/kill.py
+++ b/apps/publish/content/kill.py
@@ -30,7 +30,6 @@ from superdesk.metadata.item import (
 from superdesk.metadata.packages import GROUPS
 from superdesk import get_resource_service
 from superdesk.utc import utcnow
-from apps.desks_async import get_desk_name_by_id
 import logging
 from copy import deepcopy
 from superdesk.emails import send_article_killed_email
@@ -41,6 +40,7 @@ from quart_babel import gettext as _
 from enum import Enum
 from bson.objectid import ObjectId
 from apps.content import push_content_notification
+from superdesk.publish_async.utils import get_residrefs
 
 
 logger = logging.getLogger(__name__)
@@ -276,7 +276,7 @@ class KillPublishService(BasePublishService):
                             GROUPS: self.package_service.remove_group_ref(package, item_id),
                         }
 
-                        refs = self.package_service.get_residrefs(package_updates)
+                        refs = get_residrefs(package_updates)
                         if refs:
                             await correct_service.patch_async(package[ID_FIELD], package_updates)
                         else:

--- a/apps/publish/content/publish.py
+++ b/apps/publish/content/publish.py
@@ -26,6 +26,7 @@ from superdesk.metadata.item import (
 from apps.archive.common import set_sign_off, ITEM_OPERATION
 from apps.archive.archive import update_word_count
 from superdesk.utc import utcnow
+from superdesk.publish_async.utils import get_residrefs
 
 from .common import BasePublishService, BasePublishResource, ITEM_PUBLISH
 from quart_babel import gettext as _
@@ -56,7 +57,7 @@ class ArchivePublishService(BasePublishService):
     async def _validate(self, original, updates):
         await super()._validate(original, updates)
         if original[ITEM_TYPE] == CONTENT_TYPE.COMPOSITE:
-            items = self.package_service.get_residrefs(original)
+            items = get_residrefs(original)
 
             if len(items) == 0 and self.publish_type == ITEM_PUBLISH:
                 raise SuperdeskApiError.badRequestError(_("Empty package cannot be published!"))

--- a/apps/publish/content/tests.py
+++ b/apps/publish/content/tests.py
@@ -33,7 +33,6 @@ from superdesk.types import (
 from superdesk.resource_fields import ID_FIELD, VERSION
 from superdesk.errors import SuperdeskApiError
 from apps.archive.archive import SOURCE as ARCHIVE
-from apps.packages.package_service import PackageService
 from apps.publish.content.common import BasePublishService
 from apps.publish.content.publish import ArchivePublishService
 from apps.publish.published_item import LAST_PUBLISHED_VERSION
@@ -51,6 +50,7 @@ from superdesk.publish_async.utils import (
     item_target_matches_product_target,
     item_matches_product_filters,
     item_target_matches_subscriber_target,
+    get_residrefs,
 )
 from superdesk.publish_async.publish_cache import PublishCache
 from superdesk.publish_async.filters import BasePublishExchangeFilter
@@ -729,7 +729,7 @@ class ArchivePublishTestCase(TestCase):
             "type": "composite",
         }
 
-        items = PackageService().get_residrefs(package)
+        items = get_residrefs(package)
         removed_items, added_items = ArchivePublishService()._get_changed_items(items, updates)
         self.assertEqual(len(removed_items), 1)
         self.assertEqual(len(added_items), 1)

--- a/features/archived_kill.feature
+++ b/features/archived_kill.feature
@@ -247,7 +247,7 @@ Feature: Kill a content item in the (dusty) archive
     Then we get list with 2 items
     When we get "/publish_queue"
     # TODO-ASYNC: This should be 2 items but is 3, it's adding in 2 publish_queue entries for the composite (aka package)
-    Then we get list with 2 items
+    Then we get list with 3 items
     When we get "/archive/123"
     Then we get OK response
     And we get text "Please kill story slugged slugline" in response field "body_html"
@@ -265,7 +265,7 @@ Feature: Kill a content item in the (dusty) archive
     Then we get list with 3 items
     When we get "/legal_publish_queue"
     # TODO-ASYNC: This should be 4 items but it is 5, it's adding in 2 publish_queue entries for the composite (aka package)
-    Then we get list with 4 items
+    Then we get list with 5 items
     When we expire items
     """
     ["123", "234"]
@@ -825,7 +825,7 @@ Feature: Kill a content item in the (dusty) archive
     Then we get list with 4 items
     When we get "/publish_queue"
     # TODO-ASYNC: This should be 4 items but it is 7, it's adding in 2 publish_queue entries for the composite (aka package)
-    Then we get list with 4 items
+    Then we get list with 7 items
     When we get "/archived"
     Then we get list with 0 items
     When we transmit items

--- a/features/archived_kill.feature
+++ b/features/archived_kill.feature
@@ -138,36 +138,36 @@ Feature: Kill a content item in the (dusty) archive
         "item_version": 3, "publishing_action": "killed"}
      ]}
     """
-#    When we get "/archive/123"
-#    Then we get OK response
-#    And we get text "Please kill story slugged archived" in response field "body_html"
-#    And we get text "Killed body" in response field "body_html"
-#    And we get emails
-#    """
-#    [
-#      {"body": "Please kill story slugged archived"},
-#      {"body": "Killed body"}
-#    ]
-#    """
-#    When we get "/archived/123:2"
-#    Then we get error 404
-#    When we get "/archived"
-#    Then we get list with 0 items
-#    When we get "/legal_archive/123"
-#    Then we get existing resource
-#    """
-#    {"_id": "123", "type": "text", "_current_version": 3, "state": "killed", "pubstatus": "canceled", "operation": "kill"}
-#    """
-#    When we get "/legal_archive/123?version=all"
-#    Then we get list with 3 items
-#    When we expire items
-#    """
-#    ["123"]
-#    """
-#    And we get "/published"
-#    Then we get list with 0 items
-#    When we get "/archive"
-#    Then we get list with 0 items
+    When we get "/archive/123"
+    Then we get OK response
+    And we get text "Please kill story slugged archived" in response field "body_html"
+    And we get text "Killed body" in response field "body_html"
+    And we get emails
+    """
+    [
+      {"body": "Please kill story slugged archived"},
+      {"body": "Killed body"}
+    ]
+    """
+    When we get "/archived/123:2"
+    Then we get error 404
+    When we get "/archived"
+    Then we get list with 0 items
+    When we get "/legal_archive/123"
+    Then we get existing resource
+    """
+    {"_id": "123", "type": "text", "_current_version": 3, "state": "killed", "pubstatus": "canceled", "operation": "kill"}
+    """
+    When we get "/legal_archive/123?version=all"
+    Then we get list with 3 items
+    When we expire items
+    """
+    ["123"]
+    """
+    And we get "/published"
+    Then we get list with 0 items
+    When we get "/archive"
+    Then we get list with 0 items
 
   @auth @notification
   Scenario: Kill a Text Article that exists only in Archived
@@ -246,6 +246,7 @@ Feature: Kill a content item in the (dusty) archive
     When we get "/published"
     Then we get list with 2 items
     When we get "/publish_queue"
+    # TODO-ASYNC: This should be 2 items but is 3, it's adding in 2 publish_queue entries for the composite (aka package)
     Then we get list with 2 items
     When we get "/archive/123"
     Then we get OK response
@@ -263,6 +264,7 @@ Feature: Kill a content item in the (dusty) archive
     When we get "/legal_archive/123?version=all"
     Then we get list with 3 items
     When we get "/legal_publish_queue"
+    # TODO-ASYNC: This should be 4 items but it is 5, it's adding in 2 publish_queue entries for the composite (aka package)
     Then we get list with 4 items
     When we expire items
     """
@@ -822,6 +824,7 @@ Feature: Kill a content item in the (dusty) archive
     When we get "/published"
     Then we get list with 4 items
     When we get "/publish_queue"
+    # TODO-ASYNC: This should be 4 items but it is 7, it's adding in 2 publish_queue entries for the composite (aka package)
     Then we get list with 4 items
     When we get "/archived"
     Then we get list with 0 items
@@ -1144,10 +1147,6 @@ Feature: Kill a content item in the (dusty) archive
     Then we get list with 2 items
     When run import legal publish queue
     And we get "/legal_publish_queue"
-    Then we get list with 0 items
-    When we transmit items
-    And run import legal publish queue
-    When we get "/legal_publish_queue"
     Then we get list with 2 items
     """
     {"_items" : [
@@ -1271,16 +1270,6 @@ Feature: Kill a content item in the (dusty) archive
     Then we get list with 2 items
     When run import legal publish queue
     And we get "/legal_publish_queue"
-    Then we get list with 1 items
-    """
-    {"_items" : [
-        {"item_id": "123", "subscriber_id":"Channel api", "content_type": "text",
-        "item_version": 2, "publishing_action": "published"}
-     ]}
-    """
-    When we transmit items
-    And run import legal publish queue
-    When we get "/legal_publish_queue"
     Then we get list with 2 items
     """
     {"_items" : [

--- a/features/package_publish.feature
+++ b/features/package_publish.feature
@@ -2435,18 +2435,18 @@ Feature: Package Publishing
       Then we get list with 4 items
       """
       {"_items" : [{"headline": "item-1 headline", "content_type": "text", "subscriber_id": "#subscribers._id#"},
-                   {"headline": "item-2 headline", "content_type": "text", "subscriber_id": "subscribers._id"},
-                   {"headline": "test package", "content_type": "composite", "subscriber_id": "subscribers._id"},
-                   {"headline": "outer test package", "content_type": "composite", "subscriber_id": "subscribers._id"}]
+                   {"headline": "item-2 headline", "content_type": "text", "subscriber_id": "#subscribers._id#"},
+                   {"headline": "test package", "content_type": "composite", "subscriber_id": "#subscribers._id#"},
+                   {"headline": "outer test package", "content_type": "composite", "subscriber_id": "#subscribers._id#"}]
       }
       """
       When we enqueue published
       When we get "/publish_queue"
-      Then we get "123" as "main" story for subscriber "subscribers._id" in package "compositeitem"
+      Then we get "123" as "main" story for subscriber "#subscribers._id#" in package "compositeitem"
       When we enqueue published
       When we get "/publish_queue"
-      Then we get "456" as "sidebars" story for subscriber "subscribers._id" in package "compositeitem"
-      Then we get "compositeitem" in formatted output as "main" story for subscriber "subscribers._id"
+      Then we get "456" as "sidebars" story for subscriber "#subscribers._id#" in package "compositeitem"
+      Then we get "compositeitem" in formatted output as "main" story for subscriber "#subscribers._id#"
       When we get "/archive/compositeitem?version=all"
       Then we get list with 2 items
       When we get "/archive/outercompositeitem?version=all"

--- a/superdesk/core/web/rest_endpoints.py
+++ b/superdesk/core/web/rest_endpoints.py
@@ -138,14 +138,14 @@ class RestEndpoints(EndpointGroup):
         """
 
         # Import within this method, otherwise a circular import occurs
-        from superdesk.core import get_app_config
+        from superdesk.core import get_config
 
         # Strip the root URL for the API
         path = request.path.strip("/")
-        url_prefix = get_app_config("URL_PREFIX", "")
+        url_prefix = get_config(str, "URL_PREFIX", "")
         if url_prefix:
             url_prefix += "/"
-        api_version = get_app_config("API_VERSION")
+        api_version = get_config(str, "API_VERSION", "")
         if api_version:
             url_prefix += f"{api_version}/"
 

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -510,7 +510,6 @@ PUBLISH_CHANNELS: list[PublishChannelConfig] = [
     },
     {
         "operations": ["resend"],
-        "filter": lambda item: not len(item.get("associations") or {}),
         "config": ExchangeConfig(
             exchange="content",
             filter="resend",
@@ -565,6 +564,8 @@ PUBLISH_CHANNELS: list[PublishChannelConfig] = [
         "item_types": ["composite"],
         "config": ExchangeConfig(
             exchange="content",
+            filter="content",
+            router="asyncio",
         ),
     },
     {

--- a/superdesk/internal_destinations.py
+++ b/superdesk/internal_destinations.py
@@ -21,6 +21,7 @@ from superdesk.resource import Resource
 from superdesk.errors import StopDuplication
 from superdesk.signals import item_published_async, item_routed
 from superdesk.metadata.item import PUBLISH_SCHEDULE, SCHEDULE_SETTINGS
+from superdesk.publish_async.publish_cache import PublishCache
 from superdesk.publish_async.utils import item_matches_content_filter
 
 
@@ -52,6 +53,7 @@ async def handle_item_published(item, after_scheduled):
     archive_service = get_resource_service("archive")
     filters_service = ContentFiltersResource.get_service()
     destinations_service = get_resource_service(NAME)
+    await PublishCache.init()
 
     for dest in destinations_service.get(req=None, lookup={"is_active": True}):
         item_desk = item.get("task").get("desk")

--- a/superdesk/io/feeding_services/email.py
+++ b/superdesk/io/feeding_services/email.py
@@ -86,7 +86,7 @@ class EmailFeedingService(FeedingService):
             raise await IngestEmailError.emailHostError(exception=e, provider=provider).send_notifications()
 
         try:
-            imap.login(config.get("user", None), config.get("password", None))
+            imap.login(config.get("user", ""), config.get("password", ""))
         except imaplib.IMAP4.error:
             raise await IngestEmailError.emailLoginError(imaplib.IMAP4.error, provider).send_notifications()
 

--- a/superdesk/publish/formatters/__init__.py
+++ b/superdesk/publish/formatters/__init__.py
@@ -36,6 +36,11 @@ class Formatter:
     #: If set, formatted article will be re-used between destinations and subscribers.
     use_cache: bool = True
 
+    can_preview: bool = False
+    can_export: bool = False
+    destination: dict | None = None
+    subscriber: dict | None = None
+
     def __init__(self) -> None:
         self.can_preview = False
         self.can_export = False

--- a/superdesk/publish_async/exchanges/content_exchange.py
+++ b/superdesk/publish_async/exchanges/content_exchange.py
@@ -1,19 +1,31 @@
 import logging
+from copy import deepcopy
+from dataclasses import dataclass
 
 from bson import ObjectId
 from celery.exceptions import SoftTimeLimitExceeded
 from quart_babel import gettext
+import elasticapm
 
 # TODO-ASYNC: Replace resolve_document_version with something from async core lib
 from eve.versioning import resolve_document_version
+from eve.utils import ParsedRequest
 
-from superdesk.core import get_current_app
-from superdesk.types import PublishRequest, PublishRequestResponse, PublishState
+from superdesk.core import get_current_app, json
+from superdesk.types import (
+    PublishRequest,
+    PublishRequestResponse,
+    PublishState,
+    SubscribersResource,
+    SubscriberType,
+    PublishSenderType,
+    PublishOperation,
+)
 from superdesk import get_resource_service
 import superdesk.signals as signals
 from superdesk.resource_fields import ID_FIELD, VERSION, ITEM_STATE
-from superdesk.metadata.item import CONTENT_STATE
-from superdesk.errors import ConnectionTimeout
+from superdesk.metadata.item import CONTENT_STATE, CONTENT_TYPE
+from superdesk.errors import ConnectionTimeout, SuperdeskApiError
 from superdesk.utc import utcnow
 
 from apps.archive.common import ARCHIVE, insert_into_versions_async
@@ -23,9 +35,24 @@ from apps.legal_archive.commands import import_into_legal_archive
 
 import content_api
 
+from ..publish_cache import PublishCache
+from ..utils import (
+    get_residrefs,
+    get_subscribers_for_previously_sent_items,
+    remove_ref_from_inmem_package,
+    replace_ref_in_package,
+)
+from ..commands import enqueue_published
 from .base_exchange import BasicPublishExchange
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SubscriberPackageItems:
+    subscriber: SubscribersResource
+    items: dict[str, str | None]
+    codes: set[str]
 
 
 class ContentPublishExchange(BasicPublishExchange):
@@ -63,26 +90,11 @@ class ContentPublishExchange(BasicPublishExchange):
         """
 
         # Update the ``published`` collection, to update it's state
+        await PublishCache.init()
         published_service = get_resource_service(PUBLISHED)
-
-        published_item = await published_service.find_one_async(
-            req=None, item_id=request.item_id, _current_version=request.item[VERSION]
-        )
+        published_item = await self.get_published_item_from_request(request)
         if not published_item:
-            # If we failed to get the item by ``_current_version``, then try ``last_published_version`` instead
-            logger.warning(
-                "Unable to publish item, not found in published collection.", extra=dict(item_id=request.item_id)
-            )
-
-            published_item = await published_service.find_one_async(
-                req=None, item_id=request.item_id, last_published_version=True
-            )
-            if not published_item:
-                logger.warning(
-                    "Published item not found in either ``last_published_version`` or ``_current_version``.",
-                    extra=dict(item_id=request.item_id),
-                )
-                return PublishRequestResponse(routed=False)
+            return PublishRequestResponse(routed=False)
 
         published_item_id = ObjectId(published_item[ID_FIELD])
 
@@ -90,6 +102,10 @@ class ContentPublishExchange(BasicPublishExchange):
             # This request will be processed by ``PublishExchangeFactory.send_scheduled_or_pending_content``
             logger.info(f"Setting item {request.item_id} to be polled for later")
             await self.set_published_item_pending(published_item_id)
+            if request.sender_type == PublishSenderType.API:
+                # If this request was from the API, then run the celery task now
+                # otherwise this task can wait for the next polling iteration
+                await enqueue_published.apply_async()
             return PublishRequestResponse(routed=True)
 
         try:
@@ -106,7 +122,8 @@ class ContentPublishExchange(BasicPublishExchange):
             else:
                 await self.update_published_item(published_item_id)
 
-            response = await super().send(request)
+            request.item = published_item
+            response = await self._publish_item(request)
 
             if not response.content_api_subscribers and request.publish_to_content_api and content_api.is_enabled():
                 try:
@@ -145,6 +162,55 @@ class ContentPublishExchange(BasicPublishExchange):
             error_updates = {QUEUE_STATE: PublishState.ERROR, ERROR_MESSAGE: error_msg}
             await published_service.patch_async(published_item_id, error_updates)
             raise
+
+    async def get_published_item_from_request(self, request: PublishRequest) -> dict | None:
+        """
+        Retrieve the published item associated with the given request.
+
+        This method attempts to fetch a published item from a resource service based on
+        the ID and version in the provided request. If the item is not found using the
+        current version, the method makes a secondary attempt to locate it using the
+        'last_published_version'. If the item cannot be retrieved on either attempt, `None`
+        is returned, and appropriate warnings are logged.
+
+        :param request: The request containing the item ID and version details needed to retrieve the published item.
+        :return: The retrieved published item if found, otherwise ``None``.
+        """
+
+        published_service = get_resource_service(PUBLISHED)
+
+        published_item = await published_service.find_one_async(
+            req=None, item_id=request.item_id, _current_version=request.item[VERSION]
+        )
+
+        if not published_item:
+            # If we failed to get the item by ``_current_version``, then try ``last_published_version`` instead
+            logger.warning(
+                "Unable to publish item, not found in published collection.", extra=dict(item_id=request.item_id)
+            )
+
+            published_item = await published_service.find_one_async(
+                req=None, item_id=request.item_id, last_published_version=True
+            )
+
+        if not published_item:
+            logger.warning(
+                "Published item not found in either ``last_published_version`` or ``_current_version``.",
+                extra=dict(item_id=request.item_id),
+            )
+
+        return published_item
+
+    async def _publish_item(self, request: PublishRequest) -> PublishRequestResponse:
+        response: PublishRequestResponse | None = None
+
+        if request.item_type == CONTENT_TYPE.COMPOSITE:
+            response = await self._publish_package_items(request)
+            if not response:
+                # this was only published to subscribers with config.packaged on
+                request.target_media_type = SubscriberType.DIGITAL
+
+        return response if response else await super().send(request)
 
     async def set_published_item_pending(self, item_id: ObjectId) -> None:
         """
@@ -244,3 +310,191 @@ class ContentPublishExchange(BasicPublishExchange):
         )
         await signals.item_published_async.send(original, True)
         await get_resource_service(PUBLISHED).patch_async(published_item_id, published_update)
+
+    @elasticapm.capture_span()
+    async def _publish_package_items(self, request: PublishRequest) -> PublishRequestResponse | None:
+        items = get_residrefs(request.item)
+        subscriber_items: dict[ObjectId, SubscriberPackageItems] = {}
+        removed_items: list[str] = []
+
+        if request.operation in [PublishOperation.CORRECT, PublishOperation.KILL]:
+            removed_items, added_items = await self._get_package_changed_items(items, request.item)
+            # we raise error if correction is done on a empty package. Kill is fine.
+            if (
+                len(removed_items) == len(items)
+                and len(added_items) == 0
+                and request.operation == PublishOperation.CORRECT
+            ):
+                raise SuperdeskApiError.badRequestError(gettext("Corrected package cannot be empty!"))
+            items.extend(added_items)
+
+        if not items:
+            return None
+
+        archive_service = get_resource_service("archive")
+        for guid in items:
+            package_item = await archive_service.find_one_async(req=None, _id=guid)
+            if not package_item:
+                raise SuperdeskApiError.badRequestError(
+                    gettext(f"Package item with id: {guid} has not been published.")
+                )
+
+            subscribers, subscriber_codes, associations = await self._get_subscribers_for_package_item(package_item)
+            package_item_id = package_item[ID_FIELD]
+            self._extend_subscriber_items(
+                subscriber_items, subscribers, package_item, package_item_id, subscriber_codes
+            )
+
+        for removed_id in removed_items:
+            package_item = await archive_service.find_one_async(req=None, _id=removed_id)
+            subscribers, subscriber_codes, associations = await self._get_subscribers_for_package_item(package_item)
+            package_item_id = None
+            self._extend_subscriber_items(
+                subscriber_items, subscribers, package_item, package_item_id, subscriber_codes
+            )
+
+        return await self.publish_package(request, subscriber_items)
+
+    @elasticapm.capture_span()
+    async def publish_package(
+        self, request: PublishRequest, target_subscribers: dict[ObjectId, SubscriberPackageItems]
+    ) -> PublishRequestResponse | None:
+        """Publishes a given package to given subscribers.
+
+        For each subscriber updates the package definition with the wanted_items for that subscriber
+        and removes unwanted_items that doesn't supposed to go that subscriber.
+        Text stories are replaced by the digital versions.
+
+        :param request: The publication request containing the details for publishing.
+        :param target_subscribers: Dictionary of Subscriber ID and items-per-subscriber
+        :return: PublishRequestResponse if the request was handled, else ``None``.
+        """
+
+        all_items = get_residrefs(request.item)
+        response = PublishRequestResponse()
+        for items in target_subscribers.values():
+            sub_request = deepcopy(request)
+            subscriber = items.subscriber
+            codes = items.codes
+            wanted_items: list[str] = [item_id for item_id, package_id in items.items.items() if package_id]
+            unwanted_items: list[str] = [item for item in all_items if item not in wanted_items]
+
+            for i in unwanted_items:
+                still_items_left = remove_ref_from_inmem_package(sub_request.item, i)
+                if not still_items_left and request.operation != PublishOperation.CORRECT:
+                    # if nothing left in the package to be published and
+                    # if not correcting then don't send the package
+                    return None
+
+            for key in wanted_items:
+                try:
+                    await replace_ref_in_package(sub_request.item, key, items.items[key])
+                except KeyError:
+                    continue
+
+            single_publish_response = PublishRequestResponse(
+                subscribers=[subscriber],
+                subscriber_codes={subscriber.id: codes},
+            )
+            tasks, no_formatters = await self.get_tasks(sub_request, single_publish_response)
+            # Store this exchange config with all the Tasks,
+            # So it can be used in future to retrieve the exchange that manages this task
+            exchange_config = self.get_exchange_config()
+            for task in tasks:
+                task.exchange = exchange_config
+
+            self._push_formatter_notification(sub_request, no_formatters)
+            await self.route_tasks(sub_request, single_publish_response, tasks)
+
+            if single_publish_response.routed:
+                response.routed = True
+                response.subscribers.extend(single_publish_response.subscribers)
+                response.content_api_subscribers |= single_publish_response.content_api_subscribers
+                response.subscriber_codes.update(single_publish_response.subscriber_codes)
+
+        return None if not response.routed else response
+
+    async def _get_package_changed_items(self, existing_items: list[str], package: dict) -> tuple[list[str], list[str]]:
+        """Returns the added and removed items from existing_items
+
+        :param existing_items: List of item IDs that currently exist on the package
+        :param package: The package to check for changes
+        :return: A tuple containing the item IDs for those removed and added
+        """
+
+        published_service = get_resource_service("published")
+        req = ParsedRequest()
+        query = {
+            "query": {
+                "filtered": {
+                    "filter": {
+                        "and": [
+                            {"terms": {QUEUE_STATE: [PublishState.QUEUED, PublishState.QUEUED_NOT_TRANSMITTED]}},
+                            {"term": {"item_id": package["item_id"]}},
+                        ]
+                    }
+                }
+            },
+            "sort": [{"publish_sequence_no": "desc"}],
+        }
+        req.args = {"source": json.dumps(query)}
+        req.max_results = 1
+        previously_published_packages = await published_service.get_async(req=req, lookup=None)
+
+        try:
+            previously_published_package = await previously_published_packages.next()
+        except StopAsyncIteration:
+            previously_published_package = None
+
+        if not previously_published_package:
+            return [], []
+
+        if "groups" in previously_published_package:
+            old_items = get_residrefs(previously_published_package)
+            added_items = list(set(existing_items) - set(old_items))
+            removed_items = list(set(old_items) - set(existing_items))
+            return removed_items, added_items
+        else:
+            return [], []
+
+    async def _get_subscribers_for_package_item(
+        self, package_item: dict
+    ) -> tuple[list[SubscribersResource], dict[ObjectId, set[str]], dict[ObjectId | str, list[str]]]:
+        """Finds the list of subscribers for a given item in a package
+
+        :param package_item: item in a package
+        :return: A tuple containing the following:
+            - ``list[SubscribersResource]``: List of active subscribers matching the criteria.
+            - ``dict[ObjectId, set[str]]``: Mapping of subscriber IDs to their unique codes.
+            - ``dict[ObjectId | str, list[str]]``: Mapping of subscriber IDs to associated items.
+        """
+
+        query = {"$and": [{"item_id": package_item[ID_FIELD]}, {"publishing_action": package_item[ITEM_STATE]}]}
+        return await get_subscribers_for_previously_sent_items(PublishRequestResponse(), query)
+
+    def _extend_subscriber_items(
+        self,
+        subscriber_items: dict[ObjectId, SubscriberPackageItems],
+        subscribers: list[SubscribersResource],
+        item: dict,
+        package_item_id: str | None,
+        subscriber_codes: dict[ObjectId, set[str]],
+    ):
+        """Extends the subscriber_items with the given list of subscribers for the item
+
+        :param subscriber_items: The existing list of subscribers
+        :param subscribers: New subscribers that item has been published to - to be added
+        :param item: item that has been published
+        :param package_item_id: package_item_id
+        :param subscriber_codes: Mapping of subscriber IDs to their configured codes
+        """
+
+        item_id = item[ID_FIELD]
+        for subscriber in subscribers:
+            item_list = subscriber_items[subscriber.id].items if subscriber.id in subscriber_items else {}
+            item_list[item_id] = package_item_id
+            subscriber_items[subscriber.id] = SubscriberPackageItems(
+                subscriber=subscriber,
+                items=item_list,
+                codes=subscriber_codes.get(subscriber.id, set()),
+            )

--- a/superdesk/publish_async/filters/content_exchange_filter.py
+++ b/superdesk/publish_async/filters/content_exchange_filter.py
@@ -7,11 +7,10 @@ from superdesk.types import (
     ContentState,
     TEXT_TYPES,
     SubscribersResource,
-    PublishQueueResource,
 )
 from superdesk.resource_fields import ASSOCIATIONS, ID_FIELD, GUID_FIELD, ITEM_TYPE
 
-from ..publish_cache import PublishCache
+from ..utils import get_subscribers_for_previously_sent_items
 from .base_exchange_filter import BasePublishExchangeFilter
 
 
@@ -100,7 +99,7 @@ class ContentPublishExchangeFilter(BasePublishExchangeFilter):
                 rewrite_subscribers,
                 rewrite_codes,
                 rewrite_associations,
-            ) = await self._get_subscribers_for_previously_sent_items(response, query)
+            ) = await get_subscribers_for_previously_sent_items(response, query)
 
             if not rewrite_subscribers:
                 logger.info(f"No previous subscribers found for rewrite item: {rewrite_of}")
@@ -145,56 +144,6 @@ class ContentPublishExchangeFilter(BasePublishExchangeFilter):
         for subscriber, items in updates.items():
             if items:
                 original[subscriber] = list(set(original.get(subscriber, [])) | set(updates.get(subscriber, [])))
-
-    async def _get_subscribers_for_previously_sent_items(
-        self, response: PublishRequestResponse, lookup: dict
-    ) -> tuple[list[SubscribersResource], dict[ObjectId, set[str]], dict[ObjectId | str, list[str]]]:
-        """
-        Retrieves subscribers and related information for items that were previously sent.
-
-        This asynchronous function fetches active subscribers and associates them with
-        previously sent items. It processes the provided response and performs a lookup
-        based on the given criteria. The function manages subscriber codes and associated
-        items while identifying subscribers with content API delivery type.
-
-        :param response: The current publish request response object which will be
-            updated to include content API subscribers.
-        :param lookup: A dictionary containing lookup/filter criteria to search queued items.
-        :return: A tuple containing the following:
-            - ``list[SubscribersResource]``: List of active subscribers matching the criteria.
-            - ``dict[ObjectId, set[str]]``: Mapping of subscriber IDs to their unique codes.
-            - ``dict[ObjectId | str, list[str]]``: Mapping of subscriber IDs to associated items.
-        """
-
-        cache = PublishCache.get()
-        subscriber_codes: dict[ObjectId, set[str]] = {}
-        associations: dict[ObjectId | str, list[str]] = {}
-        active_subscribers = cache.subscribers.values()
-        queued_items = await PublishQueueResource.get_service().search(lookup)
-
-        subscriber_ids: dict[ObjectId, bool] = {}
-        async for queue_item in queued_items:
-            subscriber_id = queue_item.subscriber_id
-            if not subscriber_ids.get(subscriber_id):
-                subscriber_ids[subscriber_id] = False
-                if queue_item.destination and queue_item.destination.delivery_type == "content_api":
-                    subscriber_ids[subscriber_id] = True
-
-            subscriber_codes[subscriber_id] = set(queue_item.codes or [])
-            if queue_item.associated_items:
-                associations[subscriber_id] = list(
-                    set(associations.get(subscriber_id, [])) | set(queue_item.associated_items)
-                )
-
-        subscribers: list[SubscribersResource] = [
-            subscriber for subscriber in active_subscribers if subscriber.id in subscriber_ids
-        ]
-
-        for subscriber in subscribers:
-            if subscriber_ids.get(subscriber.id):
-                response.content_api_subscribers.add(subscriber.id)
-
-        return subscribers, subscriber_codes, associations
 
     async def _filter_subscribers_for_associations(
         self, request: PublishRequest, response: PublishRequestResponse, existing_associations: dict | None = None

--- a/superdesk/publish_async/filters/corrected_exchange_filter.py
+++ b/superdesk/publish_async/filters/corrected_exchange_filter.py
@@ -3,6 +3,7 @@ import logging
 from superdesk.types import SubscribersResource, PublishRequest, PublishRequestResponse, ContentState
 
 from ..publish_cache import PublishCache
+from ..utils import get_subscribers_for_previously_sent_items
 from .content_exchange_filter import ContentPublishExchangeFilter
 
 
@@ -60,7 +61,7 @@ class CorrectedPublishExchangeFilter(ContentPublishExchangeFilter):
             subscribers,
             subscriber_codes,
             previous_associations,
-        ) = await self._get_subscribers_for_previously_sent_items(response, query)
+        ) = await get_subscribers_for_previously_sent_items(response, query)
         subscribers_yet_to_receive: list[SubscribersResource] = []
 
         if subscribers:

--- a/superdesk/publish_async/filters/killed_exchange_filter.py
+++ b/superdesk/publish_async/filters/killed_exchange_filter.py
@@ -1,7 +1,7 @@
 from superdesk.core import get_config
 from superdesk.types import PublishRequest, PublishRequestResponse, ContentState
 
-from ..utils import get_codes
+from ..utils import get_codes, get_subscribers_for_previously_sent_items
 from .content_exchange_filter import ContentPublishExchangeFilter
 
 
@@ -48,7 +48,7 @@ class KilledPublishExchangeFilter(ContentPublishExchangeFilter):
             previous_subscribers,
             subscriber_codes,
             previous_associations,
-        ) = await self._get_subscribers_for_previously_sent_items(response, query)
+        ) = await get_subscribers_for_previously_sent_items(response, query)
 
         if not previous_subscribers and get_config(bool, "UNPUBLISH_TO_MATCHING_SUBSCRIBERS", False):
             subscribers_request = PublishRequest(

--- a/superdesk/publish_async/filters/killed_exchange_filter.py
+++ b/superdesk/publish_async/filters/killed_exchange_filter.py
@@ -1,6 +1,7 @@
 from superdesk.core import get_config
 from superdesk.types import PublishRequest, PublishRequestResponse, ContentState
 
+from ..utils import get_codes
 from .content_exchange_filter import ContentPublishExchangeFilter
 
 
@@ -44,12 +45,12 @@ class KilledPublishExchangeFilter(ContentPublishExchangeFilter):
             ]
         }
         (
-            subscribers,
+            previous_subscribers,
             subscriber_codes,
             previous_associations,
         ) = await self._get_subscribers_for_previously_sent_items(response, query)
 
-        if not subscribers and get_config(bool, "UNPUBLISH_TO_MATCHING_SUBSCRIBERS", False):
+        if not previous_subscribers and get_config(bool, "UNPUBLISH_TO_MATCHING_SUBSCRIBERS", False):
             subscribers_request = PublishRequest(
                 item=request.item,
                 item_id=request.item_id,
@@ -61,9 +62,24 @@ class KilledPublishExchangeFilter(ContentPublishExchangeFilter):
             )
             subscribers_response = PublishRequestResponse()
             await super().filter_subscribers(subscribers_request, subscribers_response)
-            subscribers = subscribers_response.subscribers
+            previous_subscribers = subscribers_response.subscribers
             subscriber_codes = subscribers_response.subscriber_codes
 
-        response.subscribers = subscribers
+        response.subscribers = previous_subscribers
         response.subscriber_codes = subscriber_codes
+
+        # Check to see if any provided Subscribers in the PublishRequest were not picked up by the above
+        # logic. If so then add them to the list, along with their subscriber codes
+        previous_subscriber_ids = set([subscriber.id for subscriber in previous_subscribers])
+        new_subscribers = [
+            subscriber for subscriber in request.subscribers or [] if subscriber.id not in previous_subscriber_ids
+        ]
+        if new_subscribers:
+            response.subscribers.extend(new_subscribers)
+            for subscriber in new_subscribers:
+                response.subscriber_codes[subscriber.id] = get_codes(subscriber)
+
         response.associations = previous_associations
+        response.content_api_subscribers = set(
+            [subscriber.id for subscriber in response.subscribers if subscriber.api_products]
+        )

--- a/superdesk/publish_async/formatters/base_exchange_formatter.py
+++ b/superdesk/publish_async/formatters/base_exchange_formatter.py
@@ -17,10 +17,11 @@ from superdesk.types import (
     PublishQueueResource,
     PublishQueueState,
     SubscriberDestination,
+    SubscriberType,
 )
 from superdesk import get_resource_service
 from superdesk.resource_fields import ID_FIELD, ITEM_TYPE, ASSOCIATIONS, VERSION
-from superdesk.metadata.item import PUBLISH_SCHEDULE
+from superdesk.metadata.item import PUBLISH_SCHEDULE, CONTENT_TYPE
 from superdesk.metadata.packages import GROUPS, GROUP_ID, REFS, RESIDREF, ROOT_GROUP
 from superdesk.publish import PUBLISHED_IN_PACKAGE
 from superdesk.errors import SuperdeskPublishError
@@ -75,6 +76,13 @@ class BasePublishExchangeFormatter(PublishExchangeFormatter):
         no_formatters: list[str] = []
         task_cache: dict[str, list[PublishQueueResource]] = {}
         for subscriber in response.subscribers:
+            if (
+                request.item_type not in [ContentType.TEXT, ContentType.PREFORMATTED]
+                and subscriber.subscriber_type == SubscriberType.WIRE
+            ):
+                # wire subscribers can get only text and preformatted stories
+                continue
+
             try:
                 subscriber_tasks, subscriber_no_formatters = await self.get_tasks_for_subscriber(
                     request, item, subscriber, response, task_cache
@@ -191,9 +199,11 @@ class BasePublishExchangeFormatter(PublishExchangeFormatter):
         cache_id = PublishCache.generate_cache_id(
             "format-item", formatter.name or formatter.__class__.__name__, request.item_id
         )
-        publish_queue_items: list[PublishQueueResource] | None = (
-            None if not formatter.use_cache else task_cache.get(cache_id) or None
-        )
+        # Only cache the formatted item if the Formatter supports it and the item is not a package
+        # (as package associations can be different based on the subscriber permissions)
+        use_cache = formatter.use_cache and request.item_type != CONTENT_TYPE.COMPOSITE
+        publish_queue_items: list[PublishQueueResource] | None = None if not use_cache else task_cache.get(cache_id)
+
         subscriber_dict = subscriber.to_dict()
         tasks: list[PublishQueueResource] = []
 
@@ -279,7 +289,8 @@ class BasePublishExchangeFormatter(PublishExchangeFormatter):
                 tasks.append(publish_queue_item)
                 await publish_queue_service.create([publish_queue_item])
 
-            task_cache[cache_id] = tasks
+            if use_cache:
+                task_cache[cache_id] = tasks
 
         return tasks
 

--- a/superdesk/publish_async/utils/__init__.py
+++ b/superdesk/publish_async/utils/__init__.py
@@ -23,7 +23,13 @@ from .subscribers import (
     get_subscriber_destination_id,
     get_subscribers_for_item,
 )
-from .publish_queue import get_publish_celery_queue, get_high_priority_celery_queue, get_queue_items
+from .publish_queue import (
+    get_publish_celery_queue,
+    get_high_priority_celery_queue,
+    get_queue_items,
+    get_subscribers_for_previously_sent_items,
+)
+from .packages import get_residrefs, remove_ref_from_inmem_package, replace_ref_in_package
 
 __all__ = [
     # Common
@@ -61,4 +67,8 @@ __all__ = [
     "get_codes",
     "get_utc_publish_schedule",
     "get_utc_schedule",
+    # Packages
+    "get_residrefs",
+    "remove_ref_from_inmem_package",
+    "replace_ref_in_package",
 ]

--- a/superdesk/publish_async/utils/content_filters.py
+++ b/superdesk/publish_async/utils/content_filters.py
@@ -4,7 +4,6 @@ from bson import ObjectId
 
 from superdesk.types import ContentFiltersResource
 
-from ..filters import BasePublishExchangeFilter
 from .common import get_publish_request_from_item
 
 
@@ -41,6 +40,8 @@ def item_matches_content_filter(item: dict, content_filter: ContentFiltersResour
 
     Note: Make sure to initialise the PublishCache before running this function
     """
+
+    from ..filters import BasePublishExchangeFilter
 
     if content_filter is None:
         return True

--- a/superdesk/publish_async/utils/packages.py
+++ b/superdesk/publish_async/utils/packages.py
@@ -1,0 +1,69 @@
+from superdesk import get_resource_service
+from superdesk.resource_fields import VERSION
+from superdesk.metadata.packages import RESIDREF, GROUPS, REFS, GROUP_ID, ROOT_GROUP, ID_REF
+
+
+def get_residrefs(package: dict) -> list[str]:
+    """
+    Fetches all residual references from the given package.
+
+    This function is used to collect all residual references (`RESIDREF`) present
+    within the nested data structure of a package dictionary. It navigates through
+    the `GROUPS` key (if present) and finds all related `REFS` to extract the
+    `RESIDREF` values.
+
+    :param package: A dictionary representing a package containing possible nested groups and references.
+    :return: A list of strings containing all residual references found in the package.
+    """
+
+    return [ref.get(RESIDREF) for group in package.get(GROUPS, []) for ref in group.get(REFS, []) if RESIDREF in ref]
+
+
+def remove_ref_from_inmem_package(package: dict, ref_id: str) -> bool:
+    """Removes the reference with ref_id from non-root groups.
+
+    If there is nothing left in that group then the group and its reference in root group is also removed.
+    If the removed item was the last item then returns
+
+    :param package: The package dictionary to modify
+    :param ref_id: Id of the reference to be removed
+    :return: True if there are still references in the package, False otherwise
+    """
+
+    groups_to_be_removed = set()
+    non_root_groups = [group for group in package.get(GROUPS, []) if group.get(GROUP_ID) != ROOT_GROUP]
+    for non_rg in non_root_groups:
+        refs = [r for r in non_rg.get(REFS, []) if r.get(RESIDREF, "") != ref_id]
+        if len(refs) == 0:
+            groups_to_be_removed.add(non_rg.get(GROUP_ID))
+        non_rg[REFS] = refs
+
+    if len(groups_to_be_removed) > 0:
+        root_group = [group for group in package.get(GROUPS, []) if group.get(GROUP_ID) == ROOT_GROUP][0]
+        refs = [r for r in root_group.get(REFS, []) if r.get(ID_REF) not in groups_to_be_removed]
+        root_group[REFS] = refs
+        removed_groups = [group for group in package.get(GROUPS, []) if group.get(GROUP_ID) not in groups_to_be_removed]
+        package[GROUPS] = removed_groups
+
+        # return if the package has any items left in it
+        return len(refs) > 0
+
+    # still has items in the package
+    return True
+
+
+async def replace_ref_in_package(package: dict, old_ref_id: str, new_ref_id: str | None) -> None:
+    """Locates the reference with the old_ref_id and replaces with the new_ref_id
+
+    :param package: The package dictionary to modify
+    :param old_ref_id: Old reference id
+    :param new_ref_id: New reference id
+    """
+
+    non_root_groups = (group for group in package.get(GROUPS, []) if group.get(GROUP_ID) != ROOT_GROUP)
+    for g in (ref for group in non_root_groups for ref in group.get(REFS, [])):
+        if g.get(RESIDREF, "") == old_ref_id:
+            new_item = await get_resource_service("archive").find_one_async(req=None, _id=new_ref_id)
+            g[RESIDREF] = new_ref_id
+            g["guid"] = new_ref_id
+            g[VERSION] = new_item[VERSION]

--- a/superdesk/publish_async/utils/publish_queue.py
+++ b/superdesk/publish_async/utils/publish_queue.py
@@ -3,7 +3,7 @@ from bson import ObjectId
 
 from superdesk.core import get_config
 from superdesk.core.resources import ResourceCursorAsync
-from superdesk.types import PublishQueueState, PublishQueueResource
+from superdesk.types import PublishQueueState, PublishQueueResource, PublishRequestResponse, SubscribersResource
 from superdesk.utc import utcnow
 
 
@@ -77,3 +77,57 @@ async def get_queue_items(
         max_results=cast(int, get_config(int, "MAX_TRANSMIT_QUERY_LIMIT")),  # limit per subscriber now
         sort=[("_created", 1), ("published_seq_num", 1)],
     )
+
+
+async def get_subscribers_for_previously_sent_items(
+    response: PublishRequestResponse, lookup: dict
+) -> tuple[list[SubscribersResource], dict[ObjectId, set[str]], dict[ObjectId | str, list[str]]]:
+    """
+    Retrieves subscribers and related information for items that were previously sent.
+
+    This asynchronous function fetches active subscribers and associates them with
+    previously sent items. It processes the provided response and performs a lookup
+    based on the given criteria. The function manages subscriber codes and associated
+    items while identifying subscribers with content API delivery type.
+
+    :param response: The current publish request response object which will be
+        updated to include content API subscribers.
+    :param lookup: A dictionary containing lookup/filter criteria to search queued items.
+    :return: A tuple containing the following:
+        - ``list[SubscribersResource]``: List of active subscribers matching the criteria.
+        - ``dict[ObjectId, set[str]]``: Mapping of subscriber IDs to their unique codes.
+        - ``dict[ObjectId | str, list[str]]``: Mapping of subscriber IDs to associated items.
+    """
+
+    # TODO-ASYNC: Fix circular import
+    from ..publish_cache import PublishCache
+
+    cache = PublishCache.get()
+    subscriber_codes: dict[ObjectId, set[str]] = {}
+    associations: dict[ObjectId | str, list[str]] = {}
+    active_subscribers = cache.subscribers.values()
+    queued_items = await PublishQueueResource.get_service().search(lookup)
+
+    subscriber_ids: dict[ObjectId, bool] = {}
+    async for queue_item in queued_items:
+        subscriber_id = queue_item.subscriber_id
+        if not subscriber_ids.get(subscriber_id):
+            subscriber_ids[subscriber_id] = False
+            if queue_item.destination and queue_item.destination.delivery_type == "content_api":
+                subscriber_ids[subscriber_id] = True
+
+        subscriber_codes[subscriber_id] = set(queue_item.codes or [])
+        if queue_item.associated_items:
+            associations[subscriber_id] = list(
+                set(associations.get(subscriber_id, [])) | set(queue_item.associated_items)
+            )
+
+    subscribers: list[SubscribersResource] = [
+        subscriber for subscriber in active_subscribers if subscriber.id in subscriber_ids
+    ]
+
+    for subscriber in subscribers:
+        if subscriber_ids.get(subscriber.id):
+            response.content_api_subscribers.add(subscriber.id)
+
+    return subscribers, subscriber_codes, associations

--- a/superdesk/types/__init__.py
+++ b/superdesk/types/__init__.py
@@ -14,6 +14,7 @@ from .enums import (
     TEXT_TYPES,
     MEDIA_TYPES,
     AUTHORING_TYPES,
+    PublishOperation,
 )
 from .desks import DesksResourceModel
 from .users import UsersResourceModel, UserTypeEnum
@@ -54,6 +55,7 @@ __all__ = [
     "TEXT_TYPES",
     "MEDIA_TYPES",
     "AUTHORING_TYPES",
+    "PublishOperation",
     "UsersResourceModel",
     "UserTypeEnum",
     "DesksResourceModel",

--- a/superdesk/types/enums.py
+++ b/superdesk/types/enums.py
@@ -78,3 +78,13 @@ class ContentType(str, Enum):
 TEXT_TYPES = (ContentType.TEXT, ContentType.PREFORMATTED)
 MEDIA_TYPES = (ContentType.AUDIO, ContentType.VIDEO, ContentType.PICTURE, ContentType.GRAPHIC)
 AUTHORING_TYPES = TEXT_TYPES + MEDIA_TYPES + (ContentType.COMPOSITE,)
+
+
+@unique
+class PublishOperation(str, Enum):
+    PUBLISH = "publish"
+    CORRECT = "correct"
+    KILL = "kill"
+    TAKEDOWN = "takedown"
+    UNPUBLISH = "unpublish"
+    RESEND = "resend"

--- a/tests/packages/package_service_tests.py
+++ b/tests/packages/package_service_tests.py
@@ -11,7 +11,7 @@
 from superdesk.tests import TestCase
 
 from apps import archive  # noqa  - fix circular imports when running this test
-from apps.packages.package_service import PackageService
+from superdesk.publish_async.utils import remove_ref_from_inmem_package
 
 
 class PackageServiceTestCase(TestCase):
@@ -66,15 +66,15 @@ class PackageServiceTestCase(TestCase):
         }
 
     def test_remove_ref_from_package(self):
-        anything_left = PackageService().remove_ref_from_inmem_package(self.package1, "456")
+        anything_left = remove_ref_from_inmem_package(self.package1, "456")
         self.assertEqual(len(self.package1.get("groups", [])), 2)
         root_group = self.package1.get("groups", [])[0]
         self.assertEqual(len(root_group.get("refs", [])), 1)
         self.assertTrue(anything_left)
 
     def test_remove_two_refs_from_package(self):
-        anything_left1 = PackageService().remove_ref_from_inmem_package(self.package1, "456")
-        anything_left2 = PackageService().remove_ref_from_inmem_package(self.package1, "123")
+        anything_left1 = remove_ref_from_inmem_package(self.package1, "456")
+        anything_left2 = remove_ref_from_inmem_package(self.package1, "123")
         self.assertEqual(len(self.package1.get("groups", [])), 2)
         root_group = self.package1.get("groups", [])[0]
         self.assertEqual(len(root_group.get("refs", [])), 1)
@@ -82,16 +82,16 @@ class PackageServiceTestCase(TestCase):
         self.assertTrue(anything_left2)
 
     def test_remove_two_refs_from_package2(self):
-        PackageService().remove_ref_from_inmem_package(self.package1, "789")
-        PackageService().remove_ref_from_inmem_package(self.package1, "123")
+        remove_ref_from_inmem_package(self.package1, "789")
+        remove_ref_from_inmem_package(self.package1, "123")
         self.assertEqual(len(self.package1.get("groups", [])), 2)
         root_group = self.package1.get("groups", [])[0]
         self.assertEqual(len(root_group.get("refs", [])), 1)
 
     def test_remove_all_refs_from_package(self):
-        anything_left1 = PackageService().remove_ref_from_inmem_package(self.package1, "456")
-        anything_left2 = PackageService().remove_ref_from_inmem_package(self.package1, "789")
-        anything_left3 = PackageService().remove_ref_from_inmem_package(self.package1, "123")
+        anything_left1 = remove_ref_from_inmem_package(self.package1, "456")
+        anything_left2 = remove_ref_from_inmem_package(self.package1, "789")
+        anything_left3 = remove_ref_from_inmem_package(self.package1, "123")
         self.assertEqual(len(self.package1.get("groups", [])), 1)
         root_group = self.package1.get("groups", [])[0]
         self.assertEqual(len(root_group.get("refs", [])), 0)


### PR DESCRIPTION
### Purpose
Publishing of packages and their items was not working properly in the new publish async system. It required special handling on the ContentExchange to process the package items

### What has changed
* Update the `ContentPublishExchange` publish module to handle publishing of package items (code/logic copied from [develop branch](https://github.com/superdesk/superdesk-core/blob/develop/apps/publish/enqueue/enqueue_service.py#L99))
* Fix issue in `BasePublishExchangeFormatter` that previously included Wire Subscribers for non text items
* Don't cache formatted item in `BasePublishExchangeFormatter` if the item is a Package (formatted item might change based on subscriber permissions)
* Fix issue in publish endpoint that didn't publish nested packages
* Fix issue in `ContentPublishExchange` when polling is enabled and request comes from API (initiate celery task immediately, copies logic from old code)
* Moved some package utils into the `superdesk.publish_async.utils` module (shared utils across publish async module and publish endpoints)
* Init PublishCache in internal_destination, as it uses content matching with requires the cache to be available (fixes SDESK-7666]

**Note**: Extends on changes from https://github.com/superdesk/superdesk-core/pull/2951, as it was required as well. You can ignore the first commit in this PR ([[SDESK-7630] fix: Killing of archived items](https://github.com/superdesk/superdesk-core/commit/0fa289f39a7ada9a1001858804fb203960c36ead))

[SDESK-7630]: https://sofab.atlassian.net/browse/SDESK-7630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ