### PR TITLE
avoid deepcopy in resource manager

### DIFF
--- a/superdesk/core/mongo/mongo_manager.py
+++ b/superdesk/core/mongo/mongo_manager.py
@@ -59,20 +59,13 @@ class MongoResources:
     def get_resource_config(self, resource_name: str) -> MongoResourceConfig:
         """Gets a resource config from a registered resource
 
-        Returns a deepcopy of the config, so the original cannot be modified
-
         :raises KeyError: if a resource with the provided ``name`` is not registered
         """
-
-        return deepcopy(self._resource_configs[resource_name])
+        return self._resource_configs[resource_name]
 
     def get_all_resource_configs(self) -> Dict[str, MongoResourceConfig]:
-        """Get configs from all registered resources
-
-        Returns a deepcopy of all configs, so the originals cannot be modified
-        """
-
-        return deepcopy(self._resource_configs)
+        """Get configs from all registered resources"""
+        return self._resource_configs
 
     def get_collection_name(self, resource_name: str, versioning: bool = False) -> str:
         try:

--- a/superdesk/core/resources/resource_manager.py
+++ b/superdesk/core/resources/resource_manager.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from superdesk.core.app import SuperdeskAsyncApp
 from superdesk.core.signals import SignalGroup, Signal
 
@@ -73,12 +71,12 @@ class Resources(SignalGroup):
         :raises KeyError: If the resource is not registered
         """
 
-        return deepcopy(self._resource_configs[name])
+        return self._resource_configs[name]
 
     def get_all_configs(self) -> list[ResourceConfig]:
         """Get a copy of the configs for all the registered resources in the system"""
 
-        return deepcopy(list(self._resource_configs.values()))
+        return list(self._resource_configs.values())
 
     def get_resource_service(self, resource_name: str) -> AsyncResourceService:
         return self._resource_services[resource_name]

--- a/tests/core/mongo_test.py
+++ b/tests/core/mongo_test.py
@@ -16,11 +16,6 @@ class MongoClientTestCase(AsyncTestCase):
         with self.assertRaises(KeyError):
             self.app.mongo.get_resource_config("profiles")
 
-        # Test immutable resource config
-        modified_resource_config = self.app.mongo.get_resource_config("users_async")
-        modified_resource_config.prefix = "MONGO_MODIFIED"
-        assert self.app.mongo.get_resource_config("users_async") != modified_resource_config
-
     def test_get_mongo_clients(self):
         client, db = self.app.mongo.get_client("users_async")
         assert isinstance(client, MongoClient)

--- a/tests/core/resource_service_test.py
+++ b/tests/core/resource_service_test.py
@@ -453,9 +453,7 @@ class TestResourceService(AsyncTestCase):
         # Test with default sort in the resource config
         sort_query = [("email.keyword", 1)]
 
-        with mock.patch.object(
-            self.service.config, "default_sort", sort_query
-        ):
+        with mock.patch.object(self.service.config, "default_sort", sort_query):
             expected = SearchRequest(sort=sort_query)
             await assert_es_find_called_with(SearchRequest(), expected=expected)
             expected.where = {}

--- a/tests/core/resource_service_test.py
+++ b/tests/core/resource_service_test.py
@@ -452,15 +452,18 @@ class TestResourceService(AsyncTestCase):
 
         # Test with default sort in the resource config
         sort_query = [("email.keyword", 1)]
-        self.service.config.default_sort = sort_query
-        expected = SearchRequest(sort=sort_query)
-        await assert_es_find_called_with(SearchRequest(), expected=expected)
-        expected.where = {}
-        await assert_es_find_called_with({}, expected=expected)
 
-        # Test passing in sort param with default sort configured
-        custom_sort_query = [("scores", 1)]
-        expected = SearchRequest(sort=custom_sort_query)
-        await assert_es_find_called_with(SearchRequest(sort=custom_sort_query), expected=expected)
-        expected.where = {}
-        await assert_es_find_called_with({}, sort=custom_sort_query, expected=expected)
+        with mock.patch.object(
+            self.service.config, "default_sort", sort_query
+        ):
+            expected = SearchRequest(sort=sort_query)
+            await assert_es_find_called_with(SearchRequest(), expected=expected)
+            expected.where = {}
+            await assert_es_find_called_with({}, expected=expected)
+
+            # Test passing in sort param with default sort configured
+            custom_sort_query = [("scores", 1)]
+            expected = SearchRequest(sort=custom_sort_query)
+            await assert_es_find_called_with(SearchRequest(sort=custom_sort_query), expected=expected)
+            expected.where = {}
+            await assert_es_find_called_with({}, sort=custom_sort_query, expected=expected)


### PR DESCRIPTION
unnecessary overhead, it's used when generating links all the time

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

