### PR TITLE
[SDESK-7855] fix: Use Arrow lib for str_to_date util

### DIFF
--- a/superdesk/core/utils.py
+++ b/superdesk/core/utils.py
@@ -14,6 +14,8 @@ from importlib import import_module
 from datetime import datetime, timezone
 from uuid import uuid4
 
+import arrow
+
 from .app import get_app_config
 from .types import DefaultNoValue
 
@@ -66,8 +68,8 @@ def str_to_date(value: str | datetime | None) -> datetime | None:
     """Convert a string to a datetime instance"""
 
     if isinstance(value, str):
-        date_format: str = get_app_config("DATE_FORMAT") or "%Y-%m-%dT%H:%M:%S+0000"
-        return datetime.strptime(value, date_format).replace(tzinfo=timezone.utc)
+        value_dt = arrow.get(value).datetime
+        return value_dt if value_dt.tzinfo == timezone.utc else value_dt.astimezone(timezone.utc)
 
     return value
 


### PR DESCRIPTION
### Purpose
The Planning/flag_expired_items was raising `ValueError: time data '2025-10-19T00:00:00+00:00' does not match format '%Y-%m-%dT%H:%M:%S+0000'`. The extra `:` in the tz offset was causing this issue.

### What has changed
* Use the `arrow` library to allow supporting different formats
* Convert the value to UTC (if not already)

Resolves: [SDESK-7855](https://sofab.atlassian.net/browse/SDESK-7855)



[SDESK-7855]: https://sofab.atlassian.net/browse/SDESK-7855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ