### PR TITLE
[SDCP-994] fix: DeskResourceModel monitoring settings

### DIFF
--- a/superdesk/types/__init__.py
+++ b/superdesk/types/__init__.py
@@ -7,7 +7,6 @@ import bson
 from .enums import (
     DeskTypeEnum,
     MonitoringTypeEnum,
-    MonitoringViewEnum,
     UserTypeEnum,
     PublishState,
     ContentState,
@@ -49,7 +48,6 @@ __all__ = [
     "Id",
     "DeskTypeEnum",
     "MonitoringTypeEnum",
-    "MonitoringViewEnum",
     "UserTypeEnum",
     "PublishState",
     "ContentState",

--- a/superdesk/types/desks.py
+++ b/superdesk/types/desks.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Any
 from pydantic import Field
 
-from .enums import MonitoringTypeEnum, MonitoringViewEnum, DeskTypeEnum
+from .enums import MonitoringTypeEnum, DeskTypeEnum
 from superdesk.core.resources import ResourceModelWithObjectId, fields, dataclass, Dataclass
 from superdesk.core.resources.fields import ObjectId
 from superdesk.core.resources.validators import validate_unique_value_async, validate_data_relation_async
@@ -32,7 +32,7 @@ class DesksResourceModel(ResourceModelWithObjectId):
     desk_metadata: dict[str, Any] = Field(default_factory=dict)
     content_profiles: dict[str, Any] = Field(default_factory=dict)
     desk_language: str | None = None
-    monitoring_default_view: MonitoringViewEnum | None = None
+    monitoring_default_view: str | None = None
     default_content_profile: Annotated[str | ObjectId, validate_data_relation_async("content_types")] | None = None
     default_content_template: Annotated[ObjectId, validate_data_relation_async("content_templates")] | None = None
     slack_channel_name: str | None = Field(

--- a/superdesk/types/enums.py
+++ b/superdesk/types/enums.py
@@ -11,18 +11,10 @@ class DeskTypeEnum(str, Enum):
 class MonitoringTypeEnum(str, Enum):
     SEARCH = "search"
     STAGE = "stage"
-    SCHEDULED_DESK_OUTPUT = "scheduled_desk_output"
-    DESK_OUTPUT = "desk_output"
+    SCHEDULED_DESK_OUTPUT = "scheduledDeskOutput"
+    DESK_OUTPUT = "deskOutput"
     PERSONAL = "personal"
-    SENT_DESK_OUTPUT = "sent_desk_output"
-
-
-@unique
-class MonitoringViewEnum(str, Enum):
-    BLANK = ""
-    LIST = "list"
-    SWIMLANE = "swimlane"
-    PHOTOGRID = "photogrid"
+    SENT_DESK_OUTPUT = "sentDeskOutput"
 
 
 @unique


### PR DESCRIPTION
### Purpose
Getting desks using the new async resource/service was failing validation of the model.

### What has changed
* Fix invalid values for MonitoringTypeEnum enum (copy the allowed values from old eve resource)
* Add fix from https://github.com/superdesk/superdesk-core/pull/3044

Resolves: [SDCP-994](https://sofab.atlassian.net/browse/SDCP-994)



[SDCP-994]: https://sofab.atlassian.net/browse/SDCP-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ