### PR TITLE
[SDESK-7757] fix(capi): Init cache in get_app

### DIFF
--- a/content_api/app/__init__.py
+++ b/content_api/app/__init__.py
@@ -29,6 +29,7 @@ from superdesk.datalayer import SuperdeskDataLayer
 from superdesk.factory.elastic_apm import setup_apm
 from superdesk.validator import SuperdeskValidator
 from superdesk.factory.app import SuperdeskEve, set_error_handlers, get_media_storage_class
+from superdesk.cache import cache_backend
 
 
 def get_app(config=None):
@@ -76,6 +77,7 @@ def get_app(config=None):
 
     set_error_handlers(app)
     setup_apm(app, "Content API")
+    cache_backend.init_app(app)
 
     for module_name in app.config.get("CONTENTAPI_INSTALLED_APPS", []):
         app_module = importlib.import_module(module_name)


### PR DESCRIPTION
### Purpose
Getting a content item from the ContentAPI (via the /items endpoint) raises the following exception:
```
Traceback (most recent call last):
  File "content_api/items/service.py", line 174, in on_fetched
    get_resource_service("api_audit").audit_items(result["_items"])
  File "content_api/api_audit/service.py", line 34, in audit_items
    self._audit_docs(items)
  File "content_api/api_audit/service.py", line 56, in _audit_docs
    self.post(audit_docs)
  File "superdesk/services.py", line 197, in post
    ids = self.create(docs, **kwargs)
  File "superdesk/services.py", line 76, in create
    ids = self.backend.create(self.datasource, docs, **kwargs)
  File "superdesk/eve_backend.py", line 314, in create
    cache.clean([endpoint_name])
  File "hermes/__init__.py", line 616, in clean
    self.backend.remove(map(self.mangler.nameTag, tags))
  File "superdesk/cache.py", line 106, in remove
    return self._backend.remove(keys)
  File "superdesk/cache.py", line 93, in _backend
    return self.app.extensions["superdesk_cache"]
AttributeError: 'SuperdeskCacheBackend' object has no attribute 'app'
```

### What has changed
Init the cache app for ContentAPI


Resolves: [SDESK-7757](https://sofab.atlassian.net/browse/SDESK-7757)



[SDESK-7757]: https://sofab.atlassian.net/browse/SDESK-7757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ