### PR TITLE
[SDBELGA-1056] Add `get_all_batch_elastic` to Eve resource service

### DIFF
--- a/superdesk/eve_backend.py
+++ b/superdesk/eve_backend.py
@@ -19,6 +19,7 @@ from pymongo.collation import Collation
 from flask import current_app as app, json
 from eve.utils import document_etag, config, ParsedRequest
 from eve.io.mongo import MongoJSONEncoder
+from eve_elastic.elastic import ElasticCursor
 from superdesk.utc import utcnow
 from superdesk.logging import logger, item_msg
 from eve.methods.common import resolve_document_etag
@@ -113,6 +114,19 @@ class EveBackend:
         search_backend = self._lookup_backend(endpoint_name)
         if search_backend:
             return search_backend.find(endpoint_name, req, {})[0]
+        else:
+            logger.warn("there is no search backend for %s" % endpoint_name)
+
+    def search_raw(self, endpoint_name: str, source: dict) -> ElasticCursor | None:
+        """Search for items using search backend, without applying resource-specific filters.
+
+        :param endpoint_name: The name of the endpoint to perform the search on.
+        :param source: A dictionary containing the data to be used for the search
+        :return: An instance of ElasticCursor if the search is successful, or None if no backend is found.
+        """
+
+        if search_backend := self._lookup_backend(endpoint_name):
+            return search_backend.search(source, endpoint_name)
         else:
             logger.warn("there is no search backend for %s" % endpoint_name)
 

--- a/superdesk/eve_backend.py
+++ b/superdesk/eve_backend.py
@@ -129,6 +129,7 @@ class EveBackend:
             return search_backend.search(source, endpoint_name)
         else:
             logger.warn("there is no search backend for %s" % endpoint_name)
+            return None
 
     def get(self, endpoint_name, req, lookup, **kwargs):
         """Get list of items.

--- a/superdesk/eve_backend.py
+++ b/superdesk/eve_backend.py
@@ -115,7 +115,7 @@ class EveBackend:
         if search_backend:
             return search_backend.find(endpoint_name, req, {})[0]
         else:
-            logger.warn("there is no search backend for %s" % endpoint_name)
+            logger.warning("there is no search backend for %s" % endpoint_name)
 
     def search_raw(self, endpoint_name: str, source: dict) -> ElasticCursor | None:
         """Search for items using search backend, without applying resource-specific filters.
@@ -128,7 +128,7 @@ class EveBackend:
         if search_backend := self._lookup_backend(endpoint_name):
             return search_backend.search(source, endpoint_name)
         else:
-            logger.warn("there is no search backend for %s" % endpoint_name)
+            logger.warning("there is no search backend for %s" % endpoint_name)
             return None
 
     def get(self, endpoint_name, req, lookup, **kwargs):

--- a/superdesk/services.py
+++ b/superdesk/services.py
@@ -12,7 +12,7 @@ import random
 import pymongo
 import logging
 
-from typing import Dict, Any, List, Optional, Union
+from typing import Dict, Any, List, Optional, Union, Generator
 from flask import current_app as app, json, g
 from eve.utils import ParsedRequest, config
 from eve.methods.common import resolve_document_etag
@@ -164,6 +164,58 @@ class BaseService:
                 last_id = item["_id"]
         else:
             logger.warning("Not enough iterations for resource %s", self.datasource)
+
+    def get_all_batch_elastic(
+        self,
+        query: dict | None = None,
+        size: int = 500,
+        max_iterations: int = 10000,
+    ) -> Generator[dict, None, None]:
+        """Helper function to get all items from this resource, in batches
+
+        The default arguments allow iterating over 5 million documents.
+        If more is needed, then consider increasing ``size`` and/or ``max_iterations``
+
+        .. note::
+            If multiple documents share the same ``_created`` and ``_updated`` values,
+            pagination can become inconsistent. If this is an issue, consider using a more
+            stable unique tiebreaker (e.g. a combination of ``_created`` ``_updated`` and ``_id``).
+
+        :param query: An optional elasticsearch query used to filter items for
+        :param size: The number of items to fetch on each iteration
+        :param max_iterations: Maximum number of iterations to run, before returning gracefully
+        :return: An generator yielding a dictionary of documents
+        """
+
+        es_query = query.copy() if query else {}
+        es_query["size"] = size
+        es_query.setdefault("sort", [{"_created": "asc"}, {"_updated": "asc"}])
+
+        for _ in range(max_iterations):
+            cursor = self.backend.search_raw(self.datasource, es_query)
+            if not cursor:
+                logger.warning("No cursor returned for search", extra={"resource": self.datasource})
+                break
+
+            items = list(cursor)
+
+            if not len(items):
+                break
+
+            yield from items
+
+            try:
+                last_hit = cursor.hits["hits"]["hits"][-1]
+            except (KeyError, IndexError, TypeError):
+                last_hit = None
+
+            if not last_hit or not last_hit.get("sort"):
+                logger.warning("No sort value found in es hit for resource", extra={"resource": self.datasource})
+                break
+
+            es_query["search_after"] = last_hit["sort"]
+        else:
+            logger.warning("Not enough iterations for resource", extra={"resource": self.datasource})
 
     def _validator(self, skip_validation=False):
         resource_def = app.config["DOMAIN"][self.datasource]

--- a/superdesk/services.py
+++ b/superdesk/services.py
@@ -12,7 +12,7 @@ import random
 import pymongo
 import logging
 
-from typing import Dict, Any, List, Optional, Union, Generator
+from typing import Dict, Any, List, Optional, Union, Generator, Literal
 from flask import current_app as app, json, g
 from eve.utils import ParsedRequest, config
 from eve.methods.common import resolve_document_etag
@@ -167,7 +167,7 @@ class BaseService:
 
     def get_all_batch_elastic(
         self,
-        query: dict | None = None,
+        query: dict,
         size: int = 500,
         max_iterations: int = 10000,
     ) -> Generator[dict, None, None]:
@@ -181,15 +181,23 @@ class BaseService:
             pagination can become inconsistent. If this is an issue, consider using a more
             stable unique tiebreaker (e.g. a combination of ``_created`` ``_updated`` and ``_id``).
 
-        :param query: An optional elasticsearch query used to filter items for
+        .. note::
+            This helper uses ``search_after`` without an Elasticsearch point-in-time (PIT) or
+            snapshot. As a result, if the underlying index is updated while iteration is in
+            progress, documents may move between pages, be skipped, or be returned more than
+            once. It should therefore only be relied upon against a quiescent index, or in
+            contexts where such inconsistencies are acceptable.
+
+        :param query: An Elasticsearch query used to filter items returned by this resource
         :param size: The number of items to fetch on each iteration
         :param max_iterations: Maximum number of iterations to run, before returning gracefully
-        :return: An generator yielding a dictionary of documents
+        :return: A generator yielding a dictionary of documents
         """
 
         es_query = query.copy() if query else {}
         es_query["size"] = size
-        es_query.setdefault("sort", [{"_created": "asc"}, {"_updated": "asc"}])
+        if not es_query.get("sort"):
+            raise SuperdeskApiError.badRequestError("Running `get_all_batch_elastic` without a sort is not supported")
 
         for _ in range(max_iterations):
             cursor = self.backend.search_raw(self.datasource, es_query)
@@ -197,12 +205,13 @@ class BaseService:
                 logger.warning("No cursor returned for search", extra={"resource": self.datasource})
                 break
 
-            items = list(cursor)
+            items_yielded = False
+            for item in cursor:
+                items_yielded = True
+                yield item
 
-            if not len(items):
+            if not items_yielded:
                 break
-
-            yield from items
 
             try:
                 last_hit = cursor.hits["hits"]["hits"][-1]

--- a/tests/datalayer_tests.py
+++ b/tests/datalayer_tests.py
@@ -14,6 +14,7 @@ import superdesk
 from bson import ObjectId
 from superdesk.tests import TestCase
 from superdesk.datalayer import SuperdeskJSONEncoder
+from superdesk.errors import SuperdeskApiError
 
 
 class DatalayerTestCase(TestCase):
@@ -96,6 +97,14 @@ class DatalayerTestCase(TestCase):
             assert item["_id"] == "test-{:04d}".format(counter)
             counter += 1
         assert counter == expected_item_count
+
+    def test_get_all_batch_elastic_required_sort_field(self):
+        service = superdesk.get_resource_service("archive")
+
+        with self.assertRaises(SuperdeskApiError) as ctx:
+            service.get_all_batch_elastic({}).send(None)
+
+        self.assertEqual(ctx.exception.status_code, 400)  # bad request error
 
     def test_get_all_batch_elastic_with_lookup(self):
         expected_item_count = 20

--- a/tests/datalayer_tests.py
+++ b/tests/datalayer_tests.py
@@ -80,14 +80,42 @@ class DatalayerTestCase(TestCase):
         expected_item_count = 500
         items = []
         for i in range(expected_item_count):
-            items.append({"_id": "test-{:04d}".format(i)})
+            items.append({
+                "_id": "test-{:04d}".format(i),
+                "guid": "test-{:04d}".format(i),
+            })
         service = superdesk.get_resource_service("archive")
         service.create(items)
 
         # Use custom sort, as all items would have the same ``_created`` and ``_updated`` values
-        query = {"sort": [{"_created": "asc"}, {"_updated": "asc"}, {"_id": "asc"}]}
+        query = {"sort": [{"_created": "asc"}, {"_updated": "asc"}, {"guid": "asc"}]}
         counter = 0
         for item in service.get_all_batch_elastic(query, size=5):
             assert item["_id"] == "test-{:04d}".format(counter)
             counter += 1
         assert counter == expected_item_count
+
+    def test_get_all_batch_elastic_with_lookup(self):
+        expected_item_count = 20
+        matching = []
+        other = []
+        for i in range(expected_item_count):
+            matching.append({"_id": f"match-{i:04d}", "guid": f"match-{i:04d}", "slugline": "keep"})
+            other.append({"_id": f"skip-{i:04d}", "guid": f"skip-{i:04d}", "slugline": "drop"})
+
+        service = superdesk.get_resource_service("archive")
+        service.create(matching + other)
+
+        query = {
+            "query": {"match": {"slugline": "keep"}},
+            # Use custom sort, as all items would have the same ``_created`` and ``_updated`` values
+            "sort": [{"_created": "asc"}, {"_updated": "asc"}, {"guid": "asc"}],
+        }
+        seen = []
+        for item in service.get_all_batch_elastic(query, size=5):
+            seen.append(item)
+
+        assert len(seen) == expected_item_count
+        assert all(doc["slugline"] == "keep" for doc in seen)
+        # ensure we did not accidentally yield items from the other slugline
+        assert all(not doc["_id"].startswith("skip-") for doc in seen)

--- a/tests/datalayer_tests.py
+++ b/tests/datalayer_tests.py
@@ -75,3 +75,19 @@ class DatalayerTestCase(TestCase):
         service.create(items)
         service.delete({})
         assert 0 == service.find({}).count()
+
+    def test_get_all_batch_elastic(self):
+        expected_item_count = 500
+        items = []
+        for i in range(expected_item_count):
+            items.append({"_id": "test-{:04d}".format(i)})
+        service = superdesk.get_resource_service("archive")
+        service.create(items)
+
+        # Use custom sort, as all items would have the same ``_created`` and ``_updated`` values
+        query = {"sort": [{"_created": "asc"}, {"_updated": "asc"}, {"_id": "asc"}]}
+        counter = 0
+        for item in service.get_all_batch_elastic(query, size=5):
+            assert item["_id"] == "test-{:04d}".format(counter)
+            counter += 1
+        assert counter == expected_item_count

--- a/tests/datalayer_tests.py
+++ b/tests/datalayer_tests.py
@@ -80,10 +80,12 @@ class DatalayerTestCase(TestCase):
         expected_item_count = 500
         items = []
         for i in range(expected_item_count):
-            items.append({
-                "_id": "test-{:04d}".format(i),
-                "guid": "test-{:04d}".format(i),
-            })
+            items.append(
+                {
+                    "_id": "test-{:04d}".format(i),
+                    "guid": "test-{:04d}".format(i),
+                }
+            )
         service = superdesk.get_resource_service("archive")
         service.create(items)
 


### PR DESCRIPTION
### Purpose
We didn't have a way to iterate, in batches, items in Elasticsearch. The only way to do it was manually, and using the `from` and `to` params (which is not advisable on large indexes). The current workaround for the ProdAPI/Events endpoint is to use `size=10_000` which is not ideal.

### What has changed
* Add a new method `get_all_batch_elastic` to the Eve resource service

Resolves: [SDBELGA-1056
](https://sofab.atlassian.net/browse/SDBELGA-1056)
