### PR TITLE
[SDESK-7744] - Added NoCredentialsError handling in the amazon sqs

### DIFF
--- a/superdesk/errors.py
+++ b/superdesk/errors.py
@@ -732,6 +732,7 @@ class PublishAmazonSQSError(SuperdeskPublishError):
         15000: "Amazon SQS publish connection error",
         15001: "Amazon SQS publish client error",
         15002: "Amazon SQS publish sendMessage error",
+        15003: "Amazon SQS missing credentials error",
     }
 
     @classmethod
@@ -745,6 +746,10 @@ class PublishAmazonSQSError(SuperdeskPublishError):
     @classmethod
     def sendMessageError(cls, exception=None, destination=None):
         return PublishAmazonSQSError(15002, exception, destination)
+
+    @classmethod
+    def credentialsError(cls, exception=None, destination=None):
+        return PublishAmazonSQSError(15003, exception, destination)
 
 
 class AlreadyExistsError(Exception):

--- a/superdesk/publish/transmitters/amazon_sqs_fifo.py
+++ b/superdesk/publish/transmitters/amazon_sqs_fifo.py
@@ -19,6 +19,7 @@ errors = [
     PublishAmazonSQSError.connectionError().get_error_description(),
     PublishAmazonSQSError.clientError().get_error_description(),
     PublishAmazonSQSError.sendMessageError().get_error_description(),
+    PublishAmazonSQSError.credentialsError().get_error_description(),
 ]
 
 
@@ -30,32 +31,60 @@ class AmazonSQSFIFOPublishService(publish_service.PublishService):
 
     NAME = "Amazon SQS FIFO"
 
-    def _transmit(self, queue_item, subscriber):
-        destination = queue_item.get("destination") or {}
-        config = destination.get("config") or {}
+    def _find_matching_destination(self, subscriber, target_destination):
+        if not subscriber:
+            return {}
+
+        destinations = subscriber.get("destinations") or []
+        delivery_type = (target_destination or {}).get("delivery_type")
+        name = (target_destination or {}).get("name")
+
+        if not delivery_type or not name or not destinations:
+            return {}
+
+        for destination in destinations:
+            if delivery_type and destination.get("name") == name and destination.get("delivery_type"):
+                return destination
+
+        return {}
+
+    def _send_to_sqs(self, config, message_body, destination):
+        sqs = boto3.resource(
+            "sqs",
+            aws_access_key_id=config.get("access_key_id"),
+            aws_secret_access_key=config.get("secret_access_key"),
+            region_name=config.get("region"),
+            endpoint_url=config.get("endpoint_url"),
+        )
+        queue = sqs.get_queue_by_name(QueueName=config.get("queue_name"))
 
         try:
-            sqs = boto3.resource(
-                "sqs",
-                aws_access_key_id=config.get("access_key_id"),
-                aws_secret_access_key=config.get("secret_access_key"),
-                region_name=config.get("region"),
-                endpoint_url=config.get("endpoint_url"),
-            )
-
-            queue = sqs.get_queue_by_name(QueueName=config.get("queue_name"))
             queue.send_message(
-                MessageBody=queue_item["formatted_item"],
+                MessageBody=message_body,
                 MessageGroupId=config.get("message_group_id"),
             )
-        except NoCredentialsError as error:
-            raise PublishAmazonSQSError.credentialsError(error, destination)
         except (EndpointConnectionError, ConnectionClosedError, NewConnectionError) as error:
             raise PublishAmazonSQSError.connectionError(error, destination)
         except ClientError as error:
             raise PublishAmazonSQSError.clientError(error, destination)
         except Exception as error:
             raise PublishAmazonSQSError.sendMessageError(error, destination)
+
+    def _transmit(self, queue_item, subscriber):
+        destination = queue_item.get("destination") or {}
+        config = destination.get("config") or {}
+        message_body = queue_item["formatted_item"]
+
+        try:
+            return self._send_to_sqs(config, message_body, destination)
+        except NoCredentialsError:
+            # Retry using the matching destination's config from the subscriber
+            subscriber_destination = self._find_matching_destination(subscriber, destination) or {}
+            fallback_config = subscriber_destination.get("config") or {}
+            try:
+                return self._send_to_sqs(fallback_config, message_body, destination)
+            except NoCredentialsError as error:
+                raise PublishAmazonSQSError.credentialsError(error, destination)
 
     def _transmit_media(self, media, destination):
         # Not supported

--- a/superdesk/publish/transmitters/amazon_sqs_fifo.py
+++ b/superdesk/publish/transmitters/amazon_sqs_fifo.py
@@ -9,7 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import boto3
-from botocore.exceptions import EndpointConnectionError, ConnectionClosedError, ClientError
+from botocore.exceptions import EndpointConnectionError, ConnectionClosedError, ClientError, NoCredentialsError
 from urllib3.exceptions import NewConnectionError
 
 from superdesk.publish import publish_service, register_transmitter
@@ -48,6 +48,8 @@ class AmazonSQSFIFOPublishService(publish_service.PublishService):
                 MessageBody=queue_item["formatted_item"],
                 MessageGroupId=config.get("message_group_id"),
             )
+        except NoCredentialsError as error:
+            raise PublishAmazonSQSError.credentialsError(error, destination)
         except (EndpointConnectionError, ConnectionClosedError, NewConnectionError) as error:
             raise PublishAmazonSQSError.connectionError(error, destination)
         except ClientError as error:

--- a/superdesk/publish/transmitters/amazon_sqs_fifo.py
+++ b/superdesk/publish/transmitters/amazon_sqs_fifo.py
@@ -43,7 +43,7 @@ class AmazonSQSFIFOPublishService(publish_service.PublishService):
             return {}
 
         for destination in destinations:
-            if delivery_type and destination.get("name") == name and destination.get("delivery_type"):
+            if destination.get("name") == name and destination.get("delivery_type") == delivery_type:
                 return destination
 
         return {}

--- a/superdesk/publish/transmitters/amazon_sqs_fifo.py
+++ b/superdesk/publish/transmitters/amazon_sqs_fifo.py
@@ -49,20 +49,21 @@ class AmazonSQSFIFOPublishService(publish_service.PublishService):
         return {}
 
     def _send_to_sqs(self, config, message_body, destination):
-        sqs = boto3.resource(
-            "sqs",
-            aws_access_key_id=config.get("access_key_id"),
-            aws_secret_access_key=config.get("secret_access_key"),
-            region_name=config.get("region"),
-            endpoint_url=config.get("endpoint_url"),
-        )
-        queue = sqs.get_queue_by_name(QueueName=config.get("queue_name"))
-
         try:
+            sqs = boto3.resource(
+                "sqs",
+                aws_access_key_id=config.get("access_key_id"),
+                aws_secret_access_key=config.get("secret_access_key"),
+                region_name=config.get("region"),
+                endpoint_url=config.get("endpoint_url"),
+            )
+            queue = sqs.get_queue_by_name(QueueName=config.get("queue_name"))
             queue.send_message(
                 MessageBody=message_body,
                 MessageGroupId=config.get("message_group_id"),
             )
+        except NoCredentialsError:
+            raise
         except (EndpointConnectionError, ConnectionClosedError, NewConnectionError) as error:
             raise PublishAmazonSQSError.connectionError(error, destination)
         except ClientError as error:


### PR DESCRIPTION
### Purpose
Added retry-on-NoCredentialsError in the Amazon SQS FIFO transmitter to guard against the intermittent error.


### What has changed
- Refactor: Extract SQS setup and send into a separate function.
- Retry on missing credentials: First attempt uses `queue_item` credentials and immediately retry using the matching subscriber destination’s config. If both fail, then we finally raise the `credentialsError`

Resolves: #[7744](https://sofab.atlassian.net/browse/SDESK-7744)