### PR TITLE
[SDCP-1123] fix: Remove relation validation for PublishQueue.ingest_provider

### DIFF
--- a/superdesk/types/publish_queue.py
+++ b/superdesk/types/publish_queue.py
@@ -54,7 +54,7 @@ class PublishQueueResource(ResourceModelWithObjectId):
     moved_to_legal: bool = False
     retry_attempt: int = 0
     next_retry_attempt_at: datetime | None = None
-    ingest_provider: Annotated[fields.ObjectId | None, validate_data_relation_async("ingest_providers")] = None
+    ingest_provider: fields.ObjectId | None = None
     associated_items: list[str] | None = None
     priority: bool | None = None
 


### PR DESCRIPTION
### Purpose
Before v3.0 we has a [data relation rule](https://github.com/superdesk/superdesk-core/blob/release/2.11/superdesk/publish/publish_queue.py#L73) in place for the `PublishQueue.ingest_provider` field.

This was never really applied as we created these documents internally, which meant this validation rule was never executed.

When we moved the resource to async we kept this data relation rule, but we now apply validation rules all the time.

This causes issues when an item is fetched from a search provider, as the ID used is for the search provider and not an ingest provider.

### What has changed
* Remove the validation rule for the `ingest_provider` on the `PublishQueue` resource. It's an informative field and has no real affect on how the resource is used.

Resolves: [SDCP-1123](https://sofab.atlassian.net/browse/SDCP-1123)



[SDCP-1123]: https://sofab.atlassian.net/browse/SDCP-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ