### PR TITLE
[SDCP-1117] Add JWT token authentication for download endpoint

### DIFF
--- a/apps/export/service.py
+++ b/apps/export/service.py
@@ -8,10 +8,14 @@ from superdesk import get_resource_service
 from superdesk.errors import FormatterError, SuperdeskApiError
 from superdesk.publish.formatters import get_all_formatters
 from superdesk.utils import get_random_string
+from superdesk.auth.utils import generate_url_with_token
 from superdesk.validation import ValidationError
 from io import BytesIO
 from zipfile import ZipFile
 from quart_babel import gettext as _
+
+
+EXPORT_EXPIRY_DAYS = 7
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +82,11 @@ class ExportService(AsyncBaseService):
                 content_type="application/zip",
                 folder="temp",
             )
-            doc["url"] = app.media.url_for_download(zip_id, "application/zip")
+            doc["url"] = generate_url_with_token(
+                app.media.url_for_download(zip_id, "application/zip"),
+                expiry_days=EXPORT_EXPIRY_DAYS,
+                media_id=str(zip_id),
+            )
 
         return [len(docs)]
 

--- a/features/download.feature
+++ b/features/download.feature
@@ -1,0 +1,74 @@
+Feature: Download with JWT Token Authentication
+
+    @auth
+    Scenario: Download file with session authentication
+        Given "download"
+        """
+        [{"_id": "test123"}]
+        """
+        When we get "/download/test123"
+        Then we get error 404
+
+    Scenario: Download file without authentication returns 401
+        When we get "/download/test123"
+        Then we get error 401
+
+    @auth
+    Scenario: Export creates download URL with JWT token
+        Given "desks"
+        """
+        [{"name": "Sports"}]
+        """
+        Given "archive"
+        """
+        [{
+            "guid": "item1",
+            "type": "text",
+            "headline": "Test",
+            "slugline": "test-item",
+            "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"},
+            "unique_id": 1
+        }]
+        """
+        When we post to "/export"
+        """
+        {"item_ids": ["#archive._id#"], "format_type": "NINJSFormatter"}
+        """
+        Then we get new resource
+        """
+        {"url": "__any_value__"}
+        """
+        And we get download URL with token
+
+    @auth
+    Scenario: Download with valid JWT token succeeds without session
+        Given "desks"
+        """
+        [{"name": "Sports"}]
+        """
+        Given "archive"
+        """
+        [{
+            "guid": "item1",
+            "type": "text",
+            "headline": "Test",
+            "slugline": "test-item",
+            "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"},
+            "unique_id": 1
+        }]
+        """
+        When we post to "/export"
+        """
+        {"item_ids": ["#archive._id#"], "format_type": "NINJSFormatter"}
+        """
+        Then we get download URL with token
+        Given I logout
+        When we download the export URL with token
+        Then we get response code 200
+
+    Scenario: Download with invalid JWT token returns 401
+        When we get "/download/test123?token=invalid_token"
+        Then we get error 401
+        """
+        {"_message": "Invalid or expired token"}
+        """

--- a/features/download.feature
+++ b/features/download.feature
@@ -1,17 +1,11 @@
 Feature: Download with JWT Token Authentication
 
-    @auth
-    Scenario: Download file with session authentication
-        Given "download"
-        """
-        [{"_id": "test123"}]
-        """
-        When we get "/download/test123"
-        Then we get error 404
-
-    Scenario: Download file without authentication returns 401
+    Scenario: Download without token returns 401
         When we get "/download/test123"
         Then we get error 401
+        """
+        {"_message": "Token required"}
+        """
 
     @auth
     Scenario: Export creates download URL with JWT token

--- a/superdesk/auth/decorator.py
+++ b/superdesk/auth/decorator.py
@@ -6,6 +6,20 @@ from superdesk.core import get_current_app
 from superdesk.flask import request
 
 
+async def _call_and_await(f, *args, **kwargs):
+    response = f(*args, **kwargs)
+    if isawaitable(response):
+        response = await response
+    return response
+
+
+async def _check_session_auth(resource: Optional[str] = None):
+    auth = get_current_app().auth
+    if not await auth.authorized([], resource or "_blueprint", request.method):
+        return auth.authenticate()
+    return None
+
+
 def blueprint_auth(resource: Optional[str] = None):
     """
     This decorator is used to add authentication to a Flask Blueprint
@@ -14,13 +28,42 @@ def blueprint_auth(resource: Optional[str] = None):
     def fdec(f):
         @wraps(f)
         async def decorated(*args, **kwargs):
-            auth = get_current_app().auth
-            if not await auth.authorized([], resource or "_blueprint", request.method):
-                return auth.authenticate()
-            response = f(*args, **kwargs)
-            if isawaitable(response):
-                response = await response
-            return response
+            auth_response = await _check_session_auth(resource)
+            if auth_response:
+                return auth_response
+            return await _call_and_await(f, *args, **kwargs)
+
+        return decorated
+
+    return fdec
+
+
+def blueprint_auth_or_token(resource: Optional[str] = None):
+    """Decorator that allows authentication via JWT token query param or session.
+
+    Token takes precedence if provided.
+
+    See Also:
+        superdesk.auth.utils.generate_url_with_token: Helper to generate URLs with token.
+    """
+
+    def fdec(f):
+        @wraps(f)
+        async def decorated(*args, **kwargs):
+            from superdesk.utils import jwt_decode
+            from superdesk.errors import SuperdeskApiError
+
+            token = request.args.get("token")
+            if token:
+                payload = jwt_decode(token)
+                if payload:
+                    return await _call_and_await(f, *args, **kwargs)
+                raise SuperdeskApiError.unauthorizedError("Invalid or expired token")
+
+            auth_response = await _check_session_auth(resource)
+            if auth_response:
+                return auth_response
+            return await _call_and_await(f, *args, **kwargs)
 
         return decorated
 

--- a/superdesk/auth/decorator.py
+++ b/superdesk/auth/decorator.py
@@ -42,6 +42,7 @@ def blueprint_auth_or_token(resource: Optional[str] = None):
     """Decorator that allows authentication via JWT token query param or session.
 
     Token takes precedence if provided.
+    Token must contain '_url_path' matching the current request path.
 
     See Also:
         superdesk.auth.utils.generate_url_with_token: Helper to generate URLs with token.
@@ -53,12 +54,14 @@ def blueprint_auth_or_token(resource: Optional[str] = None):
             from superdesk.utils import jwt_decode
             from superdesk.errors import SuperdeskApiError
 
-            token = request.args.get("token")
-            if token:
-                payload = jwt_decode(token)
-                if payload:
-                    return await _call_and_await(f, *args, **kwargs)
-                raise SuperdeskApiError.unauthorizedError("Invalid or expired token")
+            if token := request.args.get("token"):
+                if not (payload := jwt_decode(token)):
+                    raise SuperdeskApiError.unauthorizedError("Invalid or expired token")
+
+                if payload.get("_url_path") != request.path:
+                    raise SuperdeskApiError.unauthorizedError("Token not valid for this URL")
+
+                return await _call_and_await(f, *args, **kwargs)
 
             auth_response = await _check_session_auth(resource)
             if auth_response:

--- a/superdesk/auth/decorator.py
+++ b/superdesk/auth/decorator.py
@@ -38,10 +38,9 @@ def blueprint_auth(resource: Optional[str] = None):
     return fdec
 
 
-def blueprint_auth_or_token(resource: Optional[str] = None):
-    """Decorator that allows authentication via JWT token query param or session.
+def blueprint_token():
+    """Decorator that requires JWT token authentication via query param.
 
-    Token takes precedence if provided.
     Token must contain '_url_path' matching the current request path.
 
     See Also:
@@ -54,18 +53,15 @@ def blueprint_auth_or_token(resource: Optional[str] = None):
             from superdesk.utils import jwt_decode
             from superdesk.errors import SuperdeskApiError
 
-            if token := request.args.get("token"):
-                if not (payload := jwt_decode(token)):
-                    raise SuperdeskApiError.unauthorizedError("Invalid or expired token")
+            if not (token := request.args.get("token")):
+                raise SuperdeskApiError.unauthorizedError("Token required")
 
-                if payload.get("_url_path") != request.path:
-                    raise SuperdeskApiError.unauthorizedError("Token not valid for this URL")
+            if not (payload := jwt_decode(token)):
+                raise SuperdeskApiError.unauthorizedError("Invalid or expired token")
 
-                return await _call_and_await(f, *args, **kwargs)
+            if payload.get("_url_path") != request.path:
+                raise SuperdeskApiError.unauthorizedError("Token not valid for this URL")
 
-            auth_response = await _check_session_auth(resource)
-            if auth_response:
-                return auth_response
             return await _call_and_await(f, *args, **kwargs)
 
         return decorated

--- a/superdesk/auth/utils.py
+++ b/superdesk/auth/utils.py
@@ -4,13 +4,16 @@ from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
 def generate_url_with_token(url: str, expiry_days: int = 7, **payload) -> str:
     """Generate a URL with JWT token for use with blueprint_auth_or_token.
 
+    The URL path is automatically stored in the token payload for validation.
+
     See Also:
         superdesk.auth.decorator.blueprint_auth_or_token: Decorator that validates the token.
     """
     from superdesk.utils import jwt_encode
 
-    token = jwt_encode(payload, expiry=expiry_days)
     parsed = urlparse(url)
+    payload["_url_path"] = parsed.path
+    token = jwt_encode(payload, expiry=expiry_days)
     query = parse_qsl(parsed.query)
     query.append(("token", token))
     return urlunparse(parsed._replace(query=urlencode(query)))

--- a/superdesk/auth/utils.py
+++ b/superdesk/auth/utils.py
@@ -1,0 +1,16 @@
+from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
+
+
+def generate_url_with_token(url: str, expiry_days: int = 7, **payload) -> str:
+    """Generate a URL with JWT token for use with blueprint_auth_or_token.
+
+    See Also:
+        superdesk.auth.decorator.blueprint_auth_or_token: Decorator that validates the token.
+    """
+    from superdesk.utils import jwt_encode
+
+    token = jwt_encode(payload, expiry=expiry_days)
+    parsed = urlparse(url)
+    query = parse_qsl(parsed.query)
+    query.append(("token", token))
+    return urlunparse(parsed._replace(query=urlencode(query)))

--- a/superdesk/auth/utils.py
+++ b/superdesk/auth/utils.py
@@ -2,12 +2,12 @@ from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
 
 
 def generate_url_with_token(url: str, expiry_days: int = 7, **payload) -> str:
-    """Generate a URL with JWT token for use with blueprint_auth_or_token.
+    """Generate a URL with JWT token for use with blueprint_token.
 
     The URL path is automatically stored in the token payload for validation.
 
     See Also:
-        superdesk.auth.decorator.blueprint_auth_or_token: Decorator that validates the token.
+        superdesk.auth.decorator.blueprint_token: Decorator that validates the token.
     """
     from superdesk.utils import jwt_encode
 

--- a/superdesk/download.py
+++ b/superdesk/download.py
@@ -11,13 +11,15 @@
 """Download module"""
 import logging
 import superdesk
+
 from superdesk.errors import SuperdeskApiError
-from superdesk.auth.decorator import blueprint_auth
-from .resource import Resource
+from superdesk.auth.decorator import blueprint_auth_or_token
 from superdesk.eve_async import AsyncBaseService
 from superdesk.core import get_current_app, get_config
 from superdesk.flask import request, Blueprint, url_for
 from superdesk.storage.superdesk_file import generate_response_for_file, get_file_request_range
+
+from .resource import Resource
 
 bp = Blueprint("download_raw", __name__)
 logger = logging.getLogger(__name__)
@@ -25,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 @bp.route("/download/<id>", methods=["GET"], defaults={"folder": None})
 @bp.route("/download/<path:folder>/<id>", methods=["GET"])
-@blueprint_auth()
+@blueprint_auth_or_token()
 async def download_file(id, folder=None):
     filename = "{}/{}".format(folder, id) if folder else id
     app = get_current_app()

--- a/superdesk/download.py
+++ b/superdesk/download.py
@@ -13,7 +13,7 @@ import logging
 import superdesk
 
 from superdesk.errors import SuperdeskApiError
-from superdesk.auth.decorator import blueprint_auth_or_token
+from superdesk.auth.decorator import blueprint_token
 from superdesk.eve_async import AsyncBaseService
 from superdesk.core import get_current_app, get_config
 from superdesk.flask import request, Blueprint, url_for
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 @bp.route("/download/<id>", methods=["GET"], defaults={"folder": None})
 @bp.route("/download/<path:folder>/<id>", methods=["GET"])
-@blueprint_auth_or_token()
+@blueprint_token()
 async def download_file(id, folder=None):
     filename = "{}/{}".format(folder, id) if folder else id
     app = get_current_app()

--- a/superdesk/tests/steps.py
+++ b/superdesk/tests/steps.py
@@ -3210,3 +3210,22 @@ async def check_audit_logs(context):
 
         audit_logs = await find_many("audit")
         assert json_match(context_data, audit_logs), str(context_data) + "\n != \n" + str(audit_logs)
+
+
+@then("we get download URL with token")
+@async_run_until_complete
+async def step_impl_download_url_with_token(context):
+    data = await get_json_data(context.response)
+    url = data.get("url", "")
+    assert "token=" in url, f"Expected URL to contain 'token=' but got: {url}"
+    context.download_url = url
+
+
+@when("we download the export URL with token")
+@async_run_until_complete
+async def step_impl_download_export_url_with_token(context):
+    assert hasattr(context, "download_url"), "No download URL saved from previous step"
+    url = context.download_url
+    parsed = urlparse(url)
+    path_with_query = parsed.path + ("?" + parsed.query if parsed.query else "")
+    context.response = await context.client.get(path_with_query, headers=context.headers)

--- a/superdesk/utils.py
+++ b/superdesk/utils.py
@@ -352,7 +352,7 @@ def jwt_decode(token) -> Optional[Dict]:
     secret_key = cast(str, get_app_config("SECRET_KEY"))
     try:
         return jwt.decode(token, secret_key, algorithms=[JWT_ALGO])
-    except jwt.InvalidSignatureError:
+    except jwt.PyJWTError:
         return None
 
 

--- a/tests/auth/utils_test.py
+++ b/tests/auth/utils_test.py
@@ -9,26 +9,20 @@ class TestGenerateUrlWithToken:
             mock_encode.return_value = "test_token"
             result = generate_url_with_token("/api/download/123", media_id="123")
             assert result == "/api/download/123?token=test_token"
-            mock_encode.assert_called_once_with(
-                {"media_id": "123", "_url_path": "/api/download/123"}, expiry=7
-            )
+            mock_encode.assert_called_once_with({"media_id": "123", "_url_path": "/api/download/123"}, expiry=7)
 
     def test_url_with_existing_query_params(self):
         with patch("superdesk.utils.jwt_encode") as mock_encode:
             mock_encode.return_value = "test_token"
             result = generate_url_with_token("/api/download/123?foo=bar", media_id="123")
             assert result == "/api/download/123?foo=bar&token=test_token"
-            mock_encode.assert_called_once_with(
-                {"media_id": "123", "_url_path": "/api/download/123"}, expiry=7
-            )
+            mock_encode.assert_called_once_with({"media_id": "123", "_url_path": "/api/download/123"}, expiry=7)
 
     def test_custom_expiry(self):
         with patch("superdesk.utils.jwt_encode") as mock_encode:
             mock_encode.return_value = "test_token"
             generate_url_with_token("/api/download/123", expiry_days=30, media_id="123")
-            mock_encode.assert_called_once_with(
-                {"media_id": "123", "_url_path": "/api/download/123"}, expiry=30
-            )
+            mock_encode.assert_called_once_with({"media_id": "123", "_url_path": "/api/download/123"}, expiry=30)
 
     def test_multiple_payload_params(self):
         with patch("superdesk.utils.jwt_encode") as mock_encode:
@@ -46,6 +40,4 @@ class TestGenerateUrlWithToken:
                 media_id="123",
             )
             assert result == "https://api.example.com/download/123?existing=param&token=test_token"
-            mock_encode.assert_called_once_with(
-                {"media_id": "123", "_url_path": "/download/123"}, expiry=7
-            )
+            mock_encode.assert_called_once_with({"media_id": "123", "_url_path": "/download/123"}, expiry=7)

--- a/tests/auth/utils_test.py
+++ b/tests/auth/utils_test.py
@@ -1,5 +1,4 @@
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from superdesk.auth.utils import generate_url_with_token
 
@@ -10,25 +9,34 @@ class TestGenerateUrlWithToken:
             mock_encode.return_value = "test_token"
             result = generate_url_with_token("/api/download/123", media_id="123")
             assert result == "/api/download/123?token=test_token"
-            mock_encode.assert_called_once_with({"media_id": "123"}, expiry=7)
+            mock_encode.assert_called_once_with(
+                {"media_id": "123", "_url_path": "/api/download/123"}, expiry=7
+            )
 
     def test_url_with_existing_query_params(self):
         with patch("superdesk.utils.jwt_encode") as mock_encode:
             mock_encode.return_value = "test_token"
             result = generate_url_with_token("/api/download/123?foo=bar", media_id="123")
             assert result == "/api/download/123?foo=bar&token=test_token"
+            mock_encode.assert_called_once_with(
+                {"media_id": "123", "_url_path": "/api/download/123"}, expiry=7
+            )
 
     def test_custom_expiry(self):
         with patch("superdesk.utils.jwt_encode") as mock_encode:
             mock_encode.return_value = "test_token"
             generate_url_with_token("/api/download/123", expiry_days=30, media_id="123")
-            mock_encode.assert_called_once_with({"media_id": "123"}, expiry=30)
+            mock_encode.assert_called_once_with(
+                {"media_id": "123", "_url_path": "/api/download/123"}, expiry=30
+            )
 
     def test_multiple_payload_params(self):
         with patch("superdesk.utils.jwt_encode") as mock_encode:
             mock_encode.return_value = "test_token"
             generate_url_with_token("/api/download/123", media_id="123", user_id="456")
-            mock_encode.assert_called_once_with({"media_id": "123", "user_id": "456"}, expiry=7)
+            mock_encode.assert_called_once_with(
+                {"media_id": "123", "user_id": "456", "_url_path": "/api/download/123"}, expiry=7
+            )
 
     def test_full_url(self):
         with patch("superdesk.utils.jwt_encode") as mock_encode:
@@ -38,3 +46,6 @@ class TestGenerateUrlWithToken:
                 media_id="123",
             )
             assert result == "https://api.example.com/download/123?existing=param&token=test_token"
+            mock_encode.assert_called_once_with(
+                {"media_id": "123", "_url_path": "/download/123"}, expiry=7
+            )

--- a/tests/auth/utils_test.py
+++ b/tests/auth/utils_test.py
@@ -1,0 +1,40 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from superdesk.auth.utils import generate_url_with_token
+
+
+class TestGenerateUrlWithToken:
+    def test_simple_url(self):
+        with patch("superdesk.utils.jwt_encode") as mock_encode:
+            mock_encode.return_value = "test_token"
+            result = generate_url_with_token("/api/download/123", media_id="123")
+            assert result == "/api/download/123?token=test_token"
+            mock_encode.assert_called_once_with({"media_id": "123"}, expiry=7)
+
+    def test_url_with_existing_query_params(self):
+        with patch("superdesk.utils.jwt_encode") as mock_encode:
+            mock_encode.return_value = "test_token"
+            result = generate_url_with_token("/api/download/123?foo=bar", media_id="123")
+            assert result == "/api/download/123?foo=bar&token=test_token"
+
+    def test_custom_expiry(self):
+        with patch("superdesk.utils.jwt_encode") as mock_encode:
+            mock_encode.return_value = "test_token"
+            generate_url_with_token("/api/download/123", expiry_days=30, media_id="123")
+            mock_encode.assert_called_once_with({"media_id": "123"}, expiry=30)
+
+    def test_multiple_payload_params(self):
+        with patch("superdesk.utils.jwt_encode") as mock_encode:
+            mock_encode.return_value = "test_token"
+            generate_url_with_token("/api/download/123", media_id="123", user_id="456")
+            mock_encode.assert_called_once_with({"media_id": "123", "user_id": "456"}, expiry=7)
+
+    def test_full_url(self):
+        with patch("superdesk.utils.jwt_encode") as mock_encode:
+            mock_encode.return_value = "test_token"
+            result = generate_url_with_token(
+                "https://api.example.com/download/123?existing=param",
+                media_id="123",
+            )
+            assert result == "https://api.example.com/download/123?existing=param&token=test_token"


### PR DESCRIPTION
### Purpose
Allow download URLs to work across subdomains by supporting JWT token authentication.

### What has changed
- Add `blueprint_auth_or_token` decorator that accepts either a JWT token query param or session auth
- Add `generate_url_with_token` helper in `superdesk/auth/utils.py` to generate signed URLs
- Update `/download` endpoint to use the new decorator
- Update export service to append JWT token to download URLs (7-day expiry)
- Add unit and behave tests

This enables export download URLs to work when the API and client are on different subdomains (e.g., `server1-uat.superdesk.pro` and `server1-uat-api.superdesk.pro`) without requiring cross-subdomain session cookies.

Resolves: [SDCP-1117]


[SDCP-1117]: https://sofab.atlassian.net/browse/SDCP-1117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ