### PR TITLE
Content lists: sticky on move, unique positions, and article content enrichment

### DIFF
--- a/apps/content_lists/article_content.py
+++ b/apps/content_lists/article_content.py
@@ -1,0 +1,71 @@
+from typing import Any
+
+import superdesk
+from superdesk.core.types import RestGetResponse
+from superdesk.etree import parse_html
+
+
+async def attach_article_content(items: list[dict[str, Any]]) -> None:
+    """Add an ``article_content`` summary to each content list item in place."""
+    article_ids = [item["content"] for item in items if item.get("content")]
+    if not article_ids:
+        for item in items:
+            item["article_content"] = None
+        return
+
+    archive_service = superdesk.get_resource_service("archive")
+    cursor = await archive_service.get_from_mongo_async(
+        req=None,
+        lookup={"_id": {"$in": article_ids}},
+        projection={"headline": 1, "state": 1, "associations": 1, "body_html": 1},
+    )
+    articles_by_id: dict[str, dict[str, Any]] = {}
+    async for article in cursor:
+        articles_by_id[article["_id"]] = article
+
+    for item in items:
+        article = articles_by_id.get(item.get("content"))
+        item["article_content"] = _build_article_content(article) if article else None
+
+
+def _build_article_content(article: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "title": article.get("headline"),
+        "state": article.get("state"),
+        "thumbnail": _get_thumbnail(article),
+    }
+
+
+def _get_thumbnail(article: dict[str, Any]) -> dict[str, Any] | str | None:
+    feature_media = (article.get("associations") or {}).get("featuremedia") or {}
+    thumbnail = (feature_media.get("renditions") or {}).get("thumbnail")
+    if thumbnail:
+        return thumbnail
+
+    body_html = article.get("body_html")
+    if body_html:
+        return _first_body_html_image(body_html)
+
+    return None
+
+
+def _first_body_html_image(body_html: str) -> str | None:
+    try:
+        root = parse_html(body_html, content="html")
+    except Exception:
+        return None
+    img = root.find(".//img")
+    if img is None:
+        return None
+    src = img.get("src")
+    return src or None
+
+
+async def enrich_fetched_response(doc: RestGetResponse) -> None:
+    """Hook for ``on_fetched``: enriches all items in a search response."""
+    await attach_article_content(doc.get("_items") or [])
+
+
+async def enrich_fetched_item(item: dict[str, Any]) -> None:
+    """Hook for ``on_fetched_item``: enriches a single item."""
+    await attach_article_content([item])

--- a/apps/content_lists/article_content.py
+++ b/apps/content_lists/article_content.py
@@ -17,7 +17,17 @@ async def attach_article_content(items: list[dict[str, Any]]) -> None:
     cursor = await archive_service.get_from_mongo_async(
         req=None,
         lookup={"_id": {"$in": article_ids}},
-        projection={"headline": 1, "state": 1, "associations": 1, "body_html": 1},
+        projection={
+            "headline": 1,
+            "state": 1,
+            "associations": 1,
+            "body_html": 1,
+            "anpa_category": 1,
+            "subject": 1,
+            "_updated": 1,
+            "_created": 1,
+            "firstpublished": 1,
+        },
     )
     articles_by_id: dict[str, dict[str, Any]] = {}
     async for article in cursor:
@@ -29,11 +39,18 @@ async def attach_article_content(items: list[dict[str, Any]]) -> None:
 
 
 def _build_article_content(article: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "title": article.get("headline"),
-        "state": article.get("state"),
-        "thumbnail": _get_thumbnail(article),
-    }
+    content: dict[str, Any] = {}
+    if "headline" in article:
+        content["title"] = article["headline"]
+    if "state" in article:
+        content["state"] = article["state"]
+    thumbnail = _get_thumbnail(article)
+    if thumbnail is not None:
+        content["thumbnail"] = thumbnail
+    for field in ("anpa_category", "subject", "_updated", "_created", "firstpublished"):
+        if field in article:
+            content[field] = article[field]
+    return content
 
 
 def _get_thumbnail(article: dict[str, Any]) -> dict[str, Any] | str | None:

--- a/apps/content_lists/rest_endpoints.py
+++ b/apps/content_lists/rest_endpoints.py
@@ -1,8 +1,10 @@
 from bson import ObjectId
 
-from superdesk.core.types import Request, Response
+from superdesk.core.types import Request, Response, RestGetResponse
 from superdesk.core.web import Endpoint
 from superdesk.core.resources import ResourceRestEndpoints
+
+from .article_content import enrich_fetched_item, enrich_fetched_response
 
 
 class ContentListItemsEndpoints(ResourceRestEndpoints):
@@ -23,3 +25,9 @@ class ContentListItemsEndpoints(ResourceRestEndpoints):
         data = await request.get_json()
         result = await self.service.bulk_patch(list_id, data)
         return Response(body=result.to_dict(), status_code=200)
+
+    async def on_fetched(self, request: Request, doc: RestGetResponse) -> None:
+        await enrich_fetched_response(doc)
+
+    async def on_fetched_item(self, request: Request, doc: dict) -> None:
+        await enrich_fetched_item(doc)

--- a/apps/content_lists/service.py
+++ b/apps/content_lists/service.py
@@ -67,7 +67,8 @@ class ContentListItemsService(AsyncResourceService[ContentListItem]):
             elif action == "move":
                 existing = await self.find_one(req=None, list_id=list_id, content=content_id)
                 if existing:
-                    await self.update(existing.id, {"position": item_data.get("position")})
+                    new_sticky = item_data.get("sticky", existing.sticky)
+                    await self.update(existing.id, {"position": item_data.get("position"), "sticky": new_sticky})
                     touched_contents.append(content_id)
             elif action == "delete":
                 existing = await self.find_one(req=None, list_id=list_id, content=content_id)
@@ -85,36 +86,62 @@ class ContentListItemsService(AsyncResourceService[ContentListItem]):
         return result
 
     async def _renumber(self, list_id: ObjectId, touched_contents: list[str]) -> None:
-        """Rewrite non-sticky positions as a contiguous ``0..N-1`` sequence.
+        """Reassign positions so every item has a unique slot.
 
-        Items in ``touched_contents`` (added or moved in this batch) win position
-        ties: when an item lands on a slot already occupied, the touched item
-        keeps the slot and the prior occupant shifts to the next one. Later
-        entries in ``touched_contents`` outrank earlier ones.
+        Sticky items keep their declared position. Non-sticky items in
+        ``touched_contents`` (added or moved in this batch) also anchor at the
+        position they were just set to. Remaining untouched non-sticky items
+        fill the lowest-numbered free positions in their previous order. If
+        two anchors land on the same slot, sticky beats non-sticky and the
+        most recently touched wins within a group; the loser spills to the
+        nearest higher free slot.
         """
         docs = await self.mongo_async.find(
-            {"list_id": list_id, "sticky": {"$ne": True}},
-            projection={"_id": 1, "content": 1, "position": 1},
+            {"list_id": list_id},
+            projection={"_id": 1, "content": 1, "position": 1, "sticky": 1},
         ).to_list(None)
+        if not docs:
+            return
 
         touched_rank = {c: i for i, c in enumerate(touched_contents)}
 
-        def sort_key(d: dict) -> tuple:
-            pos = d.get("position")
+        def anchor_priority(d: dict) -> tuple:
             rank = touched_rank.get(d.get("content"))
             return (
-                pos is None,
-                pos if pos is not None else 0,
-                rank is None,
-                -rank if rank is not None else 0,
+                0 if d.get("sticky") else 1,
+                -(rank if rank is not None else -1),
                 d["_id"],
             )
 
-        docs.sort(key=sort_key)
+        anchors = [d for d in docs if d.get("sticky") or d.get("content") in touched_rank]
+        anchors.sort(key=anchor_priority)
+
+        placement: dict[int, dict] = {}
+        for doc in anchors:
+            pos = doc.get("position")
+            slot = pos if pos is not None and pos >= 0 else 0
+            while slot in placement:
+                slot += 1
+            placement[slot] = doc
+
+        rest = [d for d in docs if not d.get("sticky") and d.get("content") not in touched_rank]
+        rest.sort(
+            key=lambda d: (
+                d.get("position") is None,
+                d.get("position") if d.get("position") is not None else 0,
+                d["_id"],
+            )
+        )
+        next_slot = 0
+        for doc in rest:
+            while next_slot in placement:
+                next_slot += 1
+            placement[next_slot] = doc
+            next_slot += 1
 
         ops = [
             UpdateOne({"_id": doc["_id"]}, {"$set": {"position": i}})
-            for i, doc in enumerate(docs)
+            for i, doc in placement.items()
             if doc.get("position") != i
         ]
         if ops:

--- a/features/content_lists.feature
+++ b/features/content_lists.feature
@@ -160,6 +160,87 @@ Feature: Content Lists
         """
 
     @auth
+    Scenario: Move action toggles sticky flag on an item
+        Given an archive item "article-1"
+        When we post to "/content_lists"
+        """
+        {"name": "Breaking News", "type": "manual"}
+        """
+        Then we get OK response
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": null,
+            "items": [{"action": "add", "contentId": "article-1", "position": 0}]
+        }
+        """
+        Then we get OK response
+        And we store response as "content_lists"
+        When we get "/content_lists/#content_lists._id#/items"
+        Then we get existing resource
+        """
+        {"_items": [{"content": "article-1", "position": 0, "sticky": false}]}
+        """
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": "#content_lists.content_list_items_updated_at#",
+            "items": [{"action": "move", "contentId": "article-1", "position": 3, "sticky": true}]
+        }
+        """
+        Then we get OK response
+        And we store response as "content_lists"
+        When we get "/content_lists/#content_lists._id#/items"
+        Then we get existing resource
+        """
+        {"_items": [{"content": "article-1", "position": 3, "sticky": true}]}
+        """
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": "#content_lists.content_list_items_updated_at#",
+            "items": [{"action": "move", "contentId": "article-1", "position": 2, "sticky": false}]
+        }
+        """
+        Then we get OK response
+        When we get "/content_lists/#content_lists._id#/items"
+        Then we get existing resource
+        """
+        {"_items": [{"content": "article-1", "position": 2, "sticky": false}]}
+        """
+
+    @auth
+    Scenario: Move action preserves sticky flag when not provided
+        Given an archive item "article-1"
+        When we post to "/content_lists"
+        """
+        {"name": "Breaking News", "type": "manual"}
+        """
+        Then we get OK response
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": null,
+            "items": [{"action": "add", "contentId": "article-1", "position": 0, "sticky": true}]
+        }
+        """
+        Then we get OK response
+        And we store response as "content_lists"
+        When we bulk patch items for "/content_lists/#content_lists._id#/items"
+        """
+        {
+            "updatedAt": "#content_lists.content_list_items_updated_at#",
+            "items": [{"action": "move", "contentId": "article-1", "position": 4}]
+        }
+        """
+        Then we get OK response
+        When we get "/content_lists/#content_lists._id#/items"
+        Then we get existing resource
+        """
+        {"_items": [{"content": "article-1", "position": 4, "sticky": true}]}
+        """
+
+    @auth
     Scenario: Moving an item shifts other items to keep positions unique
         Given an archive item "article-a"
         And an archive item "article-b"


### PR DESCRIPTION
### Summary

**Replaces https://github.com/superdesk/superdesk-core/pull/3222**

Builds on the position-management work already merged via #3218 to extend
content list items with sticky support and article metadata:

1. **Sticky flag is read/written on the `move` action** — items can be pinned
   or unpinned in place, without removing and re-adding them. When `sticky`
   isn't supplied on a move, the item's existing value is preserved.
2. **Position uniqueness now spans sticky items too** — sticky and just-moved
   items anchor at their declared slots and everything else fills the
   remaining slots, so no two items ever share a position.
3. **List item responses are enriched with an `article_content` summary**
   resolved from the referenced archive item.

> Targets `feature/content-lists-with-develop`. The original
> `SDESK-7929-SDESK-7935-Sticky-article-content` branch was cut from an older
> base and could no longer be merged cleanly; this branch was re-cut from the
> current `feature/content-lists-with-develop` and carries only the net-new
> work (the "Update positions" commit it built on is already upstream as
> #3218).

### Changes

**`apps/content_lists/service.py`**
- `move` action reads `sticky` from the payload (falling back to the item's
  current value) and persists it alongside the new position.
- `_renumber` rewritten to keep every position unique across *all* items, not
  just non-sticky ones. Sticky items and items touched in the current batch
  are placed first as "anchors" at their declared positions; remaining items
  fill the lowest free slots in their prior order. On a tie, sticky beats
  non-sticky and the most recently touched item wins within a group — the
  loser spills to the next free slot.

**`apps/content_lists/article_content.py`** *(new)*
- `attach_article_content` enriches list items in place with an
  `article_content` object, batch-fetching the referenced archive items from
  Mongo in a single query.
- The summary includes `title` (headline), `state`, and `thumbnail`, plus
  `anpa_category`, `subject`, `_updated`, `_created`, and `firstpublished`.
- Every field is **omitted when absent** on the article rather than emitted as
  `null`, so the payload only carries data that actually exists.
- Thumbnail resolution prefers the feature-media `thumbnail` rendition and
  falls back to the first `<img>` in `body_html`.
- Exposes `enrich_fetched_response` / `enrich_fetched_item` hooks.

**`apps/content_lists/rest_endpoints.py`**
- Wires enrichment into `on_fetched` (list) and `on_fetched_item` (single), so
  every read of content-list items includes `article_content`.

**`features/content_lists.feature`**
- New scenario: *Move action toggles sticky flag on an item*.
- New scenario: *Move action preserves sticky flag when not provided*.

### Example response

​```json
{
    "content": "urn:newsml:...",
    "position": 0,
    "sticky": true,
    "article_content": {
        "title": "Breaking news headline",
        "state": "published",
        "thumbnail": { "href": "...", "mimetype": "image/jpeg" },
        "anpa_category": [{ "qcode": "a", "name": "Domestic" }],
        "subject": [{ "qcode": "01000000", "name": "arts" }],
        "_created": "2026-05-20T09:00:00+0000",
        "_updated": "2026-05-27T10:00:00+0000",
        "firstpublished": "2026-05-20T09:30:00+0000"
    }
}
​```

### Testing

- Behave scenarios cover sticky toggle/preserve on move.
- Existing #3218 position-uniqueness scenarios continue to pass.

### Notes for reviewers

The diff against `feature/content-lists-with-develop` is scoped to **4 files** —
`service.py`, the new `article_content.py`, `rest_endpoints.py`, and
`content_lists.feature`. The `service.py` changes are a clean forward evolution
of the `_renumber` implementation from #3218 (no revert of upstream work).

Handles [SDESK-7929](https://sofab.atlassian.net/browse/SDESK-7929) [SDESK-7935](https://sofab.atlassian.net/browse/SDESK-7935) [SDESK-7936](https://sofab.atlassian.net/browse/SDESK-7936)

[SDESK-7929]: https://sofab.atlassian.net/browse/SDESK-7929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ