### PR TITLE
fix flaky behave test

### DIFF
--- a/features/content_duplication.feature
+++ b/features/content_duplication.feature
@@ -646,6 +646,7 @@ Feature: Duplication of Content
       {"embargo": "#DATE+2#", "publish_schedule": "#DATE+1#", "schedule_settings": {"time_zone": "Europe/Helsinki"}}
       """
       Then we get response code 200
+      And we store response in "archive_with_schedule"
       When we post to "/archive/123/duplicate" with success
       """
       {"desk": "#desks._id#","type": "archive", "preserve_embargo_and_schedule": true}
@@ -653,5 +654,5 @@ Feature: Duplication of Content
       And we get "/archive/#duplicate._id#"
       Then we get existing resource
       """
-      {"embargo": "#DATE+2#", "publish_schedule": "#DATE+1#", "schedule_settings": {"time_zone": "Europe/Helsinki"}}
+      {"embargo": "#archive_with_schedule.embargo#", "publish_schedule": "#archive_with_schedule.publish_schedule#", "schedule_settings": {"time_zone": "#archive_with_schedule.schedule_settings.time_zone#"}}
       """


### PR DESCRIPTION
Fix flaky duplication test by making embargo/schedule assertion deterministic. Before it was sometimes failing due to 1s difference.

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

