### PR TITLE
[SDESK-7630] Fix behave tests

### DIFF
--- a/apps/legal_archive/commands.py
+++ b/apps/legal_archive/commands.py
@@ -35,7 +35,7 @@ from superdesk.users.services import get_display_name
 from apps.archive.common import ARCHIVE
 from superdesk.metadata.item import ITEM_STATE, CONTENT_STATE, PUBLISH_STATES
 from superdesk.lock import lock, unlock
-from superdesk.errors import update_notifiers
+from superdesk.errors import update_notifiers, SuperdeskApiError
 from superdesk.activity import ACTIVITY_ERROR
 from superdesk.utc import utcnow
 
@@ -492,6 +492,11 @@ async def import_into_legal_archive(self, item_id):
         return
     try:
         await LegalArchiveImport().upsert_into_legal_archive(item_id)
+    except SuperdeskApiError as error:
+        if error.status_code == 403:
+            # A forbidden error has occurred, no need to retry this one
+            raise
+        raise self.retry()
     except Exception:
         # we can't loose stuff for legal archive.
         logger.exception("Failed to process legal archive doc {}. Retrying again.".format(item_id))

--- a/features/http_push.feature
+++ b/features/http_push.feature
@@ -1,7 +1,6 @@
 Feature: HTTP Push publishing
 
     @auth
-    @http_mock_adapter
     Scenario: Publish a text item
         Given "products"
         """
@@ -69,8 +68,6 @@ Feature: HTTP Push publishing
         When we publish "#archive._id#" with "publish" type and "published" state
         Then we get OK response
 
-        When we transmit published
-        # TODO-ASYNC: We're using mock PublishConsumer, so HTTP push is not actually happening
         Then we pushed 1 item
         """
         [{
@@ -92,7 +89,6 @@ Feature: HTTP Push publishing
         {"body_html": "corrected"}
         """
 
-        When we transmit published
         Then we pushed 1 item
         """
         [{"guid": "#archive.guid#", "type": "text", "version": "4", "body_html": "corrected"}]
@@ -100,14 +96,12 @@ Feature: HTTP Push publishing
 
         When we rewrite "#archive._id#"
         And we publish "#REWRITE_ID#" with "publish" type and "published" state
-        And we transmit published
         Then we pushed 1 item
         """
         [{"guid": "#REWRITE_ID#", "evolvedfrom": "#archive.guid#"}]
         """
 
         When we publish "#archive._id#" with "kill" type and "killed" state
-        When we transmit published
         Then we pushed 1 item
         """
         [{"guid": "#archive.guid#", "type": "text", "pubstatus": "canceled", "version": "5"}]

--- a/features/internal_destinations.feature
+++ b/features/internal_destinations.feature
@@ -808,6 +808,7 @@ Feature: Internal Destinations
         Then we get list with 0 items
         When we get "/published"
         Then we get list with 1 items
+
     @auth
     Scenario: Item created sucessfully for destinations on publish does not depend on send_after_schedule internal destinations
         When we post to "archive" with success
@@ -876,4 +877,4 @@ Feature: Internal Destinations
         When we get "/archive"
         Then we get list with 0 items
         When we get "/published"
-        Then we get list with 4 items
+        Then we get list with 5 items

--- a/features/publish_embedded.feature
+++ b/features/publish_embedded.feature
@@ -146,12 +146,8 @@ Feature: Publish embedded items feature
       "is_active": true,
       "subscriber_type": "all",
       "sequence_num_settings":{"min" : 1, "max" : 10}, "email": "test@test.com",
-      "api_products": ["58f6120488ea94d000369a32", "58f6120488ea94d000369a32"]
+      "api_products": ["58f6120488ea94d000369a32", "58f6120488ea94d000369a33"]
     }]
-    """
-    And "vocabularies"
-    """
-    [{"_id": "crop_sizes", "items": [{"is_active": true, "name": "3:2", "width": 3, "height": 2}]}]
     """
 
     @auth
@@ -477,7 +473,7 @@ Feature: Publish embedded items feature
         Then we assert the content api item "foo" is published to subscriber "#subscribers._id#"
         Then we assert the content api item "foo" is not published to subscriber "58f6113988ea94d000369a30"
         Then we assert content api item "foo" with associated item "embedded1" is published to "58f6115b88ea94d000369a31"
-        Then we assert content api item "foo" with associated item "embedded1" is published to "#subscribers._id#"
+        Then we assert content api item "foo" with associated item "embedded1" is not published to "#subscribers._id#"
         Then we assert content api item "foo" with associated item "embedded1" is not published to "58f6110d88ea94d000369a2f"
 
     @auth

--- a/features/rundowns.feature
+++ b/features/rundowns.feature
@@ -49,7 +49,7 @@ Feature: Rundowns
         When we delete "/shows/#shows._id#"
         Then we get error 409
         """
-        {"message": "Can't remove show if there are rundowns."}
+        {"_error": {"code": 409, "message": "Can't remove show if there are rundowns."}, "_status": "ERR"}
         """
 
         When we delete "/rundowns/#rundowns._id#"

--- a/features/user_availability.feature
+++ b/features/user_availability.feature
@@ -465,7 +465,8 @@ Feature: User Availability
         """
         {
             "username": "foo",
-            "user_type": "user"
+            "user_type": "user",
+            "email": "foo@example.com"
         }
         """
 
@@ -479,7 +480,8 @@ Feature: User Availability
         """
         {
             "username": "bar",
-            "user_type": "user"
+            "user_type": "user",
+            "email": "bar@example.com"
         }
         """
 

--- a/superdesk/auth_server/oauth2.py
+++ b/superdesk/auth_server/oauth2.py
@@ -37,7 +37,7 @@ class SuperdeskOAuth2Server(OAuth2Server):
         return OAuth2Client(client_data, auth_methods=["client_secret_basic"], allowed_scopes=allowed_scopes)
 
 
-TOKEN_ENDPOINT = "/auth_server/token"
+TOKEN_ENDPOINT = "auth_server/token"
 authorization = SuperdeskOAuth2Server(TOKEN_ENDPOINT)
 
 module = Module(name="superdesk.auth_server.oauth2", init=authorization.init_app)

--- a/superdesk/publish_async/filters/content_exchange_filter.py
+++ b/superdesk/publish_async/filters/content_exchange_filter.py
@@ -187,6 +187,7 @@ class ContentPublishExchangeFilter(BasePublishExchangeFilter):
                 target_media_type=request.target_media_type,
                 sender_type=request.sender_type,
                 subscribers=response.subscribers.copy(),
+                publish_to_content_api=request.publish_to_content_api,
             )
             assoc_response = PublishRequestResponse()
             await super().filter_subscribers(assoc_request, assoc_response)
@@ -208,6 +209,6 @@ class ContentPublishExchangeFilter(BasePublishExchangeFilter):
                     associations[subscriber_id].append(assoc_id)
                     assoc_subscribers.add(subscriber_id)
 
-            request.item["subscribers"] = list(assoc_subscribers)
+            item["subscribers"] = list(assoc_subscribers)
 
         return associations

--- a/superdesk/publish_async/resources/filter_conditions/service.py
+++ b/superdesk/publish_async/resources/filter_conditions/service.py
@@ -62,7 +62,7 @@ class FilterConditionsService(AsyncResourceService[FilterConditionsResource]):
         if doc.operator not in parameter[0].operators:
             print(parameter[0].operators)
             raise SuperdeskApiError.badRequestError(
-                gettext(f"Filter condition:{doc.name} has unidentified operator: {doc.operator}")
+                gettext(f"Filter condition:{doc.name} has unidentified operator: {doc.operator.value}")
             )
 
     def _are_equal(self, fc1: FilterConditionsResource, fc2: FilterConditionsResource) -> bool:

--- a/superdesk/tests/publish/mock_consumer.py
+++ b/superdesk/tests/publish/mock_consumer.py
@@ -6,13 +6,29 @@ class MockPublishConsumer(AsyncioPublishConsumer):
     name: str = "mock"
 
     async def transmit_item(self, task: PublishQueueResource) -> bool:
-        if task.destination and task.destination.delivery_type == "File":
+        if self._allow_normal_publish(task):
             # If the destination is a local file, then follow normal consumer code
             return await super().transmit_item(task)
 
         # Otherwise mock transmission and simply mark the item as published
         await PublishQueueResource.get_service().update(task.id, {"state": PublishQueueState.SUCCESS}, task.etag, task)
         return True
+
+    def _allow_normal_publish(self, task: PublishQueueResource) -> bool:
+        if not task.destination:
+            return False
+
+        delivery_type = "" if not task.destination else task.destination.delivery_type.lower()
+
+        if delivery_type == "file":
+            # Allow local file transmission
+            return True
+        elif delivery_type == "http_push":
+            # Allow mock HTTP transmission
+            config = {} if not task.destination.config else task.destination.config.copy()
+            return config.get("resource_url") == "mock://publish" and config.get("assets_url") == "mock://assets"
+
+        return False
 
 
 publish_components = [MockPublishConsumer]

--- a/superdesk/tests/publish_steps.py
+++ b/superdesk/tests/publish_steps.py
@@ -9,7 +9,6 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 
-import requests_mock
 from behave import when, then  # @UnresolvedImport
 from behave.api.async_step import async_run_until_complete
 from superdesk.core import json
@@ -82,14 +81,3 @@ def then_we_pushed_x_items(context, count):
         context_data = json.loads(apply_placeholders(context, context.text))
         for i, _ in enumerate(context_data):
             assert_equal(json_match(context_data[i], history[i].json()), True, msg="item[%d]: %s" % (i, history[i]))
-
-
-@when("we transmit published")
-@async_run_until_complete
-async def when_we_transmit_published(context):
-    with requests_mock.Mocker() as m:
-        context.http_mock = m
-        m.post("mock://publish", text=json.dumps({}))
-        m.post("mock://assets", text=json.dumps({}))
-        await transmit.apply_async()
-        await transmit.apply_async()

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -29,6 +29,7 @@ from inspect import isawaitable
 from urllib.parse import urlparse
 from pathlib import Path
 import yaml
+import requests_mock
 
 from behave import given, when, then  # @UnresolvedImport
 from behave.api.async_step import async_run_until_complete
@@ -676,11 +677,6 @@ async def step_impl_run_update_ingest_command(context, provider_name):
 
 @mock.patch.object(ftp, "ftp_connect", return_value=mock.MagicMock())
 @mock.patch.object(update_ingest, "is_scheduled", return_value=True)
-@async_run_until_complete
-async def run_update_ingest_ftp_step(*args):
-    await run_update_ingest_ftp(*args)
-
-
 async def run_update_ingest_ftp(*args):
     def retrieve_and_parse_side_effect(ftp, config, filename, provider, registered_parser):
         created = datetime.now() + timedelta(days=365)
@@ -2034,7 +2030,7 @@ async def when_we_setup_test_user(context):
     if context.text:
         user_data = json.loads(apply_placeholders(context, context.text))
         user_data.setdefault("username", "test-user-123")
-        user_data.setdefault("password", "pwd")
+        user_data.setdefault("password", "password123")
         user_data.setdefault("email", "test123@example.com")
     else:
         user_data = deepcopy(tests.test_user)
@@ -2369,7 +2365,7 @@ async def login_as(context, username, password, user_type):
         "is_active": True,
         "is_enabled": True,
         "needs_activation": False,
-        "email": "behave_test_user@sourcefabric.org",
+        "email": f"behave_test_{username}@sourcefabric.org",
         user_type: user_type,
     }
 
@@ -2503,18 +2499,22 @@ async def step_field_name_does_not_exist(context, field_name):
 @when('we publish "{item_id}" with "{pub_type}" type and "{state}" state')
 @async_run_until_complete
 async def step_impl_when_publish_url(context, item_id, pub_type, state):
-    item_id = apply_placeholders(context, item_id)
-    res = await get_res("/archive/" + item_id, context)
-    headers = if_match(context, res.get("_etag"))
-    context_data = {"state": state}
-    if context.text:
-        data = apply_placeholders(context, context.text)
-        context_data.update(json.loads(data))
-    data = json.dumps(context_data)
-    context.response = await context.client.patch(
-        get_prefixed_url(context.app, "/archive/{}/{}".format(pub_type, item_id)), data=data, headers=headers
-    )
-    await store_placeholder(context, "archive_{}".format(pub_type))
+    with requests_mock.Mocker() as m:
+        context.http_mock = m
+        m.post("mock://publish", text=json.dumps({}))
+        m.post("mock://assets", text=json.dumps({}))
+        item_id = apply_placeholders(context, item_id)
+        res = await get_res("/archive/" + item_id, context)
+        headers = if_match(context, res.get("_etag"))
+        context_data = {"state": state}
+        if context.text:
+            data = apply_placeholders(context, context.text)
+            context_data.update(json.loads(data))
+        data = json.dumps(context_data)
+        context.response = await context.client.patch(
+            get_prefixed_url(context.app, "/archive/{}/{}".format(pub_type, item_id)), data=data, headers=headers
+        )
+        await store_placeholder(context, "archive_{}".format(pub_type))
 
 
 @then('the ingest item is routed based on routing scheme and rule "{rule_name}"')
@@ -3098,7 +3098,7 @@ async def step_impl_when_oauth2_client_auth(context, client_id, password):
     ]
     headers = unique_headers(headers, context.headers)
     context.response = await context.client.post(
-        get_prefixed_url(context.app, TOKEN_ENDPOINT), data={"grant_type": "client_credentials"}, headers=headers
+        get_prefixed_url(context.app, TOKEN_ENDPOINT), form={"grant_type": "client_credentials"}, headers=headers
     )
 
 
@@ -3148,7 +3148,7 @@ async def setp_impl_when_we_init_data(context, entity):
 async def when_we_run_task(context, name):
     task = celery.signature(name)
     assert task is not None
-    await task.apply()
+    await task.apply_async()
 
 
 @when('the lock expires "{url}"')


### PR DESCRIPTION
### Purpose
To get the remaining behave tests passing

### What has changed
* If a permission error is raised during LegalArchiveImport task, don't inform celery to retry
* Fix auth server test not sending form, and fix endpoint URL to prefix with API prefix
* Implement mock consumer for HTTP Push
* Fix issue with setting up more users in tests (validation failing due to email address already in use)
* Fix issue in new publish async code, that doesn't populate the association subscribers

Resolves: [SDESK-7630](https://sofab.atlassian.net/browse/SDESK-7630)



[SDESK-7630]: https://sofab.atlassian.net/browse/SDESK-7630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ