### PR TITLE
[SDESK-7945] - Resend action fails to get the destination credentials

### DIFF
--- a/superdesk/publish/publish_queue.py
+++ b/superdesk/publish/publish_queue.py
@@ -99,63 +99,12 @@ class PublishQueueService(BaseService):
             if subscriber_id:
                 subscriber = subscriber_service.find_one(req=None, _id=subscriber_id)
 
-            self._hydrate_destination_secrets(doc, subscriber)
+            subscriber_service.hydrate_destination_secrets(doc.get("destination") or {}, subscriber)
             self._set_queue_state(doc, {})
             doc["moved_to_legal"] = False
 
             if "published_seq_num" not in doc and subscriber:
                 doc["published_seq_num"] = subscriber_service.generate_sequence_number(subscriber)
-
-    def _hydrate_destination_secrets(self, doc, subscriber):
-        destination = doc.get("destination") or {}
-        if not subscriber:
-            return
-
-        secret_fields = self._get_secret_fields()
-        subscriber_destination = self._match_subscriber_destination(destination, subscriber.get("destinations") or [])
-        if not subscriber_destination:
-            return
-
-        self._copy_destination_secrets(destination, subscriber_destination, secret_fields)
-
-    def _get_secret_fields(self):
-        from superdesk.publish.subscribers import SECRET_FIELDS
-
-        return SECRET_FIELDS
-
-    def _match_subscriber_destination(self, queued_destination, subscriber_destinations):
-        secret_fields = self._get_secret_fields()
-        queued_identity = self._destination_identity(queued_destination, secret_fields)
-
-        for subscriber_destination in subscriber_destinations:
-            if queued_destination.get("_id") and queued_destination.get("_id") == subscriber_destination.get("_id"):
-                return subscriber_destination
-
-            if self._destination_identity(subscriber_destination, secret_fields) != queued_identity:
-                continue
-
-            return subscriber_destination
-
-        return None
-
-    def _destination_identity(self, destination, secret_fields):
-        config = destination.get("config") or {}
-        config = {key: value for key, value in config.items() if key not in secret_fields}
-
-        return {
-            "name": destination.get("name"),
-            "format": destination.get("format"),
-            "delivery_type": destination.get("delivery_type"),
-            "config": config,
-        }
-
-    def _copy_destination_secrets(self, destination, source_destination, secret_fields):
-        destination_config = destination.setdefault("config", {})
-        source_config = source_destination.get("config") or {}
-
-        for field in secret_fields:
-            if field in source_config:
-                destination_config.setdefault(field, source_config[field])
 
     def on_updated(self, updates, original):
         if updates.get("state", "") != original.get("state", ""):

--- a/superdesk/publish/publish_queue.py
+++ b/superdesk/publish/publish_queue.py
@@ -16,6 +16,7 @@ from superdesk.notification import push_notification
 from superdesk.resource import Resource
 from superdesk.services import BaseService
 from superdesk.utils import SuperdeskBaseEnum
+from superdesk.utils import ListCursor
 from flask import current_app as app
 
 logger = logging.getLogger(__name__)
@@ -48,6 +49,7 @@ class PublishQueueResource(Resource):
                 "format": {"type": "string", "required": True},
                 "delivery_type": {"type": "string", "required": True},
                 "config": {"type": "dict"},
+                "_id": {"type": "string"},
             },
         },
         PUBLISHED_IN_PACKAGE: {"type": "string"},
@@ -90,6 +92,20 @@ class PublishQueueResource(Resource):
 
 
 class PublishQueueService(BaseService):
+    def get(self, req, lookup):
+        subscriber_service = get_resource_service("subscribers")
+        queue_items = list(super().get(req, lookup))
+
+        return ListCursor(
+            [
+                {
+                    **doc,
+                    "destination": subscriber_service.hide_destination_secrets(doc.get("destination") or {}),
+                }
+                for doc in queue_items
+            ]
+        )
+
     def on_create(self, docs):
         subscriber_service = get_resource_service("subscribers")
 

--- a/superdesk/publish/publish_queue.py
+++ b/superdesk/publish/publish_queue.py
@@ -16,7 +16,6 @@ from superdesk.notification import push_notification
 from superdesk.resource import Resource
 from superdesk.services import BaseService
 from superdesk.utils import SuperdeskBaseEnum
-from superdesk.utils import ListCursor
 from flask import current_app as app
 
 logger = logging.getLogger(__name__)
@@ -92,20 +91,6 @@ class PublishQueueResource(Resource):
 
 
 class PublishQueueService(BaseService):
-    def get(self, req, lookup):
-        subscriber_service = get_resource_service("subscribers")
-        queue_items = list(super().get(req, lookup))
-
-        return ListCursor(
-            [
-                {
-                    **doc,
-                    "destination": subscriber_service.hide_destination_secrets(doc.get("destination") or {}),
-                }
-                for doc in queue_items
-            ]
-        )
-
     def on_create(self, docs):
         subscriber_service = get_resource_service("subscribers")
 

--- a/superdesk/publish/publish_queue.py
+++ b/superdesk/publish/publish_queue.py
@@ -19,8 +19,6 @@ from superdesk.utils import SuperdeskBaseEnum
 from flask import current_app as app
 
 logger = logging.getLogger(__name__)
-
-SECRET_FIELDS = ("secret_token", "password", "apiKey", "access_key_id", "secret_access_key")
 PUBLISHED_IN_PACKAGE = "published_in_package"
 
 
@@ -96,48 +94,53 @@ class PublishQueueService(BaseService):
         subscriber_service = get_resource_service("subscribers")
 
         for doc in docs:
-            self._hydrate_destination_secrets(doc, subscriber_service)
+            subscriber = None
+            subscriber_id = doc.get("subscriber_id")
+            if subscriber_id:
+                subscriber = subscriber_service.find_one(req=None, _id=subscriber_id)
+
+            self._hydrate_destination_secrets(doc, subscriber)
             self._set_queue_state(doc, {})
             doc["moved_to_legal"] = False
 
-            if "published_seq_num" not in doc:
-                subscriber = subscriber_service.find_one(req=None, _id=doc["subscriber_id"])
+            if "published_seq_num" not in doc and subscriber:
                 doc["published_seq_num"] = subscriber_service.generate_sequence_number(subscriber)
 
-    def _hydrate_destination_secrets(self, doc, subscriber_service):
+    def _hydrate_destination_secrets(self, doc, subscriber):
         destination = doc.get("destination") or {}
-        subscriber_id = doc.get("subscriber_id")
-
-        if not destination or not subscriber_id:
-            return
-
-        subscriber = subscriber_service.find_one(req=None, _id=subscriber_id)
         if not subscriber:
             return
 
+        secret_fields = self._get_secret_fields()
         subscriber_destination = self._match_subscriber_destination(destination, subscriber.get("destinations") or [])
         if not subscriber_destination:
             return
 
-        self._copy_destination_secrets(destination, subscriber_destination)
+        self._copy_destination_secrets(destination, subscriber_destination, secret_fields)
+
+    def _get_secret_fields(self):
+        from superdesk.publish.subscribers import SECRET_FIELDS
+
+        return SECRET_FIELDS
 
     def _match_subscriber_destination(self, queued_destination, subscriber_destinations):
-        queued_identity = self._destination_identity(queued_destination)
+        secret_fields = self._get_secret_fields()
+        queued_identity = self._destination_identity(queued_destination, secret_fields)
 
         for subscriber_destination in subscriber_destinations:
             if queued_destination.get("_id") and queued_destination.get("_id") == subscriber_destination.get("_id"):
                 return subscriber_destination
 
-            if self._destination_identity(subscriber_destination) != queued_identity:
+            if self._destination_identity(subscriber_destination, secret_fields) != queued_identity:
                 continue
 
             return subscriber_destination
 
         return None
 
-    def _destination_identity(self, destination):
+    def _destination_identity(self, destination, secret_fields):
         config = destination.get("config") or {}
-        config = {key: value for key, value in config.items() if key not in SECRET_FIELDS}
+        config = {key: value for key, value in config.items() if key not in secret_fields}
 
         return {
             "name": destination.get("name"),
@@ -146,11 +149,11 @@ class PublishQueueService(BaseService):
             "config": config,
         }
 
-    def _copy_destination_secrets(self, destination, source_destination):
+    def _copy_destination_secrets(self, destination, source_destination, secret_fields):
         destination_config = destination.setdefault("config", {})
         source_config = source_destination.get("config") or {}
 
-        for field in SECRET_FIELDS:
+        for field in secret_fields:
             if field in source_config:
                 destination_config.setdefault(field, source_config[field])
 

--- a/superdesk/publish/publish_queue.py
+++ b/superdesk/publish/publish_queue.py
@@ -20,7 +20,7 @@ from flask import current_app as app
 
 logger = logging.getLogger(__name__)
 
-
+SECRET_FIELDS = ("secret_token", "password", "apiKey", "access_key_id", "secret_access_key")
 PUBLISHED_IN_PACKAGE = "published_in_package"
 
 
@@ -96,12 +96,63 @@ class PublishQueueService(BaseService):
         subscriber_service = get_resource_service("subscribers")
 
         for doc in docs:
+            self._hydrate_destination_secrets(doc, subscriber_service)
             self._set_queue_state(doc, {})
             doc["moved_to_legal"] = False
 
             if "published_seq_num" not in doc:
                 subscriber = subscriber_service.find_one(req=None, _id=doc["subscriber_id"])
                 doc["published_seq_num"] = subscriber_service.generate_sequence_number(subscriber)
+
+    def _hydrate_destination_secrets(self, doc, subscriber_service):
+        destination = doc.get("destination") or {}
+        subscriber_id = doc.get("subscriber_id")
+
+        if not destination or not subscriber_id:
+            return
+
+        subscriber = subscriber_service.find_one(req=None, _id=subscriber_id)
+        if not subscriber:
+            return
+
+        subscriber_destination = self._match_subscriber_destination(destination, subscriber.get("destinations") or [])
+        if not subscriber_destination:
+            return
+
+        self._copy_destination_secrets(destination, subscriber_destination)
+
+    def _match_subscriber_destination(self, queued_destination, subscriber_destinations):
+        queued_identity = self._destination_identity(queued_destination)
+
+        for subscriber_destination in subscriber_destinations:
+            if queued_destination.get("_id") and queued_destination.get("_id") == subscriber_destination.get("_id"):
+                return subscriber_destination
+
+            if self._destination_identity(subscriber_destination) != queued_identity:
+                continue
+
+            return subscriber_destination
+
+        return None
+
+    def _destination_identity(self, destination):
+        config = destination.get("config") or {}
+        config = {key: value for key, value in config.items() if key not in SECRET_FIELDS}
+
+        return {
+            "name": destination.get("name"),
+            "format": destination.get("format"),
+            "delivery_type": destination.get("delivery_type"),
+            "config": config,
+        }
+
+    def _copy_destination_secrets(self, destination, source_destination):
+        destination_config = destination.setdefault("config", {})
+        source_config = source_destination.get("config") or {}
+
+        for field in SECRET_FIELDS:
+            if field in source_config:
+                destination_config.setdefault(field, source_config[field])
 
     def on_updated(self, updates, original):
         if updates.get("state", "") != original.get("state", ""):

--- a/superdesk/publish/subscribers.py
+++ b/superdesk/publish/subscribers.py
@@ -146,18 +146,6 @@ class SubscribersService(CacheableService):
 
         self._copy_destination_secrets(destination, subscriber_destination)
 
-    def hide_destination_secrets(self, destination):
-        if not destination:
-            return destination
-
-        return {
-            **destination,
-            "config": {
-                key: value for key, value in (destination.get("config") or {}).items() if key not in SECRET_FIELDS
-            },
-            "_id": get_destination_id(destination),
-        }
-
     def keep_destinations_secrets(self, updates, original):
         """Populate the secrets removed on fetch so those won't be overridden on save."""
         original_destinations = original.get("destinations") or []

--- a/superdesk/publish/subscribers.py
+++ b/superdesk/publish/subscribers.py
@@ -27,6 +27,8 @@ from superdesk.notification import push_notification
 
 logger = logging.getLogger(__name__)
 
+SECRET_FIELDS = ("secret_token", "password", "apiKey", "access_key_id", "secret_access_key")
+
 
 def get_destination_id(destination) -> str:
     if destination.get("_id"):
@@ -108,7 +110,7 @@ class SubscribersResource(Resource):
 
 class SubscribersService(CacheableService):
     cache_lookup = {"is_active": True}
-    hide_fields = ("secret_token", "password", "apiKey", "access_key_id", "secret_access_key")
+    hide_fields = SECRET_FIELDS
 
     def get(self, req, lookup):
         if req is None:

--- a/superdesk/publish/subscribers.py
+++ b/superdesk/publish/subscribers.py
@@ -146,8 +146,20 @@ class SubscribersService(CacheableService):
 
         self._copy_destination_secrets(destination, subscriber_destination)
 
+    def hide_destination_secrets(self, destination):
+        if not destination:
+            return destination
+
+        return {
+            **destination,
+            "config": {
+                key: value for key, value in (destination.get("config") or {}).items() if key not in SECRET_FIELDS
+            },
+            "_id": get_destination_id(destination),
+        }
+
     def keep_destinations_secrets(self, updates, original):
-        """Populate the secrets removed on fetch so those won't be overriden on save."""
+        """Populate the secrets removed on fetch so those won't be overridden on save."""
         original_destinations = original.get("destinations") or []
         updates_destinations = updates.get("destinations") or []
         for destination in original_destinations:
@@ -163,7 +175,9 @@ class SubscribersService(CacheableService):
         queued_identity = self._destination_identity(queued_destination)
 
         for subscriber_destination in subscriber_destinations:
-            if queued_destination.get("_id") and queued_destination.get("_id") == subscriber_destination.get("_id"):
+            if queued_destination.get("_id") and queued_destination.get("_id") == get_destination_id(
+                subscriber_destination
+            ):
                 return subscriber_destination
 
             if self._destination_identity(subscriber_destination) != queued_identity:

--- a/superdesk/publish/subscribers.py
+++ b/superdesk/publish/subscribers.py
@@ -136,6 +136,16 @@ class SubscribersService(CacheableService):
         self._validate_products_destinations(subscriber)
         self.keep_destinations_secrets(updates, original)
 
+    def hydrate_destination_secrets(self, destination, subscriber):
+        if not subscriber or not destination:
+            return
+
+        subscriber_destination = self._match_subscriber_destination(destination, subscriber.get("destinations") or [])
+        if not subscriber_destination:
+            return
+
+        self._copy_destination_secrets(destination, subscriber_destination)
+
     def keep_destinations_secrets(self, updates, original):
         """Populate the secrets removed on fetch so those won't be overriden on save."""
         original_destinations = original.get("destinations") or []
@@ -148,6 +158,39 @@ class SubscribersService(CacheableService):
                 if dest_id == update_destination.get("_id"):
                     for field, value in destination["config"].items():
                         update_destination["config"].setdefault(field, value)
+
+    def _match_subscriber_destination(self, queued_destination, subscriber_destinations):
+        queued_identity = self._destination_identity(queued_destination)
+
+        for subscriber_destination in subscriber_destinations:
+            if queued_destination.get("_id") and queued_destination.get("_id") == subscriber_destination.get("_id"):
+                return subscriber_destination
+
+            if self._destination_identity(subscriber_destination) != queued_identity:
+                continue
+
+            return subscriber_destination
+
+        return None
+
+    def _destination_identity(self, destination):
+        config = destination.get("config") or {}
+        config = {key: value for key, value in config.items() if key not in SECRET_FIELDS}
+
+        return {
+            "name": destination.get("name"),
+            "format": destination.get("format"),
+            "delivery_type": destination.get("delivery_type"),
+            "config": config,
+        }
+
+    def _copy_destination_secrets(self, destination, source_destination):
+        destination_config = destination.setdefault("config", {})
+        source_config = source_destination.get("config") or {}
+
+        for field in SECRET_FIELDS:
+            if field in source_config:
+                destination_config.setdefault(field, source_config[field])
 
     def on_updated(self, updates, original):
         push_notification("subscriber:update", _id=[original.get(config.ID_FIELD)])

--- a/tests/publish/get_queue_items_tests.py
+++ b/tests/publish/get_queue_items_tests.py
@@ -19,7 +19,7 @@ from superdesk.utc import utcnow
 from apps.publish.enqueue import enqueue_service
 from superdesk.publish.publish_queue import PUBLISHED_IN_PACKAGE
 from superdesk.publish import publish_queue
-from superdesk.publish.subscribers import SubscribersService
+from superdesk.publish.subscribers import SubscribersService, get_destination_id
 from superdesk.metadata.item import CONTENT_TYPE, ITEM_TYPE
 
 
@@ -185,7 +185,6 @@ class QueueItemsTestCase(TestCase):
                 "_id": subscriber_id,
                 "destinations": [
                     {
-                        "_id": "ftp-destination-1",
                         "name": "FTP Destination",
                         "format": "ftp ninjs",
                         "delivery_type": "ftp",
@@ -210,6 +209,7 @@ class QueueItemsTestCase(TestCase):
         doc = {
             "subscriber_id": subscriber_id,
             "destination": {
+                "_id": get_destination_id(subscriber_service.find_one.return_value["destinations"][0]),
                 "name": "FTP Destination",
                 "format": "ftp ninjs",
                 "delivery_type": "ftp",
@@ -230,3 +230,32 @@ class QueueItemsTestCase(TestCase):
         self.assertEqual(doc["destination"]["config"]["access_key_id"], "access-key-id")
         self.assertEqual(doc["destination"]["config"]["secret_access_key"], "secret-access-key")
         self.assertEqual(doc["published_seq_num"], 7)
+
+    @mock.patch.object(publish_queue, "get_resource_service")
+    def test_get_redacts_destination_secrets(self, fake_get_resource_service):
+        fake_get_resource_service.return_value = SubscribersService("subscribers", backend=MagicMock())
+
+        service = publish_queue.PublishQueueService(backend=MagicMock())
+        service.backend.get.return_value = [
+            {
+                "_id": ObjectId(),
+                "destination": {
+                    "name": "FTP Destination",
+                    "format": "ftp ninjs",
+                    "delivery_type": "ftp",
+                    "config": {
+                        "host": "127.0.0.1",
+                        "username": "superdesk",
+                        "password": "superdesk",
+                        "passive": True,
+                    },
+                },
+            }
+        ]
+
+        items = list(service.get(None, None))
+
+        self.assertEqual(
+            items[0]["destination"]["config"], {"host": "127.0.0.1", "username": "superdesk", "passive": True}
+        )
+        self.assertNotIn("password", items[0]["destination"]["config"])

--- a/tests/publish/get_queue_items_tests.py
+++ b/tests/publish/get_queue_items_tests.py
@@ -174,3 +174,54 @@ class QueueItemsTestCase(TestCase):
         service.get_from_mongo.return_value = cursor
         service.delete({"_id": "4567"})
         assert fake_storage_delete.call_args == mock.call("TEST ID")
+
+    @mock.patch.object(publish_queue, "get_resource_service")
+    def test_on_create_hydrates_missing_destination_secrets(self, fake_get_resource_service):
+        subscriber_id = ObjectId()
+        subscriber_service = fake_get_resource_service.return_value
+        subscriber_service.find_one.return_value = {
+            "_id": subscriber_id,
+            "destinations": [
+                {
+                    "_id": "ftp-destination-1",
+                    "name": "FTP Destination",
+                    "format": "ftp ninjs",
+                    "delivery_type": "ftp",
+                    "config": {
+                        "host": "127.0.0.1",
+                        "username": "superdesk",
+                        "password": "superdesk",
+                        "secret_token": "secret-token",
+                        "apiKey": "api-key",
+                        "access_key_id": "access-key-id",
+                        "secret_access_key": "secret-access-key",
+                        "passive": True,
+                    },
+                }
+            ],
+        }
+
+        service = publish_queue.PublishQueueService(backend=MagicMock())
+        doc = {
+            "subscriber_id": subscriber_id,
+            "destination": {
+                "name": "FTP Destination",
+                "format": "ftp ninjs",
+                "delivery_type": "ftp",
+                "config": {
+                    "host": "127.0.0.1",
+                    "username": "superdesk",
+                    "passive": True,
+                },
+            },
+            "published_seq_num": 2,
+            "state": "pending",
+        }
+
+        service.on_create([doc])
+
+        self.assertEqual(doc["destination"]["config"]["password"], "superdesk")
+        self.assertEqual(doc["destination"]["config"]["secret_token"], "secret-token")
+        self.assertEqual(doc["destination"]["config"]["apiKey"], "api-key")
+        self.assertEqual(doc["destination"]["config"]["access_key_id"], "access-key-id")
+        self.assertEqual(doc["destination"]["config"]["secret_access_key"], "secret-access-key")

--- a/tests/publish/get_queue_items_tests.py
+++ b/tests/publish/get_queue_items_tests.py
@@ -19,6 +19,7 @@ from superdesk.utc import utcnow
 from apps.publish.enqueue import enqueue_service
 from superdesk.publish.publish_queue import PUBLISHED_IN_PACKAGE
 from superdesk.publish import publish_queue
+from superdesk.publish.subscribers import SubscribersService
 from superdesk.metadata.item import CONTENT_TYPE, ITEM_TYPE
 
 
@@ -178,28 +179,32 @@ class QueueItemsTestCase(TestCase):
     @mock.patch.object(publish_queue, "get_resource_service")
     def test_on_create_hydrates_missing_destination_secrets(self, fake_get_resource_service):
         subscriber_id = ObjectId()
-        subscriber_service = fake_get_resource_service.return_value
-        subscriber_service.find_one.return_value = {
-            "_id": subscriber_id,
-            "destinations": [
-                {
-                    "_id": "ftp-destination-1",
-                    "name": "FTP Destination",
-                    "format": "ftp ninjs",
-                    "delivery_type": "ftp",
-                    "config": {
-                        "host": "127.0.0.1",
-                        "username": "superdesk",
-                        "password": "superdesk",
-                        "secret_token": "secret-token",
-                        "apiKey": "api-key",
-                        "access_key_id": "access-key-id",
-                        "secret_access_key": "secret-access-key",
-                        "passive": True,
-                    },
-                }
-            ],
-        }
+        subscriber_service = SubscribersService("subscribers", backend=MagicMock())
+        subscriber_service.find_one = MagicMock(
+            return_value={
+                "_id": subscriber_id,
+                "destinations": [
+                    {
+                        "_id": "ftp-destination-1",
+                        "name": "FTP Destination",
+                        "format": "ftp ninjs",
+                        "delivery_type": "ftp",
+                        "config": {
+                            "host": "127.0.0.1",
+                            "username": "superdesk",
+                            "password": "superdesk",
+                            "secret_token": "secret-token",
+                            "apiKey": "api-key",
+                            "access_key_id": "access-key-id",
+                            "secret_access_key": "secret-access-key",
+                            "passive": True,
+                        },
+                    }
+                ],
+            }
+        )
+        subscriber_service.generate_sequence_number = MagicMock(return_value=7)
+        fake_get_resource_service.return_value = subscriber_service
 
         service = publish_queue.PublishQueueService(backend=MagicMock())
         doc = {
@@ -214,7 +219,6 @@ class QueueItemsTestCase(TestCase):
                     "passive": True,
                 },
             },
-            "published_seq_num": 2,
             "state": "pending",
         }
 
@@ -225,3 +229,4 @@ class QueueItemsTestCase(TestCase):
         self.assertEqual(doc["destination"]["config"]["apiKey"], "api-key")
         self.assertEqual(doc["destination"]["config"]["access_key_id"], "access-key-id")
         self.assertEqual(doc["destination"]["config"]["secret_access_key"], "secret-access-key")
+        self.assertEqual(doc["published_seq_num"], 7)

--- a/tests/publish/get_queue_items_tests.py
+++ b/tests/publish/get_queue_items_tests.py
@@ -230,32 +230,3 @@ class QueueItemsTestCase(TestCase):
         self.assertEqual(doc["destination"]["config"]["access_key_id"], "access-key-id")
         self.assertEqual(doc["destination"]["config"]["secret_access_key"], "secret-access-key")
         self.assertEqual(doc["published_seq_num"], 7)
-
-    @mock.patch.object(publish_queue, "get_resource_service")
-    def test_get_redacts_destination_secrets(self, fake_get_resource_service):
-        fake_get_resource_service.return_value = SubscribersService("subscribers", backend=MagicMock())
-
-        service = publish_queue.PublishQueueService(backend=MagicMock())
-        service.backend.get.return_value = [
-            {
-                "_id": ObjectId(),
-                "destination": {
-                    "name": "FTP Destination",
-                    "format": "ftp ninjs",
-                    "delivery_type": "ftp",
-                    "config": {
-                        "host": "127.0.0.1",
-                        "username": "superdesk",
-                        "password": "superdesk",
-                        "passive": True,
-                    },
-                },
-            }
-        ]
-
-        items = list(service.get(None, None))
-
-        self.assertEqual(
-            items[0]["destination"]["config"], {"host": "127.0.0.1", "username": "superdesk", "passive": True}
-        )
-        self.assertNotIn("password", items[0]["destination"]["config"])


### PR DESCRIPTION
### Purpose
This PR fixes publish queue resend failures when queued destination secrets were lost from the stored queue snapshot. Resend was reusing the queue item’s destination config as-is, so missing auth secrets caused `Auth error` on retry.

### What has changed
- Hydrates missing destination secret fields on publish queue create by looking up the live subscriber destination.
- Added a regression test

### Steps to test
1. Create or use a publish queue item whose `destination.config.password` is missing but the actual subscriber destination has the password.
2. Trigger resend from the publish queue UI.
3. Verify the resend succeeds.

Resolves: #[SDESK-7945](https://sofab.atlassian.net/browse/SDESK-7945)

[SDESK-7945]: https://sofab.atlassian.net/browse/SDESK-7945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ