### PR TITLE
feat: Add WebP support for image renditions

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -378,6 +378,21 @@ Uses for generation of media url ``(<media_prefix>/<media_id>)``::
     # or using api view
     '/api/upload-raw'
 
+``RENDITION_FORMAT``
+^^^^^^^^^^^^^^^^^^^^
+
+Default: ``None``
+
+When set to ``"webp"``, all image renditions (except the original) will be generated 
+in WebP format, resulting in smaller file sizes while maintaining image quality.
+The original image format is preserved for compatibility.
+
+Example::
+
+    RENDITION_FORMAT = "webp"
+
+Note: Requires Pillow to be compiled with WebP support.
+
 .. _settings.amazons3:
 
 Amazon S3 settings

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -792,6 +792,9 @@ RENDITIONS = {
 
 NINJS_COMMON_RENDITIONS = list(RENDITIONS["picture"].keys())
 
+#: rendition output format - set to "webp" to generate all renditions in WebP format
+RENDITION_FORMAT = env("RENDITION_FORMAT", None)
+
 #: BCRYPT work factor
 BCRYPT_GENSALT_WORK_FACTOR = 12
 

--- a/superdesk/media/renditions.py
+++ b/superdesk/media/renditions.py
@@ -89,7 +89,8 @@ def generate_renditions(
     elif ext not in ("jpeg", "gif", "tiff", "png", "webp"):
         ext = "png"
 
-    if get_app_config("RENDITION_FORMAT") == "webp":
+    rendition_format = str(get_app_config("RENDITION_FORMAT") or "").lower()
+    if rendition_format == "webp":
         ext = "webp"
 
     # make baseImage rendition first

--- a/superdesk/media/renditions.py
+++ b/superdesk/media/renditions.py
@@ -86,8 +86,12 @@ def generate_renditions(
     ext = content_type.split("/")[1].lower()
     if ext in ("JPG", "jpg"):
         ext = "jpeg"
-    elif ext not in ("jpeg", "gif", "tiff", "png"):
+    elif ext not in ("jpeg", "gif", "tiff", "png", "webp"):
         ext = "png"
+
+    if get_app_config("RENDITION_FORMAT") == "webp":
+        ext = "webp"
+
     # make baseImage rendition first
     base_image = rendition_config.pop("baseImage", None)
     specs = list(rendition_config.items())

--- a/tests/media/renditions_tests.py
+++ b/tests/media/renditions_tests.py
@@ -120,6 +120,7 @@ class GenerateRenditionsTestCase(TestCase):
         renditions = get_renditions_spec()
         # Create a simple WebP image for testing
         from io import BytesIO
+
         img = Image.new("RGB", (400, 300), color="red")
         webp_buffer = BytesIO()
         img.save(webp_buffer, "webp")

--- a/tests/media/renditions_tests.py
+++ b/tests/media/renditions_tests.py
@@ -89,3 +89,50 @@ class GenerateRenditionsTestCase(TestCase):
         self.assertEqual(1200, landscape["CropRight"])
         self.assertEqual(500, landscape["CropTop"])
         self.assertEqual(1100, landscape["CropBottom"])
+
+    async def test_generate_renditions_webp_format(self):
+        """Test that RENDITION_FORMAT config converts renditions to WebP"""
+        self.app.config["RENDITION_FORMAT"] = "webp"
+        inserted = []
+        renditions = get_renditions_spec()
+        with open(IMG_PATH, "rb") as original:
+            generated = generate_renditions(
+                original, "id", inserted, "image", "image/jpeg", renditions, self.app.media.url_for_media
+            )
+
+        # Original stays JPEG
+        self.assertIn("original", generated)
+        self.assertEqual("image/jpeg", generated["original"]["mimetype"])
+
+        # All other renditions should be WebP
+        self.assertIn("thumbnail", generated)
+        self.assertEqual("image/webp", generated["thumbnail"]["mimetype"])
+
+        self.assertIn("viewImage", generated)
+        self.assertEqual("image/webp", generated["viewImage"]["mimetype"])
+
+        self.assertIn("baseImage", generated)
+        self.assertEqual("image/webp", generated["baseImage"]["mimetype"])
+
+    async def test_generate_renditions_preserves_webp_original(self):
+        """Test that WebP originals are handled correctly"""
+        inserted = []
+        renditions = get_renditions_spec()
+        # Create a simple WebP image for testing
+        from io import BytesIO
+        img = Image.new("RGB", (400, 300), color="red")
+        webp_buffer = BytesIO()
+        img.save(webp_buffer, "webp")
+        webp_buffer.seek(0)
+
+        generated = generate_renditions(
+            webp_buffer, "id", inserted, "image", "image/webp", renditions, self.app.media.url_for_media
+        )
+
+        # Original should be WebP
+        self.assertIn("original", generated)
+        self.assertEqual("image/webp", generated["original"]["mimetype"])
+
+        # Renditions should also be WebP (format preserved)
+        self.assertIn("thumbnail", generated)
+        self.assertEqual("image/webp", generated["thumbnail"]["mimetype"])


### PR DESCRIPTION
### Purpose
This PR adds WebP support to Superdesk's image rendition system to enable more efficient image storage and delivery. 

Currently, WebP images uploaded to Superdesk are automatically converted to PNG during rendition generation, which defeats the purpose of using WebP. Additionally, there's no way to convert other formats (JPEG, PNG, GIF) to WebP for renditions.

### What has changed
<!--- Explain what has changed and how -->
1. Format Recognition Fix: Added webp to the tuple of supported image formats in [renditions.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (line 89) to prevent automatic conversion of WebP images to PNG. 

2. Configurable WebP Conversion: Added new RENDITION_FORMAT configuration setting that enables conversion of JPEG/PNG/GIF/TIFF images to WebP format for renditions (lines 92-93 in renditions.py). 

3. Configuration Setting: Added RENDITION_FORMAT to [default_settings.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with environment variable support. 

4. Documentation: Added documentation for the RENDITION_FORMAT setting in [settings.rst](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), including usage examples and WebP requirements. 

5. Test Coverage: Added two test cases in [renditions_tests.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html):
- test_generate_renditions_webp_format(): Validates JPEG→WebP conversion when config is enabled
- test_generate_renditions_preserves_webp_original(): Ensures native WebP images remain in WebP format

Important: Original images are always preserved in their source format regardless of the rendition format setting.

### Steps to test
1. Test WebP Format Preservation:

- Upload a WebP image without setting RENDITION_FORMAT
- Verify that renditions are generated in WebP format (not converted to PNG)
- Verify the original image remains in WebP format

2. Test WebP Conversion:

- Set environment variable: RENDITION_FORMAT=webp
- Restart the application to load the new configuration
- Upload a JPEG, PNG, or GIF image
- Verify that generated renditions are in WebP format
- Verify the original image is preserved in its original format

3. Test Backward Compatibility:

- Without setting RENDITION_FORMAT (or set to any other value)
- Upload JPEG/PNG/GIF images
- Verify renditions are generated in the original format as before

Note: This is an opt-in feature. Without setting RENDITION_FORMAT=webp, behavior remains unchanged from current production.

