### PR TITLE
[SDCP-978] Disable task expiry for celery publish router

### DIFF
--- a/superdesk/publish_async/routers/celery_router.py
+++ b/superdesk/publish_async/routers/celery_router.py
@@ -44,7 +44,7 @@ class CeleryPublishRouter(AsyncioPublishRouter):
         )
 
 
-@celery.task(soft_time_limit=600, expires=10)
+@celery.task(soft_time_limit=600)
 async def send_task_to_consumer(consumer_name: str, subscriber_id: ObjectId, task_ids: list[ObjectId]) -> None:
     """
     An asynchronous function to send tasks to a specified consumer by identifying the subscriber


### PR DESCRIPTION
### Purpose
If a publish task uses celery, and that task is not picked up within 10 seconds, the task is ignored leaving the publish queue entry in `routed` state.

### What has changed
Remove the task expiry

Resolves: [SDCP-978](https://sofab.atlassian.net/browse/SDCP-978)



[SDCP-978]: https://sofab.atlassian.net/browse/SDCP-978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ