### PR TITLE
[SDESK-7855] New bulk_update for async resource services

### DIFF
--- a/superdesk/core/elastic/async_client.py
+++ b/superdesk/core/elastic/async_client.py
@@ -11,6 +11,7 @@
 from typing import Optional, List, Dict, Any, Tuple, cast, overload
 import logging
 
+from bson import ObjectId
 from elasticsearch import AsyncElasticsearch
 from elasticsearch.exceptions import NotFoundError, TransportError, RequestError
 from elasticsearch.helpers import async_bulk
@@ -57,7 +58,16 @@ class ElasticResourceAsyncClient(BaseElasticResourceClient):
         # where as if `stats_only=True`, then `failed` is just a number
         return success, cast(List[Dict[str, Any]], failed)
 
-    async def bulk_update(self, ids: set[str], updates: dict) -> tuple[int, list[dict]]:
+    async def bulk_update(self, ids: set[str | ObjectId], updates: dict) -> tuple[int, list[dict]]:
+        """
+        Handles the bulk update operation for the Elasticsearch index, applying updates to a list of
+        documents identified by their IDs.
+
+        :param ids: A set of IDs for the items to be updated. Each ID can either be a string or an ObjectId.
+        :param updates: A dictionary containing the fields and values to update.
+        :return: A tuple containing the number of updated documents and a list of failed update responses.
+        """
+
         success, failed = await async_bulk(self.elastic, **self._get_bulk_update_args(ids, updates))
         if self.config.force_refresh:
             await self.elastic.indices.refresh(index=self.config.index)

--- a/superdesk/core/elastic/async_client.py
+++ b/superdesk/core/elastic/async_client.py
@@ -57,6 +57,15 @@ class ElasticResourceAsyncClient(BaseElasticResourceClient):
         # where as if `stats_only=True`, then `failed` is just a number
         return success, cast(List[Dict[str, Any]], failed)
 
+    async def bulk_update(self, ids: set[str], updates: dict) -> tuple[int, list[dict]]:
+        success, failed = await async_bulk(self.elastic, **self._get_bulk_update_args(ids, updates))
+        if self.config.force_refresh:
+            await self.elastic.indices.refresh(index=self.config.index)
+
+        # Cast `failed` to dict, because if we pass `stats_only=False`, then we get the full document
+        # where as if `stats_only=True`, then `failed` is just a number
+        return success, cast(list[dict], failed)
+
     async def update(self, item_id: str, updates: Dict[str, Any]) -> Any:
         """Update a document in Elasticsearch
 

--- a/superdesk/core/elastic/base_client.py
+++ b/superdesk/core/elastic/base_client.py
@@ -106,6 +106,17 @@ class BaseElasticResourceClient:
             index=self.config.index,
             actions=actions,
             stats_only=False,
+            raise_on_error=False,
+        )
+
+    def _get_bulk_update_args(self, ids: set[str], updates: dict) -> dict:
+        return dict(
+            actions=[
+                dict(_op_type="update", _index=self.config.index, _id=str(item_id), doc=updates) for item_id in ids
+            ],
+            # chunk_size=500,
+            raise_on_error=False,
+            stats_only=False,
         )
 
     def _get_update_args(self, item_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:

--- a/superdesk/core/elastic/base_client.py
+++ b/superdesk/core/elastic/base_client.py
@@ -13,6 +13,7 @@ import ast
 
 import simplejson as json
 from eve.io.mongo.parser import parse
+from bson import ObjectId
 
 from superdesk.errors import SuperdeskApiError
 from superdesk.core.types import SearchRequest, SortParam, ElasticResourceConfig, ElasticClientConfig, ProjectedFieldArg
@@ -109,12 +110,11 @@ class BaseElasticResourceClient:
             raise_on_error=False,
         )
 
-    def _get_bulk_update_args(self, ids: set[str], updates: dict) -> dict:
+    def _get_bulk_update_args(self, ids: set[str | ObjectId], updates: dict) -> dict:
         return dict(
             actions=[
                 dict(_op_type="update", _index=self.config.index, _id=str(item_id), doc=updates) for item_id in ids
             ],
-            # chunk_size=500,
             raise_on_error=False,
             stats_only=False,
         )

--- a/superdesk/core/elastic/resources.py
+++ b/superdesk/core/elastic/resources.py
@@ -105,6 +105,9 @@ class ElasticResources:
             source_name, client_config, resource_config
         )
 
+    def elastic_is_enabled(self, resource_name: str) -> bool:
+        return resource_name in self._resource_clients
+
     def get_elastic_index_name(self, resource_name: str) -> str:
         try:
             return self._resource_clients[resource_name].config.index

--- a/superdesk/core/elastic/sync_client.py
+++ b/superdesk/core/elastic/sync_client.py
@@ -53,6 +53,15 @@ class ElasticResourceClient(BaseElasticResourceClient):
         # where as if `stats_only=True`, then `failed` is just a number
         return success, cast(List[Dict[str, Any]], failed)
 
+    def bulk_update(self, ids: set[str], updates: dict) -> tuple[int, list[Dict[str, Any]]]:
+        success, failed = bulk(self.elastic, **self._get_bulk_update_args(ids, updates))
+        if self.config.force_refresh:
+            self.elastic.indices.refresh(index=self.config.index)
+
+        # Cast `failed` to dict, because if we pass `stats_only=False`, then we get the full document
+        # where as if `stats_only=True`, then `failed` is just a number
+        return success, cast(list[dict], failed)
+
     def update(self, item_id: str, updates: Dict[str, Any]) -> Any:
         """Update a document in Elasticsearch
 

--- a/superdesk/core/elastic/sync_client.py
+++ b/superdesk/core/elastic/sync_client.py
@@ -10,6 +10,7 @@
 
 from typing import Optional, List, Dict, Any, Tuple, cast, overload
 
+from bson import ObjectId
 from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import NotFoundError, TransportError, RequestError
 from elasticsearch.helpers import bulk
@@ -53,7 +54,16 @@ class ElasticResourceClient(BaseElasticResourceClient):
         # where as if `stats_only=True`, then `failed` is just a number
         return success, cast(List[Dict[str, Any]], failed)
 
-    def bulk_update(self, ids: set[str], updates: dict) -> tuple[int, list[Dict[str, Any]]]:
+    def bulk_update(self, ids: set[str | ObjectId], updates: dict) -> tuple[int, list[Dict[str, Any]]]:
+        """
+        Handles the bulk update operation for the Elasticsearch index, applying updates to a list of
+        documents identified by their IDs.
+
+        :param ids: A set of IDs for the items to be updated. Each ID can either be a string or an ObjectId.
+        :param updates: A dictionary containing the fields and values to update.
+        :return: A tuple containing the number of updated documents and a list of failed update responses.
+        """
+
         success, failed = bulk(self.elastic, **self._get_bulk_update_args(ids, updates))
         if self.config.force_refresh:
             self.elastic.indices.refresh(index=self.config.index)

--- a/superdesk/core/resources/resource_manager.py
+++ b/superdesk/core/resources/resource_manager.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Sequence
+from typing import Awaitable
 import asyncio
 
 from bson import ObjectId
@@ -108,7 +108,7 @@ class Resources(SignalGroup):
 
         :param jobs: A list of tuples, where each tuple contains:
             - The resource name as a string.
-            - A list of resource IDs (strings or ObjectId instances) to update.
+            - A set of resource IDs (strings or ObjectId instances) to update.
             - A dictionary containing the fields to update.
         """
 

--- a/superdesk/core/resources/resource_manager.py
+++ b/superdesk/core/resources/resource_manager.py
@@ -1,3 +1,9 @@
+from typing import Awaitable, Sequence
+import asyncio
+
+from bson import ObjectId
+from pymongo.results import UpdateResult
+
 from superdesk.core.app import SuperdeskAsyncApp
 from superdesk.core.signals import SignalGroup, Signal
 
@@ -86,3 +92,32 @@ class Resources(SignalGroup):
         for service in self._resource_services:
             if hasattr(service, "_instance"):
                 del service._instance
+
+    async def bulk_update_resources(
+        self, jobs: list[tuple[str, set[str | ObjectId], dict]]
+    ) -> list[tuple[UpdateResult, tuple[int, list[dict]] | None]]:
+        """
+        Performs bulk updates on a list of resources.
+
+        This asynchronous method processes a series of update jobs, where each job specifies
+        a resource type, a list of resource identifiers, and the updates to be applied.
+        For each job, it retrieves the appropriate resource service, prepares updates, and
+        applies updates in bulk asynchronously.
+
+        The function skips jobs with missing identifiers or updates.
+
+        :param jobs: A list of tuples, where each tuple contains:
+            - The resource name as a string.
+            - A list of resource IDs (strings or ObjectId instances) to update.
+            - A dictionary containing the fields to update.
+        """
+
+        tasks: list[Awaitable[tuple[UpdateResult, tuple[int, list[dict]] | None]]] = []
+        for resource, ids, updates in jobs:
+            if not ids or not updates:
+                continue
+
+            service = self.get_resource_service(resource)
+            tasks.append(service.bulk_update(ids, updates))
+
+        return list(await asyncio.gather(*tasks))

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -28,10 +28,12 @@ import ast
 import simplejson as json
 from copy import deepcopy
 from hashlib import sha1
+import asyncio
 
 from bson import ObjectId, UuidRepresentation
 from bson.json_util import dumps, DEFAULT_JSON_OPTIONS
 from pymongo.collation import Collation
+from pymongo.results import UpdateResult
 from motor.motor_asyncio import AsyncIOMotorCursor
 
 # TODO-ASYNC: Replace Eve's parser with our own
@@ -48,7 +50,7 @@ from superdesk.resource_fields import ID_FIELD, VERSION_ID_FIELD, CURRENT_VERSIO
 
 from ..app import SuperdeskAsyncApp, get_current_async_app, get_config
 from .cursor import ElasticsearchResourceCursorAsync, MongoResourceCursorAsync, ResourceCursorAsync
-from .utils import get_projection_from_request, combine_projection_args
+from .utils import get_projection_from_request, get_projection_arg
 from .types import ResourceModelType
 
 logger = logging.getLogger(__name__)
@@ -295,24 +297,33 @@ class AsyncResourceService(Generic[ResourceModelType]):
         cursor = await self.find({ID_FIELD: {"$in": ids}}, use_mongo=True, projection=projection)
         return await cursor.to_list_raw()
 
-    async def search(self, lookup: Dict[str, Any], use_mongo=False) -> ResourceCursorAsync[ResourceModelType]:
+    async def search(
+        self, lookup: Dict[str, Any], use_mongo=False, projection: ProjectedFieldArg | None = None
+    ) -> ResourceCursorAsync[ResourceModelType]:
         """Search the resource using the provided ``lookup``
 
         Will use Elasticsearch if configured for this resource and ``use_mongo == False``.
 
         :param lookup: Dictionary to search
         :param use_mongo: Force to use MongoDB instead of Elasticsearch
+        :param projection: Optional projection to apply to the search results
         :return: A ``ResourceCursorAsync`` instance with the response
         """
 
         try:
             if not use_mongo:
-                response = await self.elastic.search(lookup)
+                response = await self.elastic.search(lookup, projection=projection)
                 return ElasticsearchResourceCursorAsync(cast(Type[ResourceModelType], self.config.data_class), response)
         except ElasticNotConfiguredForResource:
             pass
 
-        response = self.mongo_async.find(lookup)
+        projection_arg = None if projection is None else get_projection_arg(projection)
+
+        if projection_arg:
+            response = self.mongo_async.find(lookup, projection=projection_arg)
+        else:
+            response = self.mongo_async.find(lookup)
+
         return MongoResourceCursorAsync(
             cast(Type[ResourceModelType], self.config.data_class), self.mongo_async, response, lookup
         )
@@ -1012,6 +1023,74 @@ class AsyncResourceService(Generic[ResourceModelType]):
         if search_request.case_insensitive:
             return Collation(get_config(str, "MONGO_LOCALE", "en"), strength=2)
         return None
+
+    async def bulk_update(
+        self, ids: set[str | ObjectId], updates: dict
+    ) -> tuple[UpdateResult, tuple[int, list[dict]] | None]:
+        """
+        Asynchronously applies updates to multiple items in both MongoDB and Elasticsearch.
+
+        This method updates items in MongoDB and, if enabled, Elasticsearch. It ensures that the
+        updates performed on both databases match the provided IDs and logs any inconsistencies.
+
+        MongoDB and Elasticsearch updates are concurrently updated.
+
+        Errors are raised if the MongoDB operation is not acknowledged, while warnings are logged for any
+        discrepancies between the number of IDs provided and the number of items updated.
+
+        :param updates: A dictionary containing the fields and values to update.
+        :param ids: A list of IDs for the items to be updated. Each ID can either be a string or an ObjectId.
+        :raises Exception: If the MongoDB update operation is not acknowledged.
+        """
+
+        mongo_task = self.mongo_async.update_many({"_id": {"$in": list(ids)}}, {"$set": updates})
+        mongo_result: UpdateResult
+        elastic_result: tuple[int, list[dict]] | None = None
+        if not self.app.elastic.elastic_is_enabled(self.resource_name):
+            # Only MongoDB is enabled
+            mongo_result = await mongo_task
+        else:
+            # MongoDB and Elasticsearch are enabled
+            elastic_task = self.elastic.bulk_update(ids, updates)
+            mongo_result, elastic_result = await asyncio.gather(mongo_task, elastic_task)
+
+        if not mongo_result.acknowledged:
+            raise SuperdeskApiError.badRequestError("Failed to bulk update items in MongoDB")
+
+        if mongo_result.modified_count != len(ids):
+            logger.warning(
+                "Number of items updated in MongoDB does not match the number of IDs provided",
+                extra={
+                    "resource": self.resource_name,
+                    "ids": ids,
+                    "updated_in_mongo": mongo_result.modified_count,
+                    "mongo_result": mongo_result.raw_result,
+                },
+            )
+
+        if elastic_result is not None:
+            if elastic_result[0] != len(ids):
+                logger.warning(
+                    "Number of items updated in Elasticsearch does not match the number of IDs provided",
+                    extra={
+                        "resource": self.resource_name,
+                        "ids": ids,
+                        "updated_in_elastic": elastic_result[0],
+                        "elastic_errors": elastic_result[1],
+                    },
+                )
+            elif len(elastic_result[1]):
+                logger.warning(
+                    "Errors occurred while updating items in Elasticsearch",
+                    extra={
+                        "resource": self.resource_name,
+                        "ids": ids,
+                        "updated_in_elastic": elastic_result[0],
+                        "elastic_errors": elastic_result[1],
+                    },
+                )
+
+        return mongo_result, elastic_result
 
 
 class AsyncCacheableService(AsyncResourceService[ResourceModelType]):

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -317,7 +317,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
         except ElasticNotConfiguredForResource:
             pass
 
-        projection_arg = None if projection is None else get_projection_arg(projection)
+        projection_arg = None if projection is None else self._get_mongo_projection_argument(projection)
 
         if projection_arg:
             response = self.mongo_async.find(lookup, projection=projection_arg)
@@ -780,9 +780,15 @@ class AsyncResourceService(Generic[ResourceModelType]):
 
         return await self.mongo_async.count_documents(lookup or {})
 
-    def _get_mongo_projection_argument(self, req: SearchRequest) -> list[str] | dict[str, bool] | None:
-        projection_include, projection_fields = get_projection_from_request(req)
-        if projection_fields:
+    def _get_mongo_projection_argument(
+        self, req: SearchRequest | ProjectedFieldArg
+    ) -> list[str] | dict[str, bool] | None:
+        if isinstance(req, SearchRequest):
+            projection_include, projection_fields = get_projection_from_request(req)
+        else:
+            projection_include, projection_fields = get_projection_arg(req)
+
+        if projection_include is not None and projection_fields is not None:
             return projection_fields if projection_include else {field: False for field in projection_fields}
 
         return None
@@ -1038,9 +1044,10 @@ class AsyncResourceService(Generic[ResourceModelType]):
         Errors are raised if the MongoDB operation is not acknowledged, while warnings are logged for any
         discrepancies between the number of IDs provided and the number of items updated.
 
+        :param ids: A set of IDs for the items to be updated. Each ID can either be a string or an ObjectId.
         :param updates: A dictionary containing the fields and values to update.
-        :param ids: A list of IDs for the items to be updated. Each ID can either be a string or an ObjectId.
-        :raises Exception: If the MongoDB update operation is not acknowledged.
+        :return: A tuple containing the result of the MongoDB update and Elasticsearch operations.
+        :raises SuperdeskApiError.badRequestError: If the MongoDB update operation is not acknowledged.
         """
 
         mongo_task = self.mongo_async.update_many({"_id": {"$in": list(ids)}}, {"$set": updates})

--- a/superdesk/core/resources/utils.py
+++ b/superdesk/core/resources/utils.py
@@ -25,13 +25,19 @@ SYSTEM_FIELDS = {"_id", "_type", "_resource", "_etag"}
 
 
 def get_projection_from_request(req: SearchRequest) -> tuple[bool, list[str]] | tuple[None, None]:
-    """Convert request projection param into common format used by Mongo or Elastic
+    """
+    Extracts and parses projection fields from a given SearchRequest.
 
-    :param req: A SearchRequest with an optional projection param
-    :return: One of the following depending on expected projection:
-        tuple[None, None] If no projection is to be used
-        tuple[True, list[str]] When projection is to include fields
-        tuple[False, list[str]] When projection is to exclude fields
+    This function processes the search request to determine the projection
+    fields specified either in the request arguments or directly as a
+    projection attribute, if available. It returns the parsed projection
+    information in a standardized format for further use.
+
+    :param req: An instance of SearchRequest containing the client's query data including optional projection details.
+    :returns: One of the following depending on expected projection:
+        - (True, list): For inclusive projection, where specified fields are included in the output.
+        - (False, list): For exclusive projection, where specified fields are excluded from the output.
+        - (None, None): When no projection is applied.
     :raises SuperdeskApiError.badRequestError: If the projection param is of an unsupported type
     """
 
@@ -40,6 +46,29 @@ def get_projection_from_request(req: SearchRequest) -> tuple[bool, list[str]] | 
         projection_data = json.loads(req.args["projections"])
     elif req.projection:
         projection_data = req.projection
+
+    return get_projection_arg(projection_data)
+
+
+def get_projection_arg(projection_data: ProjectedFieldArg | None) -> tuple[bool, list[str]] | tuple[None, None]:
+    """Get normalized projection argument from request
+
+    Processes the given projection data and determines the type of projection to apply
+    to a query. It supports inclusion or exclusion of fields based on the structure and
+    value of the provided data.
+
+    :param projection_data: Projection data used to determine field inclusion or exclusion. Acceptable types are:
+        - None: No projection is used.
+        - list or set: Specifies fields to include in the projection.
+        - dict: Specifies fields and their projection type. The values in the
+          dictionary are inspected to determine whether fields should be included
+          or excluded.
+    :returns: One of the following depending on expected projection:
+        - (True, list): For inclusive projection, where specified fields are included in the output.
+        - (False, list): For exclusive projection, where specified fields are excluded from the output.
+        - (None, None): When no projection is applied.
+    :raises SuperdeskApiError.badRequestError: If the projection param is of an unsupported type
+    """
 
     if not projection_data:
         # No projection will be used

--- a/superdesk/core/types/search.py
+++ b/superdesk/core/types/search.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias
 from typing_extensions import TypedDict
 from enum import Enum, unique
 
@@ -9,7 +9,7 @@ from pydantic_core import PydanticCustomError
 
 #: The data type for projections, either a list of field names, or a dictionary containing
 #: the field and enable/disable state
-ProjectedFieldArg = (
+ProjectedFieldArg: TypeAlias = (
     list[str]
     | set[str]
     | dict[str, Literal[0]]

--- a/superdesk/core/utils.py
+++ b/superdesk/core/utils.py
@@ -11,7 +11,7 @@
 from typing import TypeVar, cast, AsyncGenerator, Any
 from typing_extensions import Self
 from importlib import import_module
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import uuid4
 
 from .app import get_app_config
@@ -67,7 +67,7 @@ def str_to_date(value: str | datetime | None) -> datetime | None:
 
     if isinstance(value, str):
         date_format: str = get_app_config("DATE_FORMAT") or "%Y-%m-%dT%H:%M:%S+0000"
-        return datetime.strptime(value, date_format)
+        return datetime.strptime(value, date_format).replace(tzinfo=timezone.utc)
 
     return value
 

--- a/tests/core/elastic_async_test.py
+++ b/tests/core/elastic_async_test.py
@@ -30,9 +30,11 @@ class ElasticAsyncClientTestCase(AsyncTestCase):
         self.assertEqual(await client.count(), 1)
         self.assertFalse(await client.is_empty())
 
-    async def test_bulk_insert(self):
+    async def test_bulk_operations(self):
         self.app.elastic.init_index("users_async")
         client = self.app.elastic.get_client_async("users_async")
+
+        # Test inserting documents
         count, errors = await client.bulk_insert(
             [
                 User(id="user_1", first_name="John", last_name="Doe").to_dict(),
@@ -43,6 +45,58 @@ class ElasticAsyncClientTestCase(AsyncTestCase):
         self.assertEqual(count, 3)
         self.assertEqual(errors, [])
         self.assertEqual(await client.count(), 3)
+
+        # Test inserting documents, 1 with errors
+        user_5 = User(id="user_4", first_name="John", last_name="Doe").to_dict()
+        user_5.update({"_id": "user_5", "last_name": {"test": True}})
+        count, errors = await client.bulk_insert(
+            [
+                User(id="user_4", first_name="John", last_name="Doe").to_dict(),
+                user_5,
+                User(id="user_6", first_name="Jane", last_name="Doe").to_dict(),
+            ]
+        )
+        self.assertEqual(count, 2)
+        self.assertEqual(await client.count(), 5)
+
+        self.assertEqual(len(errors), 1)
+        error = errors[0]["index"]
+        self.assertTrue(error["_index"].startswith("sptest_users_async"))
+        self.assertEqual(error["_id"], "user_5")
+        self.assertEqual(error["status"], 400)
+        self.assertEqual(error["error"]["type"], "mapper_parsing_exception")
+        self.assertIn("last_name", error["error"]["reason"])
+        self.assertIn("'{test=true}'", error["error"]["reason"])
+
+        # Test updating documents
+        count, errors = await client.bulk_update({"user_1", "user_2", "user_6"}, {"score": 1, "token": "abcd123"})
+        self.assertEqual(count, 3)
+        self.assertEqual(errors, [])
+
+        response = await client.search({})
+        items = {item["_id"]: item["_source"] for item in response.get("hits").get("hits")}
+        # Assert matched items were updated
+        self.assertDictContains(items["user_1"], {"score": 1, "token": "abcd123"})
+        self.assertDictContains(items["user_2"], {"score": 1, "token": "abcd123"})
+        self.assertDictContains(items["user_6"], {"score": 1, "token": "abcd123"})
+        # Assert unmatched items were not updated
+        self.assertNotIn("score", items["user_3"])
+        self.assertNotIn("token", items["user_3"])
+        self.assertNotIn("score", items["user_4"])
+        self.assertNotIn("token", items["user_4"])
+
+        # Test updating documents, 1 with errors
+        count, errors = await client.bulk_update({"user_3", "user_4"}, {"score": 25, "token": {"foo_bar": 1234}})
+        self.assertEqual(count, 0)
+        self.assertEqual(len(errors), 2)
+
+        error = errors[0]["update"]
+        self.assertTrue(error["_index"].startswith("sptest_users_async"))
+        self.assertIn(error["_id"], {"user_3", "user_4"})
+        self.assertEqual(error["status"], 400)
+        self.assertEqual(error["error"]["type"], "mapper_parsing_exception")
+        self.assertIn("token", error["error"]["reason"])
+        self.assertIn("'{foo_bar=1234}'", error["error"]["reason"])
 
     async def test_update(self):
         self.app.elastic.init_index("users_async")

--- a/tests/core/elastic_sync_test.py
+++ b/tests/core/elastic_sync_test.py
@@ -30,9 +30,11 @@ class ElasticClientTestCase(AsyncTestCase):
         self.assertEqual(client.count(), 1)
         self.assertFalse(client.is_empty())
 
-    def test_bulk_insert(self):
+    def test_bulk_operations(self):
         self.app.elastic.init_index("users_async")
         client = self.app.elastic.get_client("users_async")
+
+        # Test inserting documents
         count, errors = client.bulk_insert(
             [
                 User(id="user_1", first_name="John", last_name="Doe").to_dict(),
@@ -43,6 +45,58 @@ class ElasticClientTestCase(AsyncTestCase):
         self.assertEqual(count, 3)
         self.assertEqual(errors, [])
         self.assertEqual(client.count(), 3)
+
+        # Test inserting documents, 1 with errors
+        user_5 = User(id="user_4", first_name="John", last_name="Doe").to_dict()
+        user_5.update({"_id": "user_5", "last_name": {"test": True}})
+        count, errors = client.bulk_insert(
+            [
+                User(id="user_4", first_name="John", last_name="Doe").to_dict(),
+                user_5,
+                User(id="user_6", first_name="Jane", last_name="Doe").to_dict(),
+            ]
+        )
+        self.assertEqual(count, 2)
+        self.assertEqual(client.count(), 5)
+
+        self.assertEqual(len(errors), 1)
+        error = errors[0]["index"]
+        self.assertTrue(error["_index"].startswith("sptest_users_async"))
+        self.assertEqual(error["_id"], "user_5")
+        self.assertEqual(error["status"], 400)
+        self.assertEqual(error["error"]["type"], "mapper_parsing_exception")
+        self.assertIn("last_name", error["error"]["reason"])
+        self.assertIn("'{test=true}'", error["error"]["reason"])
+
+        # Test updating documents
+        count, errors = client.bulk_update({"user_1", "user_2", "user_6"}, {"score": 1, "token": "abcd123"})
+        self.assertEqual(count, 3)
+        self.assertEqual(errors, [])
+
+        response = client.search({})
+        items = {item["_id"]: item["_source"] for item in response.get("hits").get("hits")}
+        # Assert matched items were updated
+        self.assertDictContains(items["user_1"], {"score": 1, "token": "abcd123"})
+        self.assertDictContains(items["user_2"], {"score": 1, "token": "abcd123"})
+        self.assertDictContains(items["user_6"], {"score": 1, "token": "abcd123"})
+        # Assert unmatched items were not updated
+        self.assertNotIn("score", items["user_3"])
+        self.assertNotIn("token", items["user_3"])
+        self.assertNotIn("score", items["user_4"])
+        self.assertNotIn("token", items["user_4"])
+
+        # Test updating documents, 1 with errors
+        count, errors = client.bulk_update({"user_3", "user_4"}, {"score": 25, "token": {"foo_bar": 1234}})
+        self.assertEqual(count, 0)
+        self.assertEqual(len(errors), 2)
+
+        error = errors[0]["update"]
+        self.assertTrue(error["_index"].startswith("sptest_users_async"))
+        self.assertIn(error["_id"], {"user_3", "user_4"})
+        self.assertEqual(error["status"], 400)
+        self.assertEqual(error["error"]["type"], "mapper_parsing_exception")
+        self.assertIn("token", error["error"]["reason"])
+        self.assertIn("'{foo_bar=1234}'", error["error"]["reason"])
 
     def test_update(self):
         test_user = john_doe()

--- a/tests/core/resource_service_test.py
+++ b/tests/core/resource_service_test.py
@@ -465,3 +465,22 @@ class TestResourceService(AsyncTestCase):
             await assert_es_find_called_with(SearchRequest(sort=custom_sort_query), expected=expected)
             expected.where = {}
             await assert_es_find_called_with({}, sort=custom_sort_query, expected=expected)
+
+    async def test_bulk_update(self):
+        users = all_users()
+        await self.service.create(users)
+        for index in range(len(users)):
+            self.assertEqual(users[index], await self.service.find_by_id(users[index].id))
+
+        await self.service.bulk_update({users[0].id, users[2].id}, {"score": 2, "token": "abcd123"})
+        users[0].score = users[2].score = 2
+        users[0].token = users[2].token = "abcd123"
+
+        for index in range(len(users)):
+            mongo_item = await self.service.mongo_async.find_one({"_id": users[index].id})
+            mongo_item.pop("_type", None)
+            self.assertEqual(users[index], User(**mongo_item))
+
+            es_item = await self.service.elastic.find_by_id(users[index].id)
+            es_item.pop("_type", None)
+            self.assertEqual(users[index], User(**es_item))


### PR DESCRIPTION
### Purpose
Provide the ability to apply an update to many documents, using bulk DB interfaces.

### What has changed
* Add `bulk_update` to elastic client
* Add `bulk_update` to resource service
* Fix `superdesk.core.str_to_date` by setting tzinfo to utc (`DATE_FORMAT` uses UTC anyway)
* Add unit tests

Resolves: [SDESK-7855](https://sofab.atlassian.net/browse/SDESK-7855)



[SDESK-7855]: https://sofab.atlassian.net/browse/SDESK-7855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ