### PR TITLE
fix ap ingest: ignore failing association parse errors

### DIFF
--- a/superdesk/io/feed_parsers/ap_media.py
+++ b/superdesk/io/feed_parsers/ap_media.py
@@ -275,7 +275,10 @@ class APMediaFeedParser(FeedParser):
         if related_id:
             item["associations"] = {}
             for key, raw in associations.items():
-                item["associations"]["{}--{}".format(related_id, key)] = self.parse(raw, provider)
+                try:
+                    item["associations"]["{}--{}".format(related_id, key)] = self.parse(raw, provider)
+                except Exception as exc:
+                    logger.warning("Failed to parse association '%s': %s", key, exc)
 
     def _parse_renditions(self, renditions, item):
         try:

--- a/superdesk/io/feed_parsers/ap_media.py
+++ b/superdesk/io/feed_parsers/ap_media.py
@@ -278,7 +278,7 @@ class APMediaFeedParser(FeedParser):
                 try:
                     item["associations"]["{}--{}".format(related_id, key)] = self.parse(raw, provider)
                 except Exception as exc:
-                    logger.warning("Failed to parse association '%s': %s", key, exc)
+                    logger.warning("Failed to parse association '%s': %s", key, exc, exc_info=True)
 
     def _parse_renditions(self, renditions, item):
         try:

--- a/tests/io/feed_parsers/ap_media_test.py
+++ b/tests/io/feed_parsers/ap_media_test.py
@@ -33,3 +33,42 @@ class SimpleTestCase(APMediaTestCase):
 
     def test_headline(self):
         self.assertEqual(self.item.get("headline"), "US Paul Simon Poets Society")
+
+
+class AssociationsErrorHandlingTest(TestCase):
+    def test_parse_associations_ignores_invalid_association_items(self):
+        parser = APMediaFeedParser()
+        parser.RELATED_ID = "related"
+
+        parsed = parser.parse(
+            {
+                "data": {
+                    "item": {
+                        "altids": {"itemid": "main"},
+                        "version": 1,
+                        "type": "text",
+                        "slugline": "MAIN-SLUG",
+                    }
+                },
+                "api_version": "1.0",
+                "associations": {
+                    "good": {
+                        "data": {
+                            "item": {
+                                "altids": {"itemid": "assoc"},
+                                "version": 1,
+                                "type": "text",
+                                "slugline": "ASSOC-SLUG",
+                            }
+                        },
+                        "api_version": "1.0",
+                    },
+                    "bad": {"data": {}},
+                },
+            },
+            {"source": "Test"},
+        )
+
+        self.assertIn("associations", parsed)
+        self.assertIn("related--good", parsed["associations"])
+        self.assertNotIn("related--bad", parsed["associations"])


### PR DESCRIPTION
Wrap each association parse in a try/except so a malformed association item does not abort the whole document parse. Failed associations are logged as warnings and skipped.

SDCP-1145

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

