### PR TITLE
handle article/section blocks in editor utils

### DIFF
--- a/superdesk/editor_utils.py
+++ b/superdesk/editor_utils.py
@@ -300,6 +300,13 @@ class DraftJSHTMLExporter:
         self.exporter = HTML(
             {
                 "engine": DOM.LXML,
+                "block_map": dict(
+                    BLOCK_MAP,
+                    **{
+                        "article": "article",
+                        "section": "section",
+                    },
+                ),
                 "style_map": dict(
                     STYLE_MAP,
                     **{
@@ -596,13 +603,13 @@ class Editor3Content(EditorContent):
         if self.is_html:
             root = parse_html(value, "html")
             for i, elem in enumerate(root):
-                try:
-                    block_type = next((key for key, val in BLOCK_MAP.items() if val == elem.tag))
-                    depth = 0
-                except StopIteration:
-                    block_type = None
-                    depth = 0
-                    if elem.tag == "figure":
+                # Check for standard block types in BLOCK_MAP, then check for custom article/section types
+                block_type = next((key for key, val in BLOCK_MAP.items() if val == elem.tag), None)
+                depth = 0
+                if block_type is None:
+                    if elem.tag in ("article", "section"):
+                        block_type = elem.tag
+                    elif elem.tag == "figure":
                         try:
                             m = re.search(r'<!-- EMBED START (?:Image|Video) {id: "(.*)"}', str(root[i - 1]).strip())
                             media = self.item["associations"][m.group(1)]

--- a/tests/editor_utils_test.py
+++ b/tests/editor_utils_test.py
@@ -2175,3 +2175,59 @@ class Editor3TestCase(TestCase):
         editor = Editor3Content(item)
         html = editor.html
         assert html == "<p>first line<br>second line</p>"
+
+    def test_article_and_section_blocks_mixed(self):
+        """Check that article and section blocks can be mixed with other block types"""
+        draftjs_data = {
+            "blocks": [
+                {
+                    "key": "1",
+                    "text": "Regular paragraph",
+                    "type": "unstyled",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "2",
+                    "text": "Article content",
+                    "type": "article",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+                {
+                    "key": "3",
+                    "text": "Section content",
+                    "type": "section",
+                    "depth": 0,
+                    "inlineStyleRanges": [],
+                    "entityRanges": [],
+                    "data": {},
+                },
+            ],
+            "entityMap": {},
+        }
+
+        expected = "<p>Regular paragraph</p>\n<article>Article content</article>\n<section>Section content</section>"
+
+        item = self.build_item(draftjs_data)
+        editor = Editor3Content(item)
+        html = editor.html
+        self.assertEqual(html, expected)
+
+    def test_article_and_section_from_html(self):
+        """Check that article and section HTML elements are converted to blocks correctly"""
+        html = "<article>Article content</article><section>Section content</section>"
+
+        item = {"body_html": html, "fields_meta": {}}
+        editor = Editor3Content(item, field="body_html", is_html=True)
+
+        # Check that blocks were created
+        self.assertEqual(len(editor.content_state["blocks"]), 2)
+        self.assertEqual(editor.content_state["blocks"][0]["type"], "article")
+        self.assertEqual(editor.content_state["blocks"][0]["text"], "Article content")
+        self.assertEqual(editor.content_state["blocks"][1]["type"], "section")
+        self.assertEqual(editor.content_state["blocks"][1]["text"], "Section content")


### PR DESCRIPTION
atm it breaks eg save/autosave, draftjs supports those

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: SDESK-7848

