### PR TITLE
avoid hardcoding datetime offset

### DIFF
--- a/features/internal_destinations.feature
+++ b/features/internal_destinations.feature
@@ -72,10 +72,9 @@ Feature: Internal Destinations
             "subject":[{"qcode": "17004000", "name": "Statistics"}],
             "anpa_category": [{"qcode": "A", "name": "Sport"}],
             "anpa_take_key": "Take",
-            "publish_schedule": "2099-05-19T10:15:00",
+            "publish_schedule": "2035-05-19T10:15:00+0100",
             "schedule_settings": {
-                "time_zone": "Europe/London",
-                "utc_publish_schedule": "2099-05-19T10:15:00+0000"
+                "time_zone": "Europe/London"
             }
         }]
         """
@@ -85,7 +84,7 @@ Feature: Internal Destinations
         """
         When we publish "#archive._id#" with "publish" type and "published" state
         """
-        {"publish_schedule": "2099-05-19T10:15:00",
+        {"publish_schedule": "2035-05-19T10:15:00+0100",
         "schedule_settings": {"time_zone": "Europe/London"}}
         """
         Then we get OK response
@@ -99,10 +98,10 @@ Feature: Internal Destinations
             "state": "scheduled",
             "task": {"desk": "#origin_desk#", "stage": "#origin_stage#"},
             "body_html": "Body $10",
-            "publish_schedule": "2099-05-19T10:15:00+0000",
+            "publish_schedule": "2035-05-19T10:15:00+0100",
             "schedule_settings": {
                 "time_zone": "Europe/London",
-                "utc_publish_schedule": "2099-05-19T10:15:00+0000"
+                "utc_publish_schedule": "2035-05-19T09:15:00+0000"
             }
         }]}
         """

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -84,7 +84,7 @@ BEHAVE_TESTS_FIXTURES_PATH = ABS_PATH + "/features/steps/fixtures"
 
 IF_MATCH = True
 BANDWIDTH_SAVER = False
-DATE_FORMAT = "%Y-%m-%dT%H:%M:%S+0000"
+DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 ELASTIC_DATE_FORMAT = "%Y-%m-%d"
 ELASTIC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 #: default size of elastic queries generated on server

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -8,7 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from bson import ObjectId
 from eve.utils import date_to_str
@@ -24,7 +24,7 @@ class CeleryTestCase(TestCase):
         self.assertEqual(try_cast(str(self._id)), self._id)
 
     def test_cast_datetime(self):
-        date = datetime(2012, 12, 12, 12, 12, 12, 0)
+        date = datetime(2012, 12, 12, 12, 12, 12, 0, tzinfo=timezone.utc)
         with self.app.app_context():
             s = date_to_str(date)
             self.assertEqual(try_cast(s).day, date.day)


### PR DESCRIPTION
### Purpose

atm server only accepts times with `+0000` offset and that forces client to send wrong data
when it needs to send local time. 

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

