### PR TITLE
Revert "bump minimal urllib3 version"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup, find_packages
 LONG_DESCRIPTION = "Superdesk Server Core"
 
 install_requires = [
-    "urllib3>=2.6.3,<3",
+    "urllib3>=1.26,<3",
     "elasticsearch[async]<7.18",  # we are using oss version on test server
     "flask-mail>=0.9,<0.11",
     "arrow>=0.4,<=1.4.0",


### PR DESCRIPTION
Reverts superdesk/superdesk-core#3156

will first make sure it's updated in repos using develop so it's not breaking anything