### PR TITLE
[SDBELGA-1112] Add fields to superdesk.core.resources

### DIFF
--- a/superdesk/core/openapi.py
+++ b/superdesk/core/openapi.py
@@ -26,7 +26,9 @@ class OpenApiSchemaGenerator(GenerateJsonSchema):
         def _process_node(node: dict) -> None:
             self._remove_none_from_optional_fields(node)
             for field in {"elastic_mapping", "include_in_parent", "nested"}:
-                node.pop(field, None)
+                value = node.pop(field, None)
+                if value:
+                    node[f"x-{field}"] = value
 
             if node.get("items"):
                 _process_node(node["items"])
@@ -386,7 +388,7 @@ class OpenAPISpec:
         self.add_path("/" + endpoint.url, endpoint_spec)
         return self
 
-    def add_model(self, model: type[BaseModel]) -> "OpenAPISpec":
+    def add_model(self, model: type[BaseModel], tags: list[str] | None = None) -> "OpenAPISpec":
         """
         Adds a given Pydantic based model to the OpenAPI specification and generates its schema.
 
@@ -401,6 +403,8 @@ class OpenAPISpec:
 
         schema = OpenApiSchemaGenerator.get_model_schema(model)
         self.add_schemas(schema.pop("$defs", {}))
+        if tags:
+            schema["x-tags"] = tags
         self.add_schema(model.__name__, schema)
         return self
 

--- a/superdesk/core/openapi.py
+++ b/superdesk/core/openapi.py
@@ -440,16 +440,8 @@ class OpenAPISpec:
             schema.pop("additionalProperties", None)
         return self
 
-    def to_string(self, output_format: str, pretty_print: bool = True) -> str:
-        """
-        Converts the specification to either JSON or YAML string format based on the provided
-        output format. Optionally, the output can be pretty-printed with indentation.
-
-        :param output_format: The desired output format for the specification. It must be either "json" or "yaml".
-        :param pretty_print: If True, the output will be formatted with indentation for better readability. Defaults to True.
-        :return str: The formatted specification as a string.
-        :raises ValueError: If the provided output format is neither "json" nor "yaml".
-        """
+    def to_dict(self) -> dict:
+        """Converts the specification to a dictionary, ready to turn into JSON or YAML."""
 
         spec = deepcopy(self.spec)
         for attribute in {"servers", "tags", "paths"}:
@@ -463,6 +455,20 @@ class OpenAPISpec:
         if not spec["components"]:
             spec.pop("components", None)
 
+        return spec
+
+    def to_string(self, output_format: str, pretty_print: bool = True) -> str:
+        """
+        Converts the specification to either JSON or YAML string format based on the provided
+        output format. Optionally, the output can be pretty-printed with indentation.
+
+        :param output_format: The desired output format for the specification. It must be either "json" or "yaml".
+        :param pretty_print: If True, the output will be formatted with indentation for better readability. Defaults to True.
+        :return str: The formatted specification as a string.
+        :raises ValueError: If the provided output format is neither "json" nor "yaml".
+        """
+
+        spec = self.to_dict()
         kwargs: dict = {} if not pretty_print else {"indent": 4}
         if output_format == "json":
             return json.dumps(spec, **kwargs)

--- a/superdesk/core/openapi.py
+++ b/superdesk/core/openapi.py
@@ -25,7 +25,7 @@ class OpenApiSchemaGenerator(GenerateJsonSchema):
 
         def _process_node(node: dict) -> None:
             self._remove_none_from_optional_fields(node)
-            for field in {"elastic_mapping", "include_in_parent", "nested"}:
+            for field in ("elastic_mapping", "include_in_parent", "nested"):
                 value = node.pop(field, None)
                 if value:
                     node[f"x-{field}"] = value

--- a/superdesk/core/resources/fields.py
+++ b/superdesk/core/resources/fields.py
@@ -120,6 +120,8 @@ if TYPE_CHECKING:
     Keyword = Annotated[str, ...]
     TextWithKeyword = Annotated[str, ...]
     HTML = Annotated[str, ...]
+    KeywordWithHTML = Annotated[str, ...]
+    Slugline = Annotated[str, ...]
     ObjectId = Annotated[BsonObjectId, ...]
     DateWithOptionalTime = Annotated[str, ...]
 else:
@@ -148,11 +150,38 @@ else:
         json_schema = {"type": "string", "format": "html"}
         elastic_mapping = {"type": "text", "analyzer": "html_field_analyzer"}
 
+    class KeywordWithHTML(CustomStringField, str):
+        """Elasticsearch keyword field with a HTML sub-field"""
+
+        json_schema = {"type": "string", "format": "html"}
+        elastic_mapping = {
+            "type": "keyword",
+            "fields": {
+                "analyzed": {"type": "text", "analyzer": "html_field_analyzer"},
+            },
+        }
+
+    class Slugline(CustomStringField, str):
+        """Slugline field. Provides sub-fields for keyword, HTML & text with `phrase_prefix_analyzer`
+
+        Note: Due to performance and JVM heap issues, the `fielddata` option has been removed
+        """
+
+        json_schema = {"type": "string"}
+        elastic_mapping = {
+            "type": "text",
+            "fields": {
+                "phrase": {"type": "text", "analyzer": "phrase_prefix_analyzer"},
+                "keyword": {"type": "keyword"},
+                "text": {"type": "text", "analyzer": "html_field_analyzer"},
+            },
+        }
+
     class ObjectId(BsonObjectId, CustomStringField[BsonObjectId]):
         """Elasticsearch ObjectId field"""
 
-        json_schema = {"type": "string", "format": "objectid"}
-        elastic_mapping = {"type": "text"}
+        json_schema = {"type": "string", "format": "objectid", "examples": [str(BsonObjectId())]}
+        elastic_mapping = {"type": "keyword"}
         core_type = BsonObjectId
 
         @classmethod
@@ -167,11 +196,11 @@ else:
         json_schema = {
             "type": "string",
             "anyOf": [
-                {"title": "Date", "pattern": "^\d{4}-\d{2}-\d{2}$"},
-                {"title": "Date and time", "pattern": "^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?)$"},
+                {"title": "Date", "pattern": r"^\d{4}-\d{2}-\d{2}$"},
+                {"title": "Date and time", "pattern": r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?)$"},
                 {
                     "title": "Date, time and UTC offset",
-                    "pattern": "^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}(:?\d{2})?)?)?$",
+                    "pattern": r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}(:?\d{2})?)?)?$",
                 },
             ],
             "examples": [

--- a/superdesk/core/resources/fields.py
+++ b/superdesk/core/resources/fields.py
@@ -151,7 +151,7 @@ else:
         elastic_mapping = {"type": "text", "analyzer": "html_field_analyzer"}
 
     class KeywordWithHTML(CustomStringField, str):
-        """Elasticsearch keyword field with a HTML sub-field"""
+        """Elasticsearch keyword field with an HTML sub-field"""
 
         json_schema = {"type": "string", "format": "html"}
         elastic_mapping = {
@@ -180,7 +180,7 @@ else:
     class ObjectId(BsonObjectId, CustomStringField[BsonObjectId]):
         """Elasticsearch ObjectId field"""
 
-        json_schema = {"type": "string", "format": "objectid", "examples": [str(BsonObjectId())]}
+        json_schema = {"type": "string", "format": "objectid", "examples": ["507f1f77bcf86cd799439011"]}
         elastic_mapping = {"type": "keyword"}
         core_type = BsonObjectId
 

--- a/tests/core/resource_model_test.py
+++ b/tests/core/resource_model_test.py
@@ -113,11 +113,11 @@ class ResourceModelTest(TestCase):
                             "scheme": {"type": "text"},
                         },
                     },
-                    "profile_id": {"type": "text"},
+                    "profile_id": {"type": "keyword"},
                     "related_items": {
                         "type": "nested",
                         "properties": {
-                            "_id": {"type": "text"},
+                            "_id": {"type": "keyword"},
                             "link_type": {"type": "keyword"},
                             "slugline": {"type": "text", "analyzer": "html_field_analyzer"},
                         },

--- a/tests/io/update_ingest_tests.py
+++ b/tests/io/update_ingest_tests.py
@@ -783,5 +783,7 @@ class UpdateIngestTest(TestCase):
 
         # update an event
         ingested, ids = await ingest_item(item, provider=provider, feeding_service={})
-        self.assertTrue(ingested)
+        # The Event was manually updated by a user (as it has a `version_creator` now)
+        # Therefore, the Event should not be updated upon ingesting
+        self.assertFalse(ingested)
         self.assertEqual([], ids)


### PR DESCRIPTION
### Purpose
Changes required for the new unified resource in the Planning module.

### What has changed
* Add `KeywordWithHTML` and `Slugline` fields to `superdesk.core.resources`
  * Note: `fielddata` was removed in this version of `Slugline`, as it has a performance hit and shouldn't be used in newer code.
* Modify OpenAPISchemaGenerator to include `x-elastic-mapping`, so it can be shown in the generated spec
* Modify mapping for `ObjectId`, it should be `keyword` not `text`

Resolves: [SDBELGA-1112](https://sofab.atlassian.net/browse/SDBELGA-1112)



[SDBELGA-1112]: https://sofab.atlassian.net/browse/SDBELGA-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ