### PR TITLE
[SDESK-7913] Follow-up to: fix `_get_config` returning None in email layer

### DIFF
--- a/superdesk/core/emails.py
+++ b/superdesk/core/emails.py
@@ -106,7 +106,7 @@ def _get_request_hash(request: EmailRequest) -> str:
 
 
 def _get_config() -> EmailConfig:
-    return EmailConfig().load_from_dict(get_current_app().config, prefix="MAIL", freeze=True)
+    return EmailConfig.create_from_dict(get_current_app().config, prefix="MAIL", freeze=True)
 
 
 class EmailFactory:


### PR DESCRIPTION
### Purpose

Fixes a regression introduced by in #3236, which replaced flask-mail with aiosmtplib. Sending any email currently raises `AttributeError: 'NoneType' object has no attribute 'server'` and the request 500s, so no mail is ever sent.

https://github.com/superdesk/superdesk-client-core/actions/runs/27967723265/job/82926944146

Another alternative would have been to make `load_from_dict` return self but I'm not sure if that could have other implications/side-effects.

### What has changed

`_get_config()` used `EmailConfig().load_from_dict(...)`, but `load_from_dict` mutates in place and returns `None`, so `_get_config()` failed at `config.server`. Switched to the `EmailConfig.create_from_dict(...)` classmethod, which returns the populated instance.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: follow-up to SDESK-7913 (#3236)