### PR TITLE
[SDCP-910] Update metadata stored in binraries of all renditions

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -941,6 +941,16 @@ class BasePublishService(BaseService):
             updated_renditions = deepcopy(renditions)
             updates["renditions"] = updated_renditions
 
+            original_metadata = get_metadata_from_item(original, mapping)
+            updated_metadata = get_metadata_from_item(updated, mapping)
+
+            original_state = original.get("state")
+            updated_state = updated.get("state")
+
+            should_update_metadata = updated_state in PUBLISH_STATES and (
+                    original_state != updated_state or original_metadata != updated_metadata
+            )
+
             for rendition_key, rendition_data in renditions.items():
                 if not rendition_data or not isinstance(rendition_data, dict):
                     continue
@@ -949,18 +959,18 @@ class BasePublishService(BaseService):
                 if not media_id:
                     continue
 
-                original_metadata = get_metadata_from_item(original, mapping)
-                metadata = get_metadata_from_item(updated, mapping)
-
-                if original_metadata == metadata:
+                if not should_update_metadata and original_metadata == updated_metadata:
                     continue
 
                 picture = app.media.get(media_id)
                 binary = picture.read()
-                updated_binary = write_metadata(binary, metadata)
-                if updated_binary != binary:
+                updated_binary = write_metadata(binary, updated_metadata)
+
+                if updated_binary != binary or should_update_metadata:
                     updated_media_id = app.media.put(
-                        updated_binary, content_type=picture.content_type, filename=picture.filename
+                        updated_binary,
+                        content_type=picture.content_type,
+                        filename=picture.filename,
                     )
                     updated_renditions[rendition_key].update(
                         {

--- a/features/content_publish.feature
+++ b/features/content_publish.feature
@@ -5131,3 +5131,513 @@ Feature: Content Publishing
         }
       }
       """
+
+    @auth
+    Scenario: Correcting an item and its association
+      Given config update
+      """
+      {
+        "PUBLISH_ASSOCIATED_ITEMS": true
+      }
+      """
+      And "validators"
+        """
+        [
+            {"_id": "publish_text", "act": "publish", "type": "text", "schema":{}}
+        ]
+        """
+      And "desks"
+        """
+        [{"name": "Sports", "members":[{"user":"#CONTEXT_USER_ID#"}]}]
+        """
+      And "archive"
+        """
+        [
+            {
+                "_id": "1234",
+                "guid": "1234",
+                "slugline": "picture",
+                "headline": "picture",
+                "alt_text": "alt_text",
+                "description_text": "description_text",
+                "type": "text",
+                "state": "in_progress",
+                "operation": "update",
+                "_current_version": 1,
+                "task": {
+                    "desk": "#desks._id#",
+                    "stage": "#desks.incoming_stage#",
+                    "user": "#CONTEXT_USER_ID#"
+                }
+            },
+            {
+              "_id": "5678",
+              "guid": "5678",
+              "slugline": "story",
+              "headline": "story headline",
+              "type": "text",
+              "state": "in_progress",
+              "_current_version": 1,
+              "associations": {
+                "picture": {
+                  "_id": "1234",
+                  "guid": "1234",
+                  "slugline": "picture",
+                  "state": "in_progress",
+                  "_current_version": 1
+                }
+              }
+            }
+        ]
+      """
+      When we publish "5678" with "publish" type and "published" state
+      Then we get OK response
+      And we get existing resource
+      """
+        {
+            "_id": "5678",
+            "guid": "5678",
+            "_current_version": 2,
+            "slugline": "story",
+            "headline": "story headline",
+            "state": "published",
+            "operation": "publish",
+            "associations": {
+                "picture": {
+                "_id": "1234",
+                "slugline": "picture",
+                "state": "published",
+                "_current_version": 2
+                }
+            }
+        }
+      """
+      When we publish "5678" with "correct" type and "corrected" state
+      """
+      {
+          "headline": "corrected story headline",
+          "correction_sequence": "2",
+          "associations": {
+            "picture": {
+              "_id": "1234",
+              "slugline": "corrected picture",
+              "_current_version": 2
+            }
+          }
+      }
+      """
+      Then we get OK response
+      And we get existing resource
+      """
+      {
+          "_id": "5678",
+          "guid": "5678",
+          "slugline": "story",
+          "headline": "corrected story headline",
+          "state": "corrected",
+          "associations": {
+            "picture": {
+              "_id": "1234",
+              "slugline": "corrected picture",
+              "state": "corrected",
+              "_current_version": 3
+            }
+          }
+      }
+      """
+      When we publish "5678" with "correct" type and "corrected" state
+      """
+      {
+          "headline": "re corrected story headline",
+          "correction_sequence": "3",
+          "associations": {
+            "picture": {
+              "_id": "1234",
+              "slugline": "re corrected picture",
+              "_current_version": 4
+            }
+          }
+      }
+      """
+      Then we get OK response
+      And we get existing resource
+      """
+      {
+          "_id": "5678",
+          "guid": "5678",
+          "slugline": "story",
+          "headline": "re corrected story headline",
+          "state": "corrected",
+          "associations": {
+            "picture": {
+              "_id": "1234",
+              "slugline": "re corrected picture",
+              "state": "corrected",
+              "_current_version": 4
+            }
+          }
+      }
+      """
+
+    @auth
+    Scenario: Publishing item with associated image still in progress, without modifying the image
+      Given config update
+      """
+      {
+        "PUBLISH_ASSOCIATED_ITEMS": true
+      }
+      """
+      And "validators"
+        """
+        [
+            {"_id": "publish_text", "act": "publish", "type": "text", "schema":{}}
+        ]
+        """
+      And "desks"
+        """
+        [{"name": "Sports", "members":[{"user":"#CONTEXT_USER_ID#"}]}]
+        """
+      And "archive"
+        """
+        [
+            {
+                "_id": "img1",
+                "guid": "img1",
+                "slugline": "picture",
+                "headline": "picture",
+                "type": "picture",
+                "state": "in_progress",
+                "_current_version": 1
+            },
+            {
+                "_id": "text1",
+                "guid": "text1",
+                "slugline": "story",
+                "headline": "story headline",
+                "type": "text",
+                "state": "in_progress",
+                "_current_version": 1,
+                "associations": {
+                  "picture": {
+                    "_id": "img1",
+                    "guid": "img1",
+                    "slugline": "picture",
+                    "type": "picture",
+                    "state": "in_progress",
+                    "_current_version": 1
+                  }
+                },
+                "task": {
+                  "desk": "#desks._id#",
+                  "stage": "#desks.incoming_stage#",
+                  "user": "#CONTEXT_USER_ID#"
+                }
+            }
+        ]
+        """
+      When we publish "text1" with "publish" type and "published" state
+      Then we get OK response
+      And we get existing resource
+      """
+        {
+            "_id": "text1",
+            "guid": "text1",
+            "slugline": "story",
+            "headline": "story headline",
+            "state": "published",
+            "operation": "publish",
+            "associations": {
+                "picture": {
+                  "_id": "img1",
+                  "slugline": "picture",
+                  "state": "published",
+                  "_current_version": 2
+                }
+            }
+        }
+      """
+
+    @auth
+    Scenario: All image renditions preserve mapped metadata after publish (SDCP-910)
+      Given config update
+      """
+      {
+        "PICTURE_METADATA_MAPPING": {
+          "slugline": "Title",
+          "description_text": "Description",
+          "headline": "Headline",
+          "byline": "Creator",
+          "copyrightnotice": "CopyrightNotice",
+          "creditline": "CreditLine",
+          "extra.filename": "JobId"
+        }
+      }
+      """
+      And "desks"
+      """
+      [{"name": "Sports", "members":[{"user":"#CONTEXT_USER_ID#"}]}]
+      """
+      And "validators"
+      """
+      [
+        {"_id": "publish_picture", "act": "publish", "type": "picture", "schema": {}}
+      ]
+      """
+      And "vocabularies"
+      """
+      [{
+        "_id": "crop_sizes",
+        "unique_field": "name",
+        "items": [
+          {"is_active": true, "name": "original", "width": 800, "height": 600},
+          {"is_active": true, "name": "viewImage", "width": 640, "height": 480},
+          {"is_active": true, "name": "thumbnail", "width": 200, "height": 150}
+        ]
+      }]
+      """
+
+      When we upload a file "bike.jpg" to "archive"
+      When we publish "#archive._id#" with "publish" type and "published" state
+      """
+      {
+        "slugline": "SDCP910-Test-Image",
+        "headline": "Comprehensive Metadata Test Image",
+        "description_text": "This image tests all metadata fields for SDCP-910 verification",
+        "byline": "Test Photographer",
+        "copyrightnotice": "Copyright 2023 Test Organization",
+        "creditline": "Photo by Test Photographer/Test Organization",
+        "extra": {"filename": "SDCP910-COMPLETE-REF"}
+      }
+      """
+      Then we get OK response
+
+      # Verify metadata exists in ALL renditions using archive_publish
+      And we get picture metadata "{{ archive_publish.renditions.original.media }}"
+      """
+      {
+        "JobId": "SDCP910-COMPLETE-REF",
+        "Title": "SDCP910-Test-Image",
+        "Description": "This image tests all metadata fields for SDCP-910 verification",
+        "Headline": "Comprehensive Metadata Test Image",
+        "Creator": ["Test Photographer"],
+        "CopyrightNotice": "Copyright 2023 Test Organization",
+        "CreditLine": "Photo by Test Photographer/Test Organization"
+      }
+      """
+      And we get picture metadata "{{ archive_publish.renditions.viewImage.media }}"
+      """
+      {
+        "JobId": "SDCP910-COMPLETE-REF",
+        "Title": "SDCP910-Test-Image",
+        "Description": "This image tests all metadata fields for SDCP-910 verification",
+        "Headline": "Comprehensive Metadata Test Image",
+        "Creator": ["Test Photographer"],
+        "CopyrightNotice": "Copyright 2023 Test Organization",
+        "CreditLine": "Photo by Test Photographer/Test Organization"
+      }
+      """
+      And we get picture metadata "{{ archive_publish.renditions.thumbnail.media }}"
+      """
+      {
+        "JobId": "SDCP910-COMPLETE-REF",
+        "Title": "SDCP910-Test-Image",
+        "Description": "This image tests all metadata fields for SDCP-910 verification",
+        "Headline": "Comprehensive Metadata Test Image",
+        "Creator": ["Test Photographer"],
+        "CopyrightNotice": "Copyright 2023 Test Organization",
+        "CreditLine": "Photo by Test Photographer/Test Organization"
+      }
+      """
+
+      # Also verify the published version has the same metadata in all renditions
+      When we get "/published"
+      Then we get list with 1 items
+      And we get picture metadata "{{ items.0.renditions.original.media }}"
+      """
+      {
+        "JobId": "SDCP910-COMPLETE-REF",
+        "Title": "SDCP910-Test-Image",
+        "Description": "This image tests all metadata fields for SDCP-910 verification",
+        "Headline": "Comprehensive Metadata Test Image",
+        "Creator": ["Test Photographer"],
+        "CopyrightNotice": "Copyright 2023 Test Organization",
+        "CreditLine": "Photo by Test Photographer/Test Organization"
+      }
+      """
+      And we get picture metadata "{{ items.0.renditions.viewImage.media }}"
+      """
+      {
+        "JobId": "SDCP910-COMPLETE-REF",
+        "Title": "SDCP910-Test-Image",
+        "Description": "This image tests all metadata fields for SDCP-910 verification",
+        "Headline": "Comprehensive Metadata Test Image",
+        "Creator": ["Test Photographer"],
+        "CopyrightNotice": "Copyright 2023 Test Organization",
+        "CreditLine": "Photo by Test Photographer/Test Organization"
+      }
+      """
+      And we get picture metadata "{{ items.0.renditions.thumbnail.media }}"
+      """
+      {
+        "JobId": "SDCP910-COMPLETE-REF",
+        "Title": "SDCP910-Test-Image",
+        "Description": "This image tests all metadata fields for SDCP-910 verification",
+        "Headline": "Comprehensive Metadata Test Image",
+        "Creator": ["Test Photographer"],
+        "CopyrightNotice": "Copyright 2023 Test Organization",
+        "CreditLine": "Photo by Test Photographer/Test Organization"
+      }
+      """
+
+    @auth @notification
+    Scenario: Update published article with associated images without errors (SDESK-7755)
+      Given empty "subscribers"
+      And config update
+      """
+      { "PUBLISH_ASSOCIATED_ITEMS": true,
+        "PICTURE_METADATA_MAPPING": {}
+      }
+      """
+      And "desks"
+      """
+      [{ "name": "News", "content_expiry": 60 }]
+      """
+      And "validators"
+      """
+      [
+        {"_id": "publish_text", "act": "publish", "type": "text", "schema": {}},
+        {"_id": "correct_text", "act": "correct", "type": "text", "schema": {}},
+        {"_id": "publish_picture", "act": "publish", "type": "picture", "schema": {}}
+      ]
+      """
+      And "vocabularies"
+      """
+      [{
+        "_id": "crop_sizes",
+        "unique_field": "name",
+        "items": [
+          {"is_active": true, "name": "original", "width": 800, "height": 600}
+        ]
+      }]
+      """
+      And "archive"
+      """
+      [
+        {
+          "_id": "img-1",
+          "guid": "img-1",
+          "_current_version": 1,
+          "type": "picture",
+          "slugline": "Associated image",
+          "headline": "Associated image",
+          "state": "in_progress",
+          "task": {
+            "desk": "#desks._id#",
+            "stage": "#desks.incoming_stage#",
+            "user": "#CONTEXT_USER_ID#"
+          },
+          "renditions": {
+            "original": {"width": 800, "height": 600, "media": "media-id-1"}
+          }
+        },
+        {
+          "_id": "art-1",
+          "guid": "art-1",
+          "_current_version": 1,
+          "type": "text",
+          "headline": "Main Article",
+          "slugline": "Main Article",
+          "body_html": "Initial article body",
+          "state": "in_progress",
+          "task": {
+            "desk": "#desks._id#",
+            "stage": "#desks.incoming_stage#",
+            "user": "#CONTEXT_USER_ID#"
+          },
+          "associations": {
+            "featuremedia": {
+              "_id": "img-1",
+              "guid": "img-1",
+              "type": "picture",
+              "slugline": "Associated image",
+              "headline": "Associated image",
+              "state": "in_progress",
+              "renditions": {
+                "original": {"width": 800, "height": 600, "media": "media-id-1"}
+              }
+            }
+          }
+        }
+      ]
+      """
+
+      # Step 1: Schedule the article with its associated image
+      When we publish "art-1" with "publish" type and "published" state
+      """
+      {
+          "publish_schedule": "#DATE+1#",
+          "schedule_settings": {"time_zone": "Europe/Prague"}
+      }
+      """
+      Then we get OK response
+
+      # Step 2: Let the scheduled items publish
+      When the publish schedule lapses
+      """
+      ["art-1", "img-1"]
+      """
+
+      # Step 3: Complete the publish queue workflow
+      When we enqueue published
+      And we transmit items
+      And run import legal publish queue
+
+      # Step 4: Verify both items are now published
+      When we get "/archive/art-1"
+      Then we get existing resource
+      """
+      {
+        "_id": "art-1",
+        "state": "published"
+      }
+      """
+
+      When we get "/archive/img-1"
+      Then we get existing resource
+      """
+      {
+        "_id": "img-1",
+        "state": "published"
+      }
+      """
+
+      # Step 5: Update only text fields of the published article
+      When we publish "art-1" with "correct" type and "corrected" state
+      """
+      {
+        "headline": "Main Article Updated",
+        "body_html": "Updated article body text"
+      }
+      """
+      Then we get OK response
+
+      # Step 6: Verify article republished successfully with image intact
+      When we get "/archive/art-1"
+      Then we get existing resource
+      """
+      {
+        "_id": "art-1",
+        "headline": "Main Article Updated",
+        "body_html": "Updated article body text"
+      }
+      """
+
+      # Step 7: Verify the associated image remains unchanged
+      When we get "/archive/img-1"
+      Then we get existing resource
+      """
+      {
+        "_id": "img-1",
+        "headline": "Associated image"
+      }
+      """

--- a/features/publish_correction.feature
+++ b/features/publish_correction.feature
@@ -68,3 +68,225 @@ Feature: Content Correction
         {"_items": [{"item_id": "123", "subscriber_id": "#sub1#", "publishing_action": "corrected"}]}
         """
 
+    @auth
+    Scenario: Correcting a story should not auto-correct its associated photo unless modified
+        # Setup publishing product and subscriber
+        When we post to "/products" with success
+        """
+        {"name": "photo-test", "codes": "abc,xyz", "product_type": "both"}
+        """
+        When we post to "/subscribers" with "sub1" and success
+        """
+        {
+            "name": "Photo Channel", "media_type": "media", "subscriber_type": "wire",
+            "sequence_num_settings": {"min": 1, "max": 10}, "email": "photo@test.com",
+            "products": ["#products._id#"], "is_active": true,
+            "destinations": [
+                {"name": "Test", "format": "nitf", "delivery_type": "email", "config": {"recipients": "photo@test.com"}}
+            ]
+        }
+        """
+
+        # Create a photo and a story with association
+        Given "desks"
+        """
+        [{"name": "News", "members":[{"user":"#CONTEXT_USER_ID#"}]}]
+        """
+        And "archive"
+        """
+        [
+            {
+            "_id": "tag:example.com,0000:newsml_PHOTO1",
+            "guid": "tag:example.com,0000:newsml_PHOTO1",
+            "unique_name": "photo_1",
+            "type": "photo",
+            "state": "in_progress",
+            "headline": "Photo A",
+            "task": {
+                "desk": "#desks._id#",
+                "stage": "#desks.incoming_stage#",
+                "user": "#CONTEXT_USER_ID#"
+            }
+            },
+            {
+            "_id": "tag:example.com,0000:newsml_STORY1",
+            "guid": "tag:example.com,0000:newsml_STORY1",
+            "unique_name": "story_1",
+            "type": "text",
+            "headline": "Story A",
+            "state": "in_progress",
+            "associations": {
+                "featuremedia": {
+                    "_id": "tag:example.com,0000:newsml_PHOTO1",
+                    "guid": "tag:example.com,0000:newsml_PHOTO1",
+                    "type": "picture"
+                }
+            },
+            "task": {
+                "desk": "#desks._id#",
+                "stage": "#desks.incoming_stage#",
+                "user": "#CONTEXT_USER_ID#"
+            }
+            }
+        ]
+        """
+
+        # Publish both
+        When we publish "tag:example.com,0000:newsml_PHOTO1" with "publish" type and "published" state
+        Then we get OK response
+        When we publish "tag:example.com,0000:newsml_STORY1" with "publish" type and "published" state
+        Then we get OK response
+
+        # Now correct only the story (photo should remain untouched)
+        When we publish "tag:example.com,0000:newsml_STORY1" with "correct" type and "corrected" state
+        """
+        {"headline": "Story A - corrected"}
+        """
+        Then we get OK response
+
+        # Validate correction
+        When we get "/published"
+        Then we get list with 3 items
+        """
+        {
+            "_items": [
+            {"guid": "tag:example.com,0000:newsml_PHOTO1", "headline": "Photo A", "state": "published"},
+            {"guid": "tag:example.com,0000:newsml_STORY1", "headline": "Story A", "state": "published"},
+            {"guid": "tag:example.com,0000:newsml_STORY1", "headline": "Story A - corrected", "state": "corrected"}
+            ]
+        }
+        """
+
+    @auth
+    Scenario: Publish new article with both published and corrected associated items
+        # Step 1: Setup publishing product and subscriber
+        When we post to "/products" with success
+        """
+        {"name": "mix-test", "codes": "abc,xyz", "product_type": "both"}
+        """
+        When we post to "/subscribers" with "sub-mixed" and success
+        """
+        {
+            "name": "Mixed Channel", "media_type": "media", "subscriber_type": "wire",
+            "sequence_num_settings": {"min": 1, "max": 10}, "email": "mix@test.com",
+            "products": ["#products._id#"], "is_active": true,
+            "destinations": [
+                {
+                    "name": "MixDest", "format": "nitf", "delivery_type": "email",
+                    "config": {"recipients": "mix@test.com"}
+                }
+            ]
+        }
+        """
+
+        # Step 2: Setup desks and content items
+        Given "desks"
+        """
+        [{"name": "MixedDesk", "members":[{"user":"#CONTEXT_USER_ID#"}]}]
+        """
+        And "archive"
+        """
+        [
+            {
+                "_id": "tag:example.com,2025:newsml_PUBLISHED_ARTICLE",
+                "guid": "tag:example.com,2025:newsml_PUBLISHED_ARTICLE",
+                "type": "text",
+                "headline": "Published Article",
+                "state": "in_progress",
+                "task": {
+                    "desk": "#desks._id#",
+                    "stage": "#desks.incoming_stage#",
+                    "user": "#CONTEXT_USER_ID#"
+                }
+            },
+            {
+                "_id": "tag:example.com,2025:newsml_CORRECTABLE_ARTICLE",
+                "guid": "tag:example.com,2025:newsml_CORRECTABLE_ARTICLE",
+                "type": "text",
+                "headline": "Correctable Article",
+                "state": "in_progress",
+                "task": {
+                    "desk": "#desks._id#",
+                    "stage": "#desks.incoming_stage#",
+                    "user": "#CONTEXT_USER_ID#"
+                }
+            }
+        ]
+        """
+
+        # Step 3: Publish both articles
+        When we publish "tag:example.com,2025:newsml_PUBLISHED_ARTICLE" with "publish" type and "published" state
+        Then we get OK response
+
+        When we publish "tag:example.com,2025:newsml_CORRECTABLE_ARTICLE" with "publish" type and "published" state
+        Then we get OK response
+
+        # Step 4: Send a correction to the second article
+        When we publish "tag:example.com,2025:newsml_CORRECTABLE_ARTICLE" with "correct" type and "corrected" state
+        """
+        {"headline": "Corrected Article"}
+        """
+        Then we get OK response
+
+        # Step 5: Create a new article with both published and corrected items as associations
+        When we post to "/archive" with "tag:example.com,2025:newsml_MAIN_ARTICLE" and success
+        """
+        {
+            "_id": "tag:example.com,2025:newsml_MAIN_ARTICLE",
+            "guid": "tag:example.com,2025:newsml_MAIN_ARTICLE",
+            "type": "text",
+            "headline": "Main Article with Mixed Associations",
+            "state": "in_progress",
+            "task": {
+                "desk": "#desks._id#",
+                "stage": "#desks.incoming_stage#",
+                "user": "#CONTEXT_USER_ID#"
+            },
+            "associations": {
+                "related-published": {
+                    "_id": "tag:example.com,2025:newsml_PUBLISHED_ARTICLE",
+                    "guid": "tag:example.com,2025:newsml_PUBLISHED_ARTICLE",
+                    "type": "text"
+                },
+                "related-corrected": {
+                    "_id": "tag:example.com,2025:newsml_CORRECTABLE_ARTICLE",
+                    "guid": "tag:example.com,2025:newsml_CORRECTABLE_ARTICLE",
+                    "type": "text"
+                }
+            }
+        }
+        """
+
+        # Step 6: Publish the new article with both associated items
+        When we publish "tag:example.com,2025:newsml_MAIN_ARTICLE" with "publish" type and "published" state
+        Then we get OK response
+
+        # Step 7: Verify that all items are in published/corrected state
+        When we get "/published"
+        Then we get list with 4 items
+        """
+        {
+            "_items": [
+                {
+                    "guid": "tag:example.com,2025:newsml_PUBLISHED_ARTICLE",
+                    "headline": "Published Article",
+                    "state": "published"
+                },
+                {
+                    "guid": "tag:example.com,2025:newsml_CORRECTABLE_ARTICLE",
+                    "headline": "Correctable Article",
+                    "state": "published"
+                },
+                {
+                    "guid": "tag:example.com,2025:newsml_CORRECTABLE_ARTICLE",
+                    "headline": "Corrected Article",
+                    "state": "corrected"
+                },
+                {
+                    "guid": "tag:example.com,2025:newsml_MAIN_ARTICLE",
+                    "headline": "Main Article with Mixed Associations",
+                    "state": "published"
+                }
+            ]
+        }
+        """


### PR DESCRIPTION
### Purpose
Copy the changes from this [PR](https://github.com/superdesk/superdesk-core/pull/3012) to v2.9

### What has changed
* Update item renditions if media metadata, item states or media binary have changed
* Add tests from
  * https://github.com/superdesk/superdesk-core/pull/2981
  * https://github.com/superdesk/superdesk-core/pull/2989
  * https://github.com/superdesk/superdesk-core/pull/2894
  * https://github.com/superdesk/superdesk-core/pull/3012

Resolves: [SDCP-910](https://sofab.atlassian.net/browse/SDCP-910)



[SDCP-910]: https://sofab.atlassian.net/browse/SDCP-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ