### PR TITLE
avoid random photo metadata updates

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -967,10 +967,14 @@ class BasePublishService(BaseService):
                 if not media_id:
                     continue
 
-                picture = app.media.get(media_id)
-                binary = picture.read()
+                original_metadata = get_metadata_from_item(original, mapping)
                 metadata = get_metadata_from_item(updated, mapping)
 
+                if original_metadata == metadata:
+                    continue
+
+                picture = app.media.get(media_id)
+                binary = picture.read()
                 updated_binary = write_metadata(binary, metadata)
                 if updated_binary != binary:
                     updated_media_id = app.media.put(


### PR DESCRIPTION
binary can change when updating usinga same metadata due to the sequence it's written so avoid updates
when there were no changes on the item that would
require metadata changes.

SDCP-943

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

