### PR TITLE
[SDBELGA-1059] - Support deletes during init for items marked for deletion

### DIFF
--- a/apps/prepopulate/app_initialize.py
+++ b/apps/prepopulate/app_initialize.py
@@ -357,12 +357,22 @@ class AppInitializeWithDataCommand(superdesk.Command):
                 data = [item for item in data if item and not item.get("_deleted")]
                 data = [app.data.mongo._mongotize(item, service.datasource) for item in data]
 
-                for deleted_id in deleted_ids:
-                    if service.find_one(None, _id=deleted_id):
-                        service.delete({"_id": deleted_id})
-                        logger.info(" - deleted tombstone record: %s", deleted_id)
-                    else:
-                        logger.info(" - record marked for deletion already missing: %s", deleted_id)
+                if deleted_ids:
+                    delete_lookup = {"_id": {"$in": deleted_ids}}
+                    delete_lookup = app.data.mongo._mongotize(delete_lookup, service.datasource)
+                    deleted_result = service.delete(delete_lookup)
+                    deleted_id_set = set()
+                    for item in deleted_result or []:
+                        if isinstance(item, dict) and "_id" in item:
+                            deleted_id_set.add(str(item["_id"]))
+                        else:
+                            deleted_id_set.add(str(item))
+
+                    for deleted_id in deleted_ids:
+                        if str(deleted_id) in deleted_id_set:
+                            logger.info(" - deleted tombstone record: %s", deleted_id)
+                        else:
+                            logger.info(" - record marked for deletion already missing: %s", deleted_id)
 
                 existing = service.get_from_mongo(None, {})
                 existing_data = []

--- a/apps/prepopulate/app_initialize.py
+++ b/apps/prepopulate/app_initialize.py
@@ -353,9 +353,19 @@ class AppInitializeWithDataCommand(superdesk.Command):
                 service = superdesk.get_resource_service(entity_name)
                 json_data = json.loads(app_prepopulation.read())
                 data = [fillEnvironmentVariables(item) for item in json_data]
-                data = [app.data.mongo._mongotize(item, service.datasource) for item in data if item]
-                existing_data = []
+                deleted_ids = [item["_id"] for item in data if item and item.get("_deleted") and item.get("_id")]
+                data = [item for item in data if item and not item.get("_deleted")]
+                data = [app.data.mongo._mongotize(item, service.datasource) for item in data]
+
+                for deleted_id in deleted_ids:
+                    if service.find_one(None, _id=deleted_id):
+                        service.delete({"_id": deleted_id})
+                        logger.info(" - deleted tombstone record: %s", deleted_id)
+                    else:
+                        logger.info(" - record marked for deletion already missing: %s", deleted_id)
+
                 existing = service.get_from_mongo(None, {})
+                existing_data = []
                 update_data = True
                 if not do_patch and existing.count() > 0:
                     logger.info(" - data already exists none will be loaded")

--- a/tests/prepopulate/app_initialization_test.py
+++ b/tests/prepopulate/app_initialization_test.py
@@ -101,6 +101,21 @@ class AppInitializeWithDataCommandTestCase(TestCase):
         self.assertEqual("Urgency", urgency["display_name"])
         self.assertEqual("init", urgency["_etag"])
 
+    def test_init_deletes_tombstone_records(self):
+        init_dir = tempfile.mkdtemp("init", "test")
+        self.app.config.update({"INIT_DATA_PATH": init_dir})
+        self.addCleanup(self.app.config.pop, "INIT_DATA_PATH", None)
+        self.addCleanup(shutil.rmtree, init_dir)
+
+        with open(os.path.join(init_dir, "vocabularies.json"), "w") as f:
+            f.write(json.dumps([{"_id": "urgency", "_deleted": True}]))
+            f.flush()
+
+        self._run(["vocabularies"])
+
+        urgency = self.app.data.find_one("vocabularies", req=None, _id="urgency")
+        self.assertIsNone(urgency)
+
     def test_init_can_combine_files_from_folders(self):
         init_dir = tempfile.mkdtemp("init", "test")
         self.app.config.update({"INIT_DATA_PATH": init_dir})

--- a/tests/prepopulate/app_initialization_test.py
+++ b/tests/prepopulate/app_initialization_test.py
@@ -102,6 +102,10 @@ class AppInitializeWithDataCommandTestCase(TestCase):
         self.assertEqual("init", urgency["_etag"])
 
     def test_init_deletes_tombstone_records(self):
+        self._run(["vocabularies"])
+        urgency = self.app.data.find_one("vocabularies", req=None, _id="urgency")
+        self.assertIsNotNone(urgency)
+
         init_dir = tempfile.mkdtemp("init", "test")
         self.app.config.update({"INIT_DATA_PATH": init_dir})
         self.addCleanup(self.app.config.pop, "INIT_DATA_PATH", None)


### PR DESCRIPTION
### Purpose
Enable seed-data marked as `_deleted` to be deleted from existing databases during `app:initialize_data`.

### What has changed
- `app:initialize_data` now treats records with _deleted: true as delete markers
- Added a test to verify tombstone records are removed during initialization

### Steps to test
- Add a JSON seed record with "_deleted": true for an existing document
- Run `python manage.py app:initialize_data`
- Verify the matching document is removed from MongoDB
- Verify normal seed records still load and update as before

Resolves: #[SDBELGA-1059](https://sofab.atlassian.net/browse/SDBELGA-1059)



[SDBELGA-1059]: https://sofab.atlassian.net/browse/SDBELGA-1059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ