### PR TITLE
[STT-17421] Stories modified by "Set default template metadata" macro don't display content in the editor

### DIFF
--- a/superdesk/macros/set_default_template_metadata.py
+++ b/superdesk/macros/set_default_template_metadata.py
@@ -49,6 +49,11 @@ def set_default_template_metadata(item, **kwargs):
     fields_to_exclude = get_app_config("DEFAULT_TEMPLATE_METADATA_MACRO_EXCLUDE", [])
     fields_to_override = get_app_config("DEFAULT_TEMPLATE_METADATA_MACRO_OVERRIDE", [])
 
+    # fields_meta contains client-side DraftJS editor state, not editorial metadata.
+    # It should never be copied from a template into an item, matching the behavior
+    # of render_content_template() which excludes it via TEMPLATE_DATA_IGNORE_FIELDS.
+    fields_to_exclude.append("fields_meta")
+
     """Replace some metadata from default content template"""
 
     content_template = get_default_content_template(item, **kwargs)

--- a/superdesk/macros/set_default_template_metadata.py
+++ b/superdesk/macros/set_default_template_metadata.py
@@ -46,15 +46,15 @@ def get_default_content_template(item, **kwargs):
 
 
 def set_default_template_metadata(item, **kwargs):
-    fields_to_exclude = get_app_config("DEFAULT_TEMPLATE_METADATA_MACRO_EXCLUDE", [])
+    """Replace some metadata from default content template"""
+
+    fields_to_exclude = list(get_app_config("DEFAULT_TEMPLATE_METADATA_MACRO_EXCLUDE", []))
     fields_to_override = get_app_config("DEFAULT_TEMPLATE_METADATA_MACRO_OVERRIDE", [])
 
     # fields_meta contains client-side DraftJS editor state, not editorial metadata.
     # It should never be copied from a template into an item, matching the behavior
     # of render_content_template() which excludes it via TEMPLATE_DATA_IGNORE_FIELDS.
     fields_to_exclude.append("fields_meta")
-
-    """Replace some metadata from default content template"""
 
     content_template = get_default_content_template(item, **kwargs)
     if not content_template:

--- a/tests/macros/set_default_template_metadata_test.py
+++ b/tests/macros/set_default_template_metadata_test.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2024 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.tests import TestCase
+from superdesk.macros.set_default_template_metadata import set_default_template_metadata
+
+
+class SetDefaultTemplateMetadataTestCase(TestCase):
+    """Tests for the 'Set default template metadata' core macro.
+
+    These tests verify that the macro correctly fills empty metadata fields
+    from the desk's default content template, while ensuring that
+    ``fields_meta`` (a client-side DraftJS editor state) is never copied
+    from the template into the item — which would cause the editor to
+    display an empty body even when ``body_html`` has content.
+    """
+
+    DESK_ID = "test-desk-1"
+    TEMPLATE_ID = "test-template-1"
+
+    EMPTY_DRAFTJS_STATE = {
+        "blocks": [
+            {
+                "key": "test1",
+                "text": "",
+                "type": "unstyled",
+                "depth": 0,
+                "inlineStyleRanges": [],
+                "entityRanges": [],
+            }
+        ],
+        "entityMap": {},
+    }
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.app.data.insert(
+            "desks",
+            [
+                {
+                    "_id": self.DESK_ID,
+                    "name": "Test Desk",
+                    "default_content_template": self.TEMPLATE_ID,
+                }
+            ],
+        )
+        self.app.data.insert(
+            "content_templates",
+            [
+                {
+                    "_id": self.TEMPLATE_ID,
+                    "template_name": "test template",
+                    "template_type": "create",
+                    "data": {
+                        "headline": "",
+                        "body_html": "",
+                        "urgency": 3,
+                        "slugline": "Default slugline",
+                        "fields_meta": {
+                            "headline": {"draftjsState": [self.EMPTY_DRAFTJS_STATE]},
+                            "body_html": {"draftjsState": [self.EMPTY_DRAFTJS_STATE]},
+                        },
+                    },
+                }
+            ],
+        )
+        self.app.data.insert(
+            "vocabularies",
+            [
+                {"_id": "categories", "items": [{"is_active": True, "name": "General", "qcode": "a"}]},
+            ],
+        )
+
+    def _create_ingested_item(self):
+        return {
+            "_id": "test-item-1",
+            "type": "text",
+            "headline": "Original headline from ingest",
+            "body_html": "<p>Original body content from ingest</p>",
+        }
+
+    async def test_fields_meta_not_copied(self):
+        """Ensure fields_meta is never copied from the template into the item."""
+        item = self._create_ingested_item()
+        result = set_default_template_metadata(item, dest_desk_id=self.DESK_ID)
+        self.assertIsNotNone(result, "Macro should return the item")
+        self.assertNotIn(
+            "fields_meta",
+            result,
+            "fields_meta must not be copied from the template into the item",
+        )
+
+    async def test_metadata_fields_copied(self):
+        """Ensure empty metadata fields are filled from the template."""
+        item = self._create_ingested_item()
+        # Remove urgency so it can be filled from the template
+        item.pop("urgency", None)
+        result = set_default_template_metadata(item, dest_desk_id=self.DESK_ID)
+        self.assertIsNotNone(result, "Macro should return the item")
+        self.assertEqual(result.get("urgency"), 3, "urgency should be filled from the template")
+        self.assertEqual(result.get("slugline"), "Default slugline", "slugline should be filled from the template")
+
+    async def test_existing_fields_not_overwritten(self):
+        """Ensure fields already present in the item are not overwritten by empty template values."""
+        item = self._create_ingested_item()
+        result = set_default_template_metadata(item, dest_desk_id=self.DESK_ID)
+        self.assertIsNotNone(result, "Macro should return the item")
+        self.assertEqual(
+            result.get("headline"),
+            "Original headline from ingest",
+            "headline should not be overwritten by the template's empty headline",
+        )
+        self.assertEqual(
+            result.get("body_html"),
+            "<p>Original body content from ingest</p>",
+            "body_html should not be overwritten by the template's empty body_html",
+        )
+
+    async def test_fields_meta_not_copied_when_item_has_no_fields_meta(self):
+        """Ensure the macro doesn't introduce fields_meta on ingested items (the STT-17421 scenario)."""
+        item = self._create_ingested_item()
+        # Ingested items have no fields_meta at all
+        self.assertNotIn("fields_meta", item)
+        result = set_default_template_metadata(item, dest_desk_id=self.DESK_ID)
+        self.assertIsNotNone(result, "Macro should return the item")
+        self.assertNotIn(
+            "fields_meta",
+            result,
+            "fields_meta must not be introduced on ingested items by the macro",
+        )


### PR DESCRIPTION
### Purpose
This PR fixes a bug where stories processed by the "Set default template metadata" macro show an empty body in the editor despite the body being present in the published data. On save, the headline also disappears.

### What has changed
- The `set_default_template_metadata` macro was copying `fields_meta` (client-side DraftJS editor state) from the desk's default content template into ingested items. Since templates store empty DraftJS states for `body_html` and `headline`, the editor would render nothing while the string values remained intact. On save, strings were regenerated from the empty DraftJS states, wiping the headline.
- Added `fields_meta` to the macro's exclusion list, matching the existing behavior of `render_content_template()` which already excludes it via `TEMPLATE_DATA_IGNORE_FIELDS`.
- Added unit tests covering the fix.

### Steps to test
1. Set up a content template with empty body/headline and a default metadata field (e.g. urgency). Assign it as the default content template for a desk.
2. Configure the "Set Default Template Metadata" macro as an incoming rule on the desk's stage.
3. Fetch an ingested article (with body content but no fields_meta) to that desk.
4. Open the article in the editor. Body and headline should display correctly.
5. Save the article. Headline should remain intact.
6. Verify in the DB that the fetched item has no fields_meta copied from the template.

Resolves: #[STT-1741](https://sofab.atlassian.net/browse/STT-1741)



[STT-1741]: https://sofab.atlassian.net/browse/STT-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ