### PR TITLE
[STT-1516] Allow `on_fetched` and `aggs` for search endpoint requests to be disabled

### DIFF
--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -11,11 +11,11 @@
 import superdesk
 
 from copy import deepcopy
-from eve_elastic.elastic import set_filters, fix_query
+from eve.utils import ParsedRequest
+from eve_elastic.elastic import set_filters
 
-from superdesk.core import json, get_current_app, get_app_config, get_current_async_app
+from superdesk.core import json, get_current_app, get_app_config
 from superdesk.resource_fields import ITEMS
-from superdesk.types import ArchiveResourceModel
 from superdesk.eve_async import AsyncBaseService, ElasticAsyncEveCursor
 from superdesk import get_resource_service
 from superdesk.metadata.item import CONTENT_STATE, ITEM_STATE, get_schema
@@ -25,7 +25,6 @@ from apps.archive.archive import SOURCE as ARCHIVE, private_content_filter
 from superdesk.resource import build_custom_hateoas
 from apps.publish.published_item import published_item_fields
 from superdesk import es_utils
-from superdesk.utils import ListCursor
 
 
 class SearchService(AsyncBaseService):
@@ -121,7 +120,9 @@ class SearchService(AsyncBaseService):
             pass
 
         app = get_current_app()
-        if app.data.elastic.should_aggregate(req):
+        if "aggs" in args and args["aggs"] is not None:
+            source["aggs"] = args["aggs"]
+        elif "aggs" not in args and app.data.elastic.should_aggregate(req):
             source["aggs"] = self.aggregations
 
         if app.data.elastic.should_highlight(req):
@@ -226,7 +227,7 @@ class SearchService(AsyncBaseService):
 
         return docs
 
-    async def get_async(self, req, lookup) -> ElasticAsyncEveCursor:
+    async def get_async(self, req: ParsedRequest | None, lookup: dict | None) -> ElasticAsyncEveCursor:
         """
         Runs elastic search on multiple doc types.
         """
@@ -249,12 +250,13 @@ class SearchService(AsyncBaseService):
 
         cursor = await self.elastic_async.search(query, types, params)
 
-        app = get_current_app().as_any()
-        for resource in types:
-            response = {ITEMS: [doc async for doc in cursor if doc["_type"] == resource]}
-            await getattr(app, "on_fetched_resource").call_async(resource, response)
-            await getattr(app, "on_fetched_resource_%s_async" % resource).call_async(response)
-            await getattr(app, "on_fetched_resource_%s" % resource).call_async(response)
+        if not req or not req.args or req.args.get("run_signals", True):
+            app = get_current_app().as_any()
+            for resource in types:
+                response = {ITEMS: [doc async for doc in cursor if doc["_type"] == resource]}
+                await getattr(app, "on_fetched_resource").call_async(resource, response)
+                await getattr(app, "on_fetched_resource_%s_async" % resource).call_async(response)
+                await getattr(app, "on_fetched_resource_%s" % resource).call_async(response)
 
         return cursor
 

--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -227,10 +227,18 @@ class SearchService(AsyncBaseService):
 
         return docs
 
-    async def get_async(self, req: ParsedRequest | None, lookup: dict | None) -> ElasticAsyncEveCursor:
+    async def get_async(
+        self, req: ParsedRequest | None, lookup: dict | None, signals: bool = True
+    ) -> ElasticAsyncEveCursor:
         """
         Runs elastic search on multiple doc types.
+
+        :param req: object representing the HTTP request
+        :param lookup: requested item lookup
+        :param signals: whether to execute resource signals or not
+        :return: Elasticsearch results cursor object
         """
+
         query = self._get_query(req)
         fields = self._get_projected_fields(req)
         types = self._get_types(req)
@@ -250,7 +258,7 @@ class SearchService(AsyncBaseService):
 
         cursor = await self.elastic_async.search(query, types, params)
 
-        if not req or not req.args or req.args.get("run_signals", True):
+        if signals:
             app = get_current_app().as_any()
             for resource in types:
                 response = {ITEMS: [doc async for doc in cursor if doc["_type"] == resource]}


### PR DESCRIPTION
### Purpose
To improve performance of requests, support disabling content `search` endpoint's use of `on_fetched` signals and generation of aggregations.

Resolves: [STT-1516](https://sofab.atlassian.net/browse/STT-1516)



[STT-1516]: https://sofab.atlassian.net/browse/STT-1516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ