### PR TITLE
[SDESK-7811] Include marker user and date in `item:marked_desks` notification

### DIFF
--- a/apps/marked_desks/service.py
+++ b/apps/marked_desks/service.py
@@ -80,8 +80,6 @@ class MarkedForDesksService(AsyncBaseService):
                 marked=int(marked_desks_on),
                 item_id=item["_id"],
                 mark_id=str(doc["marked_desk"]),
-                # Included on a mark so open editors can reflect it with the real marker, not a
-                # fabricated one. Absent on an unmark, which only needs the desk id.
                 user_marked=new_mark["user_marked"] if marked_desks_on else None,
                 date_marked=new_mark["date_marked"] if marked_desks_on else None,
             )

--- a/apps/marked_desks/service.py
+++ b/apps/marked_desks/service.py
@@ -76,7 +76,14 @@ class MarkedForDesksService(AsyncBaseService):
                     await published_service.system_update_async(published_item["_id"], updates, published_item)
 
             push_notification(
-                "item:marked_desks", marked=int(marked_desks_on), item_id=item["_id"], mark_id=str(doc["marked_desk"])
+                "item:marked_desks",
+                marked=int(marked_desks_on),
+                item_id=item["_id"],
+                mark_id=str(doc["marked_desk"]),
+                # Included on a mark so open editors can reflect it with the real marker, not a
+                # fabricated one. Absent on an unmark, which only needs the desk id.
+                user_marked=new_mark["user_marked"] if marked_desks_on else None,
+                date_marked=new_mark["date_marked"] if marked_desks_on else None,
             )
 
             app = get_current_app().as_any()


### PR DESCRIPTION
### Purpose

The `item:marked_desks` websocket notification did not carry who marked the desk or when. The authoring-react editor that wants to reflect a mark made from another surface (the monitoring list, or another session) needs these values.

### What has changed

`MarkedForDesksService.create_async` now includes `user_marked` and `date_marked` in the `item:marked_desks` push notification when a desk is marked. Both values are already computed a few lines above when the mark is created, so this just forwards them. They are omitted on an unmark, which only needs the desk id.

Required by https://github.com/superdesk/superdesk-client-core/pull/5249

Resolves: [SDESK-7811]


[SDESK-7811]: https://sofab.atlassian.net/browse/SDESK-7811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ