### PR TITLE
[STT-1203] Add async signals for item_duplicate/d

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -542,6 +542,7 @@ class ArchiveService(AsyncBaseService, HighlightsSearchMixin):
 
         convert_task_attributes_to_objectId(new_doc)
         await transtype_metadata(new_doc)
+        await signals.item_duplicate_async.send(new_doc, original_doc, operation)
         signals.item_duplicate.send(self, item=new_doc, original=original_doc, operation=operation)
         await get_model(ItemModel).create_async([new_doc])
         await self._duplicate_versions(original_doc["_id"], new_doc)
@@ -564,6 +565,7 @@ class ArchiveService(AsyncBaseService, HighlightsSearchMixin):
                 {"duplicate_id": original_doc["_id"]}, new_doc, operation or ITEM_DUPLICATED_FROM
             )
 
+        await signals.item_duplicated_async.send(new_doc, original_doc, operation)
         signals.item_duplicated.send(self, item=new_doc, original=original_doc, operation=operation)
 
         return new_doc["guid"]
@@ -600,7 +602,6 @@ class ArchiveService(AsyncBaseService, HighlightsSearchMixin):
                 "marked_desks",
                 "_type",
                 "event_id",
-                "assignment_id",
                 PROCESSED_FROM,
                 "translations",
                 "translation_id",

--- a/features/content_duplication.feature
+++ b/features/content_duplication.feature
@@ -627,19 +627,6 @@ Feature: Duplication of Content
       """
 
     @auth
-    Scenario: Planning assignment is removed from an item on duplication
-      When we patch given
-      """
-      {"assignment_id": "1234"}
-      """
-      When we post to "/archive/123/duplicate" with success
-      """
-      {"desk": "#desks._id#","type": "archive"}
-      """
-      When we get "/archive/#duplicate._id#"
-      Then we get "assignment_id" does not exist
-
-    @auth
     Scenario: Auto publish flag is removed on duplication
       When we patch given
       """

--- a/superdesk/signals.py
+++ b/superdesk/signals.py
@@ -29,7 +29,9 @@ __all__ = [
     "item_validate",
     "item_routed",
     "item_duplicate",
+    "item_duplicate_async",
     "item_duplicated",
+    "item_duplicated_async",
     "archived_item_removed",
     "item_resend",
     "item_resent",
@@ -150,6 +152,7 @@ item_routed = signals.signal("item:routed")
 #: :param original: original item
 #: :param operation: operation
 item_duplicate = signals.signal("item:duplicate")
+item_duplicate_async = AsyncSignal[dict, dict, str]("item:duplicate")
 
 
 #: Sent after item is duplicated
@@ -161,6 +164,7 @@ item_duplicate = signals.signal("item:duplicate")
 #: :param original: original item
 #: :param operation: operation
 item_duplicated = signals.signal("item:duplicated")
+item_duplicated_async = AsyncSignal[dict, dict, str]("item:duplicate")
 
 
 #: Sent then item is removed from archived


### PR DESCRIPTION
### Purpose
Add async signals for `item_duplicate` and `item_duplicated`

Note: Assigned this to v3.1 as ``assignment_id`` is no longer removed in core code, but in the Planning module (which is in v3.1).
