### PR TITLE
[SDESK-7725] - Skip re-fetch on POST when no projection is defined

### DIFF
--- a/features/auth_server_clients.feature
+++ b/features/auth_server_clients.feature
@@ -151,3 +151,25 @@ Feature: Authorization Server Client Management
         """
         {"_status": "ERR", "_issues": {"scope": {"0": "Input should be 'ARCHIVE_READ', 'DESKS_READ', 'PLANNING_READ', 'CONTACTS_READ', 'USERS_READ', 'ASSIGNMENTS_READ' or 'EVENTS_READ'"}}}
         """
+
+     @auth
+     Scenario: Can register client and authenticate with returned secret
+         When we post to "/auth_server_clients"
+         """
+         [{
+             "name": "Test Client",
+             "scope": ["ARCHIVE_READ", "USERS_READ"]
+         }]
+         """
+         Then we get OK response
+         And we get existing resource
+         """
+         {
+             "_id": "#auth_server_clients._id#",
+             "password": "#auth_server_clients.password#",
+             "name": "Test Client",
+             "scope": ["ARCHIVE_READ", "USERS_READ"]
+         }
+         """
+         When we do OAuth2 client authentication with id "#auth_server_clients._id#" and password "#auth_server_clients.password#"
+         Then we get a valid access token

--- a/superdesk/core/resources/resource_rest_endpoints.py
+++ b/superdesk/core/resources/resource_rest_endpoints.py
@@ -463,11 +463,12 @@ class ResourceRestEndpoints(RestEndpoints):
                 )
                 self._log_traceback(exception, "Unexpected exception while creating item")
 
-        if self.endpoint_config.exclude_fields_in_response:
+        post_projection = self.get_exclude_fields_projection("POST")
+        if post_projection:
             # If projection is enabled, we fetch all newly created items with projection applied
             # That way projection is applied to all Create request responses
             model_instances = await self.service.find_by_ids(
-                [instance.id for instance in model_instances], projection=self.get_exclude_fields_projection("POST")
+                [instance.id for instance in model_instances], projection=post_projection
             )
 
         results: list[dict]

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -3091,6 +3091,9 @@ async def step_impl_given_authorized_client(context):
 async def step_impl_when_oauth2_client_auth(context, client_id, password):
     from superdesk.auth_server.oauth2 import TOKEN_ENDPOINT
 
+    client_id = apply_placeholders(context, client_id)
+    password = apply_placeholders(context, password)
+
     encoded_user_pass = b64encode(b"%s:%s" % (client_id.encode(), password.encode())).decode("ascii")
     headers = [
         ("Content-Type", "multipart/form-data"),


### PR DESCRIPTION
### Purpose
This PR skips the unnecessary re-fetch on POST requests for `auth_server_clients`. Previously after client creation, the flow would refetch from the db and return the hashed password instead of the plain text secret that was just generated thus overwriting it and it ends up on the UI. 

### What has changed
- Updated `resource_rest_endpoints.py` to only re-fetch if a POST projection is actually defined
- Confirmed no breaking changes for `users_async` and `subscribers` since they have POST projections defined already

### Steps to test
1. In the settings, go to Production API and create a new client
2. On save, confirm the client secret shown is the plain text version and not the hashed version
3. Locally, test that the credentials work by running for example:
Request:
```
CLIENT_ID=69429608e319ec9077d4859b
CLIENT_SECRET=ej9Vh87ospwD53q4ohrvlm0lMdDcrKhbUYt4nDoV

curl -u "CLIENT_ID:CLIENT_SECRET" \
  -X POST "http://localhost:5000/api/auth_server/token" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=client_credentials"
```
Response should be:
```
{"access_token": "eyJhbG...", "expires_in": 86400, "token_type": "Bearer"}
```
NOTE: Follow the [guide](https://superdesk.readthedocs.io/en/latest/auth_server.html#testing) for local testing. 


Resolves: #[SDESK-7725](https://sofab.atlassian.net/browse/SDESK-7725)



[SDESK-7725]: https://sofab.atlassian.net/browse/SDESK-7725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ