### PR TITLE
[SDESK-7591] Fix missing await call from instance logs

### DIFF
--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -564,7 +564,7 @@ async def remove_media_files(doc, published=False):
 
                 if await references.count() == 0:
                     logger.info("Deleting media:%s", media)
-                    app.media.delete_async(media)
+                    await app.media.delete_async(media)
                 else:
                     logger.info("Keeping media:%s due to references", media)
             except Exception:


### PR DESCRIPTION
### Purpose
Fixes error found on `sd-async` instance while working on [SDESK-7591]



[SDESK-7591]: https://sofab.atlassian.net/browse/SDESK-7591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ