### PR TITLE
[SDAN-741] improve: Add title attribute to web endpoints

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,5 +18,5 @@ moto[sqs]==5.0.18
 pyexiv2>=2.12.0,<2.13; sys_platform == 'linux'
 
 -e .
--e git+https://github.com/superdesk/superdesk-planning.git@release/3.0#egg=superdesk_planning
+-e git+https://github.com/superdesk/superdesk-planning.git@v3.0.0-alpha.1#egg=superdesk_planning
 -e git+https://github.com/superdesk/sams.git@develop#egg=sams_client&subdirectory=src/clients/python/

--- a/superdesk/core/types/web.py
+++ b/superdesk/core/types/web.py
@@ -232,6 +232,9 @@ class Endpoint:
     #: Name of the endpoint (must be unique)
     name: str
 
+    #: Title of the endpoint (used for HATEOAS links)
+    title: str
+
     #: HTTP Methods allowed for this endpoint
     methods: list[HTTP_METHOD]
 
@@ -246,6 +249,7 @@ class Endpoint:
         func: EndpointFunction,
         methods: list[HTTP_METHOD] | None = None,
         name: str | None = None,
+        title: str | None = None,
         auth: AuthConfig = None,
         parent: Union["EndpointGroup", None] = None,
     ):
@@ -253,6 +257,7 @@ class Endpoint:
         self.func = func
         self.methods = methods or ["GET"]
         self.name = name or func.__name__
+        self.title = title or self.name.replace("_", " ").title()
         self.auth = auth
         self.parent = parent
 
@@ -285,6 +290,7 @@ class EndpointGroup(Endpoint):
         self,
         url: str,
         name: str | None = None,
+        title: str | None = None,
         methods: list[HTTP_METHOD] | None = None,
         auth: AuthConfig = None,
     ):

--- a/superdesk/core/web/endpoints.py
+++ b/superdesk/core/web/endpoints.py
@@ -133,6 +133,7 @@ class EndpointGroup(EndpointGroupProtocol):
         self,
         url: str,
         name: str | None = None,
+        title: str | None = None,
         methods: list[HTTP_METHOD] | None = None,
         auth: AuthConfig = None,
     ):
@@ -149,6 +150,7 @@ class EndpointGroup(EndpointGroupProtocol):
                 func,
                 methods=methods,
                 name=name,
+                title=title,
                 auth=auth,
                 parent=self,
             )
@@ -161,7 +163,13 @@ class EndpointGroup(EndpointGroupProtocol):
         return return_404()
 
 
-def endpoint(url: str, name: str | None = None, methods: list[HTTP_METHOD] | None = None, auth: AuthConfig = None):
+def endpoint(
+    url: str,
+    name: str | None = None,
+    title: str | None = None,
+    methods: list[HTTP_METHOD] | None = None,
+    auth: AuthConfig = None,
+):
     """Decorator function to convert a pure function to an Endpoint instance
     which is later used to register with a Module or the app.
 
@@ -171,7 +179,8 @@ def endpoint(url: str, name: str | None = None, methods: list[HTTP_METHOD] | Non
             For example:
             - "items" becomes "{api_prefix}{api_version}/items"
             - "/custom/path" stays as "/custom/path"
-        name: The optional name of the endpoint
+        name: The optional name of the endpoint (used for registering with Flask/Quart)
+        title: The optional title of the endpoint (used for HATEOAS links)
         methods: The optional list of HTTP methods allowed
     """
 
@@ -179,6 +188,7 @@ def endpoint(url: str, name: str | None = None, methods: list[HTTP_METHOD] | Non
         return Endpoint(
             url=url,
             name=name,
+            title=title,
             methods=methods,
             func=func,
             auth=auth,

--- a/superdesk/factory/app.py
+++ b/superdesk/factory/app.py
@@ -463,14 +463,14 @@ class SuperdeskEve(eve.Eve):
                         links.append(
                             {
                                 "href": sub_endpoint.url,
-                                "title": sub_endpoint.name or sub_endpoint.url.replace("/", "_"),
+                                "title": sub_endpoint.title or sub_endpoint.name or sub_endpoint.url.replace("/", "_"),
                             }
                         )
                 else:
                     links.append(
                         {
                             "href": endpoint.url,
-                            "title": endpoint.name or endpoint.url.replace("/", "_"),
+                            "title": endpoint.title or endpoint.name or endpoint.url.replace("/", "_"),
                         }
                     )
 


### PR DESCRIPTION
### Purpose
Previously we had a `name` attribute available on Web Endpoints, which was used for HATEOAS links in root API response. This `name` attribute is also used by Flask/Quart, which changes uses of `url_for`.

### What has changed
Add a new `title` attribute to WebEndpoints so we can provide a title without affecting the `url_for` functionality.

Resolves: [SDAN-741](https://sofab.atlassian.net/browse/SDAN-741)



[SDAN-741]: https://sofab.atlassian.net/browse/SDAN-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ