### PR TITLE
[SDESK-7943] Add archived unarchive command

### DIFF
--- a/apps/archived/__init__.py
+++ b/apps/archived/__init__.py
@@ -11,6 +11,7 @@
 import superdesk
 
 from apps.archived.archived import ArchivedResource, ArchivedService
+from apps.archived.commands import UnarchiveItemCommand, cli_archived_unarchive  # noqa
 
 
 def init_app(app) -> None:

--- a/apps/archived/archived.py
+++ b/apps/archived/archived.py
@@ -65,6 +65,7 @@ PACKAGE_TYPE = "package_type"
 TAKES_PACKAGE = "takes"
 SEQUENCE = "sequence"
 LAST_TAKE = "last_take"
+SOURCE = "archived"
 
 
 class ArchivedResource(Resource):

--- a/apps/archived/commands.py
+++ b/apps/archived/commands.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import logging
+from copy import deepcopy
+from datetime import timedelta
+
+import click
+from eve.utils import ParsedRequest
+
+from superdesk.commands import cli
+from superdesk.core import get_config
+from superdesk.metadata.item import CONTENT_STATE, CONTENT_TYPE, ITEM_TYPE, PUBLISH_STATES
+from superdesk.resource_fields import ETAG, ID_FIELD, VERSION
+from superdesk.utc import utcnow, get_expiry_date
+from superdesk.types.archived import QueueState
+from superdesk import get_resource_service
+from apps.archive.common import ARCHIVE, get_expiry, insert_into_versions_async
+from apps.archive.archive import SOURCE as ARCHIVE_SOURCE
+from apps.archived.archived import SOURCE as ARCHIVED_SOURCE
+from apps.packages import PackageService
+from apps.publish.published_item import LAST_PUBLISHED_VERSION, PUBLISHED, QUEUE_STATE
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_UNARCHIVE_EXPIRY_DAYS = 7
+ARCHIVED_FIELDS_TO_REMOVE = {
+    "archived_id",
+    "item_id",
+    "queue_state",
+    "publish_state",
+    "error_message",
+    "moved_to_legal",
+    "last_queue_event",
+    "publish_sequence_no",
+    "is_take_item",
+    "digital_item_id",
+    "old_version",
+    "last_version",
+    "_links",
+    "_type",
+    ETAG,
+}
+
+
+class UnarchiveItemCommand:
+    """Command to unarchive published articles so they can be edited/corrected."""
+
+    async def run(self, item_ids: list[str], dry_run: bool = False) -> dict[str, list]:
+        """Unarchive the given item IDs.
+
+        :param item_ids: List of item IDs (GUIDs) to unarchive.
+        :param dry_run: If True, simulate without making changes.
+        :return: Dict with 'success' and 'failed' lists.
+        """
+        results: dict[str, list] = {"success": [], "failed": []}
+
+        for item_id in item_ids:
+            try:
+                await self._unarchive_item(item_id, dry_run)
+                results["success"].append(item_id)
+            except Exception as e:
+                logger.error("Failed to unarchive item %s: %s", item_id, e)
+                results["failed"].append({"item_id": item_id, "error": str(e)})
+
+        return results
+
+    async def _unarchive_item(self, item_id: str, dry_run: bool) -> None:
+        """Unarchive a single item"""
+        archived_service = get_resource_service(ARCHIVED_SOURCE)
+        archive_service = get_resource_service(ARCHIVE_SOURCE)
+
+        # Find the latest archived version
+        archived_items = await (
+            await archived_service.get_from_mongo_async(req=None, lookup={"item_id": item_id})
+        ).to_list()
+
+        if not archived_items:
+            raise ValueError("No archived items found for item_id: {}".format(item_id))
+
+        archived_items.sort(key=lambda x: x.get(VERSION, 0), reverse=True)
+        latest_item = archived_items[0]
+
+        # Collect items to restore (main item + direct package refs + takes package if applicable)
+        items_to_restore = await self._collect_items_to_restore(latest_item, archived_service)
+        restore_order = (
+            items_to_restore[1:] + items_to_restore[:1]
+            if latest_item.get(ITEM_TYPE) == CONTENT_TYPE.COMPOSITE
+            else items_to_restore
+        )
+
+        # Atomic validation: check none exist in archive
+        for item in items_to_restore:
+            existing = await archive_service.find_one_async(req=None, _id=item["item_id"])
+            if existing:
+                raise ValueError("Item already exists in archive: {}. Aborting atomic restore.".format(item["item_id"]))
+
+        if dry_run:
+            for item in restore_order:
+                logger.info("[DRY-RUN] Would unarchive item %s (version %s)", item["item_id"], item.get(VERSION))
+            return
+
+        # Restore all items
+        for item in restore_order:
+            await self._restore_to_archive(item)
+            await self._restore_to_published(item)
+
+        # Clean up archived
+        for item in items_to_restore:
+            await archived_service.command_delete({"item_id": item["item_id"]})
+            logger.info("Removed archived versions for item: %s", item["item_id"])
+
+    async def _collect_items_to_restore(self, latest_item: dict, archived_service) -> list[dict]:
+        """Collect the main item and all takes package items for atomic restoration.
+
+        :param latest_item: The latest archived version of the main item.
+        :param archived_service: The archived service.
+        :return: List of items to restore
+        """
+        items = [latest_item]
+        seen_ids = {latest_item.get("item_id")}
+
+        # Restore direct package members for composite packages.
+        if latest_item.get(ITEM_TYPE) == CONTENT_TYPE.COMPOSITE:
+            for ref in PackageService().get_item_refs(latest_item):
+                ref_id = ref.get("residRef")
+                if not ref_id or ref_id in seen_ids:
+                    continue
+
+                ref_items = await (
+                    await archived_service.get_from_mongo_async(req=None, lookup={"item_id": ref_id})
+                ).to_list()
+                if not ref_items:
+                    raise ValueError("No archived item found for package ref: {}".format(ref_id))
+
+                ref_items.sort(key=lambda x: x.get(VERSION, 0), reverse=True)
+                items.append(ref_items[0])
+                seen_ids.add(ref_id)
+
+        # Check if item is part of a takes package
+        takes_package_id = self._get_take_package_id(latest_item)
+        if takes_package_id:
+            # Find the takes package in archived
+            req = ParsedRequest()
+            req.sort = '[("%s", -1)]' % VERSION
+            take_packages = await (
+                await archived_service.get_from_mongo_async(req=req, lookup={"item_id": takes_package_id})
+            ).to_list()
+
+            if take_packages:
+                take_packages.sort(key=lambda x: x.get(VERSION, 0), reverse=True)
+                takes_package = take_packages[0]
+                items.append(takes_package)
+
+                # Find all takes in the package
+                for ref in self._get_package_refs(takes_package):
+                    take_id = ref.get("residRef")
+                    if take_id and take_id not in seen_ids:
+                        take_items = await (
+                            await archived_service.get_from_mongo_async(req=None, lookup={"item_id": take_id})
+                        ).to_list()
+                        if not take_items:
+                            raise ValueError("No archived item found for package ref: {}".format(take_id))
+                        take_items.sort(key=lambda x: x.get(VERSION, 0), reverse=True)
+                        items.append(take_items[0])
+                        seen_ids.add(take_id)
+
+        return items
+
+    def _get_take_package_id(self, item: dict) -> str | None:
+        """Get the takes package ID if the item is part of one."""
+        from superdesk.metadata.packages import LINKED_IN_PACKAGES, PACKAGE, PACKAGE_TYPE
+
+        takes_package = [
+            package.get(PACKAGE) for package in item.get(LINKED_IN_PACKAGES, []) if package.get(PACKAGE_TYPE) == "takes"
+        ]
+        if len(takes_package) > 1:
+            logger.error("Multiple takes found for item: %s", item.get(ID_FIELD))
+        return takes_package[0] if takes_package else None
+
+    def _get_package_refs(self, package: dict) -> list[dict]:
+        """Get refs from the takes package."""
+        from superdesk.metadata.packages import MAIN_GROUP
+
+        if not package:
+            return []
+        groups: list[dict] = package.get("groups", [])
+        refs: list[dict] = next((group.get("refs", []) for group in groups if group.get("id") == MAIN_GROUP), [])
+        return refs
+
+    async def _restore_to_archive(self, item: dict) -> None:
+        """Restore an item to the archive collection."""
+        archive_service = get_resource_service(ARCHIVE_SOURCE)
+        archive_item = deepcopy(item)
+
+        # Remove archived-only fields
+        for field in ARCHIVED_FIELDS_TO_REMOVE:
+            archive_item.pop(field, None)
+
+        # Set _id to original item_id
+        archive_item[ID_FIELD] = archive_item.pop("item_id", item["item_id"])
+
+        # Set versioncreated and _updated
+        archive_item["versioncreated"] = utcnow()
+        archive_item["_updated"] = utcnow()
+
+        # Set expiry
+        await self._set_expiry(archive_item)
+
+        # For composites, restore ref location to archive
+        if archive_item.get(ITEM_TYPE) == CONTENT_TYPE.COMPOSITE:
+            package_service = PackageService()
+            for ref in package_service.get_item_refs(archive_item):
+                ref["location"] = ARCHIVE
+
+        # Insert into archive using create_async to bypass on_create_async hooks
+        await archive_service.create_async([archive_item])
+        logger.info("Restored item to archive: %s", archive_item[ID_FIELD])
+
+        # Insert into archive_versions
+        await insert_into_versions_async(doc=archive_item)
+        logger.info("Inserted version for item: %s", archive_item[ID_FIELD])
+
+    async def _restore_to_published(self, item: dict) -> None:
+        """Restore an item to the published collection.
+
+        Uses post_async so PublishedItemService.on_create_async runs and sets
+        item_id, publish_sequence_no, and other critical defaults.
+        """
+        published_service = get_resource_service(PUBLISHED)
+        published_doc = deepcopy(item)
+
+        # Remove archived-only fields
+        for field in ARCHIVED_FIELDS_TO_REMOVE:
+            published_doc.pop(field, None)
+
+        # Set _id to item_id so on_create_async maps correctly
+        published_doc[ID_FIELD] = published_doc.pop("item_id", item["item_id"])
+
+        # Set queue_state and last_published_version
+        published_doc[QUEUE_STATE] = QueueState.QUEUED.value
+        published_doc[LAST_PUBLISHED_VERSION] = True
+
+        # Set versioncreated and _updated
+        published_doc["versioncreated"] = utcnow()
+        published_doc["_updated"] = utcnow()
+
+        # Ensure state is a valid publish state
+        if published_doc.get("state") not in PUBLISH_STATES:
+            published_doc["state"] = CONTENT_STATE.PUBLISHED
+
+        # Use post_async to trigger on_create_async which sets publish_sequence_no and item_id
+        await published_service.post_async([published_doc])
+        logger.info("Restored item to published: %s", item["item_id"])
+
+    async def _set_expiry(self, doc: dict) -> None:
+        """Set expiry on the restored item.
+
+        Priority:
+        1. Original desk/stage settings via get_expiry()
+        2. PUBLISHED_CONTENT_EXPIRY_MINUTES config
+        3. 7 days fallback
+        """
+        task = doc.get("task", {})
+        desk_id = task.get("desk")
+        stage_id = task.get("stage")
+
+        try:
+            if desk_id:
+                expiry = await get_expiry(desk_id, stage_id)
+                if expiry:
+                    doc["expiry"] = expiry
+                    return
+        except Exception:
+            logger.warning("Failed to get expiry for desk %s stage %s", desk_id, stage_id)
+
+        expiry_minutes = get_config(int, "PUBLISHED_CONTENT_EXPIRY_MINUTES", 0)
+        if expiry_minutes:
+            doc["expiry"] = get_expiry_date(expiry_minutes)
+        else:
+            doc["expiry"] = utcnow() + timedelta(days=DEFAULT_UNARCHIVE_EXPIRY_DAYS)
+
+
+@cli.command("archived:unarchive")
+@click.option("--item-id", "-i", multiple=True, required=True, help="Item ID(s) to unarchive")
+@click.option("--dry-run", "-d", is_flag=True, help="Simulate without making changes")
+async def cli_archived_unarchive(item_id, dry_run):
+    """Unarchive published articles so they can be edited/corrected.
+
+    Example:
+    ::
+
+        $ python manage.py archived:unarchive --item-id=urn:newsml:example.com:2023-01-01:1
+        $ python manage.py archived:unarchive -i item1 -i item2 --dry-run
+
+    """
+    item_ids = list(item_id)
+
+    if not item_ids:
+        print("No item IDs provided.")
+        return
+
+    results = await UnarchiveItemCommand().run(item_ids, dry_run=dry_run)
+
+    print("Unarchive complete:")
+    print("  Successful: {}".format(len(results["success"])))
+    print("  Failed: {}".format(len(results["failed"])))
+
+    if results["failed"]:
+        print("\nFailed items:")
+        for failure in results["failed"]:
+            print("  - {}: {}".format(failure["item_id"], failure["error"]))

--- a/apps/archived/commands.py
+++ b/apps/archived/commands.py
@@ -16,13 +16,12 @@ import click
 from eve.utils import ParsedRequest
 
 from superdesk.commands import cli
-from superdesk.core import get_config
 from superdesk.metadata.item import CONTENT_STATE, CONTENT_TYPE, ITEM_TYPE, PUBLISH_STATES
 from superdesk.resource_fields import ETAG, ID_FIELD, VERSION
-from superdesk.utc import utcnow, get_expiry_date
+from superdesk.utc import utcnow
 from superdesk.types.archived import QueueState
 from superdesk import get_resource_service
-from apps.archive.common import ARCHIVE, get_expiry, insert_into_versions_async
+from apps.archive.common import ARCHIVE, insert_into_versions_async
 from apps.archive.archive import SOURCE as ARCHIVE_SOURCE
 from apps.archived.archived import SOURCE as ARCHIVED_SOURCE
 from apps.packages import PackageService
@@ -30,7 +29,6 @@ from apps.publish.published_item import LAST_PUBLISHED_VERSION, PUBLISHED, QUEUE
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_UNARCHIVE_EXPIRY_DAYS = 7
 ARCHIVED_FIELDS_TO_REMOVE = {
     "archived_id",
     "item_id",
@@ -53,7 +51,12 @@ ARCHIVED_FIELDS_TO_REMOVE = {
 class UnarchiveItemCommand:
     """Command to unarchive published articles so they can be edited/corrected."""
 
-    async def run(self, item_ids: list[str], dry_run: bool = False) -> dict[str, list]:
+    async def run(
+        self,
+        item_ids: list[str],
+        dry_run: bool = False,
+        expiry_days: int | None = None,
+    ) -> dict[str, list]:
         """Unarchive the given item IDs.
 
         :param item_ids: List of item IDs (GUIDs) to unarchive.
@@ -64,7 +67,7 @@ class UnarchiveItemCommand:
 
         for item_id in item_ids:
             try:
-                await self._unarchive_item(item_id, dry_run)
+                await self._unarchive_item(item_id, dry_run, expiry_days)
                 results["success"].append(item_id)
             except Exception as e:
                 logger.error("Failed to unarchive item %s: %s", item_id, e)
@@ -72,7 +75,7 @@ class UnarchiveItemCommand:
 
         return results
 
-    async def _unarchive_item(self, item_id: str, dry_run: bool) -> None:
+    async def _unarchive_item(self, item_id: str, dry_run: bool, expiry_days: int | None) -> None:
         """Unarchive a single item"""
         archived_service = get_resource_service(ARCHIVED_SOURCE)
         archive_service = get_resource_service(ARCHIVE_SOURCE)
@@ -108,7 +111,7 @@ class UnarchiveItemCommand:
         restored_item_ids = []
         try:
             for item in restore_order:
-                await self._restore_to_archive(item)
+                await self._restore_to_archive(item, expiry_days)
                 await self._restore_to_published(item)
                 restored_item_ids.append(item["item_id"])
         except Exception:
@@ -215,7 +218,7 @@ class UnarchiveItemCommand:
             except Exception:
                 logger.exception("Failed to rollback published item: %s", item_id)
 
-    async def _restore_to_archive(self, item: dict) -> None:
+    async def _restore_to_archive(self, item: dict, expiry_days: int | None) -> None:
         """Restore an item to the archive collection."""
         archive_service = get_resource_service(ARCHIVE_SOURCE)
         archive_item = deepcopy(item)
@@ -232,7 +235,7 @@ class UnarchiveItemCommand:
         archive_item["_updated"] = utcnow()
 
         # Set expiry
-        await self._set_expiry(archive_item)
+        await self._set_expiry(archive_item, expiry_days)
 
         # For composites, restore ref location to archive
         if archive_item.get(ITEM_TYPE) == CONTENT_TYPE.COMPOSITE:
@@ -280,39 +283,29 @@ class UnarchiveItemCommand:
         await published_service.post_async([published_doc])
         logger.info("Restored item to published: %s", item["item_id"])
 
-    async def _set_expiry(self, doc: dict) -> None:
+    async def _set_expiry(self, doc: dict, expiry_days: int | None) -> None:
         """Set expiry on the restored item.
 
-        Priority:
-        1. PUBLISHED_CONTENT_EXPIRY_MINUTES config
-        2. Original desk/stage settings via get_expiry()
-        3. 7 days fallback
+        By default restored items do not expire.
+        Use the CLI expiry-days override to opt back in.
         """
-        task = doc.get("task", {})
-        desk_id = task.get("desk")
-        stage_id = task.get("stage")
-
-        expiry_minutes = get_config(int, "PUBLISHED_CONTENT_EXPIRY_MINUTES", 0)
-        if expiry_minutes:
-            doc["expiry"] = get_expiry_date(expiry_minutes)
+        if expiry_days is None:
+            doc["expiry"] = None
             return
 
-        try:
-            if desk_id:
-                expiry = await get_expiry(desk_id, stage_id)
-                if expiry:
-                    doc["expiry"] = expiry
-                    return
-        except Exception:
-            logger.warning("Failed to get expiry for desk %s stage %s", desk_id, stage_id)
-
-        doc["expiry"] = utcnow() + timedelta(days=DEFAULT_UNARCHIVE_EXPIRY_DAYS)
+        doc["expiry"] = utcnow() + timedelta(days=expiry_days)
 
 
 @cli.command("archived:unarchive")
 @click.argument("item_ids", nargs=-1)
 @click.option("--dry-run", "-d", is_flag=True, help="Simulate without making changes")
-async def cli_archived_unarchive(item_ids, dry_run):
+@click.option(
+    "--expiry-days",
+    type=int,
+    default=None,
+    help="Optional days until restored items expire; omit for no expiry",
+)
+async def cli_archived_unarchive(item_ids, dry_run, expiry_days):
     """Unarchive published articles so they can be edited/corrected.
 
     Example:
@@ -327,7 +320,7 @@ async def cli_archived_unarchive(item_ids, dry_run):
         print("No item IDs provided.")
         return
 
-    results = await UnarchiveItemCommand().run(item_ids, dry_run=dry_run)
+    results = await UnarchiveItemCommand().run(item_ids, dry_run=dry_run, expiry_days=expiry_days)
 
     print("Unarchive complete:")
     print("  Successful: {}".format(len(results["success"])))

--- a/apps/archived/commands.py
+++ b/apps/archived/commands.py
@@ -76,17 +76,9 @@ class UnarchiveItemCommand:
         """Unarchive a single item"""
         archived_service = get_resource_service(ARCHIVED_SOURCE)
         archive_service = get_resource_service(ARCHIVE_SOURCE)
+        published_service = get_resource_service(PUBLISHED)
 
-        # Find the latest archived version
-        archived_items = await (
-            await archived_service.get_from_mongo_async(req=None, lookup={"item_id": item_id})
-        ).to_list()
-
-        if not archived_items:
-            raise ValueError("No archived items found for item_id: {}".format(item_id))
-
-        archived_items.sort(key=lambda x: x.get(VERSION, 0), reverse=True)
-        latest_item = archived_items[0]
+        latest_item = await self._get_latest_archived_item(archived_service, item_id)
 
         # Collect items to restore (main item + direct package refs + takes package if applicable)
         items_to_restore = await self._collect_items_to_restore(latest_item, archived_service)
@@ -101,6 +93,11 @@ class UnarchiveItemCommand:
             existing = await archive_service.find_one_async(req=None, _id=item["item_id"])
             if existing:
                 raise ValueError("Item already exists in archive: {}. Aborting atomic restore.".format(item["item_id"]))
+            existing = await published_service.find_one_async(req=None, item_id=item["item_id"])
+            if existing:
+                raise ValueError(
+                    "Item already exists in published: {}. Aborting atomic restore.".format(item["item_id"])
+                )
 
         if dry_run:
             for item in restore_order:
@@ -108,14 +105,33 @@ class UnarchiveItemCommand:
             return
 
         # Restore all items
-        for item in restore_order:
-            await self._restore_to_archive(item)
-            await self._restore_to_published(item)
+        restored_item_ids = []
+        try:
+            for item in restore_order:
+                await self._restore_to_archive(item)
+                await self._restore_to_published(item)
+                restored_item_ids.append(item["item_id"])
+        except Exception:
+            await self._rollback_restored_items(restored_item_ids)
+            raise
 
         # Clean up archived
         for item in items_to_restore:
             await archived_service.command_delete({"item_id": item["item_id"]})
             logger.info("Removed archived versions for item: %s", item["item_id"])
+
+    async def _get_latest_archived_item(self, archived_service, item_id: str) -> dict:
+        req = ParsedRequest()
+        req.sort = '[("%s", -1)]' % VERSION
+        req.max_results = 1
+        archived_items = await (
+            await archived_service.get_from_mongo_async(req=req, lookup={"item_id": item_id})
+        ).to_list()
+
+        if not archived_items:
+            raise ValueError("No archived items found for item_id: {}".format(item_id))
+
+        return archived_items[0]
 
     async def _collect_items_to_restore(self, latest_item: dict, archived_service) -> list[dict]:
         """Collect the main item and all takes package items for atomic restoration.
@@ -147,30 +163,16 @@ class UnarchiveItemCommand:
         # Check if item is part of a takes package
         takes_package_id = self._get_take_package_id(latest_item)
         if takes_package_id:
-            # Find the takes package in archived
-            req = ParsedRequest()
-            req.sort = '[("%s", -1)]' % VERSION
-            take_packages = await (
-                await archived_service.get_from_mongo_async(req=req, lookup={"item_id": takes_package_id})
-            ).to_list()
+            takes_package = await self._get_latest_archived_item(archived_service, takes_package_id)
+            items.append(takes_package)
 
-            if take_packages:
-                take_packages.sort(key=lambda x: x.get(VERSION, 0), reverse=True)
-                takes_package = take_packages[0]
-                items.append(takes_package)
-
-                # Find all takes in the package
-                for ref in self._get_package_refs(takes_package):
-                    take_id = ref.get("residRef")
-                    if take_id and take_id not in seen_ids:
-                        take_items = await (
-                            await archived_service.get_from_mongo_async(req=None, lookup={"item_id": take_id})
-                        ).to_list()
-                        if not take_items:
-                            raise ValueError("No archived item found for package ref: {}".format(take_id))
-                        take_items.sort(key=lambda x: x.get(VERSION, 0), reverse=True)
-                        items.append(take_items[0])
-                        seen_ids.add(take_id)
+            # Find all takes in the package
+            for ref in self._get_package_refs(takes_package):
+                take_id = ref.get("residRef")
+                if take_id and take_id not in seen_ids:
+                    take_item = await self._get_latest_archived_item(archived_service, take_id)
+                    items.append(take_item)
+                    seen_ids.add(take_id)
 
         return items
 
@@ -194,6 +196,24 @@ class UnarchiveItemCommand:
         groups: list[dict] = package.get("groups", [])
         refs: list[dict] = next((group.get("refs", []) for group in groups if group.get("id") == MAIN_GROUP), [])
         return refs
+
+    async def _rollback_restored_items(self, restored_item_ids: list[str]) -> None:
+        if not restored_item_ids:
+            return
+
+        archive_service = get_resource_service(ARCHIVE_SOURCE)
+        published_service = get_resource_service(PUBLISHED)
+
+        for item_id in restored_item_ids:
+            try:
+                await archive_service.delete_by_article_ids([item_id])
+            except Exception:
+                logger.exception("Failed to rollback archive item: %s", item_id)
+
+            try:
+                await published_service.delete_by_article_id(item_id)
+            except Exception:
+                logger.exception("Failed to rollback published item: %s", item_id)
 
     async def _restore_to_archive(self, item: dict) -> None:
         """Restore an item to the archive collection."""
@@ -272,6 +292,11 @@ class UnarchiveItemCommand:
         desk_id = task.get("desk")
         stage_id = task.get("stage")
 
+        expiry_minutes = get_config(int, "PUBLISHED_CONTENT_EXPIRY_MINUTES", 0)
+        if expiry_minutes:
+            doc["expiry"] = get_expiry_date(expiry_minutes)
+            return
+
         try:
             if desk_id:
                 expiry = await get_expiry(desk_id, stage_id)
@@ -281,27 +306,22 @@ class UnarchiveItemCommand:
         except Exception:
             logger.warning("Failed to get expiry for desk %s stage %s", desk_id, stage_id)
 
-        expiry_minutes = get_config(int, "PUBLISHED_CONTENT_EXPIRY_MINUTES", 0)
-        if expiry_minutes:
-            doc["expiry"] = get_expiry_date(expiry_minutes)
-        else:
-            doc["expiry"] = utcnow() + timedelta(days=DEFAULT_UNARCHIVE_EXPIRY_DAYS)
+        doc["expiry"] = utcnow() + timedelta(days=DEFAULT_UNARCHIVE_EXPIRY_DAYS)
 
 
 @cli.command("archived:unarchive")
-@click.option("--item-id", "-i", multiple=True, required=True, help="Item ID(s) to unarchive")
+@click.argument("item_ids", nargs=-1)
 @click.option("--dry-run", "-d", is_flag=True, help="Simulate without making changes")
-async def cli_archived_unarchive(item_id, dry_run):
+async def cli_archived_unarchive(item_ids, dry_run):
     """Unarchive published articles so they can be edited/corrected.
 
     Example:
     ::
 
-        $ python manage.py archived:unarchive --item-id=urn:newsml:example.com:2023-01-01:1
-        $ python manage.py archived:unarchive -i item1 -i item2 --dry-run
+        $ python manage.py archived:unarchive item1 item2 --dry-run
 
     """
-    item_ids = list(item_id)
+    item_ids = list(item_ids)
 
     if not item_ids:
         print("No item IDs provided.")

--- a/apps/archived/commands.py
+++ b/apps/archived/commands.py
@@ -284,8 +284,8 @@ class UnarchiveItemCommand:
         """Set expiry on the restored item.
 
         Priority:
-        1. Original desk/stage settings via get_expiry()
-        2. PUBLISHED_CONTENT_EXPIRY_MINUTES config
+        1. PUBLISHED_CONTENT_EXPIRY_MINUTES config
+        2. Original desk/stage settings via get_expiry()
         3. 7 days fallback
         """
         task = doc.get("task", {})

--- a/tests/archived/commands_test.py
+++ b/tests/archived/commands_test.py
@@ -22,6 +22,46 @@ class UnarchiveItemCommandTestCase(TestCase):
         assert await test_utils.count("archive", {"_id": "test"}) == 1
         assert await test_utils.count("published", {"item_id": "test"}) == 1
 
+    async def test_unarchive_defaults_expiry_to_null(self):
+        await test_utils.post_items(
+            "archived",
+            [
+                {
+                    "_id": ObjectId(),
+                    "item_id": "null-expiry",
+                    "guid": "null-expiry",
+                    "type": "text",
+                    "state": "published",
+                }
+            ],
+        )
+
+        await UnarchiveItemCommand().run(["null-expiry"])
+
+        archive_doc = await test_utils.find_one("archive", _id="null-expiry")
+        assert archive_doc is not None
+        assert archive_doc.get("expiry") is None
+
+    async def test_unarchive_expiry_days_override_sets_expiry(self):
+        await test_utils.post_items(
+            "archived",
+            [
+                {
+                    "_id": ObjectId(),
+                    "item_id": "override-expiry",
+                    "guid": "override-expiry",
+                    "type": "text",
+                    "state": "published",
+                }
+            ],
+        )
+
+        await UnarchiveItemCommand().run(["override-expiry"], expiry_days=30)
+
+        archive_doc = await test_utils.find_one("archive", _id="override-expiry")
+        assert archive_doc is not None
+        assert archive_doc.get("expiry") is not None
+
     async def test_unarchive_package_restores_children(self):
         package_id = "package"
         picture_id = "picture"

--- a/tests/archived/commands_test.py
+++ b/tests/archived/commands_test.py
@@ -96,6 +96,7 @@ class UnarchiveItemCommandTestCase(TestCase):
         await UnarchiveItemCommand().run(["dry"], dry_run=True)
         assert await test_utils.count("archived", {"item_id": "dry"}) == 1
         assert await test_utils.count("archive", {"_id": "dry"}) == 0
+        assert await test_utils.count("published", {"item_id": "dry"}) == 0
 
     async def test_unarchive_collision_aborts(self):
         await test_utils.post_items(
@@ -114,3 +115,4 @@ class UnarchiveItemCommandTestCase(TestCase):
         results = await UnarchiveItemCommand().run(["coll"])
         assert len(results["failed"]) == 1
         assert await test_utils.count("archived", {"item_id": "coll"}) == 1
+        assert await test_utils.count("published", {"item_id": "coll"}) == 0

--- a/tests/archived/commands_test.py
+++ b/tests/archived/commands_test.py
@@ -1,0 +1,116 @@
+from bson import ObjectId
+from superdesk.tests import TestCase, utils as test_utils
+from apps.archived.commands import UnarchiveItemCommand
+
+
+class UnarchiveItemCommandTestCase(TestCase):
+    async def test_unarchive_single_item(self):
+        await test_utils.post_items(
+            "archived",
+            [
+                {
+                    "_id": ObjectId(),
+                    "item_id": "test",
+                    "guid": "test",
+                    "type": "text",
+                    "state": "published",
+                }
+            ],
+        )
+        await UnarchiveItemCommand().run(["test"])
+        assert await test_utils.count("archived", {"item_id": "test"}) == 0
+        assert await test_utils.count("archive", {"_id": "test"}) == 1
+        assert await test_utils.count("published", {"item_id": "test"}) == 1
+
+    async def test_unarchive_package_restores_children(self):
+        package_id = "package"
+        picture_id = "picture"
+        text_id = "text"
+
+        await test_utils.post_items(
+            "archived",
+            [
+                {
+                    "_id": ObjectId(),
+                    "item_id": picture_id,
+                    "guid": picture_id,
+                    "type": "picture",
+                    "state": "published",
+                    "headline": "Picture",
+                },
+                {
+                    "_id": ObjectId(),
+                    "item_id": text_id,
+                    "guid": text_id,
+                    "type": "text",
+                    "state": "published",
+                    "headline": "Text",
+                },
+                {
+                    "_id": ObjectId(),
+                    "item_id": package_id,
+                    "guid": package_id,
+                    "type": "composite",
+                    "state": "published",
+                    "headline": "Package",
+                    "groups": [
+                        {"id": "root", "refs": [{"idRef": "main"}], "role": "grpRole:NEP"},
+                        {
+                            "id": "main",
+                            "refs": [
+                                {"residRef": picture_id, "location": "archive"},
+                                {"residRef": text_id, "location": "archive"},
+                            ],
+                            "role": "grpRole:main",
+                        },
+                    ],
+                },
+            ],
+        )
+
+        await UnarchiveItemCommand().run([package_id])
+
+        assert await test_utils.count("archived", {"item_id": package_id}) == 0
+        assert await test_utils.count("archived", {"item_id": picture_id}) == 0
+        assert await test_utils.count("archived", {"item_id": text_id}) == 0
+        assert await test_utils.count("archive", {"_id": package_id}) == 1
+        assert await test_utils.count("archive", {"_id": picture_id}) == 1
+        assert await test_utils.count("archive", {"_id": text_id}) == 1
+        assert await test_utils.count("published", {"item_id": package_id}) == 1
+        assert await test_utils.count("published", {"item_id": picture_id}) == 1
+        assert await test_utils.count("published", {"item_id": text_id}) == 1
+
+    async def test_unarchive_dry_run(self):
+        await test_utils.post_items(
+            "archived",
+            [
+                {
+                    "_id": ObjectId(),
+                    "item_id": "dry",
+                    "guid": "dry",
+                    "type": "text",
+                    "state": "published",
+                }
+            ],
+        )
+        await UnarchiveItemCommand().run(["dry"], dry_run=True)
+        assert await test_utils.count("archived", {"item_id": "dry"}) == 1
+        assert await test_utils.count("archive", {"_id": "dry"}) == 0
+
+    async def test_unarchive_collision_aborts(self):
+        await test_utils.post_items(
+            "archived",
+            [
+                {
+                    "_id": ObjectId(),
+                    "item_id": "coll",
+                    "guid": "coll",
+                    "type": "text",
+                    "state": "published",
+                }
+            ],
+        )
+        await test_utils.post_items("archive", [{"_id": "coll", "type": "text", "state": "published"}])
+        results = await UnarchiveItemCommand().run(["coll"])
+        assert len(results["failed"]) == 1
+        assert await test_utils.count("archived", {"item_id": "coll"}) == 1


### PR DESCRIPTION
### Purpose
This PR adds a new command that allows one to restore expired published articles from the archived store so they can be corrected and republished. This adds a CLI command for unarchiving single articles and packages.

### What has changed
- Added `archived:unarchive` CLI command.
- Restores archived article(s) back into `archive` and `published`.
- Handles composite packages atomically, including the individual package members.
- Preserves expiry on restored items using desk settings, config fallback, or a 7-day default.
- Added tests

### Steps to test
1. Expire a single archived article in MongoDB, reindex `archive`, then run `archive:remove_expired` to have it removed.
2. Confirm the article is removed.
3. Run `python manage.py archived:unarchive --item-id <article-id>`.
4. Confirm the article is back in `archive` and `published`.
5. Repeat the same flow with a package and verify the package children are restored too.


Resolves: [#SDESK-7943](https://sofab.atlassian.net/browse/SDESK-7943)

