### PR TITLE
exported advisories loose formatting upon reopening them [SDBELGA-972]

### DIFF
--- a/superdesk/editor_utils.py
+++ b/superdesk/editor_utils.py
@@ -648,6 +648,12 @@ class Editor3Content(EditorContent):
                 inline_style_ranges = []
                 entity_ranges = []
                 for child in elem:
+                    if child.tag in ("br",):
+                        block_text += "\n"
+                        if child.tail and child.tail.strip():
+                            block_text += child.tail
+                        continue
+
                     child_text = "".join(child.itertext())
 
                     if child.tag in TAG_STYLE_MAP:

--- a/tests/editor_utils_test.py
+++ b/tests/editor_utils_test.py
@@ -2179,3 +2179,15 @@ class Editor3TestCase(unittest.TestCase):
         editor = Editor3Content(item)
         html = editor.html
         assert html == "<p>first line<br>second line</p>"
+
+    def test_import_br_preserves_breaks(self):
+        body_html = """
+        <p>first line<br>second line</p>
+        <p>Another paragraph</p>
+        """
+        item = {"body_html": body_html}
+        editor = Editor3Content(item, field="body_html")
+        html_after = editor.html
+
+        expected_html = "<p>first line<br>second line</p>\n<p>Another paragraph</p>"
+        self.assertEqual(html_after, expected_html)


### PR DESCRIPTION
Fixes an issue where `<br>` Tags in imported HTML were not properly preserved in `Editor3Content`. The change ensures that each `<br>` is correctly converted into a newline while retaining any trailing text. A test case has been added to confirm that line breaks and paragraph structure remain identical to the original HTML, resolving formatting issues in exported or displayed content.