### PR TITLE
[SDANSA-567] - Make Send to the default tab in the Publishing pane

### DIFF
--- a/apps/client_config.py
+++ b/apps/client_config.py
@@ -42,5 +42,6 @@ def init_app(app) -> None:
             "allow_updating_scheduled_items": app.config.get("ALLOW_UPDATING_SCHEDULED_ITEMS"),
             "corrections_workflow": app.config.get("CORRECTIONS_WORKFLOW"),
             "default_timezone": app.config.get("DEFAULT_TIMEZONE"),
+            "authoring_actions_default_tab": app.config.get("AUTHORING_ACTIONS_DEFAULT_TAB", "publish"),
         }
     )

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -1161,3 +1161,16 @@ PICTURE_METADATA_MAPPING = {}
 #: .. versionadded:: 2.8
 #:
 BROADCAST_ENABLED = strtobool(env("BROADCAST_ENABLED", "true"))
+CORRECTIONS_WORKFLOW = False
+
+#: Default tab shown in the authoring actions side panel
+#:
+#: .. versionadded:: 3.1
+#:
+AUTHORING_ACTIONS_DEFAULT_TAB = env("AUTHORING_ACTIONS_DEFAULT_TAB", "publish")
+if AUTHORING_ACTIONS_DEFAULT_TAB not in ("publish", "send_to"):
+    logger.warning(
+        "Invalid value for AUTHORING_ACTIONS_DEFAULT_TAB '%s'. Defaulting to 'publish'.",
+        AUTHORING_ACTIONS_DEFAULT_TAB,
+    )
+    AUTHORING_ACTIONS_DEFAULT_TAB = "publish"


### PR DESCRIPTION
This PR cherry-picked from STT-1484 into release/2.11 used by ANSA:
- Added new key in client config to support default tab in authoring actions to be "send_to" 

Note: This relates to this [PR](https://github.com/superdesk/superdesk-ansa/pull/32) in ANSA

Resolves: [SDANSA-567](https://sofab.atlassian.net/browse/SDANSA-567)



[SDANSA-567]: https://sofab.atlassian.net/browse/SDANSA-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ