### PR TITLE
serialize websocket broadcast on the asyncio loop thread to prevent message overlapping

### DIFF
--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -388,8 +388,16 @@ class SocketCommunication:
 
     def _broadcast_threadsafe(self, message):
         """Schedule 'broadcast' on the event loop thread."""
-        if self.loop is not None:
-            self.loop.call_soon_threadsafe(self.broadcast, message)
+        loop = self.loop
+
+        if loop is None or loop.is_closed():
+            logger.warning("Dropping websocket message because the event loop is not available")
+            return
+
+        try:
+            loop.call_soon_threadsafe(self.broadcast, message)
+        except RuntimeError:
+            logger.warning("Dropping websocket message because the event loop is closed")
 
     def _log(self, message: str, websocket: ServerConnection):
         """Log message with some websocket data like address.

--- a/superdesk/websockets_comms.py
+++ b/superdesk/websockets_comms.py
@@ -293,6 +293,7 @@ class SocketCommunication:
         self.sentry_dsn = sentry_dsn
         self.sentry_traces_sample_rate = sentry_traces_sample_rate
         self.debug = WS_DEBUG if debug is None else debug
+        self.loop: Optional[asyncio.AbstractEventLoop] = None
 
     def _add_client(self, websocket: ServerConnection):
         self.clients.add(websocket)
@@ -385,6 +386,11 @@ class SocketCommunication:
         clients = self.get_message_recipients(message_data)
         broadcast(clients, json.dumps(message_data, default=json_serialize_datetime_objectId))
 
+    def _broadcast_threadsafe(self, message):
+        """Schedule 'broadcast' on the event loop thread."""
+        if self.loop is not None:
+            self.loop.call_soon_threadsafe(self.broadcast, message)
+
     def _log(self, message: str, websocket: ServerConnection):
         """Log message with some websocket data like address.
 
@@ -423,16 +429,22 @@ class SocketCommunication:
                 integrations=[AsyncioIntegration()],
                 traces_sample_rate=self.sentry_traces_sample_rate,
             )
+
         try:
             consumer = None
+            self.loop = asyncio.get_running_loop()
             async with serve(self._connection_handler, self.host, self.port) as server:
-                loop = asyncio.get_event_loop()
-                loop.add_signal_handler(signal.SIGTERM, server.close)
+                self.loop.add_signal_handler(signal.SIGTERM, server.close)
                 # create socket message consumer
-                consumer = SocketMessageConsumer(self.broker_url, self.broadcast, self.exchange_name)
+                consumer = SocketMessageConsumer(
+                    self.broker_url,
+                    self._broadcast_threadsafe,
+                    self.exchange_name,
+                )
                 # kombu is blocking so needs to run in executor
-                loop.run_in_executor(None, consumer.run)
+                self.loop.run_in_executor(None, consumer.run)
                 await server.wait_closed()
+
         except KeyboardInterrupt:
             pass
         finally:


### PR DESCRIPTION
## Summary
`SocketCommunication.broadcast()` is currently invoked from the kombu consumer thread (the one started via `loop.run_in_executor(None, consumer.run`), and ends up calling `websockets.asyncio.server.broadcast` from that same thread.

`websockets.asyncio.server.broadcast()` writes directly to each connection's asyncio transport via `transport.write()`. Those writes are **not thread-safe** and assume they are running on the event loop thread. When a broker message arrives while the event loop is already writing a frame to the same client connection, the bytes of the two frames get interleaved on the socket.

## Symptom
After hours of normal operation, clients suddenly start receiving corrupted JSON payloads where two messages are merged at the byte level, e.g.:
```
{"_createdcae"sks": {"c3T18:44:02.527988c,e"_processcae1990,e"eventcae"resource:createdc,e"extracae{"_idcae"69f797720f9c9dd9c40a7df4",e"resourcecae"authc}}
{"_createdcae"sks": {"c3T18:43:16.292036c,e"_processcae2032,e"eventcae"item:unlockc,e"extracae{"_etagcae"c19c837deb1789e33ad0d8884906a08044aa438ec,e"itemcae"urn:newsml:superdesk2.ansa.it:sks": {"c3T16:07:52.048365:7e56a2af-9e79-4658-8f89-7fb504d4f80fc,e"item_versioncae"17c,e"lock_sessioncae"69f76aa6f4056dd13f514531",e"statecae"in_progressc,e"usercae"0d909a283e4c7d8dea4a70bfc}}
```

The connection itself stays alive, so the client gets no notifications and cannot recover other than by disconnecting and reconnecting (i.e. full refreshing the web page)
Reconnecting "fixes" it because a fresh `ServerConnection` starts with clean buffers, until the race happens again.

**The issue in the Superdesk client causes the user interface to freeze completely.**

The bug is timing-dependent: under low/steady traffic it may not surface for hours. Under bursty traffic it shows up much sooner.

## Root cause
```
kombu thread ──▶ SocketMessageConsumer.on_message
             ──▶ self.callback(body)            # = SocketCommunication.broadcast
             ──▶ websockets.asyncio.server.broadcast(clients, payload)
             ──▶ ServerConnection.send_text  ──▶ transport.write   ❌ wrong thread
```

The `websockets` requires `broadcast()` to be called from the event loop thread.

## Fix
Hop from the kombu thread to the event loop thread using `loop.call_soon_threadsafe()` before doing any websocket work. The actual broadcast logic (throttling, filtering, calling `websockets.broadcast`) is unchanged and now runs entirely on the loop thread, as required.

Three small changes in `SocketCommunication`:

1. Store the running loop in `__init__` / `main()`.
2. Add a tiny `_broadcast_threadsafe()` wrapper.
3. Pass the wrapper (instead of `self.broadcast`) to `SocketMessageConsumer`.

No public API change. No behavioural change other than the fix itself.

## Notes
- The throttling dict `self.messages` was also being mutated from the kombu thread. After this fix it's only mutated from the loop thread, which removes another (smaller) source of races.

## Testing
The fix has been tested and is currently in use in the ANSA production environment.
Before the fix, a connection could experience this issue several times a day; after applying the patch, a connection was monitored in the production environment for over 4 days and handled approximately 3 million messages without the issue occurring.
