### PR TITLE
[SDESK-7913] Handle str attachments in core email send

### DIFF
--- a/superdesk/core/emails.py
+++ b/superdesk/core/emails.py
@@ -70,12 +70,15 @@ def _get_message_from_request(request: EmailRequest) -> EmailMessage:
     if request.attachments:
         for attachment in request.attachments:
             maintype, subtype = attachment.get_content_type().split("/")
+            # Encode str payloads to bytes: a str routes to set_text_content() which rejects
+            # maintype/subtype and raises a TypeError; bytes routes to set_bytes_content() (base64).
+            data = attachment.data.encode("utf-8") if isinstance(attachment.data, str) else attachment.data
             if attachment.cid:
                 # If this Attachment has a CID, then we assume it's for embedding into the email
                 # So we use `add_related` instead of `add_attachment`.
                 # This tells email clients the file is part of the HTML structure, not a separate file to download
                 html_part.add_related(
-                    attachment.data,
+                    data,
                     maintype=maintype,
                     subtype=subtype,
                     filename=attachment.filename,
@@ -83,7 +86,7 @@ def _get_message_from_request(request: EmailRequest) -> EmailMessage:
                 )
             else:
                 msg.add_attachment(
-                    attachment.data,
+                    data,
                     maintype=maintype,
                     subtype=subtype,
                     filename=attachment.filename,

--- a/tests/send_email_test.py
+++ b/tests/send_email_test.py
@@ -1,4 +1,7 @@
+import base64
+
 from superdesk.core.emails import send_email
+from superdesk.core.types import EmailAttachment
 from superdesk.emails import send_user_status_changed_email, send_activity_emails, send_translation_changed
 from superdesk.tests import TestCase
 from unittest.mock import patch, AsyncMock
@@ -17,6 +20,25 @@ class SendEmailTestCase(TestCase):
             await send_email("foo\nbar", "admin@localhost", ["foo@example.com"], "text", "<p>html</p>")
             assert len(outbox) == 1
             assert outbox[0].subject == "foo"
+
+    async def test_send_email_with_str_attachment(self):
+        ics = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n"
+        with self.app.mail.record_messages() as outbox:
+            await send_email(
+                "subject",
+                "admin@localhost",
+                ["foo@example.com"],
+                "text",
+                "<p>html</p>",
+                attachments=[EmailAttachment(filename="invite", content_type="text/calendar", data=ics)],
+            )
+            assert len(outbox) == 1
+            attachments = list(outbox[0].iter_attachments())
+            assert len(attachments) == 1
+            part = attachments[0]
+            assert part.get_content_type() == "text/calendar"
+            assert part.get_filename() == "invite"
+            assert base64.b64decode(part.get_payload()).decode("utf-8") == ics
 
     async def test_send_activity_emails_error(self):
         recipients = ["foo", "bar"]


### PR DESCRIPTION
### Purpose

`EmailAttachment.data` is typed `str | bytes`, but the send path only worked for `bytes`. Passing a `str` attachment raised `TypeError: set_text_content() got an unexpected keyword argument 'maintype'`, breaking email delivery for that path. `flask-mail` accepted both.

### What has changed

- `_get_message_from_request` now encodes `str` payloads to `bytes` before handing them to the email library.
- Added a regression test covering a `str` attachment.

[SDESK-7913]


[SDESK-7913]: https://sofab.atlassian.net/browse/SDESK-7913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ