### PR TITLE
[SDESK-7826] fix: Add audit and WS notifications to pydantic based resources

### DIFF
--- a/features/audit.feature
+++ b/features/audit.feature
@@ -1,0 +1,63 @@
+Feature: Resource Audit Logs
+    @auth
+    @notification
+    Scenario: Pydantic resources create audit logs
+        When we post to "/filter_conditions" with success
+        """
+        [{"name": "sport", "field": "anpa_category", "operator": "in", "value": "4"}]
+        """
+        When we patch latest
+        """
+        {"name": "Sports Content", "field": "subject", "operator": "in", "value": "q"}
+        """
+        Then we get OK response
+        When we delete latest
+        Then we get OK response
+        And we get audit logs
+        """
+        [{
+            "resource": "filter_conditions",
+            "action": "created",
+            "user": "#CONTEXT_USER_ID#",
+            "audit_id": "#filter_conditions._id#",
+            "extra": {
+                "name": "sport",
+                "field": "anpa_category",
+                "operator": "in",
+                "value": "4"
+            }
+        }, {
+            "resource": "filter_conditions",
+            "action": "updated",
+            "user": "#CONTEXT_USER_ID#",
+            "audit_id": "#filter_conditions._id#"
+        }, {
+            "resource": "filter_conditions",
+            "action": "deleted",
+            "user": "#CONTEXT_USER_ID#",
+            "audit_id": "#filter_conditions._id#"
+        }]
+        """
+        And we get notifications
+        """
+        [{
+            "event": "resource:created",
+            "extra": {
+                "resource": "filter_conditions",
+                "_id": "#filter_conditions._id#"
+            }
+        }, {
+            "event": "resource:updated",
+            "extra": {
+                "resource": "filter_conditions",
+                "_id": "#filter_conditions._id#",
+                "fields": {"name": 1, "value": 1, "field": 1}
+            }
+        }, {
+            "event": "resource:deleted",
+            "extra": {
+                "resource": "filter_conditions",
+                "_id": "#filter_conditions._id#"
+            }
+        }]
+        """

--- a/superdesk/audit/__init__.py
+++ b/superdesk/audit/__init__.py
@@ -15,6 +15,8 @@ from .audit import AuditService, AuditResource
 from .commands import cli_audit_purge, PurgeAudit
 import logging
 
+from superdesk.core.resources import global_signals
+
 log = logging.getLogger(__name__)
 
 
@@ -27,6 +29,10 @@ def init_app(app) -> None:
     app.on_inserted += service.on_generic_inserted
     app.on_updated += service.on_generic_updated
     app.on_deleted_item += service.on_generic_deleted
+
+    global_signals.data.on_created += service.on_pydantic_resource_inserted
+    global_signals.data.on_updated += service.on_pydantic_resource_updated
+    global_signals.data.on_deleted += service.on_pydantic_resource_deleted
 
 
 @celery.task(soft_time_limit=600)

--- a/superdesk/audit/audit.py
+++ b/superdesk/audit/audit.py
@@ -12,6 +12,7 @@ import logging
 from superdesk.flask import g
 from superdesk.resource import Resource
 from superdesk.eve_async import AsyncBaseService
+from superdesk.core.resources import ResourceModelType
 
 log = logging.getLogger(__name__)
 
@@ -45,6 +46,9 @@ class AuditResource(Resource):
 
 
 class AuditService(AsyncBaseService):
+    async def on_pydantic_resource_inserted(self, doc: ResourceModelType):
+        await self.on_generic_inserted(doc.model_resource_name, [doc.to_dict()])
+
     async def on_generic_inserted(self, resource, docs):
         if resource in AuditResource.exclude:
             return
@@ -71,6 +75,9 @@ class AuditService(AsyncBaseService):
 
         await self.post_async([audit])
 
+    async def on_pydantic_resource_updated(self, original: ResourceModelType, updates: dict):
+        await self.on_generic_updated(original.model_resource_name, updates, original.to_dict())
+
     async def on_generic_updated(self, resource, doc, original):
         if resource in AuditResource.exclude:
             return
@@ -89,6 +96,9 @@ class AuditService(AsyncBaseService):
         if "_id" not in doc:
             audit["extra"]["_id"] = original.get("_id", None)
         await self.post_async([audit])
+
+    async def on_pydantic_resource_deleted(self, doc: ResourceModelType):
+        await self.on_generic_deleted(doc.model_resource_name, doc.to_dict())
 
     async def on_generic_deleted(self, resource, doc):
         if resource in AuditResource.exclude:

--- a/superdesk/core/resources/__init__.py
+++ b/superdesk/core/resources/__init__.py
@@ -31,6 +31,7 @@ from .resource_rest_endpoints import (
 from .service import AsyncResourceService, AsyncCacheableService
 from .resource_signals import global_signals
 from .cursor import ResourceCursorAsync
+from .types import ResourceModelType
 
 __all__ = [
     "get_projection_from_request",
@@ -55,4 +56,5 @@ __all__ = [
     "ResourceRestEndpoints",
     "ItemRequestUrlArgs",
     "ResourceCursorAsync",
+    "ResourceModelType",
 ]

--- a/superdesk/core/resources/resource_config.py
+++ b/superdesk/core/resources/resource_config.py
@@ -53,6 +53,9 @@ class ResourceConfig:
     #: Optional default projection to be used to include/exclude fields
     projection: ProjectedFieldArg | None = None
 
+    #: Boolean to indicate if websocket notifications should be sent for this resource (defaults to ``True``)
+    send_ws_notifications: bool = True
+
 
 from .resource_rest_endpoints import RestEndpointConfig  # noqa: E402
 from .model import ResourceModel  # noqa: E402

--- a/superdesk/notification.py
+++ b/superdesk/notification.py
@@ -20,6 +20,7 @@ from superdesk.core import get_current_app
 from superdesk.utils import json_serialize_datetime_objectId
 from superdesk.websockets_comms import SocketMessageProducer
 from superdesk.types import WebsocketMessageData, WebsocketMessageFilterConditions
+from superdesk.core.resources import ResourceModelType, global_signals
 
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,10 @@ def init_app(app) -> None:
     except (RuntimeError, OSError):
         # not working now, but we can try later when actually sending something
         app.notification_client = ClosedSocket()
+
+    global_signals.data.on_created += _send_pydantic_resource_inserted_notification
+    global_signals.data.on_updated += _send_pydantic_resource_updated_notification
+    global_signals.data.on_deleted += _send_pydantic_resource_deleted_notification
 
 
 def _create_socket_message(**kwargs) -> str:
@@ -88,3 +93,32 @@ def push_notification(name, filters: Optional[WebsocketMessageFilterConditions] 
         app.notification_client.send(message, name)
     except Exception as err:
         logger.exception(err)
+
+
+async def _send_pydantic_resource_inserted_notification(doc: ResourceModelType):
+    push_notification(
+        "resource:created",
+        resource=doc.model_resource_name,
+        _id=doc.id
+    )
+
+
+async def _send_pydantic_resource_updated_notification(original: ResourceModelType, updates: dict):
+    from superdesk.eve_backend import get_diff_keys
+
+    updated_fields = get_diff_keys(updates, original.to_dict())
+    if updated_fields:
+        push_notification(
+            "resource:updated",
+            resource=original.model_resource_name,
+            _id=original.id,
+            fields=updated_fields
+        )
+
+
+async def _send_pydantic_resource_deleted_notification(doc: ResourceModelType):
+    push_notification(
+        "resource:deleted",
+        resource=doc.model_resource_name,
+        _id=doc.id
+    )

--- a/superdesk/notification.py
+++ b/superdesk/notification.py
@@ -16,7 +16,7 @@ import os
 import json
 
 from datetime import datetime
-from superdesk.core import get_current_app
+from superdesk.core import get_current_app, get_current_async_app
 from superdesk.utils import json_serialize_datetime_objectId
 from superdesk.websockets_comms import SocketMessageProducer
 from superdesk.types import WebsocketMessageData, WebsocketMessageFilterConditions
@@ -95,12 +95,23 @@ def push_notification(name, filters: Optional[WebsocketMessageFilterConditions] 
         logger.exception(err)
 
 
+def _resource_ws_notifications_enabled(resource: str) -> bool:
+    resource_config = get_current_async_app().resources.get_config(resource)
+    return resource_config.send_ws_notifications
+
+
 async def _send_pydantic_resource_inserted_notification(doc: ResourceModelType):
+    if not _resource_ws_notifications_enabled(doc.model_resource_name):
+        return
+
     push_notification("resource:created", resource=doc.model_resource_name, _id=doc.id)
 
 
 async def _send_pydantic_resource_updated_notification(original: ResourceModelType, updates: dict):
     from superdesk.eve_backend import get_diff_keys
+
+    if not _resource_ws_notifications_enabled(original.model_resource_name):
+        return
 
     updated_fields = get_diff_keys(updates, original.to_dict())
     if updated_fields:
@@ -110,4 +121,7 @@ async def _send_pydantic_resource_updated_notification(original: ResourceModelTy
 
 
 async def _send_pydantic_resource_deleted_notification(doc: ResourceModelType):
+    if not _resource_ws_notifications_enabled(doc.model_resource_name):
+        return
+
     push_notification("resource:deleted", resource=doc.model_resource_name, _id=doc.id)

--- a/superdesk/notification.py
+++ b/superdesk/notification.py
@@ -96,11 +96,7 @@ def push_notification(name, filters: Optional[WebsocketMessageFilterConditions] 
 
 
 async def _send_pydantic_resource_inserted_notification(doc: ResourceModelType):
-    push_notification(
-        "resource:created",
-        resource=doc.model_resource_name,
-        _id=doc.id
-    )
+    push_notification("resource:created", resource=doc.model_resource_name, _id=doc.id)
 
 
 async def _send_pydantic_resource_updated_notification(original: ResourceModelType, updates: dict):
@@ -109,16 +105,9 @@ async def _send_pydantic_resource_updated_notification(original: ResourceModelTy
     updated_fields = get_diff_keys(updates, original.to_dict())
     if updated_fields:
         push_notification(
-            "resource:updated",
-            resource=original.model_resource_name,
-            _id=original.id,
-            fields=updated_fields
+            "resource:updated", resource=original.model_resource_name, _id=original.id, fields=updated_fields
         )
 
 
 async def _send_pydantic_resource_deleted_notification(doc: ResourceModelType):
-    push_notification(
-        "resource:deleted",
-        resource=doc.model_resource_name,
-        _id=doc.id
-    )
+    push_notification("resource:deleted", resource=doc.model_resource_name, _id=doc.id)

--- a/superdesk/publish_async/resources/publish_queue/module.py
+++ b/superdesk/publish_async/resources/publish_queue/module.py
@@ -33,4 +33,5 @@ publish_queue_resource_config = ResourceConfig(
     ),
     etag_ignore_fields=["moved_to_legal"],
     default_sort=[("_id", -1)],
+    send_ws_notifications=False,
 )

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -3197,3 +3197,16 @@ async def step_impl(context, privilege: str, username: str) -> None:
         privileges = user.get("privileges") or {}
         privileges[privilege] = 1
         await get_resource_service("users").system_update_async(user["_id"], {"privileges": privileges}, user)
+
+
+@then("we get audit logs")
+@async_run_until_complete
+async def check_audit_logs(context):
+    async with context.app.app_context():
+        context_data = json.loads(apply_placeholders(context, context.text))
+        for log in context_data:
+            if log.get("user"):
+                log["user"] = ObjectId(log["user"])
+
+        audit_logs = await find_many("audit")
+        assert json_match(context_data, audit_logs), str(context_data) + "\n != \n" + str(audit_logs)


### PR DESCRIPTION
### Purpose
With the newer Pydantic based async resources, we weren't including them in the audit log or the websocket resource notifications.

### What has changed
Add global data listeners to add audit log entries and sending of websocket notifications

Resolves: [SDESK-7826](https://sofab.atlassian.net/browse/SDESK-7826)



[SDESK-7826]: https://sofab.atlassian.net/browse/SDESK-7826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ