### PR TITLE
Support for sticky items, basic article content in the item payload

### DIFF
--- a/apps/content_lists/article_content.py
+++ b/apps/content_lists/article_content.py
@@ -1,0 +1,71 @@
+from typing import Any
+
+import superdesk
+from superdesk.core.types import RestGetResponse
+from superdesk.etree import parse_html
+
+
+async def attach_article_content(items: list[dict[str, Any]]) -> None:
+    """Add an ``article_content`` summary to each content list item in place."""
+    article_ids = [item["content"] for item in items if item.get("content")]
+    if not article_ids:
+        for item in items:
+            item["article_content"] = None
+        return
+
+    archive_service = superdesk.get_resource_service("archive")
+    cursor = await archive_service.get_from_mongo_async(
+        req=None,
+        lookup={"_id": {"$in": article_ids}},
+        projection={"headline": 1, "state": 1, "associations": 1, "body_html": 1},
+    )
+    articles_by_id: dict[str, dict[str, Any]] = {}
+    async for article in cursor:
+        articles_by_id[article["_id"]] = article
+
+    for item in items:
+        article = articles_by_id.get(item.get("content"))
+        item["article_content"] = _build_article_content(article) if article else None
+
+
+def _build_article_content(article: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "title": article.get("headline"),
+        "state": article.get("state"),
+        "thumbnail": _get_thumbnail(article),
+    }
+
+
+def _get_thumbnail(article: dict[str, Any]) -> dict[str, Any] | str | None:
+    feature_media = (article.get("associations") or {}).get("featuremedia") or {}
+    thumbnail = (feature_media.get("renditions") or {}).get("thumbnail")
+    if thumbnail:
+        return thumbnail
+
+    body_html = article.get("body_html")
+    if body_html:
+        return _first_body_html_image(body_html)
+
+    return None
+
+
+def _first_body_html_image(body_html: str) -> str | None:
+    try:
+        root = parse_html(body_html, content="html")
+    except Exception:
+        return None
+    img = root.find(".//img")
+    if img is None:
+        return None
+    src = img.get("src")
+    return src or None
+
+
+async def enrich_fetched_response(doc: RestGetResponse) -> None:
+    """Hook for ``on_fetched``: enriches all items in a search response."""
+    await attach_article_content(doc.get("_items") or [])
+
+
+async def enrich_fetched_item(item: dict[str, Any]) -> None:
+    """Hook for ``on_fetched_item``: enriches a single item."""
+    await attach_article_content([item])

--- a/apps/content_lists/rest_endpoints.py
+++ b/apps/content_lists/rest_endpoints.py
@@ -1,8 +1,10 @@
 from bson import ObjectId
 
-from superdesk.core.types import Request, Response
+from superdesk.core.types import Request, Response, RestGetResponse
 from superdesk.core.web import Endpoint
 from superdesk.core.resources import ResourceRestEndpoints
+
+from .article_content import enrich_fetched_item, enrich_fetched_response
 
 
 class ContentListItemsEndpoints(ResourceRestEndpoints):
@@ -23,3 +25,9 @@ class ContentListItemsEndpoints(ResourceRestEndpoints):
         data = await request.get_json()
         result = await self.service.bulk_patch(list_id, data)
         return Response(body=result.to_dict(), status_code=200)
+
+    async def on_fetched(self, request: Request, doc: RestGetResponse) -> None:
+        await enrich_fetched_response(doc)
+
+    async def on_fetched_item(self, request: Request, doc: dict) -> None:
+        await enrich_fetched_item(doc)

--- a/apps/content_lists/service.py
+++ b/apps/content_lists/service.py
@@ -68,8 +68,9 @@ class ContentListItemsService(AsyncResourceService[ContentListItem]):
                 existing = await self.find_one(req=None, list_id=list_id, content=content_id)
                 if existing:
                     new_position = item_data.get("position")
+                    new_sticky = item_data.get("sticky", existing.sticky)
                     await self._shift_positions_for_move(list_id, existing.id, existing.position, new_position)
-                    await self.update(existing.id, {"position": new_position})
+                    await self.update(existing.id, {"position": new_position, "sticky": new_sticky})
             elif action == "delete":
                 existing = await self.find_one(req=None, list_id=list_id, content=content_id)
                 if existing:

--- a/apps/content_lists/service.py
+++ b/apps/content_lists/service.py
@@ -86,36 +86,62 @@ class ContentListItemsService(AsyncResourceService[ContentListItem]):
         return result
 
     async def _renumber(self, list_id: ObjectId, touched_contents: list[str]) -> None:
-        """Rewrite non-sticky positions as a contiguous ``0..N-1`` sequence.
+        """Reassign positions so every item has a unique slot.
 
-        Items in ``touched_contents`` (added or moved in this batch) win position
-        ties: when an item lands on a slot already occupied, the touched item
-        keeps the slot and the prior occupant shifts to the next one. Later
-        entries in ``touched_contents`` outrank earlier ones.
+        Sticky items keep their declared position. Non-sticky items in
+        ``touched_contents`` (added or moved in this batch) also anchor at the
+        position they were just set to. Remaining untouched non-sticky items
+        fill the lowest-numbered free positions in their previous order. If
+        two anchors land on the same slot, sticky beats non-sticky and the
+        most recently touched wins within a group; the loser spills to the
+        nearest higher free slot.
         """
         docs = await self.mongo_async.find(
-            {"list_id": list_id, "sticky": {"$ne": True}},
-            projection={"_id": 1, "content": 1, "position": 1},
+            {"list_id": list_id},
+            projection={"_id": 1, "content": 1, "position": 1, "sticky": 1},
         ).to_list(None)
+        if not docs:
+            return
 
         touched_rank = {c: i for i, c in enumerate(touched_contents)}
 
-        def sort_key(d: dict) -> tuple:
-            pos = d.get("position")
+        def anchor_priority(d: dict) -> tuple:
             rank = touched_rank.get(d.get("content"))
             return (
-                pos is None,
-                pos if pos is not None else 0,
-                rank is None,
-                -rank if rank is not None else 0,
+                0 if d.get("sticky") else 1,
+                -(rank if rank is not None else -1),
                 d["_id"],
             )
 
-        docs.sort(key=sort_key)
+        anchors = [d for d in docs if d.get("sticky") or d.get("content") in touched_rank]
+        anchors.sort(key=anchor_priority)
+
+        placement: dict[int, dict] = {}
+        for doc in anchors:
+            pos = doc.get("position")
+            slot = pos if pos is not None and pos >= 0 else 0
+            while slot in placement:
+                slot += 1
+            placement[slot] = doc
+
+        rest = [d for d in docs if not d.get("sticky") and d.get("content") not in touched_rank]
+        rest.sort(
+            key=lambda d: (
+                d.get("position") is None,
+                d.get("position") if d.get("position") is not None else 0,
+                d["_id"],
+            )
+        )
+        next_slot = 0
+        for doc in rest:
+            while next_slot in placement:
+                next_slot += 1
+            placement[next_slot] = doc
+            next_slot += 1
 
         ops = [
             UpdateOne({"_id": doc["_id"]}, {"$set": {"position": i}})
-            for i, doc in enumerate(docs)
+            for i, doc in placement.items()
             if doc.get("position") != i
         ]
         if ops:

--- a/apps/content_lists/service.py
+++ b/apps/content_lists/service.py
@@ -49,12 +49,15 @@ class ContentListItemsService(AsyncResourceService[ContentListItem]):
             content_id = str(item_data["contentId"])
 
             if action == "add":
+                new_position = item_data.get("position")
+                if new_position is not None:
+                    await self._shift_positions_up(list_id, new_position)
                 await self.create(
                     [
                         {
                             "list_id": list_id,
                             "content": content_id,
-                            "position": item_data.get("position"),
+                            "position": new_position,
                             "sticky": item_data.get("sticky", False),
                             "sticky_position": item_data.get("stickyPosition"),
                             "enabled": True,
@@ -64,11 +67,16 @@ class ContentListItemsService(AsyncResourceService[ContentListItem]):
             elif action == "move":
                 existing = await self.find_one(req=None, list_id=list_id, content=content_id)
                 if existing:
-                    await self.update(existing.id, {"position": item_data.get("position")})
+                    new_position = item_data.get("position")
+                    await self._shift_positions_for_move(list_id, existing.id, existing.position, new_position)
+                    await self.update(existing.id, {"position": new_position})
             elif action == "delete":
                 existing = await self.find_one(req=None, list_id=list_id, content=content_id)
                 if existing:
+                    old_position = existing.position
                     await self.delete(existing)
+                    if old_position is not None:
+                        await self._shift_positions_down(list_id, old_position)
 
         await lists_service.mongo_async.update_one(
             {"_id": list_id},
@@ -77,3 +85,54 @@ class ContentListItemsService(AsyncResourceService[ContentListItem]):
         result = await lists_service.find_by_id(list_id)
         assert result is not None
         return result
+
+    async def _shift_positions_up(self, list_id: ObjectId, position: int) -> None:
+        """Make room at ``position`` by incrementing the position of every item at or after it."""
+        await self.mongo_async.update_many(
+            {"list_id": list_id, "sticky": {"$ne": True}, "position": {"$gte": position}},
+            {"$inc": {"position": 1}},
+        )
+
+    async def _shift_positions_down(self, list_id: ObjectId, position: int) -> None:
+        """Close the gap at ``position`` by decrementing the position of every item after it."""
+        await self.mongo_async.update_many(
+            {"list_id": list_id, "sticky": {"$ne": True}, "position": {"$gt": position}},
+            {"$inc": {"position": -1}},
+        )
+
+    async def _shift_positions_for_move(
+        self,
+        list_id: ObjectId,
+        item_id: ObjectId,
+        old_position: int | None,
+        new_position: int | None,
+    ) -> None:
+        """Reorder items affected by moving a single item from ``old_position`` to ``new_position``."""
+        if new_position == old_position:
+            return
+        if old_position is None:
+            await self._shift_positions_up(list_id, new_position)  # type: ignore[arg-type]
+            return
+        if new_position is None:
+            await self._shift_positions_down(list_id, old_position)
+            return
+        if new_position < old_position:
+            await self.mongo_async.update_many(
+                {
+                    "list_id": list_id,
+                    "sticky": {"$ne": True},
+                    "_id": {"$ne": item_id},
+                    "position": {"$gte": new_position, "$lt": old_position},
+                },
+                {"$inc": {"position": 1}},
+            )
+        else:
+            await self.mongo_async.update_many(
+                {
+                    "list_id": list_id,
+                    "sticky": {"$ne": True},
+                    "_id": {"$ne": item_id},
+                    "position": {"$gt": old_position, "$lte": new_position},
+                },
+                {"$inc": {"position": -1}},
+            )

--- a/apps/content_lists/service.py
+++ b/apps/content_lists/service.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from bson import ObjectId
+from pymongo import UpdateOne
 
 from superdesk.utc import utcnow
 from superdesk.errors import SuperdeskApiError
@@ -44,40 +45,37 @@ class ContentListItemsService(AsyncResourceService[ContentListItem]):
         if list_items_updated_at and list_items_updated_at.strftime(DATE_FORMAT) != data["updatedAt"]:
             raise SuperdeskApiError.conflictError("Content list items have been modified")
 
+        touched_contents: list[str] = []
         for item_data in data["items"]:
             action = item_data.get("action")
             content_id = str(item_data["contentId"])
 
             if action == "add":
-                new_position = item_data.get("position")
-                if new_position is not None:
-                    await self._shift_positions_up(list_id, new_position)
                 await self.create(
                     [
                         {
                             "list_id": list_id,
                             "content": content_id,
-                            "position": new_position,
+                            "position": item_data.get("position"),
                             "sticky": item_data.get("sticky", False),
                             "sticky_position": item_data.get("stickyPosition"),
                             "enabled": True,
                         }
                     ]
                 )
+                touched_contents.append(content_id)
             elif action == "move":
                 existing = await self.find_one(req=None, list_id=list_id, content=content_id)
                 if existing:
-                    new_position = item_data.get("position")
                     new_sticky = item_data.get("sticky", existing.sticky)
-                    await self._shift_positions_for_move(list_id, existing.id, existing.position, new_position)
-                    await self.update(existing.id, {"position": new_position, "sticky": new_sticky})
+                    await self.update(existing.id, {"position": item_data.get("position"), "sticky": new_sticky})
+                    touched_contents.append(content_id)
             elif action == "delete":
                 existing = await self.find_one(req=None, list_id=list_id, content=content_id)
                 if existing:
-                    old_position = existing.position
                     await self.delete(existing)
-                    if old_position is not None:
-                        await self._shift_positions_down(list_id, old_position)
+
+        await self._renumber(list_id, touched_contents)
 
         await lists_service.mongo_async.update_one(
             {"_id": list_id},
@@ -87,53 +85,38 @@ class ContentListItemsService(AsyncResourceService[ContentListItem]):
         assert result is not None
         return result
 
-    async def _shift_positions_up(self, list_id: ObjectId, position: int) -> None:
-        """Make room at ``position`` by incrementing the position of every item at or after it."""
-        await self.mongo_async.update_many(
-            {"list_id": list_id, "sticky": {"$ne": True}, "position": {"$gte": position}},
-            {"$inc": {"position": 1}},
-        )
+    async def _renumber(self, list_id: ObjectId, touched_contents: list[str]) -> None:
+        """Rewrite non-sticky positions as a contiguous ``0..N-1`` sequence.
 
-    async def _shift_positions_down(self, list_id: ObjectId, position: int) -> None:
-        """Close the gap at ``position`` by decrementing the position of every item after it."""
-        await self.mongo_async.update_many(
-            {"list_id": list_id, "sticky": {"$ne": True}, "position": {"$gt": position}},
-            {"$inc": {"position": -1}},
-        )
+        Items in ``touched_contents`` (added or moved in this batch) win position
+        ties: when an item lands on a slot already occupied, the touched item
+        keeps the slot and the prior occupant shifts to the next one. Later
+        entries in ``touched_contents`` outrank earlier ones.
+        """
+        docs = await self.mongo_async.find(
+            {"list_id": list_id, "sticky": {"$ne": True}},
+            projection={"_id": 1, "content": 1, "position": 1},
+        ).to_list(None)
 
-    async def _shift_positions_for_move(
-        self,
-        list_id: ObjectId,
-        item_id: ObjectId,
-        old_position: int | None,
-        new_position: int | None,
-    ) -> None:
-        """Reorder items affected by moving a single item from ``old_position`` to ``new_position``."""
-        if new_position == old_position:
-            return
-        if old_position is None:
-            await self._shift_positions_up(list_id, new_position)  # type: ignore[arg-type]
-            return
-        if new_position is None:
-            await self._shift_positions_down(list_id, old_position)
-            return
-        if new_position < old_position:
-            await self.mongo_async.update_many(
-                {
-                    "list_id": list_id,
-                    "sticky": {"$ne": True},
-                    "_id": {"$ne": item_id},
-                    "position": {"$gte": new_position, "$lt": old_position},
-                },
-                {"$inc": {"position": 1}},
+        touched_rank = {c: i for i, c in enumerate(touched_contents)}
+
+        def sort_key(d: dict) -> tuple:
+            pos = d.get("position")
+            rank = touched_rank.get(d.get("content"))
+            return (
+                pos is None,
+                pos if pos is not None else 0,
+                rank is None,
+                -rank if rank is not None else 0,
+                d["_id"],
             )
-        else:
-            await self.mongo_async.update_many(
-                {
-                    "list_id": list_id,
-                    "sticky": {"$ne": True},
-                    "_id": {"$ne": item_id},
-                    "position": {"$gt": old_position, "$lte": new_position},
-                },
-                {"$inc": {"position": -1}},
-            )
+
+        docs.sort(key=sort_key)
+
+        ops = [
+            UpdateOne({"_id": doc["_id"]}, {"$set": {"position": i}})
+            for i, doc in enumerate(docs)
+            if doc.get("position") != i
+        ]
+        if ops:
+            await self.mongo_async.bulk_write(ops, ordered=False)

--- a/features/content_lists.feature
+++ b/features/content_lists.feature
@@ -160,6 +160,172 @@ Feature: Content Lists
         """
 
     @auth
+    Scenario: Moving an item shifts other items to keep positions unique
+        Given an archive item "article-a"
+        And an archive item "article-b"
+        When we post to "/content_lists"
+        """
+        {"name": "Breaking News", "type": "manual"}
+        """
+        Then we get OK response
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": null,
+            "items": [
+                {"action": "add", "contentId": "article-a", "position": 0},
+                {"action": "add", "contentId": "article-b", "position": 1}
+            ]
+        }
+        """
+        Then we get OK response
+        And we store response as "content_lists"
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": "#content_lists.content_list_items_updated_at#",
+            "items": [{"action": "move", "contentId": "article-b", "position": 0}]
+        }
+        """
+        Then we get OK response
+        When we get "/content_lists/#content_lists._id#/items?sort=position"
+        Then we get list with 2 items
+        And we get existing resource
+        """
+        {"_items": [
+            {"content": "article-b", "position": 0},
+            {"content": "article-a", "position": 1}
+        ]}
+        """
+
+    @auth
+    Scenario: Adding an item at an occupied position shifts the existing items down
+        Given an archive item "article-a"
+        And an archive item "article-b"
+        And an archive item "article-c"
+        When we post to "/content_lists"
+        """
+        {"name": "Breaking News", "type": "manual"}
+        """
+        Then we get OK response
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": null,
+            "items": [
+                {"action": "add", "contentId": "article-a", "position": 0},
+                {"action": "add", "contentId": "article-b", "position": 1}
+            ]
+        }
+        """
+        Then we get OK response
+        And we store response as "content_lists"
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": "#content_lists.content_list_items_updated_at#",
+            "items": [{"action": "add", "contentId": "article-c", "position": 0}]
+        }
+        """
+        Then we get OK response
+        When we get "/content_lists/#content_lists._id#/items?sort=position"
+        Then we get list with 3 items
+        And we get existing resource
+        """
+        {"_items": [
+            {"content": "article-c", "position": 0},
+            {"content": "article-a", "position": 1},
+            {"content": "article-b", "position": 2}
+        ]}
+        """
+
+    @auth
+    Scenario: Moving an item to a higher position shifts items in between
+        Given an archive item "article-a"
+        And an archive item "article-b"
+        And an archive item "article-c"
+        And an archive item "article-d"
+        When we post to "/content_lists"
+        """
+        {"name": "Breaking News", "type": "manual"}
+        """
+        Then we get OK response
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": null,
+            "items": [
+                {"action": "add", "contentId": "article-a", "position": 0},
+                {"action": "add", "contentId": "article-b", "position": 1},
+                {"action": "add", "contentId": "article-c", "position": 2},
+                {"action": "add", "contentId": "article-d", "position": 3}
+            ]
+        }
+        """
+        Then we get OK response
+        And we store response as "content_lists"
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": "#content_lists.content_list_items_updated_at#",
+            "items": [{"action": "move", "contentId": "article-a", "position": 2}]
+        }
+        """
+        Then we get OK response
+        When we get "/content_lists/#content_lists._id#/items?sort=position"
+        Then we get list with 4 items
+        And we get existing resource
+        """
+        {"_items": [
+            {"content": "article-b", "position": 0},
+            {"content": "article-c", "position": 1},
+            {"content": "article-a", "position": 2},
+            {"content": "article-d", "position": 3}
+        ]}
+        """
+
+    @auth
+    Scenario: Deleting an item shifts the items after it up
+        Given an archive item "article-a"
+        And an archive item "article-b"
+        And an archive item "article-c"
+        When we post to "/content_lists"
+        """
+        {"name": "Breaking News", "type": "manual"}
+        """
+        Then we get OK response
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": null,
+            "items": [
+                {"action": "add", "contentId": "article-a", "position": 0},
+                {"action": "add", "contentId": "article-b", "position": 1},
+                {"action": "add", "contentId": "article-c", "position": 2}
+            ]
+        }
+        """
+        Then we get OK response
+        And we store response as "content_lists"
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": "#content_lists.content_list_items_updated_at#",
+            "items": [{"action": "delete", "contentId": "article-a"}]
+        }
+        """
+        Then we get OK response
+        When we get "/content_lists/#content_lists._id#/items?sort=position"
+        Then we get list with 2 items
+        And we get existing resource
+        """
+        {"_items": [
+            {"content": "article-b", "position": 0},
+            {"content": "article-c", "position": 1}
+        ]}
+        """
+
+    @auth
     Scenario: Delete item from content list via bulk patch
         Given an archive item "article-1"
         When we post to "/content_lists"

--- a/features/content_lists.feature
+++ b/features/content_lists.feature
@@ -160,6 +160,87 @@ Feature: Content Lists
         """
 
     @auth
+    Scenario: Move action toggles sticky flag on an item
+        Given an archive item "article-1"
+        When we post to "/content_lists"
+        """
+        {"name": "Breaking News", "type": "manual"}
+        """
+        Then we get OK response
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": null,
+            "items": [{"action": "add", "contentId": "article-1", "position": 0}]
+        }
+        """
+        Then we get OK response
+        And we store response as "content_lists"
+        When we get "/content_lists/#content_lists._id#/items"
+        Then we get existing resource
+        """
+        {"_items": [{"content": "article-1", "position": 0, "sticky": false}]}
+        """
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": "#content_lists.content_list_items_updated_at#",
+            "items": [{"action": "move", "contentId": "article-1", "position": 3, "sticky": true}]
+        }
+        """
+        Then we get OK response
+        And we store response as "content_lists"
+        When we get "/content_lists/#content_lists._id#/items"
+        Then we get existing resource
+        """
+        {"_items": [{"content": "article-1", "position": 3, "sticky": true}]}
+        """
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": "#content_lists.content_list_items_updated_at#",
+            "items": [{"action": "move", "contentId": "article-1", "position": 2, "sticky": false}]
+        }
+        """
+        Then we get OK response
+        When we get "/content_lists/#content_lists._id#/items"
+        Then we get existing resource
+        """
+        {"_items": [{"content": "article-1", "position": 2, "sticky": false}]}
+        """
+
+    @auth
+    Scenario: Move action preserves sticky flag when not provided
+        Given an archive item "article-1"
+        When we post to "/content_lists"
+        """
+        {"name": "Breaking News", "type": "manual"}
+        """
+        Then we get OK response
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": null,
+            "items": [{"action": "add", "contentId": "article-1", "position": 0, "sticky": true}]
+        }
+        """
+        Then we get OK response
+        And we store response as "content_lists"
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": "#content_lists.content_list_items_updated_at#",
+            "items": [{"action": "move", "contentId": "article-1", "position": 4}]
+        }
+        """
+        Then we get OK response
+        When we get "/content_lists/#content_lists._id#/items"
+        Then we get existing resource
+        """
+        {"_items": [{"content": "article-1", "position": 4, "sticky": true}]}
+        """
+
+    @auth
     Scenario: Moving an item shifts other items to keep positions unique
         Given an archive item "article-a"
         And an archive item "article-b"


### PR DESCRIPTION
## Summary

Adds three related capabilities to the content-lists bulk-patch flow:

1. **Sticky flag on `move`.** The `move` action now reads and writes the `sticky` field, so items can be pinned or unpinned in the same call that repositions them. When `sticky` is omitted the existing value is preserved.
2. **Article content in list-item responses.** GET responses for `/content_lists/<id>/items` are enriched with an `article_content` object (`title`, `state`, `thumbnail`) for every item. The thumbnail prefers the feature-media `thumbnail` rendition and falls back to the first `<img>` in `body_html`.
3. **Unique positions after every batch.** A new `_renumber` step runs after each bulk patch and re-assigns positions so that every item has a unique slot. Sticky items and items touched by the current batch (`add` / `move`) anchor at their declared position; untouched non-sticky items fill the lowest free slots in their previous order. If two anchors collide, sticky wins, then the most recently touched within a group, with the loser spilling to the next free slot.

## Files changed

| File | Change |
|------|--------|
| `apps/content_lists/article_content.py` | **New.** Async enrichment helpers (`attach_article_content`, `enrich_fetched_response`, `enrich_fetched_item`) and thumbnail extraction. |
| `apps/content_lists/rest_endpoints.py` | Wires `on_fetched` / `on_fetched_item` to the new enrichment hooks. |
| `apps/content_lists/service.py` | `move` reads/writes `sticky`; tracks touched items; calls new `_renumber` to keep positions unique via a single bulk `UpdateOne` write. |
| `features/content_lists.feature` | Six new BDD scenarios covering sticky toggling, sticky preservation, position shifting on move/add, position shifting on delete, and the higher-position move case. |

**Diffstat:** 4 files changed, 397 insertions(+), 2 deletions(-)

## Commits

- `97ce1273` Update positions of other items affected by moving/adding/removing
- `9cc14271` Adding article info to the list items response
- `2b9acd71` Enable sticky read/write for the move action
- `55520b25` Sync enable sticky read/write for the move action with latest changes
- `1f19b058` Merge PR #1 (sticky)
- `106a75d8` Merge PR #2 (article data)
- `4fc2e2dd` Keep list positions unique by anchoring sticky and moved items

## Behaviour notes

- `_renumber` is a no-op when nothing needs to change — only positions that actually shift are written, via a single `bulk_write(ordered=False)`.
- `move` without an explicit `sticky` keeps the previous value (verified by `Move action preserves sticky flag when not provided`).
- `article_content` is `None` for items whose archive document cannot be found, so the field is always present in responses.
- Thumbnail lookup never raises — `parse_html` failures degrade silently to `None`.

## Test plan

- [ ] Run `features/content_lists.feature` — all six new scenarios should pass alongside the existing ones.
- [ ] `GET /content_lists/<id>/items` returns `article_content` for items whose archive document exists, and `null` otherwise.
- [ ] `move` with `sticky: true` pins an item; subsequent `move` with `sticky: false` unpins it.
- [ ] Adding/moving items into occupied positions shifts neighbours so positions remain unique and contiguous from `0`.
- [ ] Deleting an item closes the gap (no holes in the position sequence).
- [ ] Sticky items keep their declared position when other items are added, moved, or deleted around them.

Resolves: [SDESK-7929](https://sofab.atlassian.net/browse/SDESK-7929) [SDESK-7935](https://sofab.atlassian.net/browse/SDESK-7935)



[SDESK-7929]: https://sofab.atlassian.net/browse/SDESK-7929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ