### PR TITLE
[CPCN-1090] Allow Elastic `track_total_hits` to accept boolean or int

### DIFF
--- a/superdesk/core/types/elastic.py
+++ b/superdesk/core/types/elastic.py
@@ -49,8 +49,8 @@ class ElasticClientConfig(ConfigModel):
     #: If ``True``, automatically requests aggregations on search.
     auto_aggregations: bool = True
 
-    #: Set the default ``track_total_hits`` for search requests. See https://www.elastic.co/guide/en/elasticsearch/reference/master/search-your-data.html#track-total-hits
-    track_total_hits: int = 10000
+    #: Set the default ``track_total_hits`` for search requests. See https://www.elastic.co/docs/solutions/search/the-search-api#track-total-hits
+    track_total_hits: int | bool = 10_000
 
     #: Number of retries when timing out
     retry_on_timeout: bool = True


### PR DESCRIPTION
### Purpose
To fix the bug of Newhub's wire search not showing the real count of items found in the search but instead showing a maximum of 10,000.

### About this PR
According to the Elasticsearch documentation, `track_total_hits` can be either an integer (to limit the count) or a boolean (`false` to disable, `true` to count all, which can be expensive).

Previously, our settings forced this value to be an integer, which meant setting it to `True` would incorrectly become `1`, interpreted as a limit. This change allows `track_total_hits` to accept either a boolean or an integer, as intended.

Resolves: [CPCN-1090]




[CPCN-1090]: https://sofab.atlassian.net/browse/CPCN-1090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ