### PR TITLE
[STT-1484] - Configure publish tab to show the "sent to" as default 

### DIFF
--- a/apps/client_config.py
+++ b/apps/client_config.py
@@ -43,5 +43,6 @@ def init_app(app) -> None:
             "allow_updating_scheduled_items": app.config.get("ALLOW_UPDATING_SCHEDULED_ITEMS"),
             "corrections_workflow": app.config.get("CORRECTIONS_WORKFLOW"),
             "default_timezone": app.config.get("DEFAULT_TIMEZONE"),
+            "authoring_actions_default_tab": app.config.get("AUTHORING_ACTIONS_DEFAULT_TAB", "publish"),
         }
     )

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -1370,14 +1370,14 @@ BROADCAST_ENABLED = strtobool(env("BROADCAST_ENABLED", "true"))
 
 CORRECTIONS_WORKFLOW = False
 
-#: Default tab shown in the authoring interactive actions panel
+#: Default tab shown in the authoring actions side panel
 #:
 #: .. versionadded:: 3.1
 #:
 AUTHORING_ACTIONS_DEFAULT_TAB = env("AUTHORING_ACTIONS_DEFAULT_TAB", "publish")
 if AUTHORING_ACTIONS_DEFAULT_TAB not in ("publish", "send_to"):
     logger.warning(
-        "Invalid AUTHORING_ACTIONS_DEFAULT_TAB '%s'. Falling back to 'publish'.",
+        "Invalid value for AUTHORING_ACTIONS_DEFAULT_TAB '%s'. Defaulting to 'publish'.",
         AUTHORING_ACTIONS_DEFAULT_TAB,
     )
     AUTHORING_ACTIONS_DEFAULT_TAB = "publish"

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -1369,3 +1369,15 @@ PICTURE_METADATA_MAPPING = {}
 BROADCAST_ENABLED = strtobool(env("BROADCAST_ENABLED", "true"))
 
 CORRECTIONS_WORKFLOW = False
+
+#: Default tab shown in the authoring interactive actions panel
+#:
+#: .. versionadded:: 3.1
+#:
+AUTHORING_ACTIONS_DEFAULT_TAB = env("AUTHORING_ACTIONS_DEFAULT_TAB", "publish")
+if AUTHORING_ACTIONS_DEFAULT_TAB not in ("publish", "send_to"):
+    logger.warning(
+        "Invalid AUTHORING_ACTIONS_DEFAULT_TAB '%s'. Falling back to 'publish'.",
+        AUTHORING_ACTIONS_DEFAULT_TAB,
+    )
+    AUTHORING_ACTIONS_DEFAULT_TAB = "publish"


### PR DESCRIPTION
### Purpose
This PR adds a config setting to allow choosing which tab the authoring actions side panel shows by default.

### What has changed
- Added `AUTHORING_ACTIONS_DEFAULT_TAB` to `default_settings.py` with validation and defaulting to “publish” 
- Send the setting through `apps/client_config.py` tot the frontend

### How to test
1. Start the server and check the `/api/client_config` endpoint. Verify `config.authoring_actions_default_tab` is “publish” by default.
2. Set `AUTHORING_ACTIONS_DEFAULT_TAB=send_to`, restart the server, and confirm `/api/client_config` now reports “send_to”.

**NOTE:** This PR is coupled with the client changes in this [PR](https://github.com/superdesk/superdesk-client-core/pull/5013).

Resolves: #[STT-1484](https://sofab.atlassian.net/browse/STT-1484)



[STT-1484]: https://sofab.atlassian.net/browse/STT-1484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ