### PR TITLE
[NHUB-627] Refactor health endpoint logic into helper function

### DIFF
--- a/superdesk/system/health.py
+++ b/superdesk/system/health.py
@@ -17,7 +17,6 @@ import logging
 import superdesk
 
 from typing import Callable, List, Tuple
-
 from superdesk.core import get_app_config, get_current_app
 from superdesk.flask import Blueprint
 
@@ -59,10 +58,17 @@ checks: List[Tuple[str, Callable[[], bool]]] = [
 ]
 
 
-@bp.route("/system/health", methods=["GET", "OPTIONS"])
-def health():
+def get_health_status(app_name: str) -> dict[str, str]:
+    """Get health status for all configured checks.
+
+    Args:
+        app_name: Name of the application
+
+    Returns:
+        Dictionary containing health status for each component and overall status
+    """
     output = {
-        "application_name": get_app_config("APPLICATION_NAME"),
+        "application_name": app_name,
     }
 
     status = True
@@ -77,6 +83,11 @@ def health():
 
     output["status"] = human(status)
     return output
+
+
+@bp.route("/system/health", methods=["GET", "OPTIONS"])
+def health():
+    return get_health_status(get_app_config("APPLICATION_NAME"))
 
 
 def init_app(app) -> None:


### PR DESCRIPTION
### Purpose
Moved health status computation to a new `get_health_status` function for better reusability. The health endpoint now calls this helper, passing the application name from config. 

This is used from https://github.com/superdesk/newsroom-core/pull/1337

Belongs to: [NHUB-627]


[NHUB-627]: https://sofab.atlassian.net/browse/NHUB-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ