### PR TITLE
[STT-1622] Embargo and Schedule info lost when doing the "Copy and send to Desk" action

### DIFF
--- a/apps/duplication/archive_duplication.py
+++ b/apps/duplication/archive_duplication.py
@@ -39,6 +39,7 @@ class DuplicateResource(Resource):
         "stage": Resource.rel("stages", False, required=False),
         "type": {"type": "string", "required": True},
         "item_id": {"type": "string", "required": False},
+        "preserve_embargo_and_schedule": {"type": "boolean", "required": False},
     }
 
     url = "archive/<{0}:guid>/duplicate".format(item_url)
@@ -100,9 +101,14 @@ class DuplicateService(AsyncBaseService):
             if not doc.get("desk"):  # item copied to personal space
                 archived_doc["state"] = CONTENT_STATE.PROGRESS
                 new_guid = await archive_service.duplicate_content(archived_doc)
-            else:  # item copied to desk - preserve embargo and schedule fields
-                extra_fields = [EMBARGO, PUBLISH_SCHEDULE, SCHEDULE_SETTINGS]
-                new_guid = await archive_service.duplicate_content(archived_doc, extra_fields=extra_fields)
+            else:  # item copied to desk
+                # Check request parameter for preserving embargo and schedule fields
+                preserve_embargo_and_schedule = doc.get("preserve_embargo_and_schedule", False)
+                if preserve_embargo_and_schedule:
+                    extra_fields = [EMBARGO, PUBLISH_SCHEDULE, SCHEDULE_SETTINGS]
+                    new_guid = await archive_service.duplicate_content(archived_doc, extra_fields=extra_fields)
+                else:
+                    new_guid = await archive_service.duplicate_content(archived_doc)
 
             guid_of_duplicated_items.append(new_guid)
 

--- a/apps/duplication/archive_duplication.py
+++ b/apps/duplication/archive_duplication.py
@@ -13,7 +13,7 @@ from eve.utils import ParsedRequest
 
 from superdesk.core import get_app_config
 from superdesk.eve_async.service import AsyncBaseService
-from superdesk.resource_fields import ID_FIELD
+from superdesk.resource_fields import ID_FIELD, PUBLISH_SCHEDULE, SCHEDULE_SETTINGS
 from superdesk.flask import request
 import superdesk
 from apps.archive.archive import SOURCE as ARCHIVE, remove_is_queued
@@ -22,7 +22,7 @@ from apps.content import push_content_notification
 from apps.tasks import send_to
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
-from superdesk.metadata.item import CONTENT_STATE, ITEM_STATE
+from superdesk.metadata.item import CONTENT_STATE, ITEM_STATE, EMBARGO
 from superdesk.metadata.utils import item_url
 from superdesk.resource import Resource
 from superdesk.workflow import is_workflow_state_transition_valid
@@ -99,8 +99,11 @@ class DuplicateService(AsyncBaseService):
 
             if not doc.get("desk"):  # item copied to personal space
                 archived_doc["state"] = CONTENT_STATE.PROGRESS
+                new_guid = await archive_service.duplicate_content(archived_doc)
+            else:  # item copied to desk - preserve embargo and schedule fields
+                extra_fields = [EMBARGO, PUBLISH_SCHEDULE, SCHEDULE_SETTINGS]
+                new_guid = await archive_service.duplicate_content(archived_doc, extra_fields=extra_fields)
 
-            new_guid = await archive_service.duplicate_content(archived_doc)
             guid_of_duplicated_items.append(new_guid)
 
         if kwargs.get("notify", True):

--- a/features/content_duplication.feature
+++ b/features/content_duplication.feature
@@ -356,7 +356,10 @@ Feature: Duplication of Content
       {"desk": "#desks._id#","type": "archive"}
       """
       And we get "/archive/#duplicate._id#"
-      Then there is no "publish_schedule" in response
+      Then we get existing resource
+      """
+      {"publish_schedule": "#DATE+1#"}
+      """
 
     @auth
     Scenario: Duplicate a published item and original item's ID is present in the duplicated item

--- a/features/content_duplication.feature
+++ b/features/content_duplication.feature
@@ -356,10 +356,7 @@ Feature: Duplication of Content
       {"desk": "#desks._id#","type": "archive"}
       """
       And we get "/archive/#duplicate._id#"
-      Then we get existing resource
-      """
-      {"publish_schedule": "#DATE+1#"}
-      """
+      Then there is no "publish_schedule" in response
 
     @auth
     Scenario: Duplicate a published item and original item's ID is present in the duplicated item
@@ -641,3 +638,20 @@ Feature: Duplication of Content
       """
       When we get "/archive/#duplicate._id#"
       Then we get "auto_publish" does not exist
+
+    @auth
+    Scenario: Duplicate preserves embargo and schedule when preserve flag is set
+      When we patch "/archive/123"
+      """
+      {"embargo": "#DATE+2#", "publish_schedule": "#DATE+1#", "schedule_settings": {"time_zone": "Europe/Helsinki"}}
+      """
+      Then we get response code 200
+      When we post to "/archive/123/duplicate" with success
+      """
+      {"desk": "#desks._id#","type": "archive", "preserve_embargo_and_schedule": true}
+      """
+      And we get "/archive/#duplicate._id#"
+      Then we get existing resource
+      """
+      {"embargo": "#DATE+2#", "publish_schedule": "#DATE+1#", "schedule_settings": {"time_zone": "Europe/Helsinki"}}
+      """


### PR DESCRIPTION
### Purpose
This PR ensures that embargo, publish_schedule, and schedule_settings fields are preserved when duplicating content to a desk in the "Send and Duplicate" flow. This is implemented via a client-side configuration flag that only affects the Send and Duplicate action, leaving regular duplication flows unchanged.

### What has changed
- Modified `DuplicateService.create_async()` to conditionally preserve fields when the flag is set
- Added test scenario 

### Steps to test
1. Configure `sendAndDuplicate.preserveEmbargoAndSchedule: true` in superdesk.config.js like for STT
2. Create a story on any desk and add embargo and publishing schedule dates
3. Save the story
4. Click the "Send and Duplicate" button (sends to the configured target desk, e.g., Deski)
5. Verify the duplicated story in the target desk has the same:
   - Embargo date
   - Publishing schedule date
   - Schedule settings (timezone)
6. Verify the original story retains its embargo and schedule information
7. Test regular "Duplicate To" flow - fields should NOT be preserved

Note: This PR is related to this [PR in superdesk-stt](https://github.com/superdesk/superdesk-stt/pull/710), and [PR in superdesk-client-core](https://github.com/superdesk/superdesk-client-core/pull/5079)

Resolves: [STT-1622](https://sofab.atlassian.net/browse/STT-1622)

[STT-1622]: https://sofab.atlassian.net/browse/STT-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ