### PR TITLE
[STT-1241] - Clear schedule when it is in the past completely

### DIFF
--- a/superdesk/publish/subscribers_schedule.py
+++ b/superdesk/publish/subscribers_schedule.py
@@ -39,13 +39,17 @@ def update_subscriber_activation_states():
                 )
             elif end == today and active:
                 # Schedule is reset after deactivation since it is now entirely in the past
-                service.system_update(subscriber["_id"], {
-                    "is_active": False,
-                    "schedule": {
-                        "start_date": None,
-                        "end_date": None,
-                    }
-                }, subscriber)
+                service.system_update(
+                    subscriber["_id"],
+                    {
+                        "is_active": False,
+                        "schedule": {
+                            "start_date": None,
+                            "end_date": None,
+                        },
+                    },
+                    subscriber,
+                )
                 logger.info(
                     f"[Subscribers Schedule]: Subscriber '{subscriber.get('name', subscriber['_id'])}' deactivated (end_date: {end})"
                 )

--- a/superdesk/publish/subscribers_schedule.py
+++ b/superdesk/publish/subscribers_schedule.py
@@ -38,7 +38,14 @@ def update_subscriber_activation_states():
                     f"[Subscribers Schedule]: Subscriber '{subscriber.get('name', subscriber['_id'])}' activated (start_date: {start})"
                 )
             elif end == today and active:
-                service.system_update(subscriber["_id"], {"is_active": False}, subscriber)
+                # Schedule is reset after deactivation since it is now entirely in the past
+                service.system_update(subscriber["_id"], {
+                    "is_active": False,
+                    "schedule": {
+                        "start_date": None,
+                        "end_date": None,
+                    }
+                }, subscriber)
                 logger.info(
                     f"[Subscribers Schedule]: Subscriber '{subscriber.get('name', subscriber['_id'])}' deactivated (end_date: {end})"
                 )


### PR DESCRIPTION
### Purpose
Small improvement to clear schedule after deactivation to allow setting a new schedule easily.

### What has changed
- If a subscriber is deactivated because the end date is today, the schedule is also reset since it is now completely in the past. 

### Steps to test
1. Set a subscriber with `is_active = True` and `schedule.end_date = today`.
2. Let the schedule logic run.
3. Confirm the subscriber is deactivated and schedule fields are cleared.

Resolves: [#STT-1241](https://sofab.atlassian.net/browse/STT-1241)

