### PR TITLE
[SDBELGA-996] - Exclude inactive users from prod api availability manager

### DIFF
--- a/prod_api/user_availability/service.py
+++ b/prod_api/user_availability/service.py
@@ -61,7 +61,7 @@ class UserAvailabilityService(ProdApiService):
                 req=None, lookup={"enabled": True}, projection={"_id": 1}
             )
         ]
-        users = get_resource_service("users").find(where={"_id": {"$in": availability_enabled}})
+        users = get_resource_service("users").find(where={"_id": {"$in": availability_enabled}, "is_active": True})
         user_data = [self._get_user_availability(user, start_date, end_date) for user in users]
         return ListCursor(user_data)
 


### PR DESCRIPTION
Added filter `'is_active': True` to the user query filter to ensure only active users are included when fetching availability data.

Resolves: [SDBELGA-996]



[SDBELGA-996]: https://sofab.atlassian.net/browse/SDBELGA-996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ