### PR TITLE
improve(s3): Improve exists by throwing exceptions

### DIFF
--- a/superdesk/storage/amazon_media_storage.py
+++ b/superdesk/storage/amazon_media_storage.py
@@ -22,6 +22,7 @@ from io import BytesIO
 
 from os.path import splitext
 from urllib.parse import urlparse
+from botocore.exceptions import ClientError
 from botocore.client import Config
 from werkzeug.datastructures import Range, FileStorage
 
@@ -482,17 +483,25 @@ class AmazonMediaStorage(SuperdeskMediaStorage):
         try:
             self.call("head_object", Key=id_or_filename)
             return True
-        except Exception:
-            # File not found
-            return False
+        except ClientError as error:
+            try:
+                if error.response["Error"]["Code"] == "404":
+                    return False
+            except (KeyError, TypeError, IndexError):
+                pass
+            raise
 
     async def _check_exists_async(self, id_or_filename):
         try:
             await self.call_async("head_object", Key=id_or_filename)
             return True
-        except Exception:
-            # File not found
-            return False
+        except ClientError as error:
+            try:
+                if error.response["Error"]["Code"] == "404":
+                    return False
+            except (KeyError, TypeError, IndexError):
+                pass
+            raise
 
     def remove_unreferenced_files(self, existing_files, resource=None):
         """Get the files from S3 and compare against existing and delete the orphans."""

--- a/superdesk/storage/amazon_media_storage.py
+++ b/superdesk/storage/amazon_media_storage.py
@@ -26,6 +26,7 @@ from botocore.exceptions import ClientError
 from botocore.client import Config
 from werkzeug.datastructures import Range, FileStorage
 
+from superdesk.core import get_config
 from superdesk.core.types import SuperdeskFile, SuperdeskAsyncFile
 from superdesk.media.media_operations import download_file_from_url, download_file_from_url_async, guess_media_extension
 from superdesk.utc import query_datetime
@@ -483,25 +484,35 @@ class AmazonMediaStorage(SuperdeskMediaStorage):
         try:
             self.call("head_object", Key=id_or_filename)
             return True
-        except ClientError as error:
+        except Exception as error:
             try:
-                if error.response["Error"]["Code"] == "404":
+                if isinstance(error, ClientError) and error.response["Error"]["Code"] == "404":
                     return False
             except (KeyError, TypeError, IndexError):
                 pass
-            raise
+
+            if get_config(bool, "SUPERDESK_DEBUG", False):
+                raise
+
+            logger.exception(error)
+            return False
 
     async def _check_exists_async(self, id_or_filename):
         try:
             await self.call_async("head_object", Key=id_or_filename)
             return True
-        except ClientError as error:
+        except Exception as error:
             try:
-                if error.response["Error"]["Code"] == "404":
+                if isinstance(error, ClientError) and error.response["Error"]["Code"] == "404":
                     return False
             except (KeyError, TypeError, IndexError):
                 pass
-            raise
+
+            if get_config(bool, "SUPERDESK_DEBUG", False):
+                raise
+
+            logger.exception(error)
+            return False
 
     def remove_unreferenced_files(self, existing_files, resource=None):
         """Get the files from S3 and compare against existing and delete the orphans."""


### PR DESCRIPTION
### Purpose
When checking if an item exists in S3, we were catching all errors and treating them if the item doesn't exist.

### What has changed
* Use the specific `ClientError` exception to catch specifically a 404, everything else should raise an exception

See: https://github.com/boto/boto3/issues/2442
