### PR TITLE
[STT-1452] - Fix the STT "Autotranslate and publish" macro 

### DIFF
--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -70,7 +70,9 @@ def compare_dictionaries(original, updates):
     return modified
 
 
-async def send_to(doc, update=None, desk_id=None, stage_id=None, user_id=None, default_stage="incoming_stage"):
+async def send_to(
+    doc, update=None, desk_id=None, stage_id=None, user_id=None, default_stage="incoming_stage", macro_kwargs=None
+):
     """Send item to given desk and stage.
 
     Applies the outgoing and incoming macros of current and destination stages
@@ -91,7 +93,7 @@ async def send_to(doc, update=None, desk_id=None, stage_id=None, user_id=None, d
     task = {"desk": desk_id, "stage": stage_id, "user": original_task.get("user") if user_id is None else user_id}
 
     if current_stage:
-        await apply_stage_rule(doc, update, current_stage, MACRO_OUTGOING)
+        await apply_stage_rule(doc, update, current_stage, MACRO_OUTGOING, macro_kwargs=macro_kwargs)
 
     if desk_id:
         # TODO-ASYNC[desks]: Use DesksResourceModel async service where when upgrading this module
@@ -128,7 +130,9 @@ async def send_to(doc, update=None, desk_id=None, stage_id=None, user_id=None, d
         doc["expiry"] = get_item_expiry(desk=desk, stage=destination_stage)
 
     if destination_stage:
-        await apply_stage_rule(doc, update, destination_stage, MACRO_INCOMING, desk=desk, task=task)
+        await apply_stage_rule(
+            doc, update, destination_stage, MACRO_INCOMING, desk=desk, task=task, macro_kwargs=macro_kwargs
+        )
         if destination_stage.get("task_status"):
             if update:
                 update["task"]["status"] = destination_stage["task_status"]
@@ -136,7 +140,7 @@ async def send_to(doc, update=None, desk_id=None, stage_id=None, user_id=None, d
                 doc["task"]["status"] = destination_stage["task_status"]
 
 
-async def apply_stage_rule(doc, update, stage, rule_type, desk=None, task=None):
+async def apply_stage_rule(doc, update, stage, rule_type, desk=None, task=None, macro_kwargs=None):
     macro_type = "{}_macro".format(rule_type)
 
     if stage.get(macro_type):
@@ -147,7 +151,7 @@ async def apply_stage_rule(doc, update, stage, rule_type, desk=None, task=None):
                 logger.warning("macro %s is missing", stage.get(macro_type))
                 return
 
-            await macro["callback"](doc, desk=desk, stage=stage, task=task)
+            await macro["callback"](doc, desk=desk, stage=stage, task=task, **(macro_kwargs or {}))
             if update:
                 modified = compare_dictionaries(original_doc, doc)
                 for i in modified:

--- a/apps/tasks.py
+++ b/apps/tasks.py
@@ -71,8 +71,14 @@ def compare_dictionaries(original, updates):
 
 
 async def send_to(
-    doc, update=None, desk_id=None, stage_id=None, user_id=None, default_stage="incoming_stage", macro_kwargs=None
-):
+    doc,
+    update=None,
+    desk_id=None,
+    stage_id=None,
+    user_id=None,
+    default_stage="incoming_stage",
+    macro_kwargs=None,
+) -> None:
     """Send item to given desk and stage.
 
     Applies the outgoing and incoming macros of current and destination stages

--- a/superdesk/internal_destinations.py
+++ b/superdesk/internal_destinations.py
@@ -81,14 +81,16 @@ async def handle_item_published(item, after_scheduled):
             item[SCHEDULE_SETTINGS] = {}
 
         new_item = deepcopy(item)
-        new_item["_internal_destination"] = {"desk": dest.get("desk"), "stage": dest.get("stage")}
 
         try:
-            await send_to(new_item, desk_id=dest["desk"], stage_id=dest.get("stage"))
+            await send_to(
+                new_item,
+                desk_id=dest["desk"],
+                stage_id=dest.get("stage"),
+                macro_kwargs={"internal_destination": dest},
+            )
         except StopDuplication:
             continue
-        finally:
-            new_item.pop("_internal_destination", None)
 
         if dest.get("macro"):
             macro = macros_service.get_macro_by_name(dest["macro"])

--- a/superdesk/internal_destinations.py
+++ b/superdesk/internal_destinations.py
@@ -81,11 +81,14 @@ async def handle_item_published(item, after_scheduled):
             item[SCHEDULE_SETTINGS] = {}
 
         new_item = deepcopy(item)
+        new_item["_internal_destination"] = {"desk": dest.get("desk"), "stage": dest.get("stage")}
 
         try:
             await send_to(new_item, desk_id=dest["desk"], stage_id=dest.get("stage"))
         except StopDuplication:
             continue
+        finally:
+            new_item.pop("_internal_destination", None)
 
         if dest.get("macro"):
             macro = macros_service.get_macro_by_name(dest["macro"])


### PR DESCRIPTION
### Purpose
This PR adds an `_internal_destination` flag so downstream macros can handle publishing the routed copy correctly.

### What has changed
- Set a temporary `_internal_destination` flag on items before calling `send_to` in internal destination routing, then remove it afterward.

### How to test
1. Have 2 Desks. Desk A and Desk B.
2. Ensure internal-destination routing is configured to Desk B with the incoming macro `auto_translate_and_publish_macro` in one of the stages.
3. Create a non-English story with headline + body like using the Pikaplus profile
4. Publish the story or use the “Send to” flow
5. Verify the routed copy in the Auto Translation desk is translated and published.

**Note**:
- This change is intended to be consumed by the STT macro update in this corresponding [PR](https://github.com/superdesk/superdesk-stt/pull/682).

Resolves : [STT-1452](https://sofab.atlassian.net/browse/STT-1452)



[STT-1452]: https://sofab.atlassian.net/browse/STT-1452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ