### PR TITLE
[SDESK-4601] fix: Send corrections when item isnt in publish_queue

### DIFF
--- a/apps/publish/enqueue/enqueue_corrected.py
+++ b/apps/publish/enqueue/enqueue_corrected.py
@@ -39,7 +39,6 @@ class EnqueueCorrectedService(EnqueueService):
         :return: (list, dict, dict) List of filtered subscribers, product codes per subscriber,
                 associations per subscriber
         """
-        subscribers, subscribers_yet_to_receive = [], []
 
         # step 1
         query = {
@@ -49,25 +48,25 @@ class EnqueueCorrectedService(EnqueueService):
 
         subscribers, subscriber_codes, previous_associations = self._get_subscribers_for_previously_sent_items(query)
 
-        if subscribers:
-            # Step 2
-            active_subscribers = list(get_resource_service("subscribers").get_active())
-            subscribers_yet_to_receive = [
-                a for a in active_subscribers if not any(a[config.ID_FIELD] == s[config.ID_FIELD] for s in subscribers)
-            ]
-
-            if len(subscribers_yet_to_receive) > 0:
-                # Step 3
-                if doc.get("target_regions"):
-                    subscribers_yet_to_receive = filter_non_digital(subscribers_yet_to_receive)
-                # Step 4
-                subscribers_yet_to_receive, codes = self.filter_subscribers(
-                    doc, subscribers_yet_to_receive, target_media_type
-                )
-                if codes:
-                    subscriber_codes.update(codes)
-        else:
+        if not subscribers:
             logger.info("No previous subscribers found for item %s", doc["item_id"])
+
+        # Step 2
+        active_subscribers = list(get_resource_service("subscribers").get_active())
+        subscribers_yet_to_receive = [
+            a for a in active_subscribers if not any(a[config.ID_FIELD] == s[config.ID_FIELD] for s in subscribers)
+        ]
+
+        if len(subscribers_yet_to_receive) > 0:
+            # Step 3
+            if doc.get("target_regions"):
+                subscribers_yet_to_receive = filter_non_digital(subscribers_yet_to_receive)
+            # Step 4
+            subscribers_yet_to_receive, codes = self.filter_subscribers(
+                doc, subscribers_yet_to_receive, target_media_type
+            )
+            if codes:
+                subscriber_codes.update(codes)
 
         subscribers = subscribers + subscribers_yet_to_receive
         associations = self._filter_subscribers_for_associations(

--- a/features/publish_correction.feature
+++ b/features/publish_correction.feature
@@ -1,0 +1,70 @@
+Feature: Content Correction
+    @auth
+    Scenario: Sending correction succeeds when item not in publish queue
+        # Setup the Product, Subscriber, Desk and Content
+        When we post to "/products" with success
+        """
+        {"name": "prod-1", "codes": "abc,xyz", "product_type": "both"}
+        """
+        When we post to "/subscribers" with "sub1" and success
+        """
+        {
+            "name": "Channel direct", "media_type": "media", "subscriber_type": "wire",
+            "sequence_num_settings": {"min" : 1, "max" : 10}, "email": "test@test.com",
+            "products": ["#products._id#"], "is_active": true,
+            "destinations": [
+                {"name": "Test","format": "nitf", "delivery_type": "email","config": {"recipients": "test@test.com"}}
+            ]
+        }
+        """
+        Given "desks"
+        """
+        [{"name": "Sports", "members":[{"user":"#CONTEXT_USER_ID#"}]}]
+        """
+        And "archive"
+        """
+        [{
+            "guid": "123", "headline": "test", "_current_version": 1, "state": "in_progress",
+            "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
+            "subject":[{"qcode": "17004000", "name": "Statistics"}],
+            "anpa_category": [{"qcode": "a"}, {"qcode": "s"}],
+            "slugline": "test",
+            "body_html": "Test Document body"
+        }]
+        """
+
+        # Publish the initial content item
+        When we publish "#archive._id#" with "publish" type and "published" state
+        Then we get OK response
+        When we get "/published"
+        Then we get list with 1 items
+        """
+        {"_items": [{"guid": "123", "headline": "test"}]}
+        """
+        When we get "/publish_queue"
+        Then we get list with 1 items
+        """
+        {"_items": [{"item_id": "123", "subscriber_id": "#sub1#", "publishing_action": "published"}]}
+        """
+
+        # Empty the publish_queue collection, send a correction making sure it goes out
+        Given empty "publish_queue"
+        When we publish "#archive._id#" with "correct" type and "corrected" state
+        """
+        {"headline": "test - corrected"}
+        """
+        Then we get OK response
+        When we get "/published"
+        Then we get list with 2 items
+        """
+        {"_items": [
+            {"guid": "123", "headline": "test"},
+            {"guid": "123", "headline": "test - corrected"}
+        ]}
+        """
+        When we get "/publish_queue"
+        Then we get list with 1 items
+        """
+        {"_items": [{"item_id": "123", "subscriber_id": "#sub1#", "publishing_action": "corrected"}]}
+        """
+


### PR DESCRIPTION
### Purpose
When sending a correction, active subscribers are only checked against if there is at least 1 entry in the publish queue

### What has changed
Always check active subscribers when sending a correction.

Resolves: [SDESK-4601](https://sofab.atlassian.net/browse/SDESK-4601)
Note: Will cherry-pick this one into `release/2.9` once merged

[SDESK-4601]: https://sofab.atlassian.net/browse/SDESK-4601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ