### PR TITLE
[SDESK-7856] fix(ingests): Support sync generators from feeding services

### DIFF
--- a/superdesk/io/feeding_services/__init__.py
+++ b/superdesk/io/feeding_services/__init__.py
@@ -11,7 +11,7 @@
 from typing import AsyncGenerator
 import logging
 import warnings
-from inspect import isawaitable
+from inspect import isawaitable, isgenerator
 from abc import ABCMeta, abstractmethod
 from datetime import timedelta, datetime
 from pytz import utc
@@ -182,7 +182,7 @@ class FeedingService(metaclass=ABCMeta):
 
             if items is None:
                 return None
-            elif isinstance(items, list):
+            elif isinstance(items, list) or isgenerator(items):
                 return list_to_async_generator(items)
             else:
                 return items

--- a/tests/io/feeding_service_tests.py
+++ b/tests/io/feeding_service_tests.py
@@ -2,6 +2,7 @@ import pytz
 import warnings
 
 from datetime import datetime
+from inspect import isgenerator, isasyncgen
 from unittest.mock import patch
 from superdesk.tests import TestCase
 from superdesk.io.feeding_services import FeedingService
@@ -12,7 +13,14 @@ class TestFeedingService(FeedingService):
     Name = "test_feeding"
 
     def _update(self, provider, update):
-        pass
+        return []
+
+
+class TestAsyncFeedingService(FeedingService):
+    Name = "test_async_feeding"
+
+    async def _update(self, provider, update):
+        return []
 
 
 class FeedingServiceParserTestCase(TestCase):
@@ -39,3 +47,14 @@ class FeedingServiceParserTestCase(TestCase):
         feeding_service = TestFeedingService()
         feeding_service.localize_timestamps(item)
         self.assertEqual(pytz.utc, item["firstcreated"].tzinfo)
+
+    async def test_update_returns_async_generator(self):
+        items = await TestFeedingService().update({"_id": "abcd123", "name": "test"}, {})
+        self.assertFalse(isgenerator(items))
+        self.assertTrue(isasyncgen(items))
+        self.assertTrue(hasattr(items, "asend"))
+
+        items = await TestAsyncFeedingService().update({"_id": "abcd123", "name": "test"}, {})
+        self.assertFalse(isgenerator(items))
+        self.assertTrue(isasyncgen(items))
+        self.assertTrue(hasattr(items, "asend"))


### PR DESCRIPTION
### Purpose
Support for sync generators was missing in new async ingest code, raising exceptions and not running those ingests.

### What has changed
* Convert all feeding service responses to async generators
* Add tests

Resolves: [SDESK-7856](https://sofab.atlassian.net/browse/SDESK-7856)



[SDESK-7856]: https://sofab.atlassian.net/browse/SDESK-7856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ