### PR TITLE
remove extra error log from ingest

### DIFF
--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -742,7 +742,6 @@ async def ingest_item(item, provider, feeding_service, rule_set=None, routing_sc
             )
 
     except Exception as ex:
-        logger.exception(ex)
         await ProviderError.ingestItemError(ex, provider, item=item).send_notifications()
         return False, []
     return True, items_ids


### PR DESCRIPTION
there is logger called when raising the error

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

