### PR TITLE
add config for amazon s3 media id time prefix

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -392,6 +392,14 @@ Default: ``'us-east-1'``
 
 Default: ``''``
 
+``AMAZON_MEDIA_ID_TIME_PREFIX``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default: ``'hourly'``
+
+Controls the auto-generated prefix folder for Amazon media IDs.
+Supported values are ``'hourly'`` (``YYYYMMDDHH/``), ``'daily'`` (``YYYYMMDD/``), and ``'none'``.
+
 ``AMAZON_S3_SUBFOLDER``
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -566,6 +566,8 @@ AMAZON_SECRET_ACCESS_KEY = env("AMAZON_SECRET_ACCESS_KEY", "")
 AMAZON_REGION = env("AMAZON_REGION", "us-east-1")
 #: amazon bucket name
 AMAZON_CONTAINER_NAME = env("AMAZON_CONTAINER_NAME", "")
+#: time-based prefix for generated Amazon media IDs (hourly, daily, none)
+AMAZON_MEDIA_ID_TIME_PREFIX = env("AMAZON_MEDIA_ID_TIME_PREFIX", "hourly")
 #: use subfolder in bucket to store files
 AMAZON_S3_SUBFOLDER = env("AMAZON_S3_SUBFOLDER", "")
 #: adds ACL when putting to S3, can be set to ``public-read``, etc.

--- a/superdesk/storage/amazon_media_storage.py
+++ b/superdesk/storage/amazon_media_storage.py
@@ -136,8 +136,15 @@ class AmazonMediaStorage(SuperdeskMediaStorage):
             extension = str(guess_media_extension(content_type)) if content_type else ""
 
         if version is True:
-            # automatic version is set on hourly granularity.
-            version = "%s/" % time.strftime("%Y%m%d%H")
+            folder_granularity = str(self.app.config.get("AMAZON_MEDIA_ID_TIME_PREFIX", "hourly")).lower()
+
+            if folder_granularity == "daily":
+                version = "%s/" % time.strftime("%Y%m%d")
+            elif folder_granularity == "none":
+                version = ""
+            else:
+                # default automatic version is set on hourly granularity.
+                version = "%s/" % time.strftime("%Y%m%d%H")
         elif version is False:
             version = ""
         else:

--- a/tests/storage/amazon_media_storage_test.py
+++ b/tests/storage/amazon_media_storage_test.py
@@ -54,13 +54,15 @@ class AmazonMediaStorageTestCase(TestCase):
             media_id = self.amazon.media_id(filename)
             self.assertEqual(filename, media_id)
 
-        with patch.dict(self.app.config, {"AMAZON_MEDIA_ID_TIME_PREFIX": "daily"}):
-            media_id = self.amazon.media_id(filename)
-            self.assertEqual("%s/%s" % (time.strftime("%Y%m%d"), filename), media_id)
+        with patch("superdesk.storage.amazon_media_storage.time.strftime", return_value="20260102"):
+            with patch.dict(self.app.config, {"AMAZON_MEDIA_ID_TIME_PREFIX": "daily"}):
+                media_id = self.amazon.media_id(filename)
+                self.assertEqual("20260102/%s" % filename, media_id)
 
-        with patch.dict(self.app.config, {"AMAZON_MEDIA_ID_TIME_PREFIX": "hourly"}):
-            media_id = self.amazon.media_id(filename)
-            self.assertEqual("%s/%s" % (time.strftime("%Y%m%d%H"), filename), media_id)
+        with patch("superdesk.storage.amazon_media_storage.time.strftime", return_value="2026010215"):
+            with patch.dict(self.app.config, {"AMAZON_MEDIA_ID_TIME_PREFIX": "hourly"}):
+                media_id = self.amazon.media_id(filename)
+                self.assertEqual("2026010215/%s" % filename, media_id)
 
     def test_put_and_delete(self):
         """Test amazon if configured.

--- a/tests/storage/amazon_media_storage_test.py
+++ b/tests/storage/amazon_media_storage_test.py
@@ -47,6 +47,21 @@ class AmazonMediaStorageTestCase(TestCase):
                 self.assertTrue(s3.get_object.called)
                 self.assertEqual(s3.get_object.call_args[1], dict(Bucket="acname", Key=path))
 
+    def test_media_id_time_prefix(self):
+        filename = "test"
+
+        with patch.dict(self.app.config, {"AMAZON_MEDIA_ID_TIME_PREFIX": "none"}):
+            media_id = self.amazon.media_id(filename)
+            self.assertEqual(filename, media_id)
+
+        with patch.dict(self.app.config, {"AMAZON_MEDIA_ID_TIME_PREFIX": "daily"}):
+            media_id = self.amazon.media_id(filename)
+            self.assertEqual("%s/%s" % (time.strftime("%Y%m%d"), filename), media_id)
+
+        with patch.dict(self.app.config, {"AMAZON_MEDIA_ID_TIME_PREFIX": "hourly"}):
+            media_id = self.amazon.media_id(filename)
+            self.assertEqual("%s/%s" % (time.strftime("%Y%m%d%H"), filename), media_id)
+
     def test_put_and_delete(self):
         """Test amazon if configured.
 


### PR DESCRIPTION
with options daily | hourly | none.

SDBELGA-1045

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

