### PR TITLE
[STT-1335] Add coverage_profiles to app:initialize_data command

### DIFF
--- a/apps/prepopulate/app_initialize.py
+++ b/apps/prepopulate/app_initialize.py
@@ -189,6 +189,7 @@ __entities__ = OrderedDict(
         ("contacts", ("contacts.json", "", False)),
         ("planning_types", ("planning_types.json", "", True)),
         ("planning_export_templates", ("planning_export_templates.json", "", True)),
+        ("coverage_profiles", ("coverage_profiles.json", "", True)),
     ]
 )
 INIT_DATA_PATH = Path(__file__).resolve().parent / "data_init"


### PR DESCRIPTION
### Purpose
The `data/coverage_profiles.json` file is not being picked up by the `app:initialize_data` command.

### What has changed
Add support for `coverages_profile` resource in `app:initialize_data` command

Resolves: [STT-1335](https://sofab.atlassian.net/browse/STT-1335)



[STT-1335]: https://sofab.atlassian.net/browse/STT-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ