### PR TITLE
fix route config error when GOOGLE auth is enabled

### DIFF
--- a/superdesk/auth/oauth.py
+++ b/superdesk/auth/oauth.py
@@ -142,8 +142,14 @@ def configure_google(app, extra_scopes: Optional[List[str]] = None, refresh: boo
     )
 
     @bp.route("/login/google")
+    def google_login():
+        return _google_login()
+
     @bp.route("/login/google/<url_id>")
-    def google_login(url_id=None):
+    def google_login_with_id(url_id=None):
+        return _google_login(url_id)
+
+    def _google_login(url_id=None):
         """Redirect to google OAuth authorization page
 
         :param url_id: used to identify the token

--- a/tests/auth/oauth_test.py
+++ b/tests/auth/oauth_test.py
@@ -1,0 +1,15 @@
+from superdesk.tests import TestCase
+from superdesk.auth.oauth import init_app
+
+
+class OAuthTestCase(TestCase):
+    async def test_oauth_setup(self):
+        self.app.config["GOOGLE_CLIENT_ID"] = "test_client_id"
+        self.app.config["GOOGLE_CLIENT_SECRET"] = "test_client_secret"
+        self.app.config["GOOGLE_LOGIN"] = True
+        init_app(self.app)
+
+        async with self.app.test_client() as client:
+            resp = await client.get("/api/login/google")
+            self.assertEqual(resp.status_code, 302)
+            self.assertIn("accounts.google.com", resp.location)


### PR DESCRIPTION
there can be only one route per function, otherwise it raises AssertionError.

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

