### PR TITLE
[STT-1640] fix(ws): Set socket keepalive & timeout options

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -341,6 +341,11 @@ Default: ``10``
 
 Default: ``3``
 
+``WS_DEBUG``
+^^^^^^^^^^^^
+
+Default: ``False``
+
 .. _settings.monitoring:
 
 Monitoring settings

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -300,6 +300,47 @@ This should be only enabled when you have dedicated worker running::
 
     $ celery -A worker worker -Q publish_priority
 
+
+.. _settings.ws:
+
+Websocket Server Settings
+-------------------------
+
+``WS_HOST``
+^^^^^^^^^^^
+
+Default: ``'0.0.0.0'``
+
+``WS_PORT``
+^^^^^^^^^^^
+
+Default: ``5100``
+
+``WS_REDIS_CONNECT_TIMEOUT``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default: ``2``
+
+``WS_REDIS_TIMEOUT``
+^^^^^^^^^^^^^^^^^^^^
+
+Default: ``120``
+
+``WS_REDIS_KEEPALIVE_IDLE``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default: ``30``
+
+``WS_REDIS_KEEPALIVE_INTERVAL``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default: ``10``
+
+``WS_REDIS_KEEPALIVE_COUNT``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default: ``3``
+
 .. _settings.monitoring:
 
 Monitoring settings

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -324,7 +324,7 @@ Default: ``2``
 ``WS_REDIS_TIMEOUT``
 ^^^^^^^^^^^^^^^^^^^^
 
-Default: ``120``
+Default: ``10``
 
 ``WS_REDIS_KEEPALIVE_IDLE``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -903,8 +903,38 @@ MACROS_MODULE = env("MACROS_MODULE", "superdesk.macros")
 WS_HOST = env("WSHOST", "0.0.0.0")
 WS_PORT = env("WSPORT", "5100")
 
-# Used by the  Kombu Connection. Only valid for the AMQP protocol
+# Used by the Kombu Connection. Only valid for the AMQP protocol
 WS_HEART_BEAT = int(env("WS_HEARTBEAT", "0"))
+
+#: Websocket Redis connection timeout
+#:
+#: .. versionadded:: 2.11, 3.1, 3.4
+#:
+WS_REDIS_CONNECT_TIMEOUT = float(env("WS_REDIS_CONNECT_TIMEOUT", 2))
+
+#: Websocket Redis read/write timeout
+#:
+#: .. versionadded:: 2.11, 3.1, 3.4
+#:
+WS_REDIS_TIMEOUT = float(env("WS_REDIS_TIMEOUT", 120))
+
+#: Websocket Redis TCP Keepalive Idle param
+#:
+#: .. versionadded:: 2.11, 3.1, 3.4
+#:
+WS_REDIS_KEEPALIVE_IDLE = int(env("WS_REDIS_KEEPALIVE_IDLE", 30))
+
+#: Websocket Redis TCP Keepalive Interval param
+#:
+#: .. versionadded:: 2.11, 3.1, 3.4
+#:
+WS_REDIS_KEEPALIVE_INTERVAL = int(env("WS_REDIS_KEEPALIVE_INTERVAL", 10))
+
+#: Websocket Redis TCP Keepalive Count param
+#:
+#: .. versionadded:: 2.11, 3.1, 3.4
+#:
+WS_REDIS_KEEPALIVE_COUNT = int(env("WS_REDIS_KEEPALIVE_COUNT", 3))
 
 #: Defines the maximum value of Publish Sequence Number after which the value will start from 1
 MAX_VALUE_OF_PUBLISH_SEQUENCE = int(env("MAX_VALUE_OF_PUBLISH_SEQUENCE", 9999))

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -936,6 +936,12 @@ WS_REDIS_KEEPALIVE_INTERVAL = int(env("WS_REDIS_KEEPALIVE_INTERVAL", 10))
 #:
 WS_REDIS_KEEPALIVE_COUNT = int(env("WS_REDIS_KEEPALIVE_COUNT", 3))
 
+#: Set Websocket server to run in debug mode
+#:
+#: .. versionadded:: 2.11, 3.1, 3.4
+#:
+WS_DEBUG = strtobool(env("WS_DEBUG", "False"))
+
 #: Defines the maximum value of Publish Sequence Number after which the value will start from 1
 MAX_VALUE_OF_PUBLISH_SEQUENCE = int(env("MAX_VALUE_OF_PUBLISH_SEQUENCE", 9999))
 

--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -916,7 +916,7 @@ WS_REDIS_CONNECT_TIMEOUT = float(env("WS_REDIS_CONNECT_TIMEOUT", 2))
 #:
 #: .. versionadded:: 2.11, 3.1, 3.4
 #:
-WS_REDIS_TIMEOUT = float(env("WS_REDIS_TIMEOUT", 120))
+WS_REDIS_TIMEOUT = float(env("WS_REDIS_TIMEOUT", 10))
 
 #: Websocket Redis TCP Keepalive Idle param
 #:

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -44,6 +44,7 @@ from superdesk.default_settings import (
     WS_REDIS_KEEPALIVE_COUNT,
     WS_REDIS_CONNECT_TIMEOUT,
     WS_REDIS_TIMEOUT,
+    WS_DEBUG,
 )
 
 
@@ -51,8 +52,12 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-logging.getLogger("websockets").setLevel(logging.INFO)
-setup_logging(logging.INFO)
+if WS_DEBUG:
+    logging.getLogger("websockets").setLevel(logging.INFO)
+    setup_logging(logging.INFO)
+else:
+    logging.getLogger("websockets").setLevel(logging.WARNING)
+    setup_logging(logging.WARNING)
 
 
 class SocketBrokerClient:
@@ -272,7 +277,7 @@ class SocketCommunication:
         *,
         sentry_dsn: Optional[str] = None,
         sentry_traces_sample_rate: Optional[float] = None,
-        debug: bool = False,
+        debug: bool | None = None,
     ):
         self.host = host
         self.port = int(port)
@@ -290,7 +295,7 @@ class SocketCommunication:
         }
         self.sentry_dsn = sentry_dsn
         self.sentry_traces_sample_rate = sentry_traces_sample_rate
-        self.debug = debug
+        self.debug = WS_DEBUG if debug is None else debug
 
     def _add_client(self, websocket: ServerConnection):
         self.clients.add(websocket)

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -37,7 +37,14 @@ from kombu.utils.debug import setup_logging
 
 from superdesk.utc import utcnow
 from superdesk.utils import get_random_string, json_serialize_datetime_objectId
-from superdesk.default_settings import WS_HEART_BEAT, env
+from superdesk.default_settings import (
+    WS_HEART_BEAT,
+    WS_REDIS_KEEPALIVE_IDLE,
+    WS_REDIS_KEEPALIVE_INTERVAL,
+    WS_REDIS_KEEPALIVE_COUNT,
+    WS_REDIS_CONNECT_TIMEOUT,
+    WS_REDIS_TIMEOUT,
+)
 
 
 logging.basicConfig(level=logging.INFO)
@@ -73,41 +80,39 @@ class SocketBrokerClient:
         """
         return self.connection and self.connection.connected
 
-    def connect(self):
-        self._close()
-        logger.info("Connecting to broker {}".format(self.url))
-
+    def _get_transport_options(self) -> dict:
         keepalive_options = {}
 
         # Start probing after 30s idle
-        if tcp_keepidle := getattr(socket, "TCP_KEEPIDLE", None) is not None:
+        if (tcp_keepidle := getattr(socket, "TCP_KEEPIDLE", None)) is not None:
             # Start probing after 30s idle (Linux)
-            keepalive_options[tcp_keepidle] = env("WS_REDIS_KEEPALIVE_IDLE", 30)
-        elif tcp_keepalive := getattr(socket, "TCP_KEEPALIVE", None) is not None:
+            keepalive_options[tcp_keepidle] = WS_REDIS_KEEPALIVE_IDLE
+        elif (tcp_keepalive := getattr(socket, "TCP_KEEPALIVE", None)) is not None:
             # Start probing after 30s idle (MacOS)
-            keepalive_options[tcp_keepalive] = env("WS_REDIS_KEEPALIVE_IDLE", 30)
+            keepalive_options[tcp_keepalive] = WS_REDIS_KEEPALIVE_IDLE
 
-        if tcp_keepintvl := getattr(socket, "TCP_KEEPINTVL", None) is not None:
+        if (tcp_keepintvl := getattr(socket, "TCP_KEEPINTVL", None)) is not None:
             # Probe every 10s after that
-            keepalive_options[tcp_keepintvl] = env("WS_REDIS_KEEPALIVE_INTERVAL", 10)
+            keepalive_options[tcp_keepintvl] = WS_REDIS_KEEPALIVE_INTERVAL
 
-        if tcp_keepcnt := getattr(socket, "TCP_KEEPCNT", None) is not None:
+        if (tcp_keepcnt := getattr(socket, "TCP_KEEPCNT", None)) is not None:
             # Kill connection after 3 failed probes
-            keepalive_options[tcp_keepcnt] = env("WS_REDIS_KEEPALIVE_COUNT", 3)
+            keepalive_options[tcp_keepcnt] = WS_REDIS_KEEPALIVE_COUNT
 
-        self.connection = Connection(
-            self.url,
-            heartbeat=WS_HEART_BEAT,
-            transport_options={
-                "socket_connect_timeout": float(env("WS_REDIS_CONNECT_TIMEOUT", 2)),
-                # Set a read timeout of 2 minutes, and to retry upon said timeout
-                "socket_timeout": float(env("WS_REDIS_TIMEOUT", 120)),
-                "retry_on_timeout": True,
-                # Enable TCP keepalive
-                "socket_keepalive": True,
-                "socket_keepalive_options": keepalive_options,
-            },
-        )
+        return {
+            "socket_connect_timeout": WS_REDIS_CONNECT_TIMEOUT,
+            # Set a read timeout of 2 minutes, and to retry upon said timeout
+            "socket_timeout": WS_REDIS_TIMEOUT,
+            "retry_on_timeout": True,
+            # Enable TCP keepalive
+            "socket_keepalive": True,
+            "socket_keepalive_options": keepalive_options,
+        }
+
+    def connect(self):
+        self._close()
+        logger.info("Connecting to broker {}".format(self.url))
+        self.connection = Connection(self.url, heartbeat=WS_HEART_BEAT, transport_options=self._get_transport_options())
         logger.info("Connected to broker {}".format(self.url))
 
     def _close(self):

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -81,20 +81,20 @@ class SocketBrokerClient:
             self.url,
             heartbeat=WS_HEART_BEAT,
             transport_options={
-                "socket_connect_timeout": env("WS_REDIS_CONNECT_TIMEOUT", 2),
+                "socket_connect_timeout": float(env("WS_REDIS_CONNECT_TIMEOUT", 2)),
                 # If no message has been consumed in 10 minutes, allow health check to run
                 # otherwise consumer loop hangs indefinitely on read timeout
-                "socket_timeout": env("WS_REDIS_TIMEOUT", 600),
+                "socket_timeout": float(env("WS_REDIS_TIMEOUT", 600)),
                 "retry_on_timeout": True,
                 # Enable TCP keepalive
                 "socket_keepalive": True,
                 "socket_keepalive_options": {
                     # Start probing after 30s idle
-                    socket.TCP_KEEPIDLE: env("WS_REDIS_KEEPALIVE_IDLE", 30),
+                    socket.TCP_KEEPIDLE: int(env("WS_REDIS_KEEPALIVE_IDLE", 30)),
                     # Probe every 10s after that
-                    socket.TCP_KEEPINTVL: env("WS_REDIS_KEEPALIVE_INTERVAL", 10),
+                    socket.TCP_KEEPINTVL: int(env("WS_REDIS_KEEPALIVE_INTERVAL", 10)),
                     # Kill connection after 3 failed probes
-                    socket.TCP_KEEPCNT: env("WS_REDIS_KEEPALIVE_COUNT", 3),
+                    socket.TCP_KEEPCNT: int(env("WS_REDIS_KEEPALIVE_COUNT", 3)),
                 },
             },
         )

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -44,8 +44,8 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-logging.getLogger("websockets").setLevel(logging.WARNING)
-setup_logging(logging.WARNING)
+logging.getLogger("websockets").setLevel(logging.INFO)
+setup_logging(logging.INFO)
 
 
 class SocketBrokerClient:
@@ -225,6 +225,30 @@ class SocketMessageConsumer(SocketBrokerClient, ConsumerMixin):
         self.should_stop = True
         super().close()
         logger.info("consumer terminated successfully")
+
+    def on_connection_revived(self):
+        """Handler called as soon as the connection is re-established after connection failure."""
+
+        super().on_connection_revived()
+        logger.info("Consumer connection re-established after previous failure")
+
+    def on_consume_ready(self, connection, channel, consumers, **kwargs):
+        """Handler called when the consumer is ready to accept messages."""
+
+        super().on_consume_ready(connection, channel, consumers, **kwargs)
+        logger.info("Consumer ready to accept messages")
+
+    def on_consume_end(self, connection, channel):
+        """Handler called after the consumers are canceled."""
+
+        super().on_consume_end(connection, channel)
+        logger.info("Consumers canceled")
+
+    def on_iteration(self):
+        """Handler called for every iteration while draining events."""
+
+        super().on_iteration()
+        logger.debug("Consumer iterating")
 
 
 class SocketCommunication:

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -104,9 +104,8 @@ class SocketBrokerClient:
             heartbeat=WS_HEART_BEAT,
             transport_options={
                 "socket_connect_timeout": float(env("WS_REDIS_CONNECT_TIMEOUT", 2)),
-                # If no message has been consumed in 10 minutes, allow health check to run
-                # otherwise consumer loop hangs indefinitely on read timeout
-                "socket_timeout": float(env("WS_REDIS_TIMEOUT", 600)),
+                # Set a read timeout of 2 minutes, and to retry upon said timeout
+                "socket_timeout": float(env("WS_REDIS_TIMEOUT", 120)),
                 "retry_on_timeout": True,
                 # Enable TCP keepalive
                 "socket_keepalive": True,

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -15,6 +15,7 @@ import logging
 import asyncio
 import signal
 import sentry_sdk
+import socket
 
 from uuid import UUID, uuid1
 from urllib.parse import urlparse, parse_qs
@@ -31,13 +32,12 @@ from kombu.pools import producers
 
 from superdesk.core import json
 
-from kombu.common import Broadcast
 from kombu.utils.debug import setup_logging
 
 
 from superdesk.utc import utcnow
 from superdesk.utils import get_random_string, json_serialize_datetime_objectId
-from superdesk.default_settings import WS_HEART_BEAT
+from superdesk.default_settings import WS_HEART_BEAT, env
 
 
 logging.basicConfig(level=logging.INFO)
@@ -76,7 +76,30 @@ class SocketBrokerClient:
     def connect(self):
         self._close()
         logger.info("Connecting to broker {}".format(self.url))
-        self.connection = Connection(self.url, heartbeat=WS_HEART_BEAT)
+
+        self.connection = Connection(
+            self.url,
+            heartbeat=WS_HEART_BEAT,
+            transport_options={
+                "socket_connect_timeout": env("WS_REDIS_CONNECT_TIMEOUT", 2),
+
+                # If no message has been consumed in 10 minutes, allow health check to run
+                # otherwise consumer loop hangs indefinitely on read timeout
+                "socket_timeout": env("WS_REDIS_TIMEOUT", 600),
+                "retry_on_timeout": True,
+
+                # Enable TCP keepalive
+                "socket_keepalive": True,
+                "socket_keepalive_options": {
+                    # Start probing after 30s idle
+                    socket.TCP_KEEPIDLE: env("WS_REDIS_KEEPALIVE_IDLE", 30),
+                    # Probe every 10s after that
+                    socket.TCP_KEEPINTVL: env("WS_REDIS_KEEPALIVE_INTERVAL", 10),
+                    # Kill connection after 3 failed probes
+                    socket.TCP_KEEPCNT: env("WS_REDIS_KEEPALIVE_COUNT", 3),
+                }
+            }
+        )
         logger.info("Connected to broker {}".format(self.url))
 
     def _close(self):

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -77,6 +77,24 @@ class SocketBrokerClient:
         self._close()
         logger.info("Connecting to broker {}".format(self.url))
 
+        keepalive_options = {}
+
+        # Start probing after 30s idle
+        if tcp_keepidle := getattr(socket, "TCP_KEEPIDLE", None) is not None:
+            # Start probing after 30s idle (Linux)
+            keepalive_options[tcp_keepidle] = env("WS_REDIS_KEEPALIVE_IDLE", 30)
+        elif tcp_keepalive := getattr(socket, "TCP_KEEPALIVE", None) is not None:
+            # Start probing after 30s idle (MacOS)
+            keepalive_options[tcp_keepalive] = env("WS_REDIS_KEEPALIVE_IDLE", 30)
+
+        if tcp_keepintvl := getattr(socket, "TCP_KEEPINTVL", None) is not None:
+            # Probe every 10s after that
+            keepalive_options[tcp_keepintvl] = env("WS_REDIS_KEEPALIVE_INTERVAL", 10)
+
+        if tcp_keepcnt := getattr(socket, "TCP_KEEPCNT", None) is not None:
+            # Kill connection after 3 failed probes
+            keepalive_options[tcp_keepcnt] = env("WS_REDIS_KEEPALIVE_COUNT", 3)
+
         self.connection = Connection(
             self.url,
             heartbeat=WS_HEART_BEAT,
@@ -88,14 +106,7 @@ class SocketBrokerClient:
                 "retry_on_timeout": True,
                 # Enable TCP keepalive
                 "socket_keepalive": True,
-                "socket_keepalive_options": {
-                    # Start probing after 30s idle
-                    socket.TCP_KEEPIDLE: int(env("WS_REDIS_KEEPALIVE_IDLE", 30)),
-                    # Probe every 10s after that
-                    socket.TCP_KEEPINTVL: int(env("WS_REDIS_KEEPALIVE_INTERVAL", 10)),
-                    # Kill connection after 3 failed probes
-                    socket.TCP_KEEPCNT: int(env("WS_REDIS_KEEPALIVE_COUNT", 3)),
-                },
+                "socket_keepalive_options": keepalive_options,
             },
         )
         logger.info("Connected to broker {}".format(self.url))

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -19,8 +19,8 @@ import socket
 
 from uuid import UUID, uuid1
 from urllib.parse import urlparse, parse_qs
-from websockets.asyncio.server import ServerConnection, broadcast, serve
-from typing import Dict, Set, Optional, Union
+from websockets.asyncio.server import ServerConnection, broadcast, serve, Server
+from typing import Dict, Set, Optional, Union, Callable
 from superdesk.types import WebsocketMessageData, WebsocketMessageFilterConditions
 from sentry_sdk.consts import SPANSTATUS
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
@@ -54,13 +54,17 @@ class SocketBrokerClient:
     """
 
     url: str
-    exchange_name: str
-    connection: Connection
+    exchange_name: str | None
+    connection: Connection | None
     socket_exchange: Exchange
 
-    def __init__(self, url, exchange_name):
+    def __init__(self, url: str, exchange_name: str | None, auto_connect: bool = True):
         self.url = url
-        self.connect()
+        self.connection = None
+
+        if auto_connect:
+            self.connect()
+
         self.exchange_name = exchange_name
         self.socket_exchange = Exchange(self.exchange_name, type="fanout")
 
@@ -163,28 +167,40 @@ class SocketMessageConsumer(SocketBrokerClient, ConsumerMixin):
     Consumer of the message.
     """
 
-    queue: Queue
+    callback: Callable[[str], None]
+    queue: Queue | None
+    queue_name: str
+    loop: asyncio.AbstractEventLoop
+    kombu_thread_heartbeat: asyncio.Event
 
-    def __init__(self, url, callback, exchange_name):
+    def __init__(
+        self,
+        url: str,
+        callback: Callable[[str], None],
+        exchange_name: str | None,
+        loop: asyncio.AbstractEventLoop,
+        kombu_thread_heartbeat: asyncio.Event,
+    ):
         """Create consumer.
 
-        :param string url: Broker URL
-        :param string host: host name running the websocket server
+        :param url: Broker URL
         :param callback: callback function to call on message arrival
+        :param exchange_name: Kombu exchange name
+        :param loop: asyncio event loop
+        :param kombu_thread_heartbeat: asyncio event to signal heartbeat from kombu thread
         """
-        super().__init__(url, exchange_name)
+
+        super().__init__(url, exchange_name, auto_connect=False)
         self.callback = callback
+        self.queue = None
         self.queue_name = "websocket_queue_{}".format(get_random_string())
-        self.queue = Queue(
-            self.queue_name,
-            exchange=self.socket_exchange,
-            message_ttl=10,
-            expires=60,
-            channel=self.connection.channel(),
-            exclusive=True,
-        )
+        self.loop = loop
+        self.kombu_thread_heartbeat = kombu_thread_heartbeat
 
     def get_consumers(self, Consumer, channel):
+        if not self.queue:
+            raise RuntimeError("Queue is not initialized, was ``connect`` called?")
+
         return [Consumer(queues=[self.queue], callbacks=[self.on_message])]
 
     def on_message(self, body, message):
@@ -200,7 +216,7 @@ class SocketMessageConsumer(SocketBrokerClient, ConsumerMixin):
             name="queue_consumer_transaction",
         )
         with sentry_sdk.start_transaction(transaction):
-            logger.debug("Queue: {}. Broadcasting message {}".format(self.queue.name, body))
+            logger.debug("Queue: {}. Broadcasting message {}".format(self.queue_name, body))
             with sentry_sdk.start_span(op="queue.process", name="queue_consumer") as span:
                 span.set_data("messaging.message.id", message.headers.get("message-id", ""))
                 span.set_data("messaging.destination.name", self.exchange_name)
@@ -249,6 +265,22 @@ class SocketMessageConsumer(SocketBrokerClient, ConsumerMixin):
 
         super().on_iteration()
         logger.debug("Consumer iterating")
+        self.loop.call_soon_threadsafe(self.kombu_thread_heartbeat.set)
+
+    def connect(self):
+        super().connect()
+        self.queue = Queue(
+            self.queue_name,
+            exchange=self.socket_exchange,
+            message_ttl=10,
+            expires=60,
+            channel=self.connection.channel(),
+            exclusive=True,
+        )
+
+    def run(self, *args, **kwargs):
+        self.connect()
+        super().run(*args, **kwargs)
 
 
 class SocketCommunication:
@@ -257,13 +289,17 @@ class SocketCommunication:
     """
 
     clients: Set[ServerConnection]
+    consumer: SocketMessageConsumer | None
+    server: Server | None
+    should_stop: bool
+    kombu_thread_heartbeat: asyncio.Event | None
 
     def __init__(
         self,
         host: str,
         port: Union[int, str],
         broker_url: str,
-        exchange_name: Optional[str] = None,
+        exchange_name: str | None = None,
         subscribe_prefix: str = "/subscribe?",
         *,
         sentry_dsn: Optional[str] = None,
@@ -287,6 +323,10 @@ class SocketCommunication:
         self.sentry_dsn = sentry_dsn
         self.sentry_traces_sample_rate = sentry_traces_sample_rate
         self.debug = debug
+        self.should_stop = False
+        self.server = None
+        self.consumer = None
+        self.kombu_thread_heartbeat = None
 
     def _add_client(self, websocket: ServerConnection):
         self.clients.add(websocket)
@@ -405,9 +445,89 @@ class SocketCommunication:
             self._remove_client(websocket)
             self._log("client done", websocket)
 
+    async def run_consumer_thread_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Runs the consumer in a separate thread loop and manages its lifecycle.
+
+        This asynchronous method starts a message consumer thread using a
+        SocketMessageConsumer instance, monitors its heartbeat through an asyncio
+        event, and handles its restart as needed. The loop keeps the consumer operational
+        and stops it gracefully when the `should_stop` flag is set to True.
+
+        :param loop: The asyncio event loop within which the consumer thread is executed.
+        """
+
+        started: bool = False
+        while not self.should_stop:
+            logger.info(f"{'Starting' if not started else 'Restarting'} message consumer")
+            started = True
+
+            # create socket message consumer and run it in a thread
+            self.kombu_thread_heartbeat = asyncio.Event()
+            self.consumer = SocketMessageConsumer(
+                self.broker_url, self.broadcast, self.exchange_name, loop, self.kombu_thread_heartbeat
+            )
+            loop.run_in_executor(None, self.consumer.run)
+
+            # Run the heartbeat checker (Kombu thread -> main thread heartbeat)
+            await self._run_kombu_thread_heartbeat_checker()
+
+            logger.info("Stopping message consumer")
+            if self.consumer:
+                # It could have been cleared aready
+                self.consumer.close()
+                self.consumer = None
+
+    async def _run_kombu_thread_heartbeat_checker(self) -> None:
+        """Runs a periodic checker for the Kombu thread heartbeat.
+
+        This method repeatedly waits for the Kombu thread heartbeat event to be set,
+        with a specified timeout defined by the WS_CONSUMER_THREAD_TIMEOUT environment
+        variable. If the event does not occur within the timeout period, a warning is
+        logged, and the loop terminates. The heartbeat event is cleared after each
+        check.
+        """
+
+        if self.kombu_thread_heartbeat is None:
+            raise RuntimeError("Kombu thread heartbeat is not set.")
+
+        while not self.should_stop:
+            try:
+                await asyncio.wait_for(
+                    self.kombu_thread_heartbeat.wait(), timeout=int(env("WS_CONSUMER_THREAD_TIMEOUT", 60))
+                )
+            except asyncio.TimeoutError:
+                logger.warning("wait_for_iteration: Timed out....")
+                break
+            finally:
+                if self.kombu_thread_heartbeat:
+                    # It could have been cleared before this is run
+                    self.kombu_thread_heartbeat.clear()
+
     def run_server(self):
         """Run websocket server."""
         asyncio.run(self.main())
+
+    def stop(self) -> None:
+        """Stops the websocket server and cleans up associated resources.
+
+        This method stops the running websocket server and cleans up the
+        consumer, if active. It also signals the kombu thread heartbeat so it
+        can be terminated.
+        """
+
+        logger.info("Stopping websocket server")
+        self.should_stop = True
+        if self.server:
+            self.server.close()
+            self.server = None
+
+        if self.kombu_thread_heartbeat:
+            self.kombu_thread_heartbeat.set()
+            self.kombu_thread_heartbeat = None
+
+        if self.consumer:
+            self.consumer.close()
+            self.consumer = None
 
     async def main(self):
         """Create websocket server and run it until it gets Ctrl+C or SIGTERM."""
@@ -418,18 +538,12 @@ class SocketCommunication:
                 traces_sample_rate=self.sentry_traces_sample_rate,
             )
         try:
-            consumer = None
             async with serve(self._connection_handler, self.host, self.port) as server:
+                self.server = server
                 loop = asyncio.get_event_loop()
-                loop.add_signal_handler(signal.SIGTERM, server.close)
-                # create socket message consumer
-                consumer = SocketMessageConsumer(self.broker_url, self.broadcast, self.exchange_name)
-                # kombu is blocking so needs to run in executor
-                loop.run_in_executor(None, consumer.run)
-                await server.wait_closed()
+                loop.add_signal_handler(signal.SIGTERM, self.stop)
+                await self.run_consumer_thread_loop(loop)
         except KeyboardInterrupt:
             pass
         finally:
-            logger.info("closing server")
-            if consumer:
-                consumer.close()
+            self.stop()

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -19,8 +19,8 @@ import socket
 
 from uuid import UUID, uuid1
 from urllib.parse import urlparse, parse_qs
-from websockets.asyncio.server import ServerConnection, broadcast, serve, Server
-from typing import Dict, Set, Optional, Union, Callable
+from websockets.asyncio.server import ServerConnection, broadcast, serve
+from typing import Dict, Set, Optional, Union
 from superdesk.types import WebsocketMessageData, WebsocketMessageFilterConditions
 from sentry_sdk.consts import SPANSTATUS
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
@@ -54,17 +54,13 @@ class SocketBrokerClient:
     """
 
     url: str
-    exchange_name: str | None
-    connection: Connection | None
+    exchange_name: str
+    connection: Connection
     socket_exchange: Exchange
 
-    def __init__(self, url: str, exchange_name: str | None, auto_connect: bool = True):
+    def __init__(self, url, exchange_name):
         self.url = url
-        self.connection = None
-
-        if auto_connect:
-            self.connect()
-
+        self.connect()
         self.exchange_name = exchange_name
         self.socket_exchange = Exchange(self.exchange_name, type="fanout")
 
@@ -166,40 +162,28 @@ class SocketMessageConsumer(SocketBrokerClient, ConsumerMixin):
     Consumer of the message.
     """
 
-    callback: Callable[[str], None]
-    queue: Queue | None
-    queue_name: str
-    loop: asyncio.AbstractEventLoop
-    kombu_thread_heartbeat: asyncio.Event
+    queue: Queue
 
-    def __init__(
-        self,
-        url: str,
-        callback: Callable[[str], None],
-        exchange_name: str | None,
-        loop: asyncio.AbstractEventLoop,
-        kombu_thread_heartbeat: asyncio.Event,
-    ):
+    def __init__(self, url, callback, exchange_name):
         """Create consumer.
 
-        :param url: Broker URL
+        :param string url: Broker URL
+        :param string host: host name running the websocket server
         :param callback: callback function to call on message arrival
-        :param exchange_name: Kombu exchange name
-        :param loop: asyncio event loop
-        :param kombu_thread_heartbeat: asyncio event to signal heartbeat from kombu thread
         """
-
-        super().__init__(url, exchange_name, auto_connect=False)
+        super().__init__(url, exchange_name)
         self.callback = callback
-        self.queue = None
         self.queue_name = "websocket_queue_{}".format(get_random_string())
-        self.loop = loop
-        self.kombu_thread_heartbeat = kombu_thread_heartbeat
+        self.queue = Queue(
+            self.queue_name,
+            exchange=self.socket_exchange,
+            message_ttl=10,
+            expires=60,
+            channel=self.connection.channel(),
+            exclusive=True,
+        )
 
     def get_consumers(self, Consumer, channel):
-        if not self.queue:
-            raise RuntimeError("Queue is not initialized, was ``connect`` called?")
-
         return [Consumer(queues=[self.queue], callbacks=[self.on_message])]
 
     def on_message(self, body, message):
@@ -215,7 +199,7 @@ class SocketMessageConsumer(SocketBrokerClient, ConsumerMixin):
             name="queue_consumer_transaction",
         )
         with sentry_sdk.start_transaction(transaction):
-            logger.debug("Queue: {}. Broadcasting message {}".format(self.queue_name, body))
+            logger.debug("Queue: {}. Broadcasting message {}".format(self.queue.name, body))
             with sentry_sdk.start_span(op="queue.process", name="queue_consumer") as span:
                 span.set_data("messaging.message.id", message.headers.get("message-id", ""))
                 span.set_data("messaging.destination.name", self.exchange_name)
@@ -264,22 +248,6 @@ class SocketMessageConsumer(SocketBrokerClient, ConsumerMixin):
 
         super().on_iteration()
         logger.debug("Consumer iterating")
-        self.loop.call_soon_threadsafe(self.kombu_thread_heartbeat.set)
-
-    def connect(self):
-        super().connect()
-        self.queue = Queue(
-            self.queue_name,
-            exchange=self.socket_exchange,
-            message_ttl=10,
-            expires=60,
-            channel=self.connection.channel(),
-            exclusive=True,
-        )
-
-    def run(self, *args, **kwargs):
-        self.connect()
-        super().run(*args, **kwargs)
 
 
 class SocketCommunication:
@@ -288,17 +256,13 @@ class SocketCommunication:
     """
 
     clients: Set[ServerConnection]
-    consumer: SocketMessageConsumer | None
-    server: Server | None
-    should_stop: bool
-    kombu_thread_heartbeat: asyncio.Event | None
 
     def __init__(
         self,
         host: str,
         port: Union[int, str],
         broker_url: str,
-        exchange_name: str | None = None,
+        exchange_name: Optional[str] = None,
         subscribe_prefix: str = "/subscribe?",
         *,
         sentry_dsn: Optional[str] = None,
@@ -322,10 +286,6 @@ class SocketCommunication:
         self.sentry_dsn = sentry_dsn
         self.sentry_traces_sample_rate = sentry_traces_sample_rate
         self.debug = debug
-        self.should_stop = False
-        self.server = None
-        self.consumer = None
-        self.kombu_thread_heartbeat = None
 
     def _add_client(self, websocket: ServerConnection):
         self.clients.add(websocket)
@@ -444,89 +404,9 @@ class SocketCommunication:
             self._remove_client(websocket)
             self._log("client done", websocket)
 
-    async def run_consumer_thread_loop(self, loop: asyncio.AbstractEventLoop) -> None:
-        """Runs the consumer in a separate thread loop and manages its lifecycle.
-
-        This asynchronous method starts a message consumer thread using a
-        SocketMessageConsumer instance, monitors its heartbeat through an asyncio
-        event, and handles its restart as needed. The loop keeps the consumer operational
-        and stops it gracefully when the `should_stop` flag is set to True.
-
-        :param loop: The asyncio event loop within which the consumer thread is executed.
-        """
-
-        started: bool = False
-        while not self.should_stop:
-            logger.info(f"{'Starting' if not started else 'Restarting'} message consumer")
-            started = True
-
-            # create socket message consumer and run it in a thread
-            self.kombu_thread_heartbeat = asyncio.Event()
-            self.consumer = SocketMessageConsumer(
-                self.broker_url, self.broadcast, self.exchange_name, loop, self.kombu_thread_heartbeat
-            )
-            loop.run_in_executor(None, self.consumer.run)
-
-            # Run the heartbeat checker (Kombu thread -> main thread heartbeat)
-            await self._run_kombu_thread_heartbeat_checker()
-
-            logger.info("Stopping message consumer")
-            if self.consumer:
-                # It could have been cleared aready
-                self.consumer.close()
-                self.consumer = None
-
-    async def _run_kombu_thread_heartbeat_checker(self) -> None:
-        """Runs a periodic checker for the Kombu thread heartbeat.
-
-        This method repeatedly waits for the Kombu thread heartbeat event to be set,
-        with a specified timeout defined by the WS_CONSUMER_THREAD_TIMEOUT environment
-        variable. If the event does not occur within the timeout period, a warning is
-        logged, and the loop terminates. The heartbeat event is cleared after each
-        check.
-        """
-
-        if self.kombu_thread_heartbeat is None:
-            raise RuntimeError("Kombu thread heartbeat is not set.")
-
-        while not self.should_stop:
-            try:
-                await asyncio.wait_for(
-                    self.kombu_thread_heartbeat.wait(), timeout=int(env("WS_CONSUMER_THREAD_TIMEOUT", 60))
-                )
-            except asyncio.TimeoutError:
-                logger.warning("wait_for_iteration: Timed out....")
-                break
-            finally:
-                if self.kombu_thread_heartbeat:
-                    # It could have been cleared before this is run
-                    self.kombu_thread_heartbeat.clear()
-
     def run_server(self):
         """Run websocket server."""
         asyncio.run(self.main())
-
-    def stop(self) -> None:
-        """Stops the websocket server and cleans up associated resources.
-
-        This method stops the running websocket server and cleans up the
-        consumer, if active. It also signals the kombu thread heartbeat so it
-        can be terminated.
-        """
-
-        logger.info("Stopping websocket server")
-        self.should_stop = True
-        if self.server:
-            self.server.close()
-            self.server = None
-
-        if self.kombu_thread_heartbeat:
-            self.kombu_thread_heartbeat.set()
-            self.kombu_thread_heartbeat = None
-
-        if self.consumer:
-            self.consumer.close()
-            self.consumer = None
 
     async def main(self):
         """Create websocket server and run it until it gets Ctrl+C or SIGTERM."""
@@ -537,12 +417,18 @@ class SocketCommunication:
                 traces_sample_rate=self.sentry_traces_sample_rate,
             )
         try:
+            consumer = None
             async with serve(self._connection_handler, self.host, self.port) as server:
-                self.server = server
                 loop = asyncio.get_event_loop()
-                loop.add_signal_handler(signal.SIGTERM, self.stop)
-                await self.run_consumer_thread_loop(loop)
+                loop.add_signal_handler(signal.SIGTERM, server.close)
+                # create socket message consumer
+                consumer = SocketMessageConsumer(self.broker_url, self.broadcast, self.exchange_name)
+                # kombu is blocking so needs to run in executor
+                loop.run_in_executor(None, consumer.run)
+                await server.wait_closed()
         except KeyboardInterrupt:
             pass
         finally:
-            self.stop()
+            logger.info("closing server")
+            if consumer:
+                consumer.close()

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -106,7 +106,7 @@ class SocketBrokerClient:
 
         return {
             "socket_connect_timeout": WS_REDIS_CONNECT_TIMEOUT,
-            # Set a read timeout of 2 minutes, and to retry upon said timeout
+            # Set a read timeout of 10 seconds, and to retry upon said timeout
             "socket_timeout": WS_REDIS_TIMEOUT,
             "retry_on_timeout": True,
             # Enable TCP keepalive

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -82,12 +82,10 @@ class SocketBrokerClient:
             heartbeat=WS_HEART_BEAT,
             transport_options={
                 "socket_connect_timeout": env("WS_REDIS_CONNECT_TIMEOUT", 2),
-
                 # If no message has been consumed in 10 minutes, allow health check to run
                 # otherwise consumer loop hangs indefinitely on read timeout
                 "socket_timeout": env("WS_REDIS_TIMEOUT", 600),
                 "retry_on_timeout": True,
-
                 # Enable TCP keepalive
                 "socket_keepalive": True,
                 "socket_keepalive_options": {
@@ -97,8 +95,8 @@ class SocketBrokerClient:
                     socket.TCP_KEEPINTVL: env("WS_REDIS_KEEPALIVE_INTERVAL", 10),
                     # Kill connection after 3 failed probes
                     socket.TCP_KEEPCNT: env("WS_REDIS_KEEPALIVE_COUNT", 3),
-                }
-            }
+                },
+            },
         )
         logger.info("Connected to broker {}".format(self.url))
 

--- a/tests/websockets_test.py
+++ b/tests/websockets_test.py
@@ -175,7 +175,7 @@ class WebsocketsTestCase(unittest.TestCase):
             client._get_transport_options(),
             {
                 "socket_connect_timeout": 2,
-                "socket_timeout": 120,
+                "socket_timeout": 10,
                 "retry_on_timeout": True,
                 "socket_keepalive": True,
                 "socket_keepalive_options": {

--- a/tests/websockets_test.py
+++ b/tests/websockets_test.py
@@ -1,14 +1,17 @@
-from typing import List
-import asyncio
 import unittest
 from unittest.mock import MagicMock, patch, ANY
 from json import dumps
 from datetime import datetime, timedelta
 from uuid import uuid4
-from superdesk.websockets_comms import SocketCommunication
+import socket
+import importlib
+
+from superdesk import default_settings
+from superdesk import websockets_comms
+
+# from superdesk.websockets_comms import SocketCommunication, SocketBrokerClient
 from superdesk.types import WebsocketMessageData
-from websockets import ServerConnection, ServerProtocol
-from websockets.protocol import OPEN
+from websockets import ServerConnection
 
 
 class TestClient(ServerConnection):
@@ -22,7 +25,7 @@ class WebsocketsTestCase(unittest.TestCase):
     @patch("superdesk.websockets_comms.broadcast")
     def test_broadcast(self, broadcast_mock):
         client = TestClient("")
-        com = SocketCommunication("host", "1", "url")
+        com = websockets_comms.SocketCommunication("host", "1", "url")
         com.clients.add(client)
 
         com.broadcast(dumps({"event": "ingest:update", "_created": datetime.now().isoformat()}))
@@ -49,7 +52,7 @@ class WebsocketsTestCase(unittest.TestCase):
         client_user_abc123_sess_67890 = TestClient("/ws/subscribe?user=abc123&session=67890")
         client_user_def456 = TestClient("/ws/subscribe?user=def456")
 
-        com = SocketCommunication("host", "1", "url")
+        com = websockets_comms.SocketCommunication("host", "1", "url")
         com._add_client(client_no_user)
         com._add_client(client_user_abc123_sess_12345)
         com._add_client(client_user_abc123_sess_67890)
@@ -165,3 +168,50 @@ class WebsocketsTestCase(unittest.TestCase):
             ),
             ANY,
         )
+
+    def test_client_transport_options(self):
+        client = websockets_comms.SocketBrokerClient("redis://localhost:6379", "superdesk_notification")
+        self.assertEqual(
+            client._get_transport_options(),
+            {
+                "socket_connect_timeout": 2,
+                "socket_timeout": 120,
+                "retry_on_timeout": True,
+                "socket_keepalive": True,
+                "socket_keepalive_options": {
+                    socket.TCP_KEEPIDLE: 30,
+                    socket.TCP_KEEPINTVL: 10,
+                    socket.TCP_KEEPCNT: 3,
+                },
+            },
+        )
+
+    def test_client_transport_options_with_env_vars(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "WS_REDIS_CONNECT_TIMEOUT": "5",
+                "WS_REDIS_TIMEOUT": "240",
+                "WS_REDIS_KEEPALIVE_IDLE": "60",
+                "WS_REDIS_KEEPALIVE_INTERVAL": "30",
+                "WS_REDIS_KEEPALIVE_COUNT": "6",
+            },
+            clear=False,
+        ):
+            importlib.reload(default_settings)
+            importlib.reload(websockets_comms)
+            client = websockets_comms.SocketBrokerClient("redis://localhost:6379", "superdesk_notification")
+            self.assertEqual(
+                client._get_transport_options(),
+                {
+                    "socket_connect_timeout": 5,
+                    "socket_timeout": 240,
+                    "retry_on_timeout": True,
+                    "socket_keepalive": True,
+                    "socket_keepalive_options": {
+                        socket.TCP_KEEPIDLE: 60,
+                        socket.TCP_KEEPINTVL: 30,
+                        socket.TCP_KEEPCNT: 6,
+                    },
+                },
+            )


### PR DESCRIPTION
### Purpose
The connection to Redis from our websocket server has reliability issues. Connection timeouts and half closed connections.

### What has changed
* Set TCP Keepalive to make sure the connection stays alive with traffic
* Set socket read/write timeout for 2 mintues

Resolves: [STT-1640](https://sofab.atlassian.net/browse/STT-1640)



[STT-1640]: https://sofab.atlassian.net/browse/STT-1640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ