### PR TITLE
Revert non-logging changes from 52299f0

### DIFF
--- a/superdesk/publish_async/formatters/base_exchange_formatter.py
+++ b/superdesk/publish_async/formatters/base_exchange_formatter.py
@@ -249,8 +249,9 @@ class BasePublishExchangeFormatter(PublishExchangeFormatter):
                     lifecycle_started_at=lifecycle_started_at,
                     lifecycle_started_ms=lifecycle_started_ms,
                 )
-                persisted_items = await publish_queue_service.create([publish_queue_item])
-                tasks.extend(persisted_items)
+                tasks.append(publish_queue_item)
+
+                await publish_queue_service.create([publish_queue_item])
 
             return tasks
         else:
@@ -361,7 +362,6 @@ class BasePublishExchangeFormatter(PublishExchangeFormatter):
             is_content_api=destination.delivery_type == "content_api",
             item_id=request.item_id,
             publishing_action=request.published_state,
-            publish_operation=request.operation,
             item_version=item[VERSION],
             formatted_item=formatted_doc,
             published_in_package=item.get(PUBLISHED_IN_PACKAGE, None),
@@ -396,8 +396,9 @@ class BasePublishExchangeFormatter(PublishExchangeFormatter):
             lifecycle_started_ms=lifecycle_started_ms,
         )
 
-        persisted_items = await PublishQueueResource.get_service().create([publish_queue_item])
-        return persisted_items[0] if persisted_items else publish_queue_item
+        await PublishQueueResource.get_service().create([publish_queue_item])
+
+        return publish_queue_item
 
     def _populate_content_api_completion_timing(
         self,

--- a/superdesk/publish_async/resources/publish_queue/service.py
+++ b/superdesk/publish_async/resources/publish_queue/service.py
@@ -1,138 +1,17 @@
-import logging
-from typing import Any, Sequence
+from typing import Any
 
 from quart_babel import gettext
-from pymongo.errors import DuplicateKeyError
 
 from superdesk.core import get_current_app
 from superdesk.core.resources import AsyncResourceService
 from superdesk.errors import SuperdeskApiError
 
-from superdesk.types import PublishQueueResource, SubscribersResource, PublishQueueState, PublishOperation
+from superdesk.types import PublishQueueResource, SubscribersResource, PublishQueueState
 from superdesk.publish_async.utils import generate_sequence_number
 from superdesk.notification import push_notification
 
 
-logger = logging.getLogger(__name__)
-
-
 class PublishQueueService(AsyncResourceService[PublishQueueResource]):
-    def _get_destination_identity(self, doc: PublishQueueResource) -> tuple[str, str]:
-        if not doc.destination:
-            return "none", "none"
-
-        destination_id = str(doc.destination._id) if doc.destination._id else None
-        if destination_id:
-            return "id", destination_id
-
-        if doc.destination.delivery_type == "content_api":
-            return "content_api", "content_api"
-
-        return (
-            str(doc.destination.delivery_type or "none"),
-            str(doc.destination.name or "none"),
-        )
-
-    def _get_duplicate_lookup(self, doc: PublishQueueResource) -> dict[str, Any]:
-        lookup: dict[str, Any] = {
-            "item_id": doc.item_id,
-            "item_version": doc.item_version,
-            "subscriber_id": doc.subscriber_id,
-            "publishing_action": doc.publishing_action,
-        }
-
-        if doc.destination and doc.destination._id:
-            lookup["destination._id"] = doc.destination._id
-        elif doc.destination and doc.destination.delivery_type == "content_api":
-            lookup["destination.delivery_type"] = "content_api"
-        elif doc.destination:
-            lookup["destination.delivery_type"] = doc.destination.delivery_type
-            lookup["destination.name"] = doc.destination.name
-
-        return lookup
-
-    async def create(self, docs: Sequence[PublishQueueResource | dict[str, Any]]) -> list[PublishQueueResource]:
-        instances = await self._convert_dicts_to_model(docs)
-        created_instances: list[PublishQueueResource] = []
-        identity_to_instance: dict[tuple[Any, ...], PublishQueueResource] = {}
-        seen_identities: set[tuple[Any, ...]] = set()
-
-        for doc in instances:
-            is_resend = doc.publish_operation == PublishOperation.RESEND
-            destination_identity_type, destination_identity_value = self._get_destination_identity(doc)
-            identity = (
-                doc.item_id,
-                doc.item_version,
-                doc.subscriber_id,
-                doc.publishing_action,
-                destination_identity_type,
-                destination_identity_value,
-            )
-
-            if not is_resend and identity in seen_identities:
-                existing_in_batch = identity_to_instance.get(identity)
-                if existing_in_batch:
-                    created_instances.append(existing_in_batch)
-                logger.warning(
-                    "Skipping duplicate publish queue item in request batch",
-                    extra=dict(
-                        item_id=doc.item_id,
-                        item_version=doc.item_version,
-                        subscriber_id=str(doc.subscriber_id),
-                        publishing_action=doc.publishing_action,
-                        destination_id=doc.destination._id if doc.destination else None,
-                        destination_name=doc.destination.name if doc.destination else None,
-                    ),
-                )
-                continue
-
-            existing = None if is_resend else await self.find_one(**self._get_duplicate_lookup(doc))
-            if existing:
-                created_instances.append(existing)
-                identity_to_instance[identity] = existing
-                logger.warning(
-                    "Skipping duplicate publish queue item already in queue",
-                    extra=dict(
-                        item_id=doc.item_id,
-                        item_version=doc.item_version,
-                        subscriber_id=str(doc.subscriber_id),
-                        publishing_action=doc.publishing_action,
-                        destination_id=doc.destination._id if doc.destination else None,
-                        destination_name=doc.destination.name if doc.destination else None,
-                        existing_queue_id=str(existing.id),
-                    ),
-                )
-                seen_identities.add(identity)
-                continue
-
-            if not is_resend:
-                seen_identities.add(identity)
-
-            try:
-                inserted = await super().create([doc])
-                created_instances.extend(inserted)
-                if inserted:
-                    identity_to_instance[identity] = inserted[0]
-            except DuplicateKeyError:
-                existing = None if is_resend else await self.find_one(**self._get_duplicate_lookup(doc))
-                if existing:
-                    created_instances.append(existing)
-                    identity_to_instance[identity] = existing
-                logger.warning(
-                    "Skipping duplicate publish queue item",
-                    extra=dict(
-                        item_id=doc.item_id,
-                        item_version=doc.item_version,
-                        subscriber_id=str(doc.subscriber_id),
-                        publishing_action=doc.publishing_action,
-                        destination_id=doc.destination._id if doc.destination else None,
-                        destination_name=doc.destination.name if doc.destination else None,
-                    ),
-                )
-                continue
-
-        return created_instances
-
     async def on_create(self, docs: list[PublishQueueResource]) -> None:
         await super().on_create(docs)
         subscriber_service = SubscribersResource.get_service()

--- a/superdesk/types/publish_queue.py
+++ b/superdesk/types/publish_queue.py
@@ -23,7 +23,6 @@ class PublishQueueState(str, Enum):
 class PublishQueueResource(ResourceModelWithObjectId):
     item_id: str
     publishing_action: str
-    publish_operation: str | None = None
 
     item_version: int
     formatted_item: str

--- a/tests/publish_async/exchanges/exchange_factory_tests.py
+++ b/tests/publish_async/exchanges/exchange_factory_tests.py
@@ -160,47 +160,6 @@ class ExchangeFactoryTestCase(TestCase):
         task_ids = [task.id for task in tasks]
         self.assertEqual(sorted(task_ids), [self.queue_items[1].id])
 
-    async def test_create_skips_duplicate_queue_items(self):
-        await SubscribersResource.get_service().create(self.subscribers)
-
-        queue_item = PublishQueueResource(  # type: ignore[call-arg]
-            destination=SubscriberDestination(format="ninjs", delivery_type="ftp", config={}, name="destination1"),
-            subscriber_id=self.subscribers[0].id,
-            state=PublishQueueState.PENDING,
-            item_id="duplicate-item",
-            publishing_action="publish",
-            item_version=1,
-            formatted_item="",
-        )
-        duplicate_queue_item = PublishQueueResource(  # type: ignore[call-arg]
-            destination=SubscriberDestination(format="ninjs", delivery_type="ftp", config={}, name="destination1"),
-            subscriber_id=self.subscribers[0].id,
-            state=PublishQueueState.PENDING,
-            item_id="duplicate-item",
-            publishing_action="publish",
-            item_version=1,
-            formatted_item="",
-        )
-
-        await PublishQueueResource.get_service().create([queue_item, duplicate_queue_item])
-
-        queue_items = [queue async for queue in PublishQueueResource.get_service().get_all()]
-        self.assertEqual(1, len(queue_items))
-
-        # Ensure duplicates are also skipped when the duplicate arrives in a later request
-        later_duplicate = PublishQueueResource(  # type: ignore[call-arg]
-            destination=SubscriberDestination(format="ninjs", delivery_type="ftp", config={}, name="destination1"),
-            subscriber_id=self.subscribers[0].id,
-            state=PublishQueueState.PENDING,
-            item_id="duplicate-item",
-            publishing_action="publish",
-            item_version=1,
-            formatted_item="",
-        )
-        await PublishQueueResource.get_service().create([later_duplicate])
-        queue_items = [queue async for queue in PublishQueueResource.get_service().get_all()]
-        self.assertEqual(1, len(queue_items))
-
     async def test_stale_routing_items_are_included_in_subscriber_tasks(self):
         """
         Queue items stuck in ``routing`` state older than 5 minutes should be


### PR DESCRIPTION
reverts code changes introduced in https://github.com/superdesk/superdesk-core/pull/3255 which are causing issues in planning, only keep logging

SDCP-1208

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

