### PR TITLE
monitoring view preference

### DIFF
--- a/apps/monitoring.py
+++ b/apps/monitoring.py
@@ -7,12 +7,10 @@ def init_app(app) -> None:
         "monitoring:view",
         {
             "type": "string",
-            "allowed": ["list", "swimlane"],
             "view": "list",
             "default": "list",
         },
         label=lazy_gettext("Monitoring view"),
-        category=lazy_gettext("monitoring"),
     )
 
     superdesk.register_default_session_preference("monitoring:view:session", None)

--- a/prod_api/tests/fixtures/users.json
+++ b/prod_api/tests/fixtures/users.json
@@ -167,14 +167,9 @@
             },
             "monitoring:view": {
                 "type": "string",
-                "allowed": [
-                    "list",
-                    "swimlane"
-                ],
                 "view": "list",
                 "default": "list",
-                "label": "Monitoring view",
-                "category": "monitoring"
+                "label": "Monitoring view"
             },
             "slack:notification": {
                 "type": "bool",


### PR DESCRIPTION
SDESK-7765

REQUIRED BY https://github.com/superdesk/superdesk-client-core/pull/4949

Dropping `category` to prevent preference from appearing in user preferences editing UI.
Dropping `allowed` here so all possible values are in one place - on the client.

@petrjasek Could you push an upgrade script for this, to do this for all `user.user_preferences` objects? `manage.py` command for generating an upgrade script didn't work for me.

<details>
<summary>error log</summary>
<pre>
(env) tomas@e14:~/superdesk-repos/superdesk/server$ python manage.py data:generate_update --resource=users
WARNING:root:SECRET_KEY is not set, hardcoded value is used instead. This should not be used on production!
WARNING:root:pyexiv2 is not installed, writing picture metadata will not work
INFO:superdesk:using redis cache backend
INFO:superdesk.backend_meta.backend_meta:version of 'superdesk-core': 2.10.0
INFO:superdesk.backend_meta.backend_meta:version of 'superdesk-planning': 2.9.0rc1
INFO:superdesk.backend_meta.backend_meta:version of 'superdesk-analytics': 2.8.0
WARNING:superdesk.auth_server.oauth2:No shared secret set, please set it using AUTH_SERVER_SHARED_SECRET environment variable or setting. Authorisation server can't be used
INFO:superdesk.websockets_comms:Connecting to broker redis://localhost:6379
INFO:superdesk.websockets_comms:Connected to broker redis://localhost:6379
/home/tomas/superdesk-repos/superdesk/server/env/lib/python3.13/site-packages/cerberus/validator.py:1666: UserWarning: No validation schema is defined for the arguments of rule 'default_language'
  warn(
WARNING:superdesk:Highcharts export server is not installed
Traceback (most recent call last):
  File "/home/tomas/superdesk-repos/superdesk/server/manage.py", line 23, in <module>
    manager.run(superdesk.COMMANDS)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/home/tomas/superdesk-repos/superdesk/server/env/lib/python3.13/site-packages/flask_script/__init__.py", line 417, in run
    result = self.handle(argv[0], argv[1:])
  File "/home/tomas/superdesk-repos/superdesk/server/env/lib/python3.13/site-packages/flask_script/__init__.py", line 356, in handle
    app_namespace, remaining_args = app_parser.parse_known_args(args)
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/linuxbrew/.linuxbrew/opt/python@3.13/lib/python3.13/argparse.py", line 1908, in parse_known_args
    return self._parse_known_args2(args, namespace, intermixed=False)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/linuxbrew/.linuxbrew/opt/python@3.13/lib/python3.13/argparse.py", line 2169, in _parse_known_args
    positionals_end_index = consume_positionals(start_index)
  File "/home/linuxbrew/.linuxbrew/opt/python@3.13/lib/python3.13/argparse.py", line 2144, in consume_positionals
    take_action(action, args)
    ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/home/linuxbrew/.linuxbrew/opt/python@3.13/lib/python3.13/argparse.py", line 2013, in take_action
    action(self, namespace, argument_values, option_string)
    ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/linuxbrew/.linuxbrew/opt/python@3.13/lib/python3.13/argparse.py", line 1260, in __call__
    setattr(namespace, key, value)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'resource_name' and no __dict__ for setting new attributes
</pre>
</details>

Here's the upgrade script I generated with copilot, double check if it's alright:
```
from superdesk.commands.data_updates import BaseDataUpdate
from eve.utils import config

class DataUpdate(BaseDataUpdate):
    resource = "users"

    def forwards(self, mongodb_collection, mongodb_database):
        # Iterate over all users with a monitoring:view preference
        for user in mongodb_collection.find({"user_preferences.monitoring:view": {"$exists": True}}):
            prefs = user.get("user_preferences", {})
            monitoring = prefs.get("monitoring:view", None)
            if isinstance(monitoring, dict):
                changed = False
                # Remove the specified keys if they exist
                for key in ["allowed", "category"]:
                    if key in monitoring:
                        monitoring.pop(key)
                        changed = True
                if changed:
                    prefs["monitoring:view"] = monitoring
                    print(
                        mongodb_collection.update_one(
                            {"_id": user.get(config.ID_FIELD)},
                            {"$set": {"user_preferences": prefs}}
                        )
                    )

    def backwards(self, mongodb_collection, mongodb_database):
        # No-op: the removed properties are not restored
        pass
```