### PR TITLE
[STT-1241] - As an STT admin I like to add a start and end date to the subscriber config via the UI

### DIFF
--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -378,7 +378,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "subscribers:schedule_update": {
         "task": "superdesk.publish.subscribers_schedule.update_subscriber_activation_states",
-        "schedule": crontab(minute="*"),
+        "schedule": crontab(minute=0, hour=local_to_utc_hour(0)),
     },
 }
 

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -379,7 +379,7 @@ CELERY_BEAT_SCHEDULE = {
     "subscribers:schedule_update": {
         "task": "superdesk.publish.subscribers_schedule.update_subscriber_activation_states",
         "schedule": crontab(minute="*"),
-    }
+    },
 }
 
 #: Sentry DSN - will report exceptions there

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -376,6 +376,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "apps.saved_searches.report",
         "schedule": crontab(minute=0),
     },
+    "subscribers:schedule_update": {
+        "task": "superdesk.publish.subscribers_schedule.update_subscriber_activation_states",
+        "schedule": crontab(minute="*"),
+    }
 }
 
 #: Sentry DSN - will report exceptions there

--- a/superdesk/publish/__init__.py
+++ b/superdesk/publish/__init__.py
@@ -22,6 +22,7 @@ from bson import ObjectId
 from superdesk.celery_app import celery
 from superdesk.publish.publish_content import PublishContent
 from superdesk import get_backend
+from .subscribers_schedule import update_subscriber_activation_states
 
 logger = logging.getLogger(__name__)
 

--- a/superdesk/publish/subscribers.py
+++ b/superdesk/publish/subscribers.py
@@ -141,7 +141,7 @@ class SubscribersService(CacheableService):
         self._validate_seq_num_settings(updates)
         subscriber = deepcopy(original)
         subscriber.update(updates)
-        
+
         self._apply_schedule_status(subscriber)
 
         # Apply the calculated status back to `updates`
@@ -320,7 +320,7 @@ class SubscribersService(CacheableService):
         now = utcnow().date()
         start_str = schedule.get("startDate")
         end_str = schedule.get("endDate")
-        
+
         start = datetime.fromisoformat(start_str).date() if start_str else None
         end = datetime.fromisoformat(end_str).date() if end_str else None
 

--- a/superdesk/publish/subscribers.py
+++ b/superdesk/publish/subscribers.py
@@ -12,6 +12,7 @@ import json
 import logging
 
 from copy import deepcopy
+from datetime import datetime
 
 from flask import current_app as app
 from superdesk import get_resource_service
@@ -23,6 +24,7 @@ from superdesk.errors import SuperdeskApiError
 from superdesk.publish import SUBSCRIBER_TYPES  # NOQA
 from superdesk.metadata.utils import ProductTypes
 from superdesk.notification import push_notification
+from superdesk.utc import utcnow
 
 
 logger = logging.getLogger(__name__)
@@ -73,8 +75,8 @@ class SubscribersResource(Resource):
         "schedule": {
             "type": "dict",
             "schema": {
-                "startDate": {"type": "datetime", "nullable": True},
-                "endDate": {"type": "datetime", "nullable": True},
+                "startDate": {"type": "string", "nullable": True},
+                "endDate": {"type": "string", "nullable": True},
             },
         },
         "products": {"type": "list", "schema": Resource.rel("products", True)},
@@ -128,6 +130,7 @@ class SubscribersService(CacheableService):
 
     def on_create(self, docs):
         for doc in docs:
+            self._apply_schedule_status(doc)
             self._validate_seq_num_settings(doc)
             self._validate_products_destinations(doc)
 
@@ -138,6 +141,13 @@ class SubscribersService(CacheableService):
         self._validate_seq_num_settings(updates)
         subscriber = deepcopy(original)
         subscriber.update(updates)
+        
+        self._apply_schedule_status(subscriber)
+
+        # Apply the calculated status back to `updates`
+        if "is_active" in subscriber:
+            updates["is_active"] = subscriber["is_active"]
+
         self._validate_products_destinations(subscriber)
         self.keep_destinations_secrets(updates, original)
 
@@ -300,6 +310,34 @@ class SubscribersService(CacheableService):
             subscriber["sequence_num_settings"] = {"min": min, "max": max}
 
         return True
+
+    def _apply_schedule_status(self, subscriber):
+        """Set is_active flag based on current time and schedule.startDate/endDate if it exists."""
+        schedule = subscriber.get("schedule")
+        if not schedule:
+            return
+
+        now = utcnow().date()
+        start_str = schedule.get("startDate")
+        end_str = schedule.get("endDate")
+        
+        start = datetime.fromisoformat(start_str).date() if start_str else None
+        end = datetime.fromisoformat(end_str).date() if end_str else None
+
+        # If schedule starts in the future but is_active=True, let it remain active
+        if start and now < start and subscriber.get("is_active") is True:
+            return
+
+        # If schedule is in the past, don't enforce any changes to status
+        if end and now > end:
+            return
+
+        if start and end and start <= now <= end:
+            subscriber["is_active"] = True
+        elif start and now < start:
+            subscriber["is_active"] = False
+        elif end and now > end:
+            subscriber["is_active"] = False
 
     def generate_sequence_number(self, subscriber):
         """

--- a/superdesk/publish/subscribers.py
+++ b/superdesk/publish/subscribers.py
@@ -70,6 +70,13 @@ class SubscribersResource(Resource):
                 },
             },
         },
+        "schedule": {
+            "type": "dict",
+            "schema": {
+                "startDate": {"type": "datetime", "nullable": True},
+                "endDate": {"type": "datetime", "nullable": True},
+            },
+        },
         "products": {"type": "list", "schema": Resource.rel("products", True)},
         "codes": {"type": "string"},
         "global_filters": {"type": "dict", "valueschema": {"type": "boolean"}},

--- a/superdesk/publish/subscribers.py
+++ b/superdesk/publish/subscribers.py
@@ -324,8 +324,9 @@ class SubscribersService(CacheableService):
         start = datetime.fromisoformat(start_str).date() if start_str else None
         end = datetime.fromisoformat(end_str).date() if end_str else None
 
-        # If schedule starts in the future but is_active=True, let it remain active
+        # If schedule is in future, and is_active is True - match start date with current date
         if start and now < start and subscriber.get("is_active") is True:
+            schedule["start_date"] = now.strftime("%Y-%m-%d")
             return
 
         # If schedule is in the past, don't enforce any changes to status

--- a/superdesk/publish/subscribers.py
+++ b/superdesk/publish/subscribers.py
@@ -75,8 +75,8 @@ class SubscribersResource(Resource):
         "schedule": {
             "type": "dict",
             "schema": {
-                "startDate": {"type": "string", "nullable": True},
-                "endDate": {"type": "string", "nullable": True},
+                "start_date": {"type": "string", "nullable": True},
+                "end_date": {"type": "string", "nullable": True},
             },
         },
         "products": {"type": "list", "schema": Resource.rel("products", True)},
@@ -318,8 +318,8 @@ class SubscribersService(CacheableService):
             return
 
         now = utcnow().date()
-        start_str = schedule.get("startDate")
-        end_str = schedule.get("endDate")
+        start_str = schedule.get("start_date")
+        end_str = schedule.get("end_date")
 
         start = datetime.fromisoformat(start_str).date() if start_str else None
         end = datetime.fromisoformat(end_str).date() if end_str else None

--- a/superdesk/publish/subscribers_schedule.py
+++ b/superdesk/publish/subscribers_schedule.py
@@ -31,7 +31,7 @@ def update_subscriber_activation_states():
             start = schedule.get("startDate")
             end = schedule.get("endDate")
             active = subscriber.get("is_active", False)
-            
+
             if start == today and not active:
                 service.system_update(subscriber["_id"], {"is_active": True}, subscriber)
                 logger.info(

--- a/superdesk/publish/subscribers_schedule.py
+++ b/superdesk/publish/subscribers_schedule.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 @celery.task(soft_time_limit=30)
 def update_subscriber_activation_states():
-    """Celery task to check scheduled subscribers and activate/deactivate them.
+    """Task to check scheduled subscribers and activate/deactivate them.
 
     Runs every minute. If a subscriber has a `schedule` field defined,
     this will check if the current time is within the start and end range
@@ -27,7 +27,7 @@ def update_subscriber_activation_states():
             ]
         }
         subscribers = list(service.get(req=None, lookup=lookup))
-        logger.info("Processing %d subscribers for schedule activation/deactivation", len(subscribers))
+        logger.info("[Subscribers Schedule]: Processing %d subscribers for schedule activation/deactivation", len(subscribers))
 
         for subscriber in subscribers:
             updated = False
@@ -36,12 +36,10 @@ def update_subscriber_activation_states():
             end = schedule.get("endDate")
             active = subscriber.get("is_active", False)
 
-
             # Determine desired state
-            should_be_active = (
-                (not start or now >= start) and
-                (not end or now <= end)
-            )
+            is_after_start = not start or now >= start
+            is_before_end = not end or now <= end
+            should_be_active = is_after_start and is_before_end
 
             if should_be_active != active:
                 service.system_update(
@@ -53,12 +51,11 @@ def update_subscriber_activation_states():
 
             if updated:
                 message = (
-                    f"Subscriber '{subscriber.get('name', subscriber['_id'])}' "
+                    f"[Subscribers Schedule]: Subscriber '{subscriber.get('name', subscriber['_id'])}' "
                     f"{'activated' if should_be_active else 'deactivated'} "
                     f"due to schedule. Start: {start}, End: {end}"
                 )
                 logger.info(message)
 
-    except Exception as e:
-        print(f"[subscribers_schedule] Error occurred: {e}")
-        logger.exception("Failed to update subscriber activation states based on schedule.")
+    except Exception:
+        logger.exception("[Subscribers Schedule]: Failed to update subscriber activation states based on schedule.")

--- a/superdesk/publish/subscribers_schedule.py
+++ b/superdesk/publish/subscribers_schedule.py
@@ -1,0 +1,64 @@
+import logging
+
+from superdesk import get_resource_service
+from superdesk.celery_app import celery
+from superdesk.utc import utcnow
+
+logger = logging.getLogger(__name__)
+
+
+@celery.task(soft_time_limit=30)
+def update_subscriber_activation_states():
+    """Celery task to check scheduled subscribers and activate/deactivate them.
+
+    Runs every minute. If a subscriber has a `schedule` field defined,
+    this will check if the current time is within the start and end range
+    and update `is_active` accordingly.
+    """
+    now = utcnow()
+    service = get_resource_service("subscribers")
+
+    try:
+        # Query for subscribers that have a schedule defined
+        lookup = {
+            "$and": [
+                {"schedule.startDate": {"$ne": None}},
+                {"schedule.endDate": {"$ne": None}},
+            ]
+        }
+        subscribers = list(service.get(req=None, lookup=lookup))
+        logger.info("Processing %d subscribers for schedule activation/deactivation", len(subscribers))
+
+        for subscriber in subscribers:
+            updated = False
+            schedule = subscriber.get("schedule") or {}
+            start = schedule.get("startDate")
+            end = schedule.get("endDate")
+            active = subscriber.get("is_active", False)
+
+
+            # Determine desired state
+            should_be_active = (
+                (not start or now >= start) and
+                (not end or now <= end)
+            )
+
+            if should_be_active != active:
+                service.system_update(
+                    subscriber["_id"],
+                    {"is_active": should_be_active},
+                    subscriber
+                )
+                updated = True
+
+            if updated:
+                message = (
+                    f"Subscriber '{subscriber.get('name', subscriber['_id'])}' "
+                    f"{'activated' if should_be_active else 'deactivated'} "
+                    f"due to schedule. Start: {start}, End: {end}"
+                )
+                logger.info(message)
+
+    except Exception as e:
+        print(f"[subscribers_schedule] Error occurred: {e}")
+        logger.exception("Failed to update subscriber activation states based on schedule.")

--- a/superdesk/publish/subscribers_schedule.py
+++ b/superdesk/publish/subscribers_schedule.py
@@ -17,8 +17,8 @@ def update_subscriber_activation_states():
         # Query for subscribers that have a schedule defined for current date
         lookup = {
             "$or": [
-                {"schedule.startDate": today},
-                {"schedule.endDate": today},
+                {"schedule.start_date": today},
+                {"schedule.end_date": today},
             ]
         }
         subscribers = list(service.get(req=None, lookup=lookup))
@@ -28,19 +28,19 @@ def update_subscriber_activation_states():
 
         for subscriber in subscribers:
             schedule = subscriber.get("schedule") or {}
-            start = schedule.get("startDate")
-            end = schedule.get("endDate")
+            start = schedule.get("start_date")
+            end = schedule.get("end_date")
             active = subscriber.get("is_active", False)
 
             if start == today and not active:
                 service.system_update(subscriber["_id"], {"is_active": True}, subscriber)
                 logger.info(
-                    f"[Subscribers Schedule]: Subscriber '{subscriber.get('name', subscriber['_id'])}' activated (startDate: {start})"
+                    f"[Subscribers Schedule]: Subscriber '{subscriber.get('name', subscriber['_id'])}' activated (start_date: {start})"
                 )
             elif end == today and active:
                 service.system_update(subscriber["_id"], {"is_active": False}, subscriber)
                 logger.info(
-                    f"[Subscribers Schedule]: Subscriber '{subscriber.get('name', subscriber['_id'])}' deactivated (endDate: {end})"
+                    f"[Subscribers Schedule]: Subscriber '{subscriber.get('name', subscriber['_id'])}' deactivated (end_date: {end})"
                 )
 
     except Exception:

--- a/superdesk/publish/subscribers_schedule.py
+++ b/superdesk/publish/subscribers_schedule.py
@@ -27,7 +27,9 @@ def update_subscriber_activation_states():
             ]
         }
         subscribers = list(service.get(req=None, lookup=lookup))
-        logger.info("[Subscribers Schedule]: Processing %d subscribers for schedule activation/deactivation", len(subscribers))
+        logger.info(
+            "[Subscribers Schedule]: Processing %d subscribers for schedule activation/deactivation", len(subscribers)
+        )
 
         for subscriber in subscribers:
             updated = False
@@ -42,11 +44,7 @@ def update_subscriber_activation_states():
             should_be_active = is_after_start and is_before_end
 
             if should_be_active != active:
-                service.system_update(
-                    subscriber["_id"],
-                    {"is_active": should_be_active},
-                    subscriber
-                )
+                service.system_update(subscriber["_id"], {"is_active": should_be_active}, subscriber)
                 updated = True
 
             if updated:

--- a/superdesk/publish/subscribers_schedule.py
+++ b/superdesk/publish/subscribers_schedule.py
@@ -2,28 +2,23 @@ import logging
 
 from superdesk import get_resource_service
 from superdesk.celery_app import celery
-from superdesk.utc import utcnow
+from superdesk.dates import get_local_today
 
 logger = logging.getLogger(__name__)
 
 
 @celery.task(soft_time_limit=30)
 def update_subscriber_activation_states():
-    """Task to check scheduled subscribers and activate/deactivate them.
-
-    Runs every minute. If a subscriber has a `schedule` field defined,
-    this will check if the current time is within the start and end range
-    and update `is_active` accordingly.
-    """
-    now = utcnow()
+    """Task to activate/deactivate subscribers whose startDate or endDate matches current today"""
+    today = get_local_today().date().isoformat()
     service = get_resource_service("subscribers")
 
     try:
-        # Query for subscribers that have a schedule defined
+        # Query for subscribers that have a schedule defined for current date
         lookup = {
-            "$and": [
-                {"schedule.startDate": {"$ne": None}},
-                {"schedule.endDate": {"$ne": None}},
+            "$or": [
+                {"schedule.startDate": today},
+                {"schedule.endDate": today},
             ]
         }
         subscribers = list(service.get(req=None, lookup=lookup))
@@ -32,28 +27,21 @@ def update_subscriber_activation_states():
         )
 
         for subscriber in subscribers:
-            updated = False
             schedule = subscriber.get("schedule") or {}
             start = schedule.get("startDate")
             end = schedule.get("endDate")
             active = subscriber.get("is_active", False)
-
-            # Determine desired state
-            is_after_start = not start or now >= start
-            is_before_end = not end or now <= end
-            should_be_active = is_after_start and is_before_end
-
-            if should_be_active != active:
-                service.system_update(subscriber["_id"], {"is_active": should_be_active}, subscriber)
-                updated = True
-
-            if updated:
-                message = (
-                    f"[Subscribers Schedule]: Subscriber '{subscriber.get('name', subscriber['_id'])}' "
-                    f"{'activated' if should_be_active else 'deactivated'} "
-                    f"due to schedule. Start: {start}, End: {end}"
+            
+            if start == today and not active:
+                service.system_update(subscriber["_id"], {"is_active": True}, subscriber)
+                logger.info(
+                    f"[Subscribers Schedule]: Subscriber '{subscriber.get('name', subscriber['_id'])}' activated (startDate: {start})"
                 )
-                logger.info(message)
+            elif end == today and active:
+                service.system_update(subscriber["_id"], {"is_active": False}, subscriber)
+                logger.info(
+                    f"[Subscribers Schedule]: Subscriber '{subscriber.get('name', subscriber['_id'])}' deactivated (endDate: {end})"
+                )
 
     except Exception:
         logger.exception("[Subscribers Schedule]: Failed to update subscriber activation states based on schedule.")

--- a/tests/publish/subscriber_schedule_test.py
+++ b/tests/publish/subscriber_schedule_test.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from bson import ObjectId
 from unittest.mock import patch
 
@@ -9,19 +9,15 @@ from superdesk.publish.subscribers_schedule import update_subscriber_activation_
 class SubscriberScheduleTestCase(TestCase):
     def setUp(self):
         super().setUp()
-        self.now = datetime(2025, 7, 14, 12, 0, 0, tzinfo=timezone.utc)
+        self.now = datetime(2025, 7, 15, 12, 0, 0, tzinfo=timezone.utc)
 
-        # Patch utcnow
-        patcher = patch("superdesk.publish.subscribers_schedule.utcnow")
-        self.mock_utcnow = patcher.start()
-        self.mock_utcnow.return_value = self.now
+        # Patch get_local_today
+        patcher = patch("superdesk.publish.subscribers_schedule.get_local_today")
+        self.mock_today = patcher.start()
+        self.mock_today.return_value = self.now
         self.addCleanup(patcher.stop)
 
-    def insert_subscriber(self, name, start_offset_days, end_offset_days, is_active):
-        """Utility to insert subscriber with schedule offset from self.now"""
-        start = self.now + timedelta(days=start_offset_days)
-        end = self.now + timedelta(days=end_offset_days)
-
+    def insert_subscriber(self, name, start_date, end_date, is_active):
         return self.app.data.insert(
             "subscribers",
             [
@@ -30,31 +26,29 @@ class SubscriberScheduleTestCase(TestCase):
                     "name": name,
                     "is_active": is_active,
                     "schedule": {
-                        "startDate": start,
-                        "endDate": end,
+                        "startDate": start_date,
+                        "endDate": end_date,
                     },
                 }
             ],
         )[0]
 
-    def test_activation_and_deactivation_logic(self):
-        # Subscriber to activate (inactive but in schedule)
-        s1 = self.insert_subscriber("activate_me", -1, 1, False)
-        # Subscriber to deactivate (active but expired)
-        s2 = self.insert_subscriber("deactivate_me", -10, -1, True)
-        # Subscriber before schedule (should be deactivated)
-        s3 = self.insert_subscriber("too_early", 1, 10, True)
-        # Subscriber already active and in schedule
-        s4 = self.insert_subscriber("already_active", -1, 1, True)
+    def test_subscriber_activation_and_deactivation_on_exact_date(self):
+        today_str = self.now.date().isoformat()
+
+        # Should be activated
+        s1 = self.insert_subscriber("should_activate", today_str, "2025-07-20", False)
+        # Should be deactivated
+        s2 = self.insert_subscriber("should_deactivate", "2025-07-01", today_str, True)
+        # Should remain unchanged (not matching today)
+        s3 = self.insert_subscriber("unchanged", "2025-07-16", "2025-07-18", False)
 
         update_subscriber_activation_states()
 
         updated_s1 = self.app.data.find_one("subscribers", req=None, _id=s1)
         updated_s2 = self.app.data.find_one("subscribers", req=None, _id=s2)
         updated_s3 = self.app.data.find_one("subscribers", req=None, _id=s3)
-        updated_s4 = self.app.data.find_one("subscribers", req=None, _id=s4)
 
         self.assertTrue(updated_s1["is_active"], "s1 should have been activated")
         self.assertFalse(updated_s2["is_active"], "s2 should have been deactivated")
-        self.assertFalse(updated_s3["is_active"], "s3 should have been deactivated")
-        self.assertTrue(updated_s4["is_active"], "s4 should remain active (no change)")
+        self.assertFalse(updated_s3["is_active"], "s3 should remain unchanged")

--- a/tests/publish/subscriber_schedule_test.py
+++ b/tests/publish/subscriber_schedule_test.py
@@ -26,8 +26,8 @@ class SubscriberScheduleTestCase(TestCase):
                     "name": name,
                     "is_active": is_active,
                     "schedule": {
-                        "startDate": start_date,
-                        "endDate": end_date,
+                        "start_date": start_date,
+                        "end_date": end_date,
                     },
                 }
             ],

--- a/tests/publish/subscriber_schedule_test.py
+++ b/tests/publish/subscriber_schedule_test.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta, timezone
+from bson import ObjectId
+from unittest.mock import patch
+
+from superdesk.tests import TestCase
+from superdesk.publish.subscribers_schedule import update_subscriber_activation_states
+
+
+class SubscriberScheduleTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.now = datetime(2025, 7, 14, 12, 0, 0, tzinfo=timezone.utc)
+
+        # Patch utcnow
+        patcher = patch("superdesk.publish.subscribers_schedule.utcnow")
+        self.mock_utcnow = patcher.start()
+        self.mock_utcnow.return_value = self.now
+        self.addCleanup(patcher.stop)
+
+    def insert_subscriber(self, name, start_offset_days, end_offset_days, is_active):
+        """Utility to insert subscriber with schedule offset from self.now"""
+        start = self.now + timedelta(days=start_offset_days)
+        end = self.now + timedelta(days=end_offset_days)
+
+        return self.app.data.insert("subscribers", [
+            {
+                "_id": ObjectId(),
+                "name": name,
+                "is_active": is_active,
+                "schedule": {
+                    "startDate": start,
+                    "endDate": end,
+                }
+            }
+        ])[0]
+
+    def test_activation_and_deactivation_logic(self):
+        # Subscriber to activate (inactive but in schedule)
+        s1 = self.insert_subscriber("activate_me", -1, 1, False)
+        # Subscriber to deactivate (active but expired)
+        s2 = self.insert_subscriber("deactivate_me", -10, -1, True)
+        # Subscriber before schedule (should be deactivated)
+        s3 = self.insert_subscriber("too_early", 1, 10, True)
+        # Subscriber already active and in schedule
+        s4 = self.insert_subscriber("already_active", -1, 1, True)
+
+        update_subscriber_activation_states()
+
+        updated_s1 = self.app.data.find_one("subscribers", req=None, _id=s1)
+        updated_s2 = self.app.data.find_one("subscribers", req=None, _id=s2)
+        updated_s3 = self.app.data.find_one("subscribers", req=None, _id=s3)
+        updated_s4 = self.app.data.find_one("subscribers", req=None, _id=s4)
+
+        self.assertTrue(updated_s1["is_active"], "s1 should have been activated")
+        self.assertFalse(updated_s2["is_active"], "s2 should have been deactivated")
+        self.assertFalse(updated_s3["is_active"], "s3 should have been deactivated")
+        self.assertTrue(updated_s4["is_active"], "s4 should remain active (no change)")

--- a/tests/publish/subscriber_schedule_test.py
+++ b/tests/publish/subscriber_schedule_test.py
@@ -22,17 +22,20 @@ class SubscriberScheduleTestCase(TestCase):
         start = self.now + timedelta(days=start_offset_days)
         end = self.now + timedelta(days=end_offset_days)
 
-        return self.app.data.insert("subscribers", [
-            {
-                "_id": ObjectId(),
-                "name": name,
-                "is_active": is_active,
-                "schedule": {
-                    "startDate": start,
-                    "endDate": end,
+        return self.app.data.insert(
+            "subscribers",
+            [
+                {
+                    "_id": ObjectId(),
+                    "name": name,
+                    "is_active": is_active,
+                    "schedule": {
+                        "startDate": start,
+                        "endDate": end,
+                    },
                 }
-            }
-        ])[0]
+            ],
+        )[0]
 
     def test_activation_and_deactivation_logic(self):
         # Subscriber to activate (inactive but in schedule)


### PR DESCRIPTION
### Purpose
Allow admins to schedule when a subscriber becomes active or inactive using start and end dates

### What has changed
- Added `schedule.start_date` and `schedule.end_date` fields to the subscribers schema.
- Implemented celery task `update_subscriber_activation_states` to auto-activate or deactivate subscribers based on current time.
- Added unit test to test logic

### Steps to test
1. Create or edit a subscriber and set schedule.start_date and schedule.end_date.
2. Ensure the subscriber is only active between those dates.
3. Confirm the task runs every day at midnight
4. Additionally, run SubscriberScheduleTestCase to verify logic.

Resolves: [STT-1241](https://sofab.atlassian.net/browse/STT-1241)

NOTES: UI part of ticket is in this [PR](https://github.com/superdesk/superdesk-client-core/pull/4884)

[STT-1241]: https://sofab.atlassian.net/browse/STT-1241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ