### PR TITLE
fix kombu json encoding error

### DIFF
--- a/superdesk/celery_app.py
+++ b/superdesk/celery_app.py
@@ -21,6 +21,7 @@ import superdesk
 from bson import ObjectId
 from celery import Celery
 from kombu.serialization import register
+from kombu.utils.json import register_type
 from eve.io.mongo import MongoJSONEncoder
 from eve.utils import str_to_date
 from flask import json, current_app as app
@@ -30,6 +31,9 @@ from superdesk.logging import logger
 
 celery = Celery(__name__)
 TaskBase = celery.Task
+
+
+register_type(ObjectId, "objectid", str, ObjectId)
 
 
 def try_cast(v):

--- a/tests/celery_tests.py
+++ b/tests/celery_tests.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 from bson import ObjectId
 from eve.utils import date_to_str
+from kombu.utils.json import dumps as kombu_dumps, loads as kombu_loads
 
 from superdesk.tests import TestCase
 from superdesk.celery_app import try_cast, loads
@@ -19,6 +20,13 @@ from superdesk.celery_app import try_cast, loads
 
 class CeleryTestCase(TestCase):
     _id = ObjectId("528de7b03b80a13eefc5e610")
+
+    def test_kombu_json_roundtrip_objectid(self):
+        payload = {"_id": self._id}
+        decoded = kombu_loads(kombu_dumps(payload))
+
+        self.assertEqual(decoded["_id"], self._id)
+        self.assertIsInstance(decoded["_id"], ObjectId)
 
     def test_cast_objectid(self):
         self.assertEqual(try_cast(str(self._id)), self._id)


### PR DESCRIPTION
seems to be happening when using celery inspection tools

```
 Control command error: EncodeError(TypeError('Object of type ObjectId is not JSON serializable')) level=ERROR process=MainProcess
 Traceback (most recent call last):
   File "/opt/superdesk/env/lib/python3.10/site-packages/kombu/serialization.py", line 41, in _reraise_errors
     yield
   File "/opt/superdesk/env/lib/python3.10/site-packages/kombu/serialization.py", line 220, in dumps
     payload = encoder(data)
   File "/opt/superdesk/env/lib/python3.10/site-packages/kombu/utils/json.py", line 63, in dumps
     return _dumps(s, cls=cls, **dict(default_kwargs, **kwargs))
   File "/usr/lib/python3.10/json/__init__.py", line 238, in dumps
     **kw).encode(obj)
   File "/usr/lib/python3.10/json/encoder.py", line 199, in encode
     chunks = self.iterencode(o, _one_shot=True)
   File "/usr/lib/python3.10/json/encoder.py", line 257, in iterencode
     return _iterencode(o, 0)
   File "/opt/superdesk/env/lib/python3.10/site-packages/kombu/utils/json.py", line 47, in default
   File "/opt/superdesk/env/lib/python3.10/site-packages/kombu/serialization.py", line 219, in dumps
     with _reraise_errors(EncodeError):
   File "/usr/lib/python3.10/contextlib.py", line 153, in __exit__
     self.gen.throw(typ, value, traceback)
   File "/opt/superdesk/env/lib/python3.10/site-packages/kombu/serialization.py", line 45, in _reraise_errors
     reraise(wrapper, wrapper(exc), sys.exc_info()[2])
   File "/opt/superdesk/env/lib/python3.10/site-packages/kombu/exceptions.py", line 34, in reraise
     raise value.with_traceback(tb)
   File "/opt/superdesk/env/lib/python3.10/site-packages/kombu/serialization.py", line 41, in _reraise_errors
     yield
   File "/opt/superdesk/env/lib/python3.10/site-packages/kombu/serialization.py", line 220, in dumps
     payload = encoder(data)
   File "/opt/superdesk/env/lib/python3.10/site-packages/kombu/utils/json.py", line 63, in dumps
     return _dumps(s, cls=cls, **dict(default_kwargs, **kwargs))
   File "/usr/lib/python3.10/json/__init__.py", line 238, in dumps
     **kw).encode(obj)
   File "/usr/lib/python3.10/json/encoder.py", line 199, in encode
     chunks = self.iterencode(o, _one_shot=True)
   File "/usr/lib/python3.10/json/encoder.py", line 257, in iterencode
     return _iterencode(o, 0)
   File "/opt/superdesk/env/lib/python3.10/site-packages/kombu/utils/json.py", line 47, in default
     return super().default(o)
   File "/usr/lib/python3.10/json/encoder.py", line 179, in default
     raise TypeError(f'Object of type {o.__class__.__name__} '
 kombu.exceptions.EncodeError: Object of type ObjectId is not JSON serializable
 ```

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

