### PR TITLE
[SDCP-1074] fix(publish): Dont use lock in CeleryConsumer.process_tasks

### DIFF
--- a/superdesk/publish_async/consumers/celery_consumer.py
+++ b/superdesk/publish_async/consumers/celery_consumer.py
@@ -20,9 +20,8 @@ class CeleryPublishConsumer(AsyncioPublishConsumer):
     publishing consumer.
 
     This class is responsible for coordinating and ensuring the transmission of tasks
-    utilizing Celery's asynchronous task queue system. It ensures no concurrent task
-    execution for the same subscriber while managing the process lifecycle, including
-    locking and unlocking resources.
+    utilizing Celery's asynchronous task queue system. It submits tasks for background
+    processing via Celery, integrating with its asynchronous execution model.
 
     Attributes:
         Inherits all attributes from AsyncioPublishConsumer.
@@ -32,12 +31,10 @@ class CeleryPublishConsumer(AsyncioPublishConsumer):
 
     async def process_tasks(self, subscriber: SubscribersResource, tasks: list[PublishQueueResource]) -> None:
         """
-        An asynchronous method to process and transmit tasks for a given subscriber.
+        Asynchronously process and transmit tasks for a given subscriber.
 
-        This method processes the provided tasks by acquiring a lock to ensure that
-        multiple tasks for the same subscriber do not overlap. For each task, it
-        schedules its execution in a high-priority Celery queue based on the task's
-        priority. After processing, the lock is released.
+        This method iterates over the provided tasks and schedules each one for
+        execution in a high-priority Celery queue based on the task's priority.
 
         :param subscriber: The subscriber resource for which the tasks are being processed.
         :param tasks: A list of tasks to be processed and transmitted.

--- a/superdesk/publish_async/consumers/celery_consumer.py
+++ b/superdesk/publish_async/consumers/celery_consumer.py
@@ -43,18 +43,8 @@ class CeleryPublishConsumer(AsyncioPublishConsumer):
         :param tasks: A list of tasks to be processed and transmitted.
         """
 
-        # We assume all tasks come from the same subscriber
-        lock_name = get_lock_id("Subscriber", "Transmit", str(subscriber.id))
-        if not lock(lock_name, expire=610):
-            logger.info(f"Task: {lock_name} is already running.")
-            return
-
-        try:
-            for task in tasks:
-                await transmit_item.apply_async(args=[task.id], queue=get_high_priority_celery_queue(task.priority))
-        finally:
-            logger.debug(f"unlock {lock_name}")
-            unlock(lock_name)
+        for task in tasks:
+            await transmit_item.apply_async(args=[task.id], queue=get_high_priority_celery_queue(task.priority))
 
 
 @celery.task(soft_time_limit=600, expires=10)


### PR DESCRIPTION
### Purpose
There is a race condition upon publishing items, if 2 workers are trying to publish to a subscriber at the exact same time. This results in the 2nd item not publishing and staying in a `routing` state, and `Task: Subscriber-Transmit-618e38c3d603dede48dbf8da is already running` in the logs. Basically silently ignoring the publish request.

### What has changed
* Remove the lock when publishing the item directly through the CeleryPublishConsumer (the lock is only required when publishing scheduled/retrying etc items, which is in another function)

Resolves: [SDCP-1074](https://sofab.atlassian.net/browse/SDCP-1074)
Note: This will **need** to be cherry-picked into a v3.4 release as well


[SDCP-1074]: https://sofab.atlassian.net/browse/SDCP-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ