### PR TITLE
[STT-1648] fix: Create published item before updating archive

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -293,6 +293,7 @@ class BasePublishService(AsyncBaseService):
             updated.update(deepcopy(updates))
         else:
             await self._publish_associated_items(original, updates)
+            updated = deepcopy(original)
             updated.update(deepcopy(updates))
 
             if updates.get(ASSOCIATIONS):

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -10,7 +10,9 @@
 
 from copy import copy, deepcopy
 import logging
+from asyncio import gather
 
+from bson import ObjectId
 from eve.versioning import resolve_document_version
 from eve.methods.common import resolve_document_etag
 from quart_babel import gettext as _
@@ -45,7 +47,7 @@ from apps.common.components.utils import get_component
 from apps.content import push_content_notification
 from apps.content_types.content_types import DEFAULT_SCHEMA
 from apps.item_autosave.components.item_autosave import ItemAutosave
-from apps.item_lock.components.item_lock import set_unlock_updates
+from apps.item_lock.components.item_lock import set_unlock_updates, LOCK_USER, LOCK_SESSION, LOCK_ACTION, LOCK_TIME
 from apps.legal_archive.commands import is_legal_archive_enabled
 from apps.packages.package_service import PackageService
 from apps.publish.published_item import LAST_PUBLISHED_VERSION, PUBLISHED, PUBLISHED_IN_PACKAGE
@@ -267,43 +269,97 @@ class BasePublishService(AsyncBaseService):
                     await insert_into_versions_async(id_=package[ID_FIELD])
                     processed_packages.append(package[ID_FIELD])
 
+    async def _process_item_updates_and_associations(self, original: dict, updates: dict) -> dict:
+        """
+        Processes item updates and associations asynchronously.
+
+        This method handles the unlocking of the given item, applies updates, and ensures proper associations and
+        publishing actions are carried out based on the item's type and the provided updates. Depending on the
+        `auto_publish` flag and item type, it may update archive versions, refresh associated items, and send
+        corresponding publish signals.
+
+        :param original: The original item data before applying updates.
+        :param updates: The dictionary containing updates to be applied to the item.
+        :returns: The updated item data after applying the updates and processing associations.
+        """
+
+        # unlock the item
+        set_unlock_updates(updates)
+
+        auto_publish = updates.get("auto_publish", False)
+        updated = deepcopy(original)
+        updated.update(deepcopy(updates))
+
+        if original[ITEM_TYPE] == CONTENT_TYPE.COMPOSITE:
+            await self._publish_package_items(original, updates)
+            await self._update_archive(original, updates, should_insert_into_versions=auto_publish)
+        else:
+            await self._publish_associated_items(original, updates)
+            updated = deepcopy(original)
+            updated.update(deepcopy(updates))
+
+            if updates.get(ASSOCIATIONS):
+                await self._refresh_associated_items(updated, skip_related=True)  # updates got lost with update
+
+            if updated.get(ASSOCIATIONS):
+                self._fix_related_references(updated, updates)
+
+            if updated[ITEM_TYPE] == "picture" or updated[ITEM_TYPE] == "video":
+                self._update_media_metadata(updates, updated)
+
+            signals.item_publish.send(self, item=updated, updates=updates)
+            await signals.item_publish_async.send(updated, updates)
+
+            await self.update_published_collection(updated)
+            await self._update_archive(original, updates, should_insert_into_versions=auto_publish)
+
+        return updated
+
+    async def _revert_resource_updates(self, original: dict) -> None:
+        """
+        Reverts resource updates to their original state in case of a failure during a publish operation.
+
+        This method performs the following steps:
+        1. Restores specific fields of the resource (state, publication status, operation, lock-related fields)
+           based on the original data to revert the state before the publish request.
+        2. Deletes any published document that was created during the failed operation.
+        3. Marks the previously successfully published version of the resource with a flag indicating it
+           as the last published version.
+
+        :param original: A dictionary containing the original resource data
+        """
+
+        # First up change the state of the failed items, to make sure they roll back to pre-publish request
+        item_id = original[ID_FIELD]
+        archive_reverts = {
+            field: original.get(field)
+            for field in {"state", "pubstatus", "operation", LOCK_USER, LOCK_SESSION, LOCK_ACTION, LOCK_TIME}
+        }
+        self.backend.update_async(self.datasource, item_id, archive_reverts, original)
+
+        # Then remove the ``published`` document that was created
+        published_service = get_resource_service(PUBLISHED)
+        await published_service.delete_async({"_id": original[ID_FIELD]})
+
+        # Next set the ``LAST_PUBLISHED_VERSION`` to True for the previous successfully published item
+        last_published = await published_service.get_last_published_version(item_id)
+        if last_published:
+            updates = {LAST_PUBLISHED_VERSION: True}
+            try:
+                await published_service.system_update_async(ObjectId(item_id), updates, last_published)
+            except Exception:
+                await published_service.system_update_async(item_id, updates, last_published)
+
     async def update_async(self, id, updates, original, raise_errors: bool = False):
         """
         Handles workflow of each Publish, Corrected, Killed and TakeDown.
         """
         try:
-            user = get_user()
-            auto_publish = updates.get("auto_publish", False)
-            target_media_type = updates.get("target_media_type")
-
-            # unlock the item
-            set_unlock_updates(updates)
-
-            updated = deepcopy(original)
-            updated.update(deepcopy(updates))
-
-            if original[ITEM_TYPE] == CONTENT_TYPE.COMPOSITE:
-                await self._publish_package_items(original, updates)
-                await self._update_archive(original, updates, should_insert_into_versions=auto_publish)
-            else:
-                await self._publish_associated_items(original, updates)
-                updated = deepcopy(original)
-                updated.update(deepcopy(updates))
-
-                if updates.get(ASSOCIATIONS):
-                    await self._refresh_associated_items(updated, skip_related=True)  # updates got lost with update
-
-                if updated.get(ASSOCIATIONS):
-                    self._fix_related_references(updated, updates)
-
-                if updated[ITEM_TYPE] == "picture" or updated[ITEM_TYPE] == "video":
-                    self._update_media_metadata(updates, updated)
-
-                signals.item_publish.send(self, item=updated, updates=updates)
-                await signals.item_publish_async.send(updated, updates)
-                await self._update_archive(original, updates, should_insert_into_versions=auto_publish)
-
-                await self.update_published_collection(published_item_id=original[ID_FIELD], updated=updated)
+            try:
+                updated = await self._process_item_updates_and_associations(original, updates)
+            except Exception:
+                await self._revert_resource_updates(original)
+                raise
 
             response = await publish_item(
                 PublishRequest(
@@ -313,7 +369,7 @@ class BasePublishService(AsyncBaseService):
                     operation=self.item_operation,
                     published_state=self.published_state,
                     sender_type=PublishSenderType.API,
-                    target_media_type=target_media_type
+                    target_media_type=updates.get("target_media_type")
                     or (
                         SubscriberType.DIGITAL
                         if updated[ITEM_TYPE] not in [CONTENT_TYPE.TEXT, CONTENT_TYPE.PREFORMATTED]
@@ -336,6 +392,7 @@ class BasePublishService(AsyncBaseService):
                 else:
                     logger.warning(error_message)
 
+            user = get_user()
             push_notification(
                 "item:publish",
                 item=str(id),
@@ -632,7 +689,7 @@ class BasePublishService(AsyncBaseService):
 
         updated = deepcopy(package)
         updated.update(updates)
-        await self.update_published_collection(published_item_id=package[ID_FIELD], updated=updated)
+        await self.update_published_collection(updated)
 
         if send_to_exchange:
             await publish_item(
@@ -646,19 +703,17 @@ class BasePublishService(AsyncBaseService):
                 publish_to_content_api=True,
             )
 
-    async def update_published_collection(self, published_item_id, updated=None):
+    async def update_published_collection(self, doc: dict):
         """Updates the published collection with the published item.
 
         Set the last_published_version to false for previous versions of the published items.
 
         :param: str published_item_id: _id of the document.
         """
-        published_item = await super().find_one_async(req=None, _id=published_item_id)
-        published_item = copy(published_item)
-        if updated:
-            published_item.update(updated)
-        await get_resource_service(PUBLISHED).update_published_items(published_item_id, LAST_PUBLISHED_VERSION, False)
-        return await get_resource_service(PUBLISHED).post_async([published_item])
+        await gather(
+            get_resource_service(PUBLISHED).update_published_items(doc[ID_FIELD], LAST_PUBLISHED_VERSION, False),
+            get_resource_service(PUBLISHED).post_async([doc]),
+        )
 
     def set_state(self, original, updates):
         """Set the state of the document based on the action (publish, correction, kill, recalled)

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -10,9 +10,7 @@
 
 from copy import copy, deepcopy
 import logging
-from asyncio import gather
 
-from bson import ObjectId
 from eve.versioning import resolve_document_version
 from eve.methods.common import resolve_document_etag
 from quart_babel import gettext as _
@@ -47,7 +45,7 @@ from apps.common.components.utils import get_component
 from apps.content import push_content_notification
 from apps.content_types.content_types import DEFAULT_SCHEMA
 from apps.item_autosave.components.item_autosave import ItemAutosave
-from apps.item_lock.components.item_lock import set_unlock_updates, LOCK_USER, LOCK_SESSION, LOCK_ACTION, LOCK_TIME
+from apps.item_lock.components.item_lock import set_unlock_updates
 from apps.legal_archive.commands import is_legal_archive_enabled
 from apps.packages.package_service import PackageService
 from apps.publish.published_item import LAST_PUBLISHED_VERSION, PUBLISHED, PUBLISHED_IN_PACKAGE
@@ -315,51 +313,12 @@ class BasePublishService(AsyncBaseService):
 
         return updated
 
-    async def _revert_resource_updates(self, original: dict) -> None:
-        """
-        Reverts resource updates to their original state in case of a failure during a publish operation.
-
-        This method performs the following steps:
-        1. Restores specific fields of the resource (state, publication status, operation, lock-related fields)
-           based on the original data to revert the state before the publish request.
-        2. Deletes any published document that was created during the failed operation.
-        3. Marks the previously successfully published version of the resource with a flag indicating it
-           as the last published version.
-
-        :param original: A dictionary containing the original resource data
-        """
-
-        # First up change the state of the failed items, to make sure they roll back to pre-publish request
-        item_id = original[ID_FIELD]
-        archive_reverts = {
-            field: original.get(field)
-            for field in {"state", "pubstatus", "operation", LOCK_USER, LOCK_SESSION, LOCK_ACTION, LOCK_TIME}
-        }
-        self.backend.update_async(self.datasource, item_id, archive_reverts, original)
-
-        # Then remove the ``published`` document that was created
-        published_service = get_resource_service(PUBLISHED)
-        await published_service.delete_async({"_id": original[ID_FIELD]})
-
-        # Next set the ``LAST_PUBLISHED_VERSION`` to True for the previous successfully published item
-        last_published = await published_service.get_last_published_version(item_id)
-        if last_published:
-            updates = {LAST_PUBLISHED_VERSION: True}
-            try:
-                await published_service.system_update_async(ObjectId(item_id), updates, last_published)
-            except Exception:
-                await published_service.system_update_async(item_id, updates, last_published)
-
     async def update_async(self, id, updates, original, raise_errors: bool = False):
         """
         Handles workflow of each Publish, Corrected, Killed and TakeDown.
         """
         try:
-            try:
-                updated = await self._process_item_updates_and_associations(original, updates)
-            except Exception:
-                await self._revert_resource_updates(original)
-                raise
+            updated = await self._process_item_updates_and_associations(original, updates)
 
             response = await publish_item(
                 PublishRequest(
@@ -703,17 +662,16 @@ class BasePublishService(AsyncBaseService):
                 publish_to_content_api=True,
             )
 
-    async def update_published_collection(self, doc: dict):
+    async def update_published_collection(self, doc: dict) -> None:
         """Updates the published collection with the published item.
 
         Set the last_published_version to false for previous versions of the published items.
 
-        :param: str published_item_id: _id of the document.
+        :param doc: The document to be used for updating and posting a new published collection.
         """
-        await gather(
-            get_resource_service(PUBLISHED).update_published_items(doc[ID_FIELD], LAST_PUBLISHED_VERSION, False),
-            get_resource_service(PUBLISHED).post_async([doc]),
-        )
+
+        await get_resource_service(PUBLISHED).update_published_items(doc[ID_FIELD], LAST_PUBLISHED_VERSION, False)
+        await get_resource_service(PUBLISHED).post_async([doc.copy()])
 
     def set_state(self, original, updates):
         """Set the state of the document based on the action (publish, correction, kill, recalled)

--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -286,14 +286,13 @@ class BasePublishService(AsyncBaseService):
 
         auto_publish = updates.get("auto_publish", False)
         updated = deepcopy(original)
-        updated.update(deepcopy(updates))
 
         if original[ITEM_TYPE] == CONTENT_TYPE.COMPOSITE:
             await self._publish_package_items(original, updates)
             await self._update_archive(original, updates, should_insert_into_versions=auto_publish)
+            updated.update(deepcopy(updates))
         else:
             await self._publish_associated_items(original, updates)
-            updated = deepcopy(original)
             updated.update(deepcopy(updates))
 
             if updates.get(ASSOCIATIONS):
@@ -308,6 +307,7 @@ class BasePublishService(AsyncBaseService):
             signals.item_publish.send(self, item=updated, updates=updates)
             await signals.item_publish_async.send(updated, updates)
 
+            updated.update(deepcopy(updates))
             await self.update_published_collection(updated)
             await self._update_archive(original, updates, should_insert_into_versions=auto_publish)
 

--- a/tests/publish/archive_publish_test.py
+++ b/tests/publish/archive_publish_test.py
@@ -1,0 +1,51 @@
+from unittest import mock
+
+from eve.utils import ParsedRequest
+
+from superdesk import get_resource_service, json
+from superdesk.tests import TestCase, utils as test_utils
+from superdesk.errors import SuperdeskApiError
+
+
+class MockAutosaveComponent:
+    async def clear(self, item_id):
+        raise Exception("Mock autosave component error")
+
+
+class ArchivePublishTest(TestCase):
+    @mock.patch("apps.publish.content.common.get_component", return_value=MockAutosaveComponent())
+    async def test_published_item_exists_when_publish_exception_raised(self, _mock):
+        # First, create the Desk and content for us to publish/test against
+        desk = {"name": "sports"}
+        await test_utils.post_items("desks", [desk])
+        item = {
+            "_id": "foo",
+            "guid": "foo",
+            "unique_name": "foo",
+            "type": "text",
+            "_current_version": 2,
+            "state": "submitted",
+            "headline": "foo",
+            "task": {"desk": desk["_id"], "stage": desk["working_stage"]},
+        }
+        await get_resource_service("archive").create_async([item])
+
+        async def get_search_count(repos: str) -> int:
+            req = ParsedRequest()
+            req.args = {"source": json.dumps({"query": {"bool": {}}}), "repo": repos}
+            cursor = await get_resource_service("search").get_async(req=req, lookup=None)
+            return await cursor.count()
+
+        # Next up, test the item can be found in the "archive" search repo and not in "published"
+        self.assertEqual(1, await get_search_count("archive,published"))
+        self.assertEqual(1, await get_search_count("archive"))
+        self.assertEqual(0, await get_search_count("published"))
+
+        # Now, publish the item (making sure that the MockAutosave exception is raised)
+        with self.assertRaises(SuperdeskApiError):
+            await get_resource_service("archive_publish").patch_async(item["_id"], {})
+
+        # Finally, test the item can be found in the "published" search repo and not in "archive"
+        self.assertEqual(1, await get_search_count("archive,published"))
+        self.assertEqual(0, await get_search_count("archive"))
+        self.assertEqual(1, await get_search_count("published"))


### PR DESCRIPTION
### Purpose
When an exception is raised during the publish process, it is possible for the archive item to be updated but the published item is not. This results in the item being `lost` to end users, as the archive item is expected to exist in the published collection.

### What has changed
* Create the published document before updating the archive collection
~~* Wrap the create/update of archive/published, and revert the archive item state so it's usable again~~

Resolves: STT-1648

