### PR TITLE
[STT-1476] fix: Add product_tests async endpoint

### DIFF
--- a/features/product_tests.feature
+++ b/features/product_tests.feature
@@ -1,0 +1,58 @@
+Feature: Product Tests
+    @auth
+    Scenario: Fails if the article does not exist
+        When we post to "products/test"
+        """
+        {"article_id": "doesn't-exist"}
+        """
+        Then we get error 400
+        """
+        {"_status": "ERR", "_message": "Article not found"}
+        """
+
+    @auth
+    Scenario: Product test endpoint
+        Given "filter_conditions"
+        """
+        [
+            {"name": "entertainment", "field": "anpa_category", "operator": "in", "value": "ent"},
+            {"name": "finance", "field": "anpa_category", "operator": "in", "value": "fin"}
+        ]
+        """
+        And "content_filters"
+        """
+        [
+            {"name": "entertainment", "content_filter": [{"expression": {"fc": ["#filter_conditions_0._id#"]}}]},
+            {"name": "finance", "content_filter": [{"expression": {"fc": ["#filter_conditions_1._id#"]}}]}
+        ]
+        """
+        And "products"
+        """
+        [
+            {
+                "name":"entertainment-1", "codes":"abc,xyz", "product_type": "both",
+                "content_filter": {"filter_id": "#content_filters_0._id#", "filter_type": "permitting"}
+            },
+            {
+                "name":"finance-1", "codes":"abc,xyz", "product_type": "both",
+                "content_filter": {"filter_id": "#content_filters_1._id#", "filter_type": "permitting"}
+            }
+        ]
+        """
+
+        When we post to "/archive"
+        """
+        [{"anpa_category": [{"qcode" : "ent", "name" : "Entertainment"}]}]
+        """
+        When we post to "products/test"
+        """
+        {"article_id": "#archive._id#"}
+        """
+        Then we get existing resource
+        """
+        {"_items": [
+            {"product_id": "#products_0._id#", "matched": true},
+            {"product_id": "#products_1._id#", "matched": false, "reason": "Story does not match the filter: finance"}
+        ]}
+        """
+

--- a/superdesk/publish_async/views.py
+++ b/superdesk/publish_async/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from pydantic import BaseModel, field_validator
 from quart_babel import gettext
 from eve.utils import ParsedRequest
@@ -16,10 +18,12 @@ from superdesk.publish_async.utils import (
     content_filter_to_elastic_query,
     item_matches_content_filter,
     get_available_filter_params,
+    test_products_against_item,
 )
 from superdesk.publish_async.publish_cache import PublishCache
 
 
+logger = logging.getLogger(__name__)
 publish_endpoints = EndpointGroup("publish", __name__)
 
 
@@ -106,3 +110,29 @@ async def content_filter_test_endpoint(request: Request) -> Response:
 
     result["_status"] = "OK"
     return Response(result, 201)
+
+
+class ProductTestBody(BaseModel):
+    article_id: str
+
+
+@publish_endpoints.endpoint(
+    "products/test", "product_tests", methods=["POST"], auth=[required_privilege_rule("products")]
+)
+async def product_test_endpoint(request: Request) -> Response:
+    body = ProductTestBody.model_validate_json(await request.get_data())
+
+    archive_service = get_resource_service("archive")
+    article = await archive_service.find_one_async(req=None, _id=body.article_id)
+
+    if not article:
+        raise SuperdeskApiError.badRequestError(gettext("Article not found"))
+
+    try:
+        await PublishCache.init()
+        results = test_products_against_item(article)
+    except Exception as ex:
+        logger.exception(ex)
+        raise SuperdeskApiError.badRequestError(gettext(f"Error in testing article: {ex}"))
+
+    return Response({"_status": "OK", "_id": body.article_id, "_items": results}, 201)


### PR DESCRIPTION
### Purpose
When rewriting the publish system with the async project, we missed the `product_tests` endpoint.

### What has changed
* Add a new endpoint, providing same functionality as the v2.x `product_tests` resource/service
* Add behave tests

Resolves: [STT-1476](https://sofab.atlassian.net/browse/STT-1476)



[STT-1476]: https://sofab.atlassian.net/browse/STT-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ