### PR TITLE
[SDESK-4601] fix(async): Send corrections when item isnt in publish_queue

### DIFF
--- a/features/publish_correction.feature
+++ b/features/publish_correction.feature
@@ -1,0 +1,69 @@
+Feature: Content Correction
+    @auth
+    Scenario: Sending correction succeeds when item not in publish queue
+        # Setup the Product, Subscriber, Desk and Content
+        When we post to "/products" with success
+        """
+        {"name": "prod-1", "codes": "abc,xyz", "product_type": "both"}
+        """
+        When we post to "/subscribers" with "sub1" and success
+        """
+        {
+            "name": "Channel direct", "media_type": "media", "subscriber_type": "wire",
+            "sequence_num_settings": {"min" : 1, "max" : 10}, "email": "test@test.com",
+            "products": ["#products._id#"], "is_active": true,
+            "destinations": [
+                {"name": "Test","format": "nitf", "delivery_type": "email","config": {"recipients": "test@test.com"}}
+            ]
+        }
+        """
+        Given "desks"
+        """
+        [{"name": "Sports", "members":[{"user":"#CONTEXT_USER_ID#"}]}]
+        """
+        And "archive"
+        """
+        [{
+            "guid": "123", "headline": "test", "_current_version": 1, "state": "in_progress",
+            "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#", "user": "#CONTEXT_USER_ID#"},
+            "subject":[{"qcode": "17004000", "name": "Statistics"}],
+            "anpa_category": [{"qcode": "a"}, {"qcode": "s"}],
+            "slugline": "test",
+            "body_html": "Test Document body"
+        }]
+        """
+
+        # Publish the initial content item
+        When we publish "#archive._id#" with "publish" type and "published" state
+        Then we get OK response
+        When we get "/published"
+        Then we get list with 1 items
+        """
+        {"_items": [{"guid": "123", "headline": "test"}]}
+        """
+        When we get "/publish_queue"
+        Then we get list with 1 items
+        """
+        {"_items": [{"item_id": "123", "subscriber_id": "#sub1#", "publishing_action": "published"}]}
+        """
+
+        # Empty the publish_queue collection, send a correction making sure it goes out
+        Given empty "publish_queue"
+        When we publish "#archive._id#" with "correct" type and "corrected" state
+        """
+        {"headline": "test - corrected"}
+        """
+        Then we get OK response
+        When we get "/published"
+        Then we get list with 2 items
+        """
+        {"_items": [
+            {"guid": "123", "headline": "test"},
+            {"guid": "123", "headline": "test - corrected"}
+        ]}
+        """
+        When we get "/publish_queue"
+        Then we get list with 1 items
+        """
+        {"_items": [{"item_id": "123", "subscriber_id": "#sub1#", "publishing_action": "corrected"}]}
+        """

--- a/superdesk/publish_async/filters/corrected_exchange_filter.py
+++ b/superdesk/publish_async/filters/corrected_exchange_filter.py
@@ -64,40 +64,40 @@ class CorrectedPublishExchangeFilter(ContentPublishExchangeFilter):
         ) = await get_subscribers_for_previously_sent_items(response, query)
         subscribers_yet_to_receive: list[SubscribersResource] = []
 
-        if subscribers:
-            # Step 2
-            cache = PublishCache.get()
-            active_subscribers = list(cache.subscribers.values())
-            subscribers_yet_to_receive = [
-                active_subscriber
-                for active_subscriber in active_subscribers
-                if not any(active_subscriber.id == previous_subscriber.id for previous_subscriber in subscribers)
-            ]
-
-            if len(subscribers_yet_to_receive) > 0:
-                # Step 3
-                if request.item.get("target_regions"):
-                    subscribers_yet_to_receive = SubscribersResource.filter_non_digital(subscribers_yet_to_receive)
-
-                # Step 4
-                subscribers_request = PublishRequest(
-                    item=request.item,
-                    item_id=request.item_id,
-                    operation=request.operation,
-                    published_state=request.published_state,
-                    item_type=request.item_type,
-                    target_media_type=request.target_media_type,
-                    sender_type=request.sender_type,
-                    subscribers=subscribers_yet_to_receive,
-                )
-                subscribers_response = PublishRequestResponse()
-                await super().filter_subscribers(subscribers_request, subscribers_response)
-
-                subscribers_yet_to_receive = subscribers_response.subscribers
-                if subscribers_response.subscriber_codes:
-                    subscriber_codes.update(subscribers_response.subscriber_codes)
-        else:
+        if not subscribers:
             logger.info(f"No previous subscribers found for item {request.item_id}")
+
+        # Step 2
+        cache = PublishCache.get()
+        active_subscribers = list(cache.subscribers.values())
+        subscribers_yet_to_receive = [
+            active_subscriber
+            for active_subscriber in active_subscribers
+            if not any(active_subscriber.id == previous_subscriber.id for previous_subscriber in subscribers)
+        ]
+
+        if len(subscribers_yet_to_receive) > 0:
+            # Step 3
+            if request.item.get("target_regions"):
+                subscribers_yet_to_receive = SubscribersResource.filter_non_digital(subscribers_yet_to_receive)
+
+            # Step 4
+            subscribers_request = PublishRequest(
+                item=request.item,
+                item_id=request.item_id,
+                operation=request.operation,
+                published_state=request.published_state,
+                item_type=request.item_type,
+                target_media_type=request.target_media_type,
+                sender_type=request.sender_type,
+                subscribers=subscribers_yet_to_receive,
+            )
+            subscribers_response = PublishRequestResponse()
+            await super().filter_subscribers(subscribers_request, subscribers_response)
+
+            subscribers_yet_to_receive = subscribers_response.subscribers
+            if subscribers_response.subscriber_codes:
+                subscriber_codes.update(subscribers_response.subscriber_codes)
 
         response.subscribers = subscribers
         subscriber_ids = set([subscriber.id for subscriber in subscribers])


### PR DESCRIPTION
### Purpose
When sending a correction, active subscribers are only checked against if there is at least 1 entry in the publish queue

### What has changed
Always check active subscribers when sending a correction.

Resolves: [SDESK-4601](https://sofab.atlassian.net/browse/SDESK-4601)
Note: This is the async version from https://github.com/superdesk/superdesk-core/pull/2979

[SDESK-4601]: https://sofab.atlassian.net/browse/SDESK-4601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ