### PR TITLE
fix wamp keyerror when processing old message

### DIFF
--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -159,7 +159,7 @@ class SocketMessageConsumer(SocketBrokerClient, ConsumerMixin):
         with sentry_sdk.start_transaction(transaction):
             logger.debug("Queue: {}. Broadcasting message {}".format(self.queue.name, body))
             with sentry_sdk.start_span(op="queue.process", name="queue_consumer") as span:
-                span.set_data("messaging.message.id", message.headers["message-id"])
+                span.set_data("messaging.message.id", message.headers.get("message-id", ""))
                 span.set_data("messaging.destination.name", self.exchange_name)
                 span.set_data("messaging.message.body.size", len(body))
                 try:


### PR DESCRIPTION
when there is a message generated with old code it throws KeyError exception.

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

