### PR TITLE
[STT-1273] Move ContentAPI/Planning config to Planning module

### DIFF
--- a/content_api/app/__init__.py
+++ b/content_api/app/__init__.py
@@ -45,6 +45,9 @@ def get_app(config=None):
     # get content api default conf
     app_config.from_object("content_api.app.settings")
 
+    if "planning.content_api" in app_config.get("CONTENT_API_MODULES", []):
+        app_config.from_object("planning.content_api.settings")
+
     # set some required fields
     app_config.update({"DOMAIN": {"upload": {}}, "SOURCES": {}})
 

--- a/content_api/app/settings.py
+++ b/content_api/app/settings.py
@@ -58,7 +58,16 @@ CONTENTAPI_INSTALLED_APPS = [
     "content_api.api_audit",
 ]
 
-CONTENT_API_MODULES = ["content_api.items.module", "content_api.auth", "planning.content_api"]
+CONTENT_API_MODULES = ["content_api.items.module", "content_api.auth"]
+
+# If the Planning module is installed, then include it by default
+# Can be overridden in the local ``settings.py`` file
+try:
+    import planning
+
+    CONTENT_API_MODULES.append("planning.content_api")
+except ImportError:
+    pass
 
 PUBLISH_MODULES = []
 

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -28,6 +28,7 @@ from re import findall
 from inspect import isawaitable
 from urllib.parse import urlparse
 from pathlib import Path
+import yaml
 
 from behave import given, when, then  # @UnresolvedImport
 from behave.api.async_step import async_run_until_complete
@@ -1006,6 +1007,14 @@ async def step_impl_when_put_url(context, url):
 @async_run_until_complete
 async def _when_we_get_url(context, url):
     await when_we_get_url(context, url)
+
+
+@when('we get raw "{url}"')
+@async_run_until_complete
+async def _when_we_get_raw_url(context, url):
+    url = apply_placeholders(context, url).encode("ascii").decode("unicode-escape")
+    async with context.app.app_context():
+        context.response = await context.client.get(url, headers=context.headers)
 
 
 async def when_we_get_url(context, url):
@@ -2825,6 +2834,18 @@ async def transmit_items(context):
 async def remove_item_from_mongo(context, _id):
     async with context.app.app_context():
         context.app.data.mongo.remove("archive", {"_id": _id})
+
+
+@then("we get yaml")
+@async_run_until_complete
+async def step_impl_then_get_yaml(context):
+    context.yaml = yaml.safe_load(await context.response.get_data(as_text=True))
+
+
+@then("we check yaml against dict")
+def step_impl_then_get_text(context):
+    context_data = json.loads(apply_placeholders(context, context.text))
+    assert json_match(context_data, context.yaml), str(context_data) + "\n != \n" + str(context.yaml)
 
 
 @then('we get text "{text}" in response field "{field}"')


### PR DESCRIPTION
### Purpose
Small changes required by the STT-1273 task

### What has changed
* Check if Planning module exists before adding to default ContentAPI modules
* If available, import Planning ContentAPI default settings
* Add behave steps for checking against yaml
