### PR TITLE
[SDESK-7907] Localize user-facing strings with gettext

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -1298,7 +1298,7 @@ class AutoSaveResource(Resource):
 class ArchiveSaveService(AsyncBaseService):
     async def create_async(self, docs, **kwargs):
         if not docs:
-            raise SuperdeskApiError.notFoundError("Content is missing")
+            raise SuperdeskApiError.notFoundError(_("Content is missing"))
 
         for doc in docs:
             editor_utils.generate_fields(doc)

--- a/apps/archive/archive_media.py
+++ b/apps/archive/archive_media.py
@@ -9,6 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import logging
+from quart_babel import gettext as _
 
 from superdesk.core import get_current_app, get_app_config
 from superdesk.resource_fields import ID_FIELD, VERSION
@@ -47,7 +48,7 @@ class ArchiveMediaService:
         inserted = []
         for doc in docs:
             if "media" not in doc or doc["media"] is None:
-                abort(400, description="No media found")
+                abort(400, description=_("No media found"))
             # check content type of video by python-magic
             content_type = app.media._get_mimetype(doc["media"])
             doc["media"].seek(0)

--- a/apps/auth/db/reset_password.py
+++ b/apps/auth/db/reset_password.py
@@ -58,7 +58,7 @@ class ResetPasswordService(AsyncBaseService):
         reset_request = await superdesk.get_resource_service("active_tokens").find_one_async(req=None, token=token)
         if not reset_request or reset_request["expire_time"] < utcnow():
             logger.warning("Invalid token received: %s" % token)
-            raise SuperdeskApiError.unauthorizedError("Invalid token received")
+            raise SuperdeskApiError.unauthorizedError(_("Invalid token received"))
 
         return reset_request
 

--- a/apps/ldap/commands.py
+++ b/apps/ldap/commands.py
@@ -11,6 +11,7 @@
 import logging
 
 import click
+from quart_babel import gettext as _
 
 from superdesk.core import get_app_config
 from superdesk.commands import cli
@@ -70,7 +71,7 @@ class ImportUserProfileFromADCommand:
         print(user_data)
 
         if len(user_data) == 0:
-            raise SuperdeskApiError.notFoundError("Username not found")
+            raise SuperdeskApiError.notFoundError(_("Username not found"))
 
         # Check if User Profile already exists in Mongo
         users_service = superdesk.get_resource_service("users")

--- a/apps/templates/content_templates.py
+++ b/apps/templates/content_templates.py
@@ -425,7 +425,7 @@ class ContentTemplatesService(AsyncBaseService):
             return
 
         if doc.get("template_desks"):
-            raise SuperdeskApiError.badRequestError("Kill templates can not be assigned to desks")
+            raise SuperdeskApiError.badRequestError(_("Kill templates can not be assigned to desks"))
         if "is_public" in doc and doc["is_public"] is False:
             raise SuperdeskApiError.badRequestError(_("Kill templates must be public"))
         doc["is_public"] = True
@@ -509,14 +509,14 @@ class ContentTemplatesApplyService(AsyncBaseService):
         item["desk_name"] = await DesksResourceModel.get_desk_name(item.get("task", {}).get("desk"))
 
         if not template_name:
-            SuperdeskApiError.badRequestError(message="Invalid Template Name")
+            SuperdeskApiError.badRequestError(message=_("Invalid Template Name"))
 
         if not item:
-            SuperdeskApiError.badRequestError(message="Invalid Item")
+            SuperdeskApiError.badRequestError(message=_("Invalid Item"))
 
         template = await superdesk.get_resource_service("content_templates").get_template_by_name(template_name)
         if not template:
-            SuperdeskApiError.badRequestError(message="Invalid Template")
+            SuperdeskApiError.badRequestError(message=_("Invalid Template"))
 
         updates = await render_content_template(item, template)
         item.update(updates)
@@ -544,7 +544,7 @@ async def render_content_template_by_name(item, template_name):
     # get the kill template
     template = await superdesk.get_resource_service("content_templates").get_template_by_name(template_name)
     if not template:
-        SuperdeskApiError.badRequestError(message="{} Template missing.".format(template_name))
+        SuperdeskApiError.badRequestError(message=_("{} Template missing.").format(template_name))
 
     # apply the kill template
     return await render_content_template(item, template)
@@ -561,7 +561,7 @@ async def render_content_template_by_id(item, template_id, update=False):
     # get the kill template
     template = await superdesk.get_resource_service("content_templates").find_one_async(req=None, _id=template_id)
     if not template:
-        SuperdeskApiError.badRequestError(message="{} Template missing.".format(template_id))
+        SuperdeskApiError.badRequestError(message=_("{} Template missing.").format(template_id))
 
     return await render_content_template(item, template, update)
 

--- a/content_api/assets/service.py
+++ b/content_api/assets/service.py
@@ -9,6 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from bson import ObjectId
+from quart_babel import gettext as _
 
 from superdesk.core import get_current_app
 from superdesk.errors import SuperdeskApiError
@@ -61,7 +62,7 @@ class AssetsService(BaseService):
             doc["mime_type"] = content_type
             doc["filemeta"] = decode_metadata(metadata)
         except Exception as io:
-            raise SuperdeskApiError.internalError("Saving file failed", exception=io)
+            raise SuperdeskApiError.internalError(_("Saving file failed"), exception=io)
 
     def download_file(self, doc):
         url = doc.get("URL")

--- a/content_api/publish/utils.py
+++ b/content_api/publish/utils.py
@@ -1,3 +1,5 @@
+from quart_babel import gettext as _
+
 from superdesk import get_resource_service
 from superdesk.resource_fields import ID_FIELD, GUID_FIELD
 from superdesk.errors import SuperdeskApiError
@@ -35,7 +37,7 @@ async def publish_doc_to_content_api(item_dict: dict) -> str:
             return create_response[0].id
 
         # This should never happen, as exceptions would be raised by ``service.create``
-        raise SuperdeskApiError.badRequestError("Failed to create item in Content API")
+        raise SuperdeskApiError.badRequestError(_("Failed to create item in Content API"))
 
 
 def process_associations(updates: ContentAPIItem, original: ContentAPIItem | None) -> None:

--- a/content_api/tokens/auth.py
+++ b/content_api/tokens/auth.py
@@ -1,4 +1,5 @@
 from eve.auth import TokenAuth
+from quart_babel import gettext as _
 
 from superdesk.utc import utcnow
 from superdesk.errors import SuperdeskApiError
@@ -44,12 +45,12 @@ class SubscriberTokenAuth(TokenAuthorization):
         token_id = self._get_auth_token_from_request(request)
 
         if token_id is None:
-            raise SuperdeskApiError.forbiddenError(message="Authorization token missing.")
+            raise SuperdeskApiError.forbiddenError(message=_("Authorization token missing."))
 
         token = await token_service.find_by_id(token_id)
         if token is None:
             await self.stop_session(request)
-            raise SuperdeskApiError.forbiddenError(message="Authorization token missing.")
+            raise SuperdeskApiError.forbiddenError(message=_("Authorization token missing."))
 
         await self.check_token_validity(token)
         await self.start_session(request, token)
@@ -61,7 +62,7 @@ class SubscriberTokenAuth(TokenAuthorization):
 
         if token.expiry and token.expiry < utcnow():
             await SubscriberTokenService().delete(token)
-            raise SuperdeskApiError.forbiddenError(message="Authorization token expired.")
+            raise SuperdeskApiError.forbiddenError(message=_("Authorization token expired."))
 
     async def start_session(self, request: Request, token: SubscriberToken) -> None:  # type: ignore[override]
         """

--- a/superdesk/activity.py
+++ b/superdesk/activity.py
@@ -13,7 +13,7 @@ import logging
 from typing import List, cast
 
 from bson.objectid import ObjectId
-from quart_babel import lazy_gettext
+from quart_babel import gettext as _, lazy_gettext
 
 import superdesk
 from superdesk import get_resource_service
@@ -111,7 +111,7 @@ class ActivityService(AsyncBaseService):
             req = ParsedRequest()
         user = get_current_app().get_current_user_dict()
         if not user:
-            raise SuperdeskApiError.notFoundError("Can not determine user")
+            raise SuperdeskApiError.notFoundError(_("Can not determine user"))
         where_cond = {}
         if req.where:
             if req.where[0] != "{":
@@ -134,26 +134,26 @@ class ActivityService(AsyncBaseService):
         """
         user = get_current_app().get_current_user_dict()
         if not user:
-            raise SuperdeskApiError.notFoundError("Can not determine user")
+            raise SuperdeskApiError.notFoundError(_("Can not determine user"))
         user_id = user.get("_id")
 
         # make sure that the user making the read notification is in the notification list
         if not self.is_recipient(updates, user_id):
-            raise SuperdeskApiError.forbiddenError("User is not in the notification list")
+            raise SuperdeskApiError.forbiddenError(_("User is not in the notification list"))
 
         # make sure the transition is from not read to read
         if not self.is_read(updates, user_id) and self.is_read(original, user_id):
-            raise SuperdeskApiError.forbiddenError("Can not set notification as read")
+            raise SuperdeskApiError.forbiddenError(_("Can not set notification as read"))
 
         # make sure that no other users are being marked as read
         for recipient in updates.get("recipients", []):
             if recipient["user_id"] != user_id:
                 if self.is_read(updates, recipient["user_id"]) != self.is_read(original, recipient["user_id"]):
-                    raise SuperdeskApiError.forbiddenError("Can not set other users notification as read")
+                    raise SuperdeskApiError.forbiddenError(_("Can not set other users notification as read"))
 
         # make sure that no other fields are being up dated just read and _updated
         if len(updates) != 2:
-            raise SuperdeskApiError.forbiddenError("Can not update")
+            raise SuperdeskApiError.forbiddenError(_("Can not update"))
 
     def is_recipient(self, activity, user_id):
         """

--- a/superdesk/auth/decorator.py
+++ b/superdesk/auth/decorator.py
@@ -2,6 +2,8 @@ from typing import Optional
 from inspect import isawaitable
 from functools import wraps
 
+from quart_babel import gettext as _
+
 from superdesk.core import get_current_app
 from superdesk.flask import request
 
@@ -54,13 +56,13 @@ def blueprint_token():
             from superdesk.errors import SuperdeskApiError
 
             if not (token := request.args.get("token")):
-                raise SuperdeskApiError.unauthorizedError("Token required")
+                raise SuperdeskApiError.unauthorizedError(_("Token required"))
 
             if not (payload := jwt_decode(token)):
-                raise SuperdeskApiError.unauthorizedError("Invalid or expired token")
+                raise SuperdeskApiError.unauthorizedError(_("Invalid or expired token"))
 
             if payload.get("_url_path") != request.path:
-                raise SuperdeskApiError.unauthorizedError("Token not valid for this URL")
+                raise SuperdeskApiError.unauthorizedError(_("Token not valid for this URL"))
 
             return await _call_and_await(f, *args, **kwargs)
 

--- a/superdesk/core/elastic/base_client.py
+++ b/superdesk/core/elastic/base_client.py
@@ -14,6 +14,7 @@ import ast
 import simplejson as json
 from eve.io.mongo.parser import parse
 from bson import ObjectId
+from quart_babel import gettext as _
 
 from superdesk.errors import SuperdeskApiError
 from superdesk.core.types import SearchRequest, SortParam, ElasticResourceConfig, ElasticClientConfig, ProjectedFieldArg
@@ -233,7 +234,7 @@ class BaseElasticResourceClient:
                 try:
                     filters.append({"term": parse(req.where)})
                 except ValueError as e:
-                    raise SuperdeskApiError.badRequestError("Invalid where argument") from e
+                    raise SuperdeskApiError.badRequestError(_("Invalid where argument")) from e
 
         _set_filters(query, filters)
 

--- a/superdesk/core/resources/resource_rest_endpoints.py
+++ b/superdesk/core/resources/resource_rest_endpoints.py
@@ -269,7 +269,7 @@ class ResourceRestEndpoints(RestEndpoints):
             service = get_current_async_app().resources.get_resource_service(parent_link.resource_name)
             item_id: str | ObjectId | None = request.get_view_args(parent_link.get_url_arg_name())
             if not item_id:
-                raise SuperdeskApiError.badRequestError("Parent resource ID not provided in URL")
+                raise SuperdeskApiError.badRequestError(gettext("Parent resource ID not provided in URL"))
             elif service.id_uses_objectid():
                 item_id = ObjectId(item_id)
 
@@ -413,7 +413,7 @@ class ResourceRestEndpoints(RestEndpoints):
         payload: dict | list[dict] | None = await request.get_json()
 
         if payload is None:
-            raise SuperdeskApiError.badRequestError("Empty payload")
+            raise SuperdeskApiError.badRequestError(gettext("Empty payload"))
 
         if isinstance(payload, dict):
             payload = [payload]
@@ -536,7 +536,7 @@ class ResourceRestEndpoints(RestEndpoints):
         payload = await request.get_json()
 
         if not payload:
-            raise SuperdeskApiError.badRequestError("Empty payload")
+            raise SuperdeskApiError.badRequestError(gettext("Empty payload"))
 
         original = await self.service.find_by_id(args.item_id)
         if original is None:

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -40,6 +40,8 @@ from motor.motor_asyncio import AsyncIOMotorCursor
 # TODO-ASYNC: Replace Eve's parser with our own
 from eve.io.mongo.parser import parse, ParseError
 
+from quart_babel import gettext as _
+
 from superdesk.core.types import SearchRequest, SortListParam, SortParam, ProjectedFieldArg
 from superdesk.core.errors import ElasticNotConfiguredForResource
 from superdesk.flask import g
@@ -896,7 +898,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
                 try:
                     where = parse(req.where)
                 except ParseError:
-                    raise SuperdeskApiError.badRequestError("Failed to parse the where filter")
+                    raise SuperdeskApiError.badRequestError(_("Failed to parse the where filter"))
 
         self._validate_lookup(where)
         where = cast_item(where or {})
@@ -964,7 +966,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
         etag = etag.replace('"', "")
 
         if etag != original.etag:
-            raise SuperdeskApiError.preconditionFailedError("Client and server etags don't match")
+            raise SuperdeskApiError.preconditionFailedError(_("Client and server etags don't match"))
 
     def generate_etag(self, value: dict[str, Any], ignore_fields: list[str] | None = None) -> str:
         if ignore_fields is not None:
@@ -1020,7 +1022,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
         """
 
         if not self.config.versioning:
-            raise SuperdeskApiError.badRequestError("Resource does not support versioning")
+            raise SuperdeskApiError.badRequestError(_("Resource does not support versioning"))
 
         item: dict | None = await self.mongo_async.find_one({ID_FIELD: item_id}, projection=projection)
         if not item:
@@ -1055,7 +1057,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
         """
 
         if not self.config.versioning:
-            raise SuperdeskApiError.badRequestError("Resource does not support versioning")
+            raise SuperdeskApiError.badRequestError(_("Resource does not support versioning"))
 
         versioned_item: dict | None = await self.mongo_versioned_async.find_one(
             {
@@ -1143,7 +1145,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
             mongo_result, elastic_result = await asyncio.gather(mongo_task, elastic_task)
 
         if not mongo_result.acknowledged:
-            raise SuperdeskApiError.badRequestError("Failed to bulk update items in MongoDB")
+            raise SuperdeskApiError.badRequestError(_("Failed to bulk update items in MongoDB"))
 
         if mongo_result.modified_count != len(ids):
             logger.warning(

--- a/superdesk/download.py
+++ b/superdesk/download.py
@@ -12,6 +12,8 @@
 import logging
 import superdesk
 
+from quart_babel import gettext as _
+
 from superdesk.errors import SuperdeskApiError
 from superdesk.auth.decorator import blueprint_token
 from superdesk.eve_async import AsyncBaseService
@@ -36,7 +38,7 @@ async def download_file(id, folder=None):
     file = await app.media.get_async(filename, "download", begin=begin, end=end)
     if file:
         return await generate_response_for_file(file, content_disposition='attachment; filename="export.zip"')
-    raise SuperdeskApiError.notFoundError("File not found on media storage.")
+    raise SuperdeskApiError.notFoundError(_("File not found on media storage."))
 
 
 def download_url(media_id):

--- a/superdesk/eve_async/service.py
+++ b/superdesk/eve_async/service.py
@@ -235,7 +235,9 @@ class AsyncBaseService(BaseService):
                 if res:
                     success.append(res)
             except Exception as ex:
-                raise SuperdeskApiError.badRequestError("Uploaded file is invalid, Error occured:{}.".format(str(ex)))
+                raise SuperdeskApiError.badRequestError(
+                    gettext("Uploaded file is invalid, Error occured:{}.").format(str(ex))
+                )
 
         if success:
             return {

--- a/superdesk/eve_backend.py
+++ b/superdesk/eve_backend.py
@@ -27,6 +27,8 @@ from eve.methods.common import resolve_document_etag
 from elasticsearch.exceptions import RequestError, NotFoundError
 
 import superdesk
+from quart_babel import gettext as _
+
 from superdesk.core import json, get_app_config, get_current_app
 from superdesk.resource_fields import ID_FIELD, ETAG, LAST_UPDATED, DATE_CREATED
 from superdesk.errors import SuperdeskApiError
@@ -870,7 +872,7 @@ class EveBackend:
         backend = self._backend(endpoint_name)
         search_backend = self._lookup_backend(endpoint_name)
         if search_backend:
-            raise SuperdeskApiError.forbiddenError(message="Can not remove from endpoint with a defined search")
+            raise SuperdeskApiError.forbiddenError(message=_("Can not remove from endpoint with a defined search"))
         backend.remove(endpoint_name, lookup)
 
     async def delete_from_mongo_async(self, endpoint_name: str, lookup: Dict[str, Any]):
@@ -886,7 +888,7 @@ class EveBackend:
         backend = self._backend(endpoint_name, use_async=True)
         search_backend = self._lookup_backend(endpoint_name, use_async=True)
         if search_backend:
-            raise SuperdeskApiError.forbiddenError(message="Can not remove from endpoint with a defined search")
+            raise SuperdeskApiError.forbiddenError(message=_("Can not remove from endpoint with a defined search"))
         await backend.remove(endpoint_name, lookup)
 
     def remove_from_search(self, endpoint_name, doc):

--- a/superdesk/io/feeding_services/__init__.py
+++ b/superdesk/io/feeding_services/__init__.py
@@ -16,6 +16,8 @@ from abc import ABCMeta, abstractmethod
 from datetime import timedelta, datetime
 from pytz import utc
 
+from quart_babel import gettext as _
+
 from superdesk.core import get_app_config
 from superdesk.core.utils import list_to_async_generator
 from superdesk.resource_fields import ID_FIELD
@@ -167,7 +169,7 @@ class FeedingService(metaclass=ABCMeta):
         :raises SuperdeskIngestError if failed to get items from provider
         """
         if self._is_closed(provider):
-            raise SuperdeskApiError.internalError("Ingest Provider is closed")
+            raise SuperdeskApiError.internalError(_("Ingest Provider is closed"))
 
         try:
             self._provider = provider

--- a/superdesk/io/ingest_provider_model.py
+++ b/superdesk/io/ingest_provider_model.py
@@ -22,6 +22,7 @@ from superdesk.activity import (
     notify_and_add_activity,
     ACTIVITY_DELETE,
 )
+from quart_babel import gettext as _
 from superdesk.errors import SuperdeskApiError
 from superdesk.io import allowed_feeding_services, allowed_feed_parsers, get_feeding_service
 from superdesk.metadata.item import CONTENT_STATE, CONTENT_TYPE
@@ -273,7 +274,7 @@ class IngestProviderService(AsyncBaseService):
         """
 
         if doc.get("last_item_update"):
-            raise SuperdeskApiError.forbiddenError("Deleting an Ingest Source after receiving items is prohibited.")
+            raise SuperdeskApiError.forbiddenError(_("Deleting an Ingest Source after receiving items is prohibited."))
 
     async def on_deleted_async(self, doc):
         """

--- a/superdesk/io/webhooks/__init__.py
+++ b/superdesk/io/webhooks/__init__.py
@@ -8,6 +8,8 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from quart_babel import gettext as _
+
 from superdesk.resource import Resource
 from superdesk.eve_async import AsyncBaseService
 from superdesk.io.commands import update_ingest
@@ -21,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 class FeedingServiceWebhookAuth(object):
     def authenticate(self):
-        abort(403, description="You are not authorized to access this resource")
+        abort(403, description=_("You are not authorized to access this resource"))
 
     def authorized(self, allowed_roles, resource, method):
         try:

--- a/superdesk/media/crop.py
+++ b/superdesk/media/crop.py
@@ -10,6 +10,7 @@
 import json
 
 from eve.utils import ParsedRequest
+from quart_babel import gettext as _
 
 import logging
 from copy import deepcopy
@@ -46,21 +47,21 @@ class CropService:
         """
         # Check if type is picture
         if original[ITEM_TYPE] != CONTENT_TYPE.PICTURE:
-            raise SuperdeskApiError.badRequestError(message="Only images can be cropped!")
+            raise SuperdeskApiError.badRequestError(message=_("Only images can be cropped!"))
 
         # Check if the renditions exists
         if not original.get("renditions"):
-            raise SuperdeskApiError.badRequestError(message="Missing renditions!")
+            raise SuperdeskApiError.badRequestError(message=_("Missing renditions!"))
 
         # Check if the original rendition exists
         if not original.get("renditions").get("original"):
-            raise SuperdeskApiError.badRequestError(message="Missing original rendition!")
+            raise SuperdeskApiError.badRequestError(message=_("Missing original rendition!"))
 
         # Check if the crop name is valid
         crop = self.get_crop_by_name(crop_name)
         crop_data = updates.get("renditions", {}).get(crop_name, {})
         if not crop and "CropLeft" in crop_data:
-            raise SuperdeskApiError.badRequestError(message="Unknown crop name! (name=%s)" % crop_name)
+            raise SuperdeskApiError.badRequestError(message=_("Unknown crop name! (name=%s)") % crop_name)
 
         self._validate_values(crop_data)
         self._validate_poi(original, updates, crop_name)
@@ -73,7 +74,7 @@ class CropService:
                 try:
                     crop[field] = int(crop[field])
                 except (TypeError, ValueError):
-                    raise SuperdeskApiError.badRequestError("Invalid value for %s in renditions" % field)
+                    raise SuperdeskApiError.badRequestError(_("Invalid value for %s in renditions") % field)
 
     def _validate_poi(self, original, updates, crop_name):
         """Validate the crop point of interest in the renditions dictionary for the given crop
@@ -123,19 +124,19 @@ class CropService:
         height = doc["CropBottom"] - doc["CropTop"]
         if not (crop.get("width") or crop.get("height") or crop.get("ratio")):
             raise SuperdeskApiError.badRequestError(
-                message="Crop data are missing. width, height or ratio need to be defined"
+                message=_("Crop data are missing. width, height or ratio need to be defined")
             )
         if crop.get("width") and crop.get("height"):
             expected_crop_width = int(crop["width"])
             expected_crop_height = int(crop["height"])
             if width < expected_crop_width or height < expected_crop_height:
                 raise SuperdeskApiError.badRequestError(
-                    message="Wrong crop size. Minimum crop size is {}x{}.".format(crop["width"], crop["height"])
+                    message=_("Wrong crop size. Minimum crop size is {}x{}.").format(crop["width"], crop["height"])
                 )
                 doc_ratio = round(width / height, 1)
                 spec_ratio = round(expected_crop_width / expected_crop_height, 1)
                 if doc_ratio != spec_ratio:
-                    raise SuperdeskApiError.badRequestError(message="Wrong aspect ratio!")
+                    raise SuperdeskApiError.badRequestError(message=_("Wrong aspect ratio!"))
         elif crop.get("ratio"):
             ratio = crop.get("ratio")
             if type(ratio) not in [int, float]:
@@ -143,7 +144,7 @@ class CropService:
                 ratio = int(ratio[0]) / int(ratio[1])
             if abs((width / height) - ratio) > 0.1:
                 raise SuperdeskApiError.badRequestError(
-                    message="Ratio %s is not respected. We got %f" % (crop.get("ratio"), abs((width / height)))
+                    message=_("Ratio %s is not respected. We got %f") % (crop.get("ratio"), abs((width / height)))
                 )
 
     def get_crop_by_name(self, crop_name):
@@ -162,7 +163,7 @@ class CropService:
             self.crop_sizes = custom_crops.get("items")
 
         if not self.crop_sizes:
-            raise SuperdeskApiError.badRequestError(message="Crops sizes couldn't be loaded!")
+            raise SuperdeskApiError.badRequestError(message=_("Crops sizes couldn't be loaded!"))
 
         return next((c for c in self.crop_sizes if c.get("name", "").lower() == crop_name.lower()), None)
 
@@ -177,12 +178,12 @@ class CropService:
         """
         original_file = get_current_app().media.fetch_rendition(original_image)
         if not original_file:
-            raise SuperdeskApiError.badRequestError("Original file couldn't be found")
+            raise SuperdeskApiError.badRequestError(_("Original file couldn't be found"))
         try:
             cropped, out = crop_image(original_file, crop_name, crop_data)
             crop = self.get_crop_by_name(crop_name)
             if not cropped:
-                raise SuperdeskApiError.badRequestError("Saving crop failed.")
+                raise SuperdeskApiError.badRequestError(_("Saving crop failed."))
             # resize if needed
             if crop.get("width") or crop.get("height"):
                 out, width, height = _resize_image(
@@ -197,7 +198,7 @@ class CropService:
         except SuperdeskApiError:
             raise
         except Exception as ex:
-            raise SuperdeskApiError.badRequestError("Generating crop failed: {}".format(str(ex)))
+            raise SuperdeskApiError.badRequestError(_("Generating crop failed: {}").format(str(ex)))
 
     def _save_cropped_image(self, file_stream, original, doc):
         """Saves the cropped image and returns the crop dictionary
@@ -231,7 +232,7 @@ class CropService:
                 app.media.delete(file_id)
             except Exception:
                 pass
-            raise SuperdeskApiError.internalError("Generating crop failed: {}".format(str(ex)), exception=ex)
+            raise SuperdeskApiError.internalError(_("Generating crop failed: {}").format(str(ex)), exception=ex)
 
     def _delete_crop_file(self, file_id):
         """Delete the crop file

--- a/superdesk/media/crop.py
+++ b/superdesk/media/crop.py
@@ -61,7 +61,9 @@ class CropService:
         crop = self.get_crop_by_name(crop_name)
         crop_data = updates.get("renditions", {}).get(crop_name, {})
         if not crop and "CropLeft" in crop_data:
-            raise SuperdeskApiError.badRequestError(message=_("Unknown crop name! (name=%s)") % crop_name)
+            raise SuperdeskApiError.badRequestError(
+                message=_("Unknown crop name! (name={name})").format(name=crop_name)
+            )
 
         self._validate_values(crop_data)
         self._validate_poi(original, updates, crop_name)
@@ -74,7 +76,9 @@ class CropService:
                 try:
                     crop[field] = int(crop[field])
                 except (TypeError, ValueError):
-                    raise SuperdeskApiError.badRequestError(_("Invalid value for %s in renditions") % field)
+                    raise SuperdeskApiError.badRequestError(
+                        _("Invalid value for {field} in renditions").format(field=field)
+                    )
 
     def _validate_poi(self, original, updates, crop_name):
         """Validate the crop point of interest in the renditions dictionary for the given crop
@@ -144,7 +148,9 @@ class CropService:
                 ratio = int(ratio[0]) / int(ratio[1])
             if abs((width / height) - ratio) > 0.1:
                 raise SuperdeskApiError.badRequestError(
-                    message=_("Ratio %s is not respected. We got %f") % (crop.get("ratio"), abs((width / height)))
+                    message=_("Ratio {ratio} is not respected. We got {actual}").format(
+                        ratio=crop.get("ratio"), actual=abs((width / height))
+                    )
                 )
 
     def get_crop_by_name(self, crop_name):

--- a/superdesk/media/media_operations.py
+++ b/superdesk/media/media_operations.py
@@ -30,6 +30,8 @@ from PIL import Image, ImageEnhance
 from .image import get_meta
 from .video import get_meta as video_meta
 
+from quart_babel import gettext as _
+
 from superdesk.core import json, get_app_config
 from superdesk.flask import url_for
 from superdesk.errors import SuperdeskApiError
@@ -108,7 +110,7 @@ def download_file_from_url(
 
     rv = session.get(_get_url_for_request(url), **request_kwargs)
     if rv.status_code not in (200, 201):
-        raise SuperdeskApiError.internalError("Failed to retrieve file from URL: %s" % url)
+        raise SuperdeskApiError.internalError(_("Failed to retrieve file from URL: %s") % url)
     content = BytesIO(rv.content)
     name, content_type = _get_name_and_content_type_from_response(content, rv.headers)
     return content, name, content_type
@@ -140,7 +142,7 @@ async def download_file_from_url_async(
     try:
         async with session.get(_get_url_for_request(url), **request_kwargs) as response:
             if response.status not in (200, 201):
-                raise SuperdeskApiError.internalError("Failed to retrieve file from URL: %s" % url)
+                raise SuperdeskApiError.internalError(_("Failed to retrieve file from URL: %s") % url)
 
             content = BytesIO(await response.read())
             name, content_type = _get_name_and_content_type_from_response(content, response.headers)
@@ -167,7 +169,7 @@ def process_file_from_stream(content, content_type=None):
     try:
         metadata = process_file(content, file_type)
     except OSError:  # error from PIL when image is supposed to be an image but is not.
-        raise SuperdeskApiError.internalError("Failed to process file")
+        raise SuperdeskApiError.internalError(_("Failed to process file"))
     file_name = get_file_name(content)
     content.seek(0)
     metadata = encode_metadata(metadata)

--- a/superdesk/media/media_operations.py
+++ b/superdesk/media/media_operations.py
@@ -110,7 +110,7 @@ def download_file_from_url(
 
     rv = session.get(_get_url_for_request(url), **request_kwargs)
     if rv.status_code not in (200, 201):
-        raise SuperdeskApiError.internalError(_("Failed to retrieve file from URL: %s") % url)
+        raise SuperdeskApiError.internalError(_("Failed to retrieve file from URL: {url}").format(url=url))
     content = BytesIO(rv.content)
     name, content_type = _get_name_and_content_type_from_response(content, rv.headers)
     return content, name, content_type
@@ -142,7 +142,7 @@ async def download_file_from_url_async(
     try:
         async with session.get(_get_url_for_request(url), **request_kwargs) as response:
             if response.status not in (200, 201):
-                raise SuperdeskApiError.internalError(_("Failed to retrieve file from URL: %s") % url)
+                raise SuperdeskApiError.internalError(_("Failed to retrieve file from URL: {url}").format(url=url))
 
             content = BytesIO(await response.read())
             name, content_type = _get_name_and_content_type_from_response(content, response.headers)

--- a/superdesk/profiling/service.py
+++ b/superdesk/profiling/service.py
@@ -11,6 +11,8 @@
 import cProfile
 import logging
 
+from quart_babel import gettext as _
+
 from superdesk.resource_fields import ID_FIELD
 from superdesk.errors import SuperdeskApiError
 from superdesk.services import BaseService
@@ -73,5 +75,5 @@ class ProfilingService(BaseService):
         sort_fields = req.sort.split(",")
         for field in sort_fields:
             if field not in self.SORT_FIELDS:
-                raise SuperdeskApiError.badRequestError("Invalid sort field %s" % field)
+                raise SuperdeskApiError.badRequestError(_("Invalid sort field %s") % field)
         return sort_fields

--- a/superdesk/profiling/service.py
+++ b/superdesk/profiling/service.py
@@ -75,5 +75,5 @@ class ProfilingService(BaseService):
         sort_fields = req.sort.split(",")
         for field in sort_fields:
             if field not in self.SORT_FIELDS:
-                raise SuperdeskApiError.badRequestError(_("Invalid sort field %s") % field)
+                raise SuperdeskApiError.badRequestError(_("Invalid sort field {field}").format(field=field))
         return sort_fields

--- a/superdesk/roles/roles.py
+++ b/superdesk/roles/roles.py
@@ -10,6 +10,7 @@
 
 import logging
 import superdesk
+from quart_babel import gettext as _
 
 from superdesk.core import get_current_app
 from superdesk.activity import add_activity, ACTIVITY_UPDATE
@@ -71,11 +72,11 @@ class RolesService(AsyncBaseService):
 
     async def on_delete_async(self, docs):
         if docs.get("is_default"):
-            raise SuperdeskApiError.forbiddenError("Cannot delete the default role")
+            raise SuperdeskApiError.forbiddenError(_("Cannot delete the default role"))
         # check if there are any users in the role
         user = await UsersResourceModel.get_service().find_one(role=docs.get("_id"))
         if user:
-            raise SuperdeskApiError.forbiddenError("Cannot delete the role, it still has users in it!")
+            raise SuperdeskApiError.forbiddenError(_("Cannot delete the role, it still has users in it!"))
 
     async def remove_old_default(self):
         # see if there is already a default role and set it to no longer default

--- a/superdesk/sams/assets.py
+++ b/superdesk/sams/assets.py
@@ -136,7 +136,7 @@ def delete(item_id):
     try:
         etag = request.headers["If-Match"]
     except KeyError:
-        raise SuperdeskApiError.badRequestError("If-Match field missing in header")
+        raise SuperdeskApiError.badRequestError(_("If-Match field missing in header"))
 
     if get_attachments_from_asset_id(item_id).count():
         raise SuperdeskApiError.badRequestError(_("Asset is attached to a news item, cannot delete"))
@@ -163,7 +163,7 @@ async def update(item_id):
     try:
         etag = request.headers["If-Match"]
     except KeyError:
-        raise SuperdeskApiError.badRequestError("If-Match field missing in header")
+        raise SuperdeskApiError.badRequestError(_("If-Match field missing in header"))
 
     if (await request.files).get("binary"):
         # The binary data was supplied so this must be a multipart request

--- a/superdesk/sams/sets.py
+++ b/superdesk/sams/sets.py
@@ -22,6 +22,7 @@
 
 import logging
 import superdesk
+from quart_babel import gettext as _
 
 from superdesk.core import get_current_app
 from superdesk.flask import Blueprint, request
@@ -80,7 +81,7 @@ def delete(item_id):
     try:
         etag = request.headers["If-Match"]
     except KeyError:
-        raise SuperdeskApiError.badRequestError("If-Match field missing in header")
+        raise SuperdeskApiError.badRequestError(_("If-Match field missing in header"))
 
     delete_response = get_sams_client().sets.delete(item_id=item_id, headers={"If-Match": etag})
     if delete_response.status_code != 204:
@@ -122,7 +123,7 @@ def update(item_id):
     try:
         etag = request.headers["If-Match"]
     except KeyError:
-        raise SuperdeskApiError.badRequestError("If-Match field missing in header")
+        raise SuperdeskApiError.badRequestError(_("If-Match field missing in header"))
 
     updates = request.get_json()
     update_response = get_sams_client().sets.update(item_id=item_id, updates=updates, headers={"If-Match": etag})

--- a/superdesk/services.py
+++ b/superdesk/services.py
@@ -16,6 +16,8 @@ from typing import Dict, Any, List, Optional, Union, Generator
 from eve.utils import ParsedRequest
 from eve.methods.common import resolve_document_etag
 
+from quart_babel import gettext as _
+
 from superdesk.resource_fields import ETAG
 from superdesk.flask import g
 from superdesk.errors import SuperdeskApiError
@@ -201,7 +203,9 @@ class BaseService:
         es_query = query.copy() if query else {}
         es_query["size"] = size
         if not es_query.get("sort"):
-            raise SuperdeskApiError.badRequestError("Running `get_all_batch_elastic` without a sort is not supported")
+            raise SuperdeskApiError.badRequestError(
+                _("Running `get_all_batch_elastic` without a sort is not supported")
+            )
 
         for _ in range(max_iterations):
             cursor = self.backend.search_raw(self.datasource, es_query)
@@ -329,7 +333,9 @@ class BaseService:
                 if res:
                     success.append(res)
             except Exception as ex:
-                raise SuperdeskApiError.badRequestError("Uploaded file is invalid, Error occured:{}.".format(str(ex)))
+                raise SuperdeskApiError.badRequestError(
+                    _("Uploaded file is invalid, Error occured:{}.").format(str(ex))
+                )
 
         if success:
             return {

--- a/superdesk/services.py
+++ b/superdesk/services.py
@@ -16,7 +16,7 @@ from typing import Dict, Any, List, Optional, Union, Generator
 from eve.utils import ParsedRequest
 from eve.methods.common import resolve_document_etag
 
-from quart_babel import gettext as _
+from quart_babel import gettext
 
 from superdesk.resource_fields import ETAG
 from superdesk.flask import g
@@ -204,7 +204,7 @@ class BaseService:
         es_query["size"] = size
         if not es_query.get("sort"):
             raise SuperdeskApiError.badRequestError(
-                _("Running `get_all_batch_elastic` without a sort is not supported")
+                gettext("Running `get_all_batch_elastic` without a sort is not supported")
             )
 
         for _ in range(max_iterations):
@@ -334,7 +334,7 @@ class BaseService:
                     success.append(res)
             except Exception as ex:
                 raise SuperdeskApiError.badRequestError(
-                    _("Uploaded file is invalid, Error occured:{}.").format(str(ex))
+                    gettext("Uploaded file is invalid, Error occured:{}.").format(str(ex))
                 )
 
         if success:

--- a/superdesk/text_checkers/ai/__init__.py
+++ b/superdesk/text_checkers/ai/__init__.py
@@ -7,6 +7,8 @@
 from typing import Any
 from inspect import isawaitable
 
+from quart_babel import gettext as _
+
 from superdesk.eve_async.service import AsyncBaseService
 from superdesk.resource import Resource
 from superdesk.errors import SuperdeskApiError
@@ -90,7 +92,7 @@ class AIService(AsyncBaseService):
         try:
             service = registered_ai_services[service]
         except KeyError:
-            raise SuperdeskApiError.notFoundError("{service} service can't be found".format(service=service))
+            raise SuperdeskApiError.notFoundError(_("{service} service can't be found").format(service=service))
 
         analyzed_data = service.analyze(item, doc.get("tags"))
         if isawaitable(analyzed_data):
@@ -163,7 +165,7 @@ class AIDataOpService(AsyncBaseService):
         try:
             service = registered_ai_services[service]
         except KeyError:
-            raise SuperdeskApiError.notFoundError("{service} service can't be found".format(service=service))
+            raise SuperdeskApiError.notFoundError(_("{service} service can't be found").format(service=service))
 
         result = service.data_operation("POST", operation, name, data)
         if isawaitable(result):
@@ -230,7 +232,7 @@ class AIImageSuggestionService(AsyncBaseService):
         try:
             service = registered_ai_services[service]
         except KeyError:
-            raise SuperdeskApiError.notFoundError("{service} service can't be found".format(service=service))
+            raise SuperdeskApiError.notFoundError(_("{service} service can't be found").format(service=service))
 
         res_data = service.search_images(items)
         if isawaitable(res_data):

--- a/superdesk/text_checkers/ai/imatrics.py
+++ b/superdesk/text_checkers/ai/imatrics.py
@@ -15,6 +15,8 @@ from collections import OrderedDict
 from typing import Optional, Dict, List, Tuple
 from urllib.parse import urljoin
 
+from quart_babel import gettext as _
+
 from superdesk.core import get_app_config
 from superdesk.text_utils import get_text
 from superdesk.errors import SuperdeskApiError
@@ -338,7 +340,7 @@ class IMatrics(AIServiceBase):
             if not uuid:
                 raise KeyError
         except KeyError:
-            raise SuperdeskApiError.badRequestError("[{name}] no tag UUID specified".format(name=self.name))
+            raise SuperdeskApiError.badRequestError(_("[{name}] no tag UUID specified").format(name=self.name))
 
         self._request("concept/delete", method="DELETE", params={"uuid": data["uuid"]})
         return {}

--- a/superdesk/text_checkers/spellcheckers/__init__.py
+++ b/superdesk/text_checkers/spellcheckers/__init__.py
@@ -12,6 +12,8 @@ from typing import Any
 import logging
 from inspect import isawaitable
 
+from quart_babel import gettext as _
+
 import superdesk
 from superdesk.eve_async.service import AsyncBaseService
 from superdesk.resource import Resource
@@ -144,7 +146,7 @@ class SpellcheckerService(AsyncBaseService):
         try:
             spellchecker = registered_spellcheckers[sc_name]
         except KeyError:
-            raise SuperdeskApiError.notFoundError("{sc_name} spellchecker can't be found".format(sc_name=sc_name))
+            raise SuperdeskApiError.notFoundError(_("{sc_name} spellchecker can't be found").format(sc_name=sc_name))
 
         if doc["suggestions"]:
             check_data = spellchecker.suggest(doc["text"], language)

--- a/superdesk/text_checkers/spellcheckers/default.py
+++ b/superdesk/text_checkers/spellcheckers/default.py
@@ -12,7 +12,8 @@ import re
 import logging
 from inspect import isawaitable
 
-# from superdesk.errors import SuperdeskApiError
+from quart_babel import gettext as _
+
 import superdesk
 from superdesk.text_checkers.spellcheckers import SPELLCHECKER_DEFAULT, CAP_SPELLING, LANG_ANY
 from superdesk.text_checkers.spellcheckers.base import SpellcheckerBase
@@ -35,7 +36,7 @@ class Default(SpellcheckerBase):
 
     async def check(self, text, language=None):
         if language is None:
-            raise SuperdeskApiError.badRequestError("missing language for default spellchecker")
+            raise SuperdeskApiError.badRequestError(_("missing language for default spellchecker"))
         dictionaries_service = superdesk.get_resource_service("dictionaries")
         model = await dictionaries_service.get_model_for_lang(language)
         err_list = []
@@ -53,7 +54,7 @@ class Default(SpellcheckerBase):
 
     async def suggest(self, text, language=None):
         if language is None:
-            raise SuperdeskApiError.badRequestError("missing language for default spellchecker")
+            raise SuperdeskApiError.badRequestError(_("missing language for default spellchecker"))
         spellcheck_service = superdesk.get_resource_service("spellcheck")
         suggestions = await spellcheck_service.suggest(text, language)
         return {"suggestions": self.list2suggestions(suggestions)}

--- a/superdesk/text_checkers/spellcheckers/grammalecte.py
+++ b/superdesk/text_checkers/spellcheckers/grammalecte.py
@@ -17,6 +17,7 @@ import json
 from urllib.parse import urljoin
 import requests
 from os.path import abspath, expanduser
+from quart_babel import gettext as _
 from superdesk.errors import SuperdeskApiError
 from superdesk.text_checkers.spellcheckers import CAP_SPELLING, CAP_GRAMMAR
 from superdesk.text_checkers.spellcheckers.base import SpellcheckerBase
@@ -218,7 +219,7 @@ class Grammalecte(SpellcheckerBase):
             check_url, data={"text": text, "options": json.dumps(self.grammalecte_config)}, timeout=self.CHECK_TIMEOUT
         )
         if r.status_code != 200:
-            raise SuperdeskApiError.internalError("Unexpected return code from Grammalecte")
+            raise SuperdeskApiError.internalError(_("Unexpected return code from Grammalecte"))
         return self.grammalecte2superdesk(text, r.json())
 
     def check(self, text, language=None):
@@ -243,7 +244,7 @@ class Grammalecte(SpellcheckerBase):
         check_url = urljoin(self.base_url, PATH_SUGGEST)
         r = requests.post(check_url, data={"token": text}, timeout=self.SUGGEST_TIMEOUT)
         if r.status_code != 200:
-            raise SuperdeskApiError.internalError("Unexpected return code from Grammalecte")
+            raise SuperdeskApiError.internalError(_("Unexpected return code from Grammalecte"))
 
         suggestions = r.json().get("suggestions", [])
         return {"suggestions": self.list2suggestions(suggestions)}

--- a/superdesk/text_checkers/spellcheckers/leuven_dutch.py
+++ b/superdesk/text_checkers/spellcheckers/leuven_dutch.py
@@ -11,6 +11,7 @@
 import os
 import logging
 import requests
+from quart_babel import gettext as _
 from superdesk.errors import SuperdeskApiError
 from superdesk.text_checkers.spellcheckers import CAP_SPELLING
 from superdesk.text_checkers.spellcheckers.base import SpellcheckerBase
@@ -47,7 +48,7 @@ class LeuvenDutch(SpellcheckerBase):
         }
         r = requests.post(check_url, data=data, timeout=self.CHECK_TIMEOUT)
         if r.status_code != 200:
-            raise SuperdeskApiError.internalError("Unexpected return code from {}".format(self.name))
+            raise SuperdeskApiError.internalError(_("Unexpected return code from {}").format(self.name))
 
         data = r.json()
 
@@ -79,7 +80,7 @@ class LeuvenDutch(SpellcheckerBase):
         }
         r = requests.post(check_url, data=data, timeout=self.SUGGEST_TIMEOUT)
         if r.status_code != 200:
-            raise SuperdeskApiError.internalError("Unexpected return code from {}".format(self.name))
+            raise SuperdeskApiError.internalError(_("Unexpected return code from {}").format(self.name))
         return {"suggestions": self.list2suggestions(r.json()["suggesties"]["output"].get("suggesties", []))}
 
     def available(self):

--- a/superdesk/upload.py
+++ b/superdesk/upload.py
@@ -12,6 +12,8 @@
 import logging
 
 import superdesk
+from quart_babel import gettext as _
+
 from superdesk.core import get_app_config, get_current_app
 from superdesk.flask import request, redirect, make_response, jsonify, Blueprint
 import json
@@ -76,7 +78,7 @@ async def get_upload_as_data_uri(media_id):
     if media_file:
         return await generate_response_for_file(media_file)
 
-    raise SuperdeskApiError.notFoundError("File not found on media storage.")
+    raise SuperdeskApiError.notFoundError(_("File not found on media storage."))
 
 
 @bp.route("/upload/config-file", methods=["POST", "OPTIONS"])
@@ -87,15 +89,15 @@ async def upload_config_file():
 
     _resource = request.args.get("resource")
     if not _resource:
-        raise SuperdeskApiError.forbiddenError("Provide required param: 'resource'.")
+        raise SuperdeskApiError.forbiddenError(_("Provide required param: 'resource'."))
 
     resource_privileges = get_resource_privileges(_resource).get("POST", None)
     if not current_user_has_privilege(resource_privileges):
-        raise SuperdeskApiError.forbiddenError("You don't have permissions to upload JSON file.")
+        raise SuperdeskApiError.forbiddenError(_("You don't have permissions to upload JSON file."))
 
     json_files = (await request.files).getlist("json_file")
     if not json_files:
-        raise SuperdeskApiError.badRequestError("Provide JSON file with key 'json_file'.")
+        raise SuperdeskApiError.badRequestError(_("Provide JSON file with key 'json_file'."))
 
     _items = []
     for _file in json_files:
@@ -110,7 +112,7 @@ async def upload_config_file():
             file_data = json.loads(_file.read())
         except Exception as ex:
             logger.error("Invalid JSON file {0}: {1}".format(file_name, str(ex)))
-            raise SuperdeskApiError.internalError("Invalid JSON file: {}.".format(file_name))
+            raise SuperdeskApiError.internalError(_("Invalid JSON file: {}.").format(file_name))
 
         if isinstance(file_data, dict):
             file_data = [file_data]
@@ -229,7 +231,7 @@ class UploadService(AsyncBaseService):
         except Exception as io:
             for file_id in inserted:
                 await delete_file_on_error_async(doc, file_id)
-            raise SuperdeskApiError.internalError("Generating renditions failed", exception=io)
+            raise SuperdeskApiError.internalError(_("Generating renditions failed"), exception=io)
 
     async def download_file(self, doc):
         url = doc.get("URL")

--- a/superdesk/upload.py
+++ b/superdesk/upload.py
@@ -12,7 +12,7 @@
 import logging
 
 import superdesk
-from quart_babel import gettext as _
+from quart_babel import gettext
 
 from superdesk.core import get_app_config, get_current_app
 from superdesk.flask import request, redirect, make_response, jsonify, Blueprint
@@ -78,7 +78,7 @@ async def get_upload_as_data_uri(media_id):
     if media_file:
         return await generate_response_for_file(media_file)
 
-    raise SuperdeskApiError.notFoundError(_("File not found on media storage."))
+    raise SuperdeskApiError.notFoundError(gettext("File not found on media storage."))
 
 
 @bp.route("/upload/config-file", methods=["POST", "OPTIONS"])
@@ -89,15 +89,15 @@ async def upload_config_file():
 
     _resource = request.args.get("resource")
     if not _resource:
-        raise SuperdeskApiError.forbiddenError(_("Provide required param: 'resource'."))
+        raise SuperdeskApiError.forbiddenError(gettext("Provide required param: 'resource'."))
 
     resource_privileges = get_resource_privileges(_resource).get("POST", None)
     if not current_user_has_privilege(resource_privileges):
-        raise SuperdeskApiError.forbiddenError(_("You don't have permissions to upload JSON file."))
+        raise SuperdeskApiError.forbiddenError(gettext("You don't have permissions to upload JSON file."))
 
     json_files = (await request.files).getlist("json_file")
     if not json_files:
-        raise SuperdeskApiError.badRequestError(_("Provide JSON file with key 'json_file'."))
+        raise SuperdeskApiError.badRequestError(gettext("Provide JSON file with key 'json_file'."))
 
     _items = []
     for _file in json_files:
@@ -112,7 +112,7 @@ async def upload_config_file():
             file_data = json.loads(_file.read())
         except Exception as ex:
             logger.error("Invalid JSON file {0}: {1}".format(file_name, str(ex)))
-            raise SuperdeskApiError.internalError(_("Invalid JSON file: {}.").format(file_name))
+            raise SuperdeskApiError.internalError(gettext("Invalid JSON file: {}.").format(file_name))
 
         if isinstance(file_data, dict):
             file_data = [file_data]
@@ -231,7 +231,7 @@ class UploadService(AsyncBaseService):
         except Exception as io:
             for file_id in inserted:
                 await delete_file_on_error_async(doc, file_id)
-            raise SuperdeskApiError.internalError(_("Generating renditions failed"), exception=io)
+            raise SuperdeskApiError.internalError(gettext("Generating renditions failed"), exception=io)
 
     async def download_file(self, doc):
         url = doc.get("URL")

--- a/superdesk/users/async_service.py
+++ b/superdesk/users/async_service.py
@@ -12,6 +12,8 @@ import logging
 from typing import Any
 from bson import ObjectId
 
+from quart_babel import gettext as _
+
 from superdesk.core.types.search import SearchRequest
 from superdesk.resource_fields import VERSION, LAST_UPDATED
 from superdesk.core import get_app_config
@@ -436,7 +438,7 @@ class DBUsersAsyncService(UsersAsyncService):
                 tokenDoc = {"user": user_id, "email": email}
                 token_id = await reset_service.store_reset_password_token(tokenDoc, email, activate_ttl, user_id)
                 if not token_id:
-                    raise SuperdeskApiError.internalError("Failed to send account activation email.")
+                    raise SuperdeskApiError.internalError(_("Failed to send account activation email."))
                 tokenDoc.update({"username": username})
 
                 await send_activate_account_email(tokenDoc, activate_ttl)
@@ -464,7 +466,7 @@ class DBUsersAsyncService(UsersAsyncService):
         user = await self.find_by_id(user_id)
 
         if not user:
-            raise SuperdeskApiError.unauthorizedError("User not found")
+            raise SuperdeskApiError.unauthorizedError(_("User not found"))
 
         if not await self.is_user_active(user):
             raise UserInactiveError()

--- a/superdesk/users/services.py
+++ b/superdesk/users/services.py
@@ -10,6 +10,7 @@
 
 import logging
 from bson import ObjectId
+from quart_babel import gettext as _
 
 from superdesk.resource_fields import ID_FIELD, VERSION, LAST_UPDATED
 from superdesk.core import get_app_config
@@ -537,7 +538,7 @@ class DBUsersService(UsersService):
                 tokenDoc = {"user": doc["_id"], "email": doc["email"]}
                 id = await reset_service.store_reset_password_token(tokenDoc, doc["email"], activate_ttl, doc["_id"])
                 if not id:
-                    raise SuperdeskApiError.internalError("Failed to send account activation email.")
+                    raise SuperdeskApiError.internalError(_("Failed to send account activation email."))
                 tokenDoc.update({"username": doc["username"]})
 
                 await send_activate_account_email(tokenDoc, activate_ttl)
@@ -564,7 +565,7 @@ class DBUsersService(UsersService):
         user = await self.find_one_async(req=None, _id=user_id)
 
         if not user:
-            raise SuperdeskApiError.unauthorizedError("User not found")
+            raise SuperdeskApiError.unauthorizedError(_("User not found"))
 
         if not self.is_user_active(user):
             raise UserInactiveError()

--- a/superdesk/vocabularies/vocabularies.py
+++ b/superdesk/vocabularies/vocabularies.py
@@ -281,7 +281,7 @@ class VocabulariesService(CachableAsyncBaseService):
         Overriding to validate vocabulary deletion
         """
         if "field_type" not in doc:
-            raise SuperdeskApiError.badRequestError("Default vocabularies cannot be deleted")
+            raise SuperdeskApiError.badRequestError(_("Default vocabularies cannot be deleted"))
 
     def _check_uniqueness(self, items, unique_field):
         """Checks the uniqueness if a unique field is defined
@@ -296,7 +296,7 @@ class VocabulariesService(CachableAsyncBaseService):
                 continue
 
             if not item.get(unique_field):
-                raise SuperdeskApiError.badRequestError("{} cannot be empty".format(unique_field))
+                raise SuperdeskApiError.badRequestError(_("{} cannot be empty").format(unique_field))
 
             unique_value = str(item.get(unique_field)).upper()
 

--- a/superdesk/vocabularies_async/service.py
+++ b/superdesk/vocabularies_async/service.py
@@ -125,7 +125,7 @@ class VocabulariesService(AsyncResourceService[VocabulariesResourceModel]):
         Overriding to validate vocabulary deletion
         """
         if not doc.field_type:
-            raise SuperdeskApiError.badRequestError("Default vocabularies cannot be deleted")
+            raise SuperdeskApiError.badRequestError(gettext("Default vocabularies cannot be deleted"))
 
     def _check_uniqueness(self, items: list[dict[str, Any]], unique_field: str) -> None:
         """Checks the uniqueness if a unique field is defined


### PR DESCRIPTION
### Purpose
Wrap user-facing error and status strings with `quart_babel.gettext` (alias `_`), add required imports, and replace hardcoded messages across multiple modules (archive, media, auth, ldap, content_api, core resources/services, upload, text_checkers, users, vocabularies, etc.).

[SDESK-7907]


[SDESK-7907]: https://sofab.atlassian.net/browse/SDESK-7907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ