### PR TITLE
[SDBELGA-1051] improve(s3-async): Use ObjectId and store filename in metadata

### DIFF
--- a/superdesk/storage/amazon_media_storage.py
+++ b/superdesk/storage/amazon_media_storage.py
@@ -153,11 +153,19 @@ class AmazonMediaStorage(SuperdeskMediaStorage):
         return unidecode.unidecode(str(_id)).translate(get_translation_table())
 
     def media_id(self, version: bool | str = True) -> str:
-        """Get the ``media_id`` path for the given ``filename``.
+        """
+        Generates a media ID string using a configurable time-based prefix and a unique identifier.
 
-        if filename doesn't have an extension one is guessed,
-        and additional *version* option to have automatic version or not to have,
-        or to send a `string` one.
+        This method generates a media ID based on a configurable time granularity or provided
+        custom version. The time granularity settings can be 'hourly', 'daily', or 'none'. A unique
+        identifier is appended to the generated string, ensuring a unique media ID is produced
+        each time the method is called.
+
+        :param version: Determines the versioning format. If True, an automatic time-based
+                        version is generated based on the 'AMAZON_MEDIA_ID_TIME_PREFIX' configuration
+                        from the application. If False, no version prefix is included. If a string is
+                        provided, it is used as a custom prefix after stripping any surrounding slashes.
+        :returns: A unique media ID string composed of the specified versioning format and a unique identifier.
         """
 
         if version is True:
@@ -324,8 +332,9 @@ class AmazonMediaStorage(SuperdeskMediaStorage):
             # probably better to turn on/off public-read on the bucket instead
             kwargs["ACL"] = acl
 
-        kwargs.setdefault("Metadata", {})
-        kwargs["Metadata"]["filename"] = filename
+        if filename:
+            kwargs.setdefault("Metadata", {})
+            kwargs["Metadata"]["filename"] = self._make_s3_safe(filename)
 
         body = content.stream if isinstance(content, FileStorage) else content
 

--- a/superdesk/storage/amazon_media_storage.py
+++ b/superdesk/storage/amazon_media_storage.py
@@ -20,13 +20,12 @@ import time
 import unidecode
 from io import BytesIO
 
-from os.path import splitext
-from urllib.parse import urlparse
 from botocore.client import Config
 from werkzeug.datastructures import Range, FileStorage
+from bson import ObjectId
 
 from superdesk.core.types import SuperdeskFile, SuperdeskAsyncFile
-from superdesk.media.media_operations import download_file_from_url, download_file_from_url_async, guess_media_extension
+from superdesk.media.media_operations import download_file_from_url, download_file_from_url_async
 from superdesk.utc import query_datetime
 from . import SuperdeskMediaStorage
 
@@ -38,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 class AmazonObjectWrapper(SuperdeskFile):
-    def __init__(self, s3_object, name, metadata):
+    def __init__(self, s3_object, key, metadata):
         super().__init__()
 
         s3_body = s3_object["Body"]
@@ -51,16 +50,15 @@ class AmazonObjectWrapper(SuperdeskFile):
         self.seek(0)
         self.content_type = s3_object["ContentType"]
         self.length = int(s3_object["ContentLength"])
-        self._name = name
-        self.filename = name
-        self.metadata = metadata
+        self.metadata = metadata or {}
+        self._name = self.filename = self.metadata.get("filename") or key
         self.upload_date = s3_object["LastModified"]
         self.md5 = s3_object["ETag"][1:-1]
-        self._id = name
+        self._id = key
 
 
 class AmazonObjectAsyncWrapper(SuperdeskAsyncFile):
-    def __init__(self, s3_object, name, metadata, begin: int = 0, end: int | None = None):
+    def __init__(self, s3_object, key, metadata, begin: int = 0, end: int | None = None):
         if s3_object.get("ContentRange"):
             # We're using a range to get partial data
             # Get the total size of the file from the range header
@@ -68,16 +66,20 @@ class AmazonObjectAsyncWrapper(SuperdeskAsyncFile):
         else:
             length = int(s3_object["ContentLength"])
 
+        if metadata is None:
+            metadata = {}
+
+        filename = metadata.get("filename") or key
         super().__init__(
             buffer=s3_object["Body"],
             content_type=s3_object["ContentType"],
             length=length,
-            name=name,
-            filename=name,
+            name=filename,
+            filename=filename,
             metadata=metadata,
             upload_date=s3_object["LastModified"],
             md5=s3_object["ETag"][1:-1],
-            media_id=name,
+            media_id=key,
             begin=begin,
             end=end,
         )
@@ -150,19 +152,13 @@ class AmazonMediaStorage(SuperdeskMediaStorage):
 
         return unidecode.unidecode(str(_id)).translate(get_translation_table())
 
-    def media_id(self, filename, content_type=None, version=True):
+    def media_id(self, version: bool | str = True) -> str:
         """Get the ``media_id`` path for the given ``filename``.
 
         if filename doesn't have an extension one is guessed,
         and additional *version* option to have automatic version or not to have,
         or to send a `string` one.
         """
-        path = urlparse(filename).path.split("/")[-1]
-        file_extension = splitext(path)[1]
-
-        extension = ""
-        if not file_extension:
-            extension = str(guess_media_extension(content_type)) if content_type else ""
 
         if version is True:
             # automatic version is set on 15mins granularity.
@@ -173,7 +169,7 @@ class AmazonMediaStorage(SuperdeskMediaStorage):
         else:
             version = "%s/" % version.strip("/")
 
-        return "%s%s%s" % (version, self._make_s3_safe(filename), extension)
+        return f"{version}{ObjectId()}"
 
     def fetch_rendition(self, rendition, resource=None):
         stream, name, mime = download_file_from_url(rendition.get("href"))
@@ -291,7 +287,9 @@ class AmazonMediaStorage(SuperdeskMediaStorage):
     def extract_metadata_from_headers(self, request_headers):
         headers = {}
         for key, value in request_headers.items():
-            if self.user_metadata_header in key:
+            if key == "filename":
+                headers["filename"] = value
+            elif self.user_metadata_header in key:
                 new_key = key.split(self.user_metadata_header)[1]
                 if value:
                     try:
@@ -300,9 +298,9 @@ class AmazonMediaStorage(SuperdeskMediaStorage):
                         logger.exception(ex)
         return headers
 
-    def _get_put_id(self, filename=None, content_type=None, _id=None, version=True, folder=None):
+    def _get_put_id(self, _id: str | None = None, version: bool | str = True, folder: str | None = None) -> str:
         if not _id:
-            _id = self.media_id(filename, content_type=content_type, version=version)
+            _id = self.media_id(version)
 
         if folder:
             _id = "%s/%s" % (folder.rstrip("/"), _id)
@@ -325,6 +323,9 @@ class AmazonMediaStorage(SuperdeskMediaStorage):
             # not sure it's really needed here,
             # probably better to turn on/off public-read on the bucket instead
             kwargs["ACL"] = acl
+
+        kwargs.setdefault("Metadata", {})
+        kwargs["Metadata"]["filename"] = filename
 
         body = content.stream if isinstance(content, FileStorage) else content
 
@@ -364,7 +365,7 @@ class AmazonMediaStorage(SuperdeskMediaStorage):
         #      and they are anyway stored in MongoDB (and still part of the file). See issue SD-4231
         logger.debug("Going to save file file=%s media=%s " % (filename, _id))
 
-        media_id = self._get_put_id(filename, content_type, _id, version, folder)
+        media_id = self._get_put_id(_id, version, folder)
         found = self._check_exists(media_id)
         if found:
             return media_id
@@ -411,7 +412,7 @@ class AmazonMediaStorage(SuperdeskMediaStorage):
         #      and they are anyway stored in MongoDB (and still part of the file). See issue SD-4231
         logger.debug("Going to save file file=%s media=%s " % (filename, _id))
 
-        media_id = self._get_put_id(filename, content_type, _id, version, folder)
+        media_id = self._get_put_id(_id, version, folder)
         found = await self._check_exists_async(media_id)
         if found:
             return media_id

--- a/tests/storage/amazon_media_storage_test.py
+++ b/tests/storage/amazon_media_storage_test.py
@@ -29,18 +29,18 @@ class AmazonMediaStorageTestCase(TestCase):
         p.start()
         self.addCleanup(p.stop)
 
-    def test_media_url(self):
-        filename = "test"
+    @patch("superdesk.storage.amazon_media_storage.ObjectId", return_value="507f1f77bcf86cd799439011")
+    def test_media_url(self, _mock_object_id):
         # automatic version is set on hourly granularity.
         time_id = time.strftime("%Y%m%d%H")
-        media_id = self.amazon.media_id(filename)
-        self.assertEqual("%s/%s" % (time_id, filename), media_id)
+        media_id = self.amazon.media_id()
+        self.assertEqual(f"{time_id}/507f1f77bcf86cd799439011", media_id)
         self.assertEqual(self.amazon.url_for_media(media_id), "https://acname.s3-us-east-1.amazonaws.com/%s" % media_id)
         sub = "test-sub"
         settings = {"AMAZON_S3_SUBFOLDER": sub, "MEDIA_PREFIX": "https://acname.s3-us-east-1.amazonaws.com/" + sub}
         with patch.dict(self.app.config, settings):
-            media_id = self.amazon.media_id(filename)
-            self.assertEqual("%s/%s" % (time_id, filename), media_id)
+            media_id = self.amazon.media_id()
+            self.assertEqual(f"{time_id}/507f1f77bcf86cd799439011", media_id)
             path = "%s/%s" % (sub, media_id)
             self.assertEqual(self.amazon.url_for_media(media_id), "https://acname.s3-us-east-1.amazonaws.com/%s" % path)
             with patch.object(self.amazon, "client") as s3:
@@ -48,22 +48,21 @@ class AmazonMediaStorageTestCase(TestCase):
                 self.assertTrue(s3.get_object.called)
                 self.assertEqual(s3.get_object.call_args[1], dict(Bucket="acname", Key=path))
 
-    def test_media_id_time_prefix(self):
-        filename = "test"
-
+    @patch("superdesk.storage.amazon_media_storage.ObjectId", return_value="507f1f77bcf86cd799439011")
+    def test_media_id_time_prefix(self, _mock_object_id):
         with patch.dict(self.app.config, {"AMAZON_MEDIA_ID_TIME_PREFIX": "none"}):
-            media_id = self.amazon.media_id(filename)
-            self.assertEqual(filename, media_id)
+            media_id = self.amazon.media_id()
+            self.assertEqual("507f1f77bcf86cd799439011", media_id)
 
         with patch("superdesk.storage.amazon_media_storage.time.strftime", return_value="20260102"):
             with patch.dict(self.app.config, {"AMAZON_MEDIA_ID_TIME_PREFIX": "daily"}):
-                media_id = self.amazon.media_id(filename)
-                self.assertEqual("20260102/%s" % filename, media_id)
+                media_id = self.amazon.media_id()
+                self.assertEqual("20260102/507f1f77bcf86cd799439011", media_id)
 
         with patch("superdesk.storage.amazon_media_storage.time.strftime", return_value="2026010215"):
             with patch.dict(self.app.config, {"AMAZON_MEDIA_ID_TIME_PREFIX": "hourly"}):
-                media_id = self.amazon.media_id(filename)
-                self.assertEqual("2026010215/%s" % filename, media_id)
+                media_id = self.amazon.media_id()
+                self.assertEqual("2026010215/507f1f77bcf86cd799439011", media_id)
 
     def test_put_and_delete(self):
         """Test amazon if configured.
@@ -84,22 +83,24 @@ class AmazonMediaStorageTestCase(TestCase):
         else:
             self.assertTrue(True)
 
-    def test_put_into_folder(self):
+    @patch("superdesk.storage.amazon_media_storage.ObjectId", return_value="507f1f77bcf86cd799439011")
+    @patch("superdesk.storage.amazon_media_storage.time.strftime", return_value="2026010215")
+    def test_put_into_folder(self, mock_time_strftime, _mock_object_id):
         data = b"test data"
         folder = "s3test"
         filename = "abc123.zip"
         content_type = "application/zip"
         self.amazon.client.put_object = Mock()
-        self.amazon.media_id = Mock(return_value=filename)
         self.amazon._check_exists = Mock(return_value=False)
 
         self.amazon.put(data, filename, content_type, folder=folder)
 
         kwargs = {
-            "Key": "{}/{}".format(folder, filename),
+            "Key": f"{folder}/2026010215/507f1f77bcf86cd799439011",
             "Body": data,
             "Bucket": "acname",
             "ContentType": content_type,
+            "Metadata": {"filename": filename},
         }
         self.amazon.client.put_object.assert_called_once_with(**kwargs)
 
@@ -148,22 +149,19 @@ class AmazonMediaStorageTestCase(TestCase):
         # leave empty when there is no extension
         self.assertEqual("", guess_media_extension("audio/foo"))
 
-    def test_media_url_none_utf8(self):
+    @patch("superdesk.storage.amazon_media_storage.ObjectId", return_value="507f1f77bcf86cd799439011")
+    def test_media_url_none_utf8(self, _mock_object_id):
         filename = "[DIARY NOTE] – Victory In The Pacific Day Commemoration - Thursday (1)"
         # automatic version is set on hourly granularity.
         time_id = time.strftime("%Y%m%d%H")
-        media_id = self.amazon.media_id(filename)
-        self.assertEqual(
-            "%s/%s" % (time_id, "DIARY NOTE - Victory In The Pacific Day Commemoration - Thursday (1)"), media_id
-        )
+        media_id = self.amazon.media_id()
+        self.assertEqual(f"{time_id}/507f1f77bcf86cd799439011", media_id)
         self.assertEqual(self.amazon.url_for_media(media_id), "https://acname.s3-us-east-1.amazonaws.com/%s" % media_id)
         sub = "test-sub"
         settings = {"AMAZON_S3_SUBFOLDER": sub, "MEDIA_PREFIX": "https://acname.s3-us-east-1.amazonaws.com/" + sub}
         with patch.dict(self.app.config, settings):
-            media_id = self.amazon.media_id(filename)
-            self.assertEqual(
-                "%s/%s" % (time_id, "DIARY NOTE - Victory In The Pacific Day Commemoration - Thursday (1)"), media_id
-            )
+            media_id = self.amazon.media_id()
+            self.assertEqual(f"{time_id}/507f1f77bcf86cd799439011", media_id)
             path = "%s/%s" % (sub, media_id)
             self.assertEqual(self.amazon.url_for_media(media_id), "https://acname.s3-us-east-1.amazonaws.com/%s" % path)
             with patch.object(self.amazon, "client") as s3:
@@ -171,7 +169,8 @@ class AmazonMediaStorageTestCase(TestCase):
                 self.assertTrue(s3.get_object.called)
                 self.assertEqual(s3.get_object.call_args[1], dict(Bucket="acname", Key=path))
 
-    def test_put_into_folder_none_utf8(self):
+    @patch("superdesk.storage.amazon_media_storage.ObjectId", return_value="507f1f77bcf86cd799439011")
+    def test_put_into_folder_none_utf8(self, _mock_object_id):
         data = b"test data"
         folder = "s3test"
         filename = "[DIARY NOTE] – Victory In The Pacific Day Commemoration - Thursday (1).pdf"
@@ -182,10 +181,11 @@ class AmazonMediaStorageTestCase(TestCase):
         self.amazon.put(data, filename, content_type, folder=folder, version=False)
 
         kwargs = {
-            "Key": "{}/{}".format(folder, "DIARY NOTE - Victory In The Pacific Day Commemoration - Thursday (1).pdf"),
+            "Key": f"{folder}/507f1f77bcf86cd799439011",
             "Body": data,
             "Bucket": "acname",
             "ContentType": content_type,
+            "Metadata": {"filename": "DIARY NOTE - Victory In The Pacific Day Commemoration - Thursday (1).pdf"},
         }
         self.amazon.client.put_object.assert_called_once_with(**kwargs)
 
@@ -198,7 +198,9 @@ class AmazonMediaStorageTestCase(TestCase):
         kwargs = {"Bucket": "acname", "Key": "DIARY NOTE - Victory In The Pacific Day Commemoration - Thursday (1).pdf"}
         self.amazon.client.get_object.assert_called_once_with(**kwargs)
 
-    def test_mimetype_detect(self):
+    @patch("superdesk.storage.amazon_media_storage.ObjectId", return_value="507f1f77bcf86cd799439011")
+    @patch("superdesk.storage.amazon_media_storage.time.strftime", return_value="2026010215")
+    def test_mimetype_detect(self, mock_time_strftime, _mock_object_id):
         # keep default mimetype
         content = b"bytes are here"
         filename = "extensionless"
@@ -206,14 +208,14 @@ class AmazonMediaStorageTestCase(TestCase):
         folder = "f1"
         self.amazon.client.put_object = Mock()
         self.amazon._check_exists = Mock(return_value=False)
-        self.amazon.media_id = Mock(return_value=filename)
         self.amazon.put(content, filename, content_type, folder=folder)
         self.amazon.client.put_object.assert_called_once_with(
             **{
-                "Key": "{}/{}".format(folder, filename),
+                "Key": f"{folder}/2026010215/507f1f77bcf86cd799439011",
                 "Body": content,
                 "Bucket": "acname",
                 "ContentType": content_type,
+                "Metadata": {"filename": filename},
             }
         )
 
@@ -224,14 +226,14 @@ class AmazonMediaStorageTestCase(TestCase):
         folder = "f1"
         self.amazon.client.put_object = Mock()
         self.amazon._check_exists = Mock(return_value=False)
-        self.amazon.media_id = Mock(return_value=filename)
         self.amazon.put(content, filename, content_type, folder=folder)
         self.amazon.client.put_object.assert_called_once_with(
             **{
-                "Key": "{}/{}".format(folder, filename),
+                "Key": f"{folder}/2026010215/507f1f77bcf86cd799439011",
                 "Body": b"bytes are here",
                 "Bucket": "acname",
                 "ContentType": "text/css",
+                "Metadata": {"filename": filename},
             }
         )
 
@@ -241,14 +243,14 @@ class AmazonMediaStorageTestCase(TestCase):
         folder = "f1"
         self.amazon.client.put_object = Mock()
         self.amazon._check_exists = Mock(return_value=False)
-        self.amazon.media_id = Mock(return_value=filename)
         self.amazon.put(content, filename, content_type, folder=folder)
         self.amazon.client.put_object.assert_called_once_with(
             **{
-                "Key": "{}/{}".format(folder, filename),
+                "Key": f"{folder}/2026010215/507f1f77bcf86cd799439011",
                 "Body": b"bytes are here",
                 "Bucket": "acname",
                 "ContentType": "image/jpeg",
+                "Metadata": {"filename": filename},
             }
         )
 
@@ -261,14 +263,14 @@ class AmazonMediaStorageTestCase(TestCase):
             folder = "f1"
             self.amazon.client.put_object = Mock()
             self.amazon._check_exists = Mock(return_value=False)
-            self.amazon.media_id = Mock(return_value=filename)
             self.amazon.put(content, filename, content_type, folder=folder)
             self.amazon.client.put_object.assert_called_once_with(
                 **{
-                    "Key": "{}/{}".format(folder, filename),
+                    "Key": f"{folder}/2026010215/507f1f77bcf86cd799439011",
                     "Body": content,
                     "Bucket": "acname",
                     "ContentType": "image/jpeg",
+                    "Metadata": {"filename": filename},
                 }
             )
 
@@ -278,14 +280,14 @@ class AmazonMediaStorageTestCase(TestCase):
                 folder = "f1"
                 self.amazon.client.put_object = Mock()
                 self.amazon._check_exists = Mock(return_value=False)
-                self.amazon.media_id = Mock(return_value=filename)
                 self.amazon.put(content, filename, content_type, folder=folder)
                 self.amazon.client.put_object.assert_called_once_with(
                     **{
-                        "Key": "{}/{}".format(folder, filename),
+                        "Key": f"{folder}/2026010215/507f1f77bcf86cd799439011",
                         "Body": content,
                         "Bucket": "acname",
                         "ContentType": "application/vnd.ms-excel",
+                        "Metadata": {"filename": filename},
                     }
                 )
 
@@ -295,14 +297,14 @@ class AmazonMediaStorageTestCase(TestCase):
                 folder = "f1"
                 self.amazon.client.put_object = Mock()
                 self.amazon._check_exists = Mock(return_value=False)
-                self.amazon.media_id = Mock(return_value=filename)
                 self.amazon.put(content, filename, content_type, folder=folder)
                 self.amazon.client.put_object.assert_called_once_with(
                     **{
-                        "Key": "{}/{}".format(folder, filename),
+                        "Key": f"{folder}/2026010215/507f1f77bcf86cd799439011",
                         "Body": content,
                         "Bucket": "acname",
                         "ContentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                        "Metadata": {"filename": filename},
                     }
                 )
 
@@ -312,13 +314,13 @@ class AmazonMediaStorageTestCase(TestCase):
                 folder = "f1"
                 self.amazon.client.put_object = Mock()
                 self.amazon._check_exists = Mock(return_value=False)
-                self.amazon.media_id = Mock(return_value=filename)
                 self.amazon.put(content, filename, content_type, folder=folder)
                 self.amazon.client.put_object.assert_called_once_with(
                     **{
-                        "Key": "{}/{}".format(folder, filename),
+                        "Key": f"{folder}/2026010215/507f1f77bcf86cd799439011",
                         "Body": content,
                         "Bucket": "acname",
                         "ContentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                        "Metadata": {"filename": filename},
                     }
                 )


### PR DESCRIPTION
### Purpose
Using filename for the ID deviates from the way Mongo GridFS uses ObjectIDs. This can cause issues for other system when/if the system changes from GridFS to S3.

### What has changed
* Use ObjectIDs for IDs when using Amazon S3 storage (still support folder and version prefixes)
* Store the filename in the metadata of the S3 object (similar to how GridFS stores the filename in it's fs.files collection)
* Still support downloading files if they're using the older filename approach

Resolves: [SDBELGA-1051](https://sofab.atlassian.net/browse/SDBELGA-1051)
Note: This is the async version from https://github.com/superdesk/superdesk-core/pull/3169


[SDBELGA-1051]: https://sofab.atlassian.net/browse/SDBELGA-1051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ