### PR TITLE
[SDESK-7914] fix: Calling Celery task directly fails

### DIFF
--- a/superdesk/celery_app/context_task.py
+++ b/superdesk/celery_app/context_task.py
@@ -123,6 +123,12 @@ class HybridAppContextTask(Task):
         self.handle_exception(exc)
 
     def _is_always_eager(self):
+        current_request = getattr(self, "request", None)
+        if current_request is None or not getattr(current_request, "id", None):
+            # If this task has not been bound to a request, then we're to process it directly
+            # This can happen when the task is called directly, instead of using `.delay` or `.apply_async`
+            return True
+
         # Prefer Celery's canonical flag because task execution can happen outside
         # the expected app-context resolution path on some runtimes.
         task_app = getattr(self, "app", None)


### PR DESCRIPTION
### Purpose
When calling a Celery task directly, instead of using `.delay` or `.apply_async`, the Task fails to update the state.

### What has changed
* When checking if the Task is to be processed eagerly, check if the Task has been bound to a request and that it has an ID.

Resolves: [SDESK-7914](https://sofab.atlassian.net/browse/SDESK-7914)



[SDESK-7914]: https://sofab.atlassian.net/browse/SDESK-7914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ