### PR TITLE
[SDESK-7798] fix(dpa_newsml): Run clean_html on ingested body

### DIFF
--- a/superdesk/io/feed_parsers/dpa_newsml.py
+++ b/superdesk/io/feed_parsers/dpa_newsml.py
@@ -8,11 +8,11 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from pytz import utc
+
 from superdesk.io.feed_parsers.newsml_2_0 import NewsMLTwoFeedParser
 from superdesk.io.registry import register_feed_parser
-from superdesk.etree import etree
-from pytz import utc
-import re
+from superdesk.etree import clean_html, to_string
 
 
 class DPAFeedParser(NewsMLTwoFeedParser):
@@ -65,13 +65,9 @@ class DPAFeedParser(NewsMLTwoFeedParser):
             if section is None:
                 continue
 
-            body_html = etree.tostring(section, encoding="unicode", method="html")
-            body_html = re.sub(
-                r'<section[^>]*class="[^"]*{}[^"]*"[^>]*>'.format(re.escape(section_class)), "", body_html
-            )
-            body_html = body_html.replace("</section>", "")
-
-            item["body_html"] = body_html
+            body_xml = clean_html(section)
+            contents = [to_string(node, encoding="unicode", method="html") for node in body_xml]
+            item["body_html"] = "\n".join(contents)
 
     def parse_content_meta(self, tree, item):
         self.parse_keywords(tree, item)

--- a/tests/io/feed_parsers/dpanewsml_test.py
+++ b/tests/io/feed_parsers/dpanewsml_test.py
@@ -86,22 +86,22 @@ class DPANewsMLTestCase(TestCase):
         with self.app.app_context():
             self.assertIsInstance(self.item.get("body_html"), str)
             expected_output = (
-                '<p><span class="dateline">London <span class="credit">(dpa)'
-                "</span> - </span>2019 gab es bittere Tränen in der Kurve"
+                "<p>London (dpa) - 2019 gab es bittere Tränen in der Kurve"
                 ", 2022 erst mächtig Wut auf englische Fans und eine Woche später ausgelassenen Jubel:"
                 " Für Eintracht Frankfurt ist London in den vergangenen Jahren zu einem Standard-Reiseziel"
                 " im europäischen Fußball-Wettbewerb geworden. Bevor es am Mittwochabend (21.00 Uhr/DAZN) "
                 "bei Tottenham Hotspur um wichtige Punkte in der Champions League geht, wird sich die Reisegruppe "
-                "um Torhüter Kevin Trapp und Routinier Makoto Hasebe bestimmt an die vergangenen London-Reisen erinnern."
-                "</p><p>Beim Topclub FC Chelsea wollte die damals von Adi Hütter trainierte Eintracht in der Saison 2018/19 "
+                "um Torhüter Kevin Trapp und Routinier Makoto Hasebe bestimmt an die vergangenen London-Reisen erinnern.</p>\n"
+                "<p>Beim Topclub FC Chelsea wollte die damals von Adi Hütter trainierte Eintracht in der Saison 2018/19 "
                 "ihre Erfolgsserie fortsetzen und nach Inter Mailand und Schachtjor Donezk auch die «Blues» aus der Europa League werfen. "
                 "Nach zwei 1:1 ging es an der Stamford Bridge in die Verlängerung und ins Elfmeterschießen. Der inzwischen abgetretene"
-                " Martin Hinteregger vergab vom Punkt, vergoss nach dem bitteren Aus Tränen und wurde anschließend in der Fankurve getröstet."
-                "</p><p>Sportlich weckt der 2:1-Erfolg im Halbfinal-Hinspiel bei West Ham United Ende April positive Erinnerungen "
+                " Martin Hinteregger vergab vom Punkt, vergoss nach dem bitteren Aus Tränen und wurde anschließend in der Fankurve getröstet.</p>\n"
+                "<p>Sportlich weckt der 2:1-Erfolg im Halbfinal-Hinspiel bei West Ham United Ende April positive Erinnerungen "
                 "- schließlich war er der Grundstein für den späteren Triumph in Sevilla. Doch eine Attacke von englischen Fans gegen "
                 "zwei Journalisten des Hessischen Rundfunks trübte das Bild. Die Rundfunk-Reporter bekamen nach eigenen Angaben «mehrfach Faustschläge an den Hinterkopf"
                 ", in den Nacken, in den Rücken». West Ham United machte die Täter später ausfindig. Eine Woche später gewann die Eintracht"
-                " auch das Rückspiel und zog ins Endspiel ein.</p><p> </p>"
+                " auch das Rückspiel und zog ins Endspiel ein.</p>\n"
+                "<p> </p>"
             )
 
             self.assertEqual(self.item.get("body_html").strip(), expected_output.strip())


### PR DESCRIPTION
### Purpose
The DPA NewsML feed parser was trying to remove the `section` element using regex, which didn't always work and also kept other HTML elements not supported by our editor.

### What has changed
Use `clean_html` to remove all unsupported html elements from the body

Resolves: [SDESK-7798](https://sofab.atlassian.net/browse/SDESK-7798)



[SDESK-7798]: https://sofab.atlassian.net/browse/SDESK-7798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ