### PR TITLE
[SDCP-1045] Catch formatting errors and place in publish queue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,11 +99,11 @@ setup(
     license="GPLv3",
     platforms=["any"],
     packages=find_packages(exclude=["tests*", "features*"]),
-    package_data=package_data,
+    package_data=package_data,  # type: ignore[arg-type]
     include_package_data=True,
     # setup_requires=["setuptools_scm"],
     install_requires=install_requires,
-    extras_require={
+    extras_require={  # type: ignore[arg-type]
         "exiv2": ["pyexiv2>=2.12.0,<2.16"],
     },
     python_requires=">=3.10",

--- a/superdesk/publish_async/formatters/base_exchange_formatter.py
+++ b/superdesk/publish_async/formatters/base_exchange_formatter.py
@@ -24,7 +24,7 @@ from superdesk.resource_fields import ID_FIELD, ITEM_TYPE, ASSOCIATIONS, VERSION
 from superdesk.metadata.item import PUBLISH_SCHEDULE, CONTENT_TYPE
 from superdesk.metadata.packages import GROUPS, GROUP_ID, REFS, RESIDREF, ROOT_GROUP
 from superdesk.publish import PUBLISHED_IN_PACKAGE
-from superdesk.errors import SuperdeskPublishError
+from superdesk.errors import SuperdeskPublishError, SuperdeskErrorWithNotifications
 from superdesk.publish_async.publish_cache import PublishCache
 from superdesk.publish_async.utils import generate_sequence_number, get_utc_schedule
 from superdesk.publish.formatters import Formatter, get_formatter
@@ -232,14 +232,36 @@ class BasePublishExchangeFormatter(PublishExchangeFormatter):
         else:
             # Either caching is not available for this formatter, or it's the first time that we format
             # this document.
-            # publish_queue_items = []
-            formatted_items = formatter.format(
-                self.filter_item_fields(item) if embed_package_items else item.copy(),
-                subscriber_dict,
-                list(response.subscriber_codes.get(subscriber.id) or set()),
-            )
-            if isawaitable(formatted_items):
-                formatted_items = await formatted_items
+
+            try:
+                formatted_items = formatter.format(
+                    self.filter_item_fields(item) if embed_package_items else item.copy(),
+                    subscriber_dict,
+                    list(response.subscriber_codes.get(subscriber.id) or set()),
+                )
+                if isawaitable(formatted_items):
+                    formatted_items = await formatted_items
+            except Exception as error:
+                logger.exception(
+                    "Failed to format item for subscriber destination",
+                    extra=dict(
+                        item_id=request.item_id,
+                        item_headline=item.get("headline"),
+                        subscriber_name=subscriber.name,
+                        destination_id=destination._id,
+                        destination_name=destination.name,
+                    ),
+                )
+                await self._create_publish_queue_item(
+                    request, item, subscriber, response, destination, "", PublishQueueState.ERROR, 0, None, str(error)
+                )
+
+                if isinstance(error, SuperdeskErrorWithNotifications):
+                    # Make sure to send email notifications if the error is designed for it
+                    # (Exception class makes sure that the email will only get sent once)
+                    await error.send_notifications()
+
+                return []
 
             for publish_data in formatted_items:
                 if isinstance(publish_data, tuple):
@@ -255,44 +277,77 @@ class BasePublishExchangeFormatter(PublishExchangeFormatter):
                 else:
                     raise RuntimeError("Invalid response from formatter")
 
-                publish_queue_item = PublishQueueResource(
-                    id=ObjectId(),
-                    state=PublishQueueState.SUCCESS
-                    if destination.delivery_type == "content_api"
-                    else PublishQueueState.ROUTING,
-                    is_content_api=destination.delivery_type == "content_api",
-                    item_id=request.item_id,
-                    publishing_action=request.published_state,
-                    item_version=item[VERSION],
-                    formatted_item=formatted_doc,
-                    published_in_package=item.get(PUBLISHED_IN_PACKAGE, None),
-                    publish_schedule=get_utc_schedule(item, PUBLISH_SCHEDULE) or None,
-                    unique_name=item.get("unique_name", None),
-                    content_type=item[ITEM_TYPE],
-                    headline=item.get("headline") or item.get("name") or item.get("slugline") or "",
-                    ingest_provider=ObjectId(item["ingest_provider"]) if item.get("ingest_provider") else None,
-                    associated_items=response.associations.get(subscriber.id, []),
-                    # The following fields are required by the model, and will be updated per subscriber & destination
-                    published_seq_num=pub_seq_num,
-                    subscriber_id=subscriber.id,  # Required by model, updated on push to queue
-                    priority=subscriber.priority,
-                    codes=list(response.subscriber_codes.get(subscriber.id) or set()),
-                    destination=destination,
-                    item=item if destination.delivery_type == "content_api" else None,
+                publish_queue_item = await self._create_publish_queue_item(
+                    request,
+                    item,
+                    subscriber,
+                    response,
+                    destination,
+                    formatted_doc,
+                    (
+                        PublishQueueState.SUCCESS
+                        if destination.delivery_type == "content_api"
+                        else PublishQueueState.ROUTING
+                    ),
+                    pub_seq_num,
+                    encoded_item,
                 )
 
-                if encoded_item:
-                    app = get_current_app()
-                    binary = BytesIO(encoded_item)
-                    publish_queue_item.encoded_item_id = app.storage.put(binary)
-
                 tasks.append(publish_queue_item)
-                await publish_queue_service.create([publish_queue_item])
 
             if use_cache:
                 task_cache[cache_id] = tasks
 
         return tasks
+
+    async def _create_publish_queue_item(
+        self,
+        request: PublishRequest,
+        item: dict,
+        subscriber: SubscribersResource,
+        response: PublishRequestResponse,
+        destination: SubscriberDestination,
+        formatted_doc: str,
+        queue_state: PublishQueueState,
+        pub_seq_num: int,
+        encoded_item: bytes | None = None,
+        error_message: str | None = None,
+    ) -> PublishQueueResource:
+        publish_queue_item = PublishQueueResource(
+            id=ObjectId(),
+            state=queue_state,
+            is_content_api=destination.delivery_type == "content_api",
+            item_id=request.item_id,
+            publishing_action=request.published_state,
+            item_version=item[VERSION],
+            formatted_item=formatted_doc,
+            published_in_package=item.get(PUBLISHED_IN_PACKAGE, None),
+            publish_schedule=get_utc_schedule(item, PUBLISH_SCHEDULE) or None,
+            unique_name=item.get("unique_name", None),
+            content_type=item[ITEM_TYPE],
+            headline=item.get("headline") or item.get("name") or item.get("slugline") or "",
+            ingest_provider=ObjectId(item["ingest_provider"]) if item.get("ingest_provider") else None,
+            associated_items=response.associations.get(subscriber.id, []),
+            # The following fields are required by the model, and will be updated per subscriber & destination
+            published_seq_num=pub_seq_num,
+            subscriber_id=subscriber.id,  # Required by model, updated on push to queue
+            priority=subscriber.priority,
+            codes=list(response.subscriber_codes.get(subscriber.id) or set()),
+            destination=destination,
+            item=item if destination.delivery_type == "content_api" else None,
+        )
+
+        if encoded_item:
+            app = get_current_app()
+            binary = BytesIO(encoded_item)
+            publish_queue_item.encoded_item_id = app.storage.put(binary)
+
+        if error_message:
+            publish_queue_item.error_message = error_message
+
+        await PublishQueueResource.get_service().create([publish_queue_item])
+
+        return publish_queue_item
 
     def filter_item_fields(self, item: dict) -> dict:
         """

--- a/tests/publish_async/exchanges/exchange_formatter_tests.py
+++ b/tests/publish_async/exchanges/exchange_formatter_tests.py
@@ -1,0 +1,86 @@
+from bson import ObjectId
+
+from superdesk.tests import TestCase
+from superdesk.types import (
+    SubscribersResource,
+    SubscriberType,
+    SubscriberDestination,
+    PublishRequest,
+    PublishRequestResponse,
+    PublishQueueResource,
+    PublishQueueState,
+)
+from superdesk.publish_async.formatters import BasePublishExchangeFormatter
+from superdesk.publish.formatters import Formatter, NINJS2Formatter, FormatReturnType
+
+
+class MockFormatter(Formatter):
+    type = "mock"
+    name = "Mock"
+    use_cache = True
+
+    async def format(self, article: dict, subscriber: dict | None, codes: list | None = None) -> FormatReturnType:
+        raise Exception("Mock formatter failed")
+
+
+class BaseExchangeFormatterTestCase(TestCase):
+    formatter: BasePublishExchangeFormatter
+    subscriber: SubscribersResource
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+
+        self.subscriber = SubscribersResource(
+            id=ObjectId(),
+            name="Mock Subscriber",
+            products=[],
+            subscriber_type=SubscriberType.WIRE,
+            email="mock@subscribers.test",
+            is_active=True,
+            destinations=[
+                SubscriberDestination(
+                    _id="dest_1",
+                    name="Mock 1 Destination",
+                    format=MockFormatter.type,
+                    delivery_type="file",
+                ),
+                SubscriberDestination(
+                    _id="dest_2",
+                    name="NINJS Destination",
+                    format=NINJS2Formatter.type,
+                    delivery_type="file",
+                ),
+                SubscriberDestination(
+                    _id="dest_3",
+                    name="Mock 3 Destination",
+                    format=MockFormatter.type,
+                    delivery_type="file",
+                ),
+            ],
+        )
+
+        await SubscribersResource.get_service().create([self.subscriber])
+
+        self.formatter = BasePublishExchangeFormatter()
+
+    async def test_stores_formatter_errors_in_publish_queue_entry(self):
+        item = dict(_id="abcd123", guid="abcd123", type="text", _current_version=1)
+        request = PublishRequest(
+            item=item,
+            item_id=item["_id"],
+            operation="publish",
+            published_state="published",
+            item_type=item["type"],
+        )
+
+        await self.formatter.get_tasks_for_subscriber(request, item, self.subscriber, PublishRequestResponse(), {})
+
+        publish_queue = {queue.destination._id: queue async for queue in PublishQueueResource.get_service().get_all()}
+
+        self.assertEqual(publish_queue["dest_1"].state, PublishQueueState.ERROR)
+        self.assertEqual(publish_queue["dest_1"].error_message, "Mock formatter failed")
+
+        self.assertEqual(publish_queue["dest_2"].state, PublishQueueState.ROUTING)
+
+        self.assertEqual(publish_queue["dest_3"].state, PublishQueueState.ERROR)
+        self.assertEqual(publish_queue["dest_3"].error_message, "Mock formatter failed")

--- a/tests/publish_async/exchanges/exchange_formatter_tests.py
+++ b/tests/publish_async/exchanges/exchange_formatter_tests.py
@@ -76,6 +76,7 @@ class BaseExchangeFormatterTestCase(TestCase):
         await self.formatter.get_tasks_for_subscriber(request, item, self.subscriber, PublishRequestResponse(), {})
 
         publish_queue = {queue.destination._id: queue async for queue in PublishQueueResource.get_service().get_all()}
+        self.assertEqual(len(publish_queue), 3)
 
         self.assertEqual(publish_queue["dest_1"].state, PublishQueueState.ERROR)
         self.assertEqual(publish_queue["dest_1"].error_message, "Mock formatter failed")


### PR DESCRIPTION
### Purpose
When processing an item for a subscriber, if any of the formats for a destination raises an exception the entire subscriber's publish_queue items are left in a `routing` state, not being picked up by the publish system.

### What has changed
* Catch formatting exceptions
* Create publish_queue entry for that destination, with a state of `error`
* Add tests
* Ignore type errors in setup.py

Resolves: [SDCP-1045](https://sofab.atlassian.net/browse/SDCP-1045)



[SDCP-1045]: https://sofab.atlassian.net/browse/SDCP-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ