### PR TITLE
avoid duplicates in publish queue

### DIFF
--- a/superdesk/publish_async/exchanges/content_exchange.py
+++ b/superdesk/publish_async/exchanges/content_exchange.py
@@ -51,6 +51,9 @@ from .base_exchange import BasicPublishExchange
 logger = logging.getLogger(__name__)
 
 
+_pending_cancellation_cleanup_tasks: set[asyncio.Task[None]] = set()
+
+
 @dataclass
 class SubscriberPackageItems:
     subscriber: SubscribersResource
@@ -72,6 +75,12 @@ class ContentPublishExchange(BasicPublishExchange):
     """
 
     name = "content"
+
+    @staticmethod
+    def _track_cancellation_cleanup_task(cleanup_task: asyncio.Task[None]) -> asyncio.Task[None]:
+        _pending_cancellation_cleanup_tasks.add(cleanup_task)
+        cleanup_task.add_done_callback(_pending_cancellation_cleanup_tasks.discard)
+        return cleanup_task
 
     async def send(self, request: PublishRequest) -> PublishRequestResponse:
         """
@@ -181,24 +190,14 @@ class ContentPublishExchange(BasicPublishExchange):
             # Request/task cancellation can be raised as Exception (py3.10) or BaseException (py3.11+).
             # If queue items were already created, keep the published item queued so the
             # enqueue beat does not create a second batch for the same item/subscriber.
-            error_updates = await self._get_cancellation_error_updates(request, str(error))
-            logger.warning(
+            await self._reset_published_item_after_cancellation(
+                published_service,
+                published_item_id,
+                request,
+                error,
+                logger.warning,
                 "Publish request cancelled during routing",
-                exc_info=True,
-                extra=dict(
-                    item_id=request.item_id,
-                    operation=request.operation,
-                    item_version=request.item.get(VERSION),
-                    resolved_queue_state=error_updates[QUEUE_STATE],
-                ),
             )
-            try:
-                await asyncio.shield(published_service.patch_async(published_item_id, error_updates))
-            except Exception:
-                logger.error(
-                    "Failed to reset published item state after cancellation",
-                    extra=dict(item_id=request.item_id),
-                )
             raise
         except Exception as error:
             if isinstance(error, KeyError):
@@ -219,27 +218,87 @@ class ContentPublishExchange(BasicPublishExchange):
             raise
         except BaseException as error:
             # Handle non-Exception base errors similarly to cancellations.
-            # asyncio.shield() protects the DB update itself from being cancelled.
-            error_updates = await self._get_cancellation_error_updates(request, str(error))
-            logger.error(
+            # Run the whole reset path in a shielded task so lookup + update can finish.
+            await self._reset_published_item_after_cancellation(
+                published_service,
+                published_item_id,
+                request,
+                error,
+                logger.error,
                 "Publish request interrupted by base exception",
-                exc_info=True,
-                extra=dict(
-                    item_id=request.item_id,
-                    operation=request.operation,
-                    item_version=request.item.get(VERSION),
-                    exception_type=type(error).__name__,
-                    resolved_queue_state=error_updates[QUEUE_STATE],
-                ),
+                exception_type=type(error).__name__,
             )
-            try:
-                await asyncio.shield(published_service.patch_async(published_item_id, error_updates))
-            except Exception:
-                logger.error(
-                    "Failed to reset published item state after cancellation",
-                    extra=dict(item_id=request.item_id),
-                )
             raise
+
+    async def _reset_published_item_after_cancellation(
+        self,
+        published_service,
+        published_item_id: ObjectId,
+        request: PublishRequest,
+        error: BaseException,
+        log_method,
+        log_message: str,
+        **extra: str,
+    ) -> None:
+        cleanup_task = self._track_cancellation_cleanup_task(
+            asyncio.create_task(
+                self._finalize_published_item_after_cancellation(
+                    published_service,
+                    published_item_id,
+                    request,
+                    error,
+                    log_method,
+                    log_message,
+                    **extra,
+                )
+            )
+        )
+
+        try:
+            await asyncio.shield(cleanup_task)
+        except asyncio.CancelledError:
+            # The current task is still cancelled, but the cleanup task keeps running.
+            return
+
+    async def _finalize_published_item_after_cancellation(
+        self,
+        published_service,
+        published_item_id: ObjectId,
+        request: PublishRequest,
+        error: BaseException,
+        log_method,
+        log_message: str,
+        **extra: str,
+    ) -> None:
+        try:
+            error_updates = await self._get_cancellation_error_updates(request, str(error))
+        except Exception:
+            logger.error(
+                "Failed to inspect publish queue during cancellation; defaulting published item to pending",
+                exc_info=True,
+                extra=dict(item_id=request.item_id),
+            )
+            error_updates = {QUEUE_STATE: PublishState.PENDING, ERROR_MESSAGE: str(error)}
+
+        log_method(
+            log_message,
+            exc_info=True,
+            extra=dict(
+                item_id=request.item_id,
+                operation=request.operation,
+                item_version=request.item.get(VERSION),
+                resolved_queue_state=error_updates[QUEUE_STATE],
+                **extra,
+            ),
+        )
+
+        try:
+            await published_service.patch_async(published_item_id, error_updates)
+        except Exception:
+            logger.error(
+                "Failed to reset published item state after cancellation",
+                extra=dict(item_id=request.item_id),
+            )
 
     async def _get_cancellation_error_updates(self, request: PublishRequest, error_message: str) -> dict:
         queue_state = PublishState.PENDING
@@ -256,15 +315,6 @@ class ContentPublishExchange(BasicPublishExchange):
         queue_lookup = {
             "item_id": request.item_id,
             "item_version": item_version,
-            "state": {
-                "$in": [
-                    PublishQueueState.ROUTING,
-                    PublishQueueState.PENDING,
-                    PublishQueueState.IN_PROGRESS,
-                    PublishQueueState.RETRYING,
-                    PublishQueueState.SUCCESS,
-                ]
-            },
         }
         queue_items = await (
             await PublishQueueResource.get_service().find(

--- a/superdesk/publish_async/exchanges/content_exchange.py
+++ b/superdesk/publish_async/exchanges/content_exchange.py
@@ -17,6 +17,8 @@ from superdesk.types import (
     PublishRequest,
     PublishRequestResponse,
     PublishState,
+    PublishQueueResource,
+    PublishQueueState,
     SubscribersResource,
     SubscriberType,
     PublishSenderType,
@@ -148,17 +150,48 @@ class ContentPublishExchange(BasicPublishExchange):
 
         except ConnectionTimeout as error:  # recoverable, set state to pending and retry next time
             error_updates = {QUEUE_STATE: PublishState.PENDING, ERROR_MESSAGE: str(error)}
+            logger.warning(
+                "Publish request hit connection timeout; resetting published item to pending",
+                exc_info=True,
+                extra=dict(
+                    item_id=request.item_id,
+                    operation=request.operation,
+                    item_version=request.item.get(VERSION),
+                    queue_state=error_updates[QUEUE_STATE],
+                ),
+            )
             await published_service.patch_async(published_item_id, error_updates)
             raise
         except SoftTimeLimitExceeded as error:
             # A celery timeout error occurred
             error_updates = {QUEUE_STATE: PublishState.PENDING, ERROR_MESSAGE: str(error)}
+            logger.warning(
+                "Publish request hit soft time limit; resetting published item to pending",
+                exc_info=True,
+                extra=dict(
+                    item_id=request.item_id,
+                    operation=request.operation,
+                    item_version=request.item.get(VERSION),
+                    queue_state=error_updates[QUEUE_STATE],
+                ),
+            )
             await published_service.patch_async(published_item_id, error_updates)
             raise
         except asyncio.CancelledError as error:
             # Request/task cancellation can be raised as Exception (py3.10) or BaseException (py3.11+).
-            # Keep the item retryable and protect the DB write from cancellation.
-            error_updates = {QUEUE_STATE: PublishState.PENDING, ERROR_MESSAGE: str(error)}
+            # If queue items were already created, keep the published item queued so the
+            # enqueue beat does not create a second batch for the same item/subscriber.
+            error_updates = await self._get_cancellation_error_updates(request, str(error))
+            logger.warning(
+                "Publish request cancelled during routing",
+                exc_info=True,
+                extra=dict(
+                    item_id=request.item_id,
+                    operation=request.operation,
+                    item_version=request.item.get(VERSION),
+                    resolved_queue_state=error_updates[QUEUE_STATE],
+                ),
+            )
             try:
                 await asyncio.shield(published_service.patch_async(published_item_id, error_updates))
             except Exception:
@@ -173,12 +206,32 @@ class ContentPublishExchange(BasicPublishExchange):
             else:
                 error_msg = str(error)
             error_updates = {QUEUE_STATE: PublishState.ERROR, ERROR_MESSAGE: error_msg}
+            logger.exception(
+                "Publish request failed with application error",
+                extra=dict(
+                    item_id=request.item_id,
+                    operation=request.operation,
+                    item_version=request.item.get(VERSION),
+                    queue_state=error_updates[QUEUE_STATE],
+                ),
+            )
             await published_service.patch_async(published_item_id, error_updates)
             raise
         except BaseException as error:
-            # Handle non-Exception base errors by resetting state so the item is retryable.
+            # Handle non-Exception base errors similarly to cancellations.
             # asyncio.shield() protects the DB update itself from being cancelled.
-            error_updates = {QUEUE_STATE: PublishState.PENDING, ERROR_MESSAGE: str(error)}
+            error_updates = await self._get_cancellation_error_updates(request, str(error))
+            logger.error(
+                "Publish request interrupted by base exception",
+                exc_info=True,
+                extra=dict(
+                    item_id=request.item_id,
+                    operation=request.operation,
+                    item_version=request.item.get(VERSION),
+                    exception_type=type(error).__name__,
+                    resolved_queue_state=error_updates[QUEUE_STATE],
+                ),
+            )
             try:
                 await asyncio.shield(published_service.patch_async(published_item_id, error_updates))
             except Exception:
@@ -187,6 +240,39 @@ class ContentPublishExchange(BasicPublishExchange):
                     extra=dict(item_id=request.item_id),
                 )
             raise
+
+    async def _get_cancellation_error_updates(self, request: PublishRequest, error_message: str) -> dict:
+        queue_state = PublishState.PENDING
+        if await self._has_publish_queue_items(request):
+            queue_state = PublishState.QUEUED
+
+        return {QUEUE_STATE: queue_state, ERROR_MESSAGE: error_message}
+
+    async def _has_publish_queue_items(self, request: PublishRequest) -> bool:
+        item_version = request.item.get(VERSION)
+        if item_version is None:
+            return False
+
+        queue_lookup = {
+            "item_id": request.item_id,
+            "item_version": item_version,
+            "state": {
+                "$in": [
+                    PublishQueueState.ROUTING,
+                    PublishQueueState.PENDING,
+                    PublishQueueState.IN_PROGRESS,
+                    PublishQueueState.RETRYING,
+                    PublishQueueState.SUCCESS,
+                ]
+            },
+        }
+        queue_items = await (
+            await PublishQueueResource.get_service().find(
+                queue_lookup,
+                max_results=1,
+            )
+        ).to_list()
+        return len(queue_items) > 0
 
     async def get_published_item_from_request(self, request: PublishRequest) -> dict | None:
         """

--- a/superdesk/publish_async/routers/asyncio_router.py
+++ b/superdesk/publish_async/routers/asyncio_router.py
@@ -1,6 +1,5 @@
-from typing import Awaitable
+import asyncio
 import logging
-from asyncio import as_completed
 from bson import ObjectId
 
 from superdesk.types import (
@@ -53,18 +52,57 @@ class AsyncioPublishRouter(PublishExchangeRouter):
         # Now send the tasks to the PublishConsumer(s)
 
         await PublishCache.init()
-        publish_tasks: list[Awaitable[None]] = []
+        publish_tasks: list[tuple[SubscribersResource, list[PublishQueueResource], asyncio.Task[None]]] = []
 
         for subscriber, tasks in self.group_tasks_by_subscriber(request, tasks):
-            publish_tasks.append(self.send_tasks_to_consumer(subscriber, tasks))
+            publish_tasks.append(
+                (subscriber, tasks, asyncio.create_task(self.send_tasks_to_consumer(subscriber, tasks)))
+            )
 
         if publish_tasks:
             failed = 0
-            for task in as_completed(publish_tasks):
+            task_metadata: dict[
+                asyncio.Task[None], tuple[SubscribersResource | None, list[PublishQueueResource] | None]
+            ] = {task: (subscriber, subscriber_tasks) for subscriber, subscriber_tasks, task in publish_tasks}
+            done, _ = await asyncio.wait([task for _, _, task in publish_tasks])
+            for task in done:
                 try:
                     await task
                 except Exception:
-                    logger.exception("Failed to process task")
+                    metadata = task_metadata.get(task)
+                    if metadata is None:
+                        logger.exception(
+                            "Failed to process routed publish tasks",
+                            extra=dict(
+                                item_id=request.item_id,
+                                operation=request.operation,
+                            ),
+                        )
+                        failed += 1
+                        continue
+                    subscriber_item: SubscribersResource | None
+                    subscriber_tasks_item: list[PublishQueueResource] | None
+                    subscriber_item, subscriber_tasks_item = metadata
+                    if subscriber_item is None or subscriber_tasks_item is None:
+                        logger.exception(
+                            "Failed to process routed publish tasks",
+                            extra=dict(
+                                item_id=request.item_id,
+                                operation=request.operation,
+                            ),
+                        )
+                        failed += 1
+                        continue
+                    logger.exception(
+                        "Failed to process routed publish tasks",
+                        extra=dict(
+                            item_id=request.item_id,
+                            operation=request.operation,
+                            subscriber_id=subscriber_item.id,
+                            task_ids=[str(queue_task.id) for queue_task in subscriber_tasks_item],
+                            queue_item_ids=[queue_task.item_id for queue_task in subscriber_tasks_item],
+                        ),
+                    )
                     failed += 1
 
             if not failed:
@@ -127,4 +165,11 @@ class AsyncioPublishRouter(PublishExchangeRouter):
             consumer = get_exchange_factory().get_subscriber_consumer(subscriber)
             await consumer.process_tasks(subscriber, tasks)
         except Exception:
-            logger.exception("Failed to process tasks for subscriber", extra=dict(subscriber_id=subscriber.id))
+            logger.exception(
+                "Failed to process tasks for subscriber",
+                extra=dict(
+                    subscriber_id=subscriber.id,
+                    task_ids=[str(task.id) for task in tasks],
+                    queue_item_ids=[task.item_id for task in tasks],
+                ),
+            )

--- a/superdesk/publish_async/routers/celery_router.py
+++ b/superdesk/publish_async/routers/celery_router.py
@@ -1,4 +1,5 @@
 from bson import ObjectId
+import logging
 from quart_babel import gettext
 from superdesk.types import PublishQueueResource, SubscribersResource
 from superdesk.celery_app import celery
@@ -7,6 +8,9 @@ from superdesk.publish_async import get_exchange_factory
 
 from .asyncio_router import AsyncioPublishRouter
 from ..utils import ContentApiSubscriber
+
+
+logger = logging.getLogger(__name__)
 
 
 class CeleryPublishRouter(AsyncioPublishRouter):
@@ -35,13 +39,26 @@ class CeleryPublishRouter(AsyncioPublishRouter):
         """
 
         consumer = get_exchange_factory().get_subscriber_consumer(subscriber)
-        await send_task_to_consumer.apply_async(
-            args=[
-                consumer.name,
-                subscriber.id,
-                [task.id for task in tasks],
-            ]
-        )
+        task_ids = [task.id for task in tasks]
+        try:
+            await send_task_to_consumer.apply_async(  # type: ignore[attr-defined]
+                args=[
+                    consumer.name,
+                    subscriber.id,
+                    task_ids,
+                ]
+            )
+        except Exception:
+            logger.exception(
+                "Failed to enqueue publish tasks to celery consumer",
+                extra=dict(
+                    subscriber_id=subscriber.id,
+                    consumer_name=consumer.name,
+                    task_ids=[str(task_id) for task_id in task_ids],
+                    queue_item_ids=[task.item_id for task in tasks],
+                ),
+            )
+            raise
 
 
 @celery.task(soft_time_limit=600)

--- a/tests/publish_async/exchanges/content_exchange_tests.py
+++ b/tests/publish_async/exchanges/content_exchange_tests.py
@@ -13,8 +13,9 @@ class ContentExchangeCancelledErrorTestCase(TestCase):
     """
     Tests that asyncio.CancelledError (a BaseException, not Exception) during
     _publish_item() does not leave published.queue_state permanently stuck at
-    in_progress.  The handler must reset the state to ``pending`` via
-    asyncio.shield() so the background worker can re-route the item.
+    in_progress. The handler should reset the item to ``pending`` when no
+    queue rows were created, but keep it ``queued`` when routing already
+    produced publish_queue items.
     """
 
     def _make_exchange(self):
@@ -25,7 +26,7 @@ class ContentExchangeCancelledErrorTestCase(TestCase):
         exchange.polling = False
         return exchange
 
-    async def test_cancellation_resets_queue_state_to_pending(self):
+    async def test_cancellation_resets_queue_state_to_pending_when_no_queue_items_exist(self):
         exchange = self._make_exchange()
 
         published_item_id = ObjectId()
@@ -73,12 +74,18 @@ class ContentExchangeCancelledErrorTestCase(TestCase):
                     ):
                         with patch.object(
                             exchange,
-                            "_publish_item",
+                            "_has_publish_queue_items",
                             new_callable=AsyncMock,
-                            side_effect=asyncio.CancelledError("request cancelled"),
+                            return_value=False,
                         ):
-                            with self.assertRaises(asyncio.CancelledError):
-                                await exchange.send(request)
+                            with patch.object(
+                                exchange,
+                                "_publish_item",
+                                new_callable=AsyncMock,
+                                side_effect=asyncio.CancelledError("request cancelled"),
+                            ):
+                                with self.assertRaises(asyncio.CancelledError):
+                                    await exchange.send(request)
 
         # The BaseException handler must have written a state reset
         self.assertTrue(
@@ -92,3 +99,69 @@ class ContentExchangeCancelledErrorTestCase(TestCase):
             PublishState.PENDING,
             "queue_state must be reset to 'pending' so the background worker can retry",
         )
+
+    async def test_cancellation_keeps_queue_state_queued_when_queue_items_exist(self):
+        exchange = self._make_exchange()
+
+        published_item_id = ObjectId()
+        published_item = {
+            "_id": published_item_id,
+            "item_id": "test-item-1",
+            "state": "published",
+            "queue_state": "in_progress",
+            "type": "text",
+            "operation": "publish",
+        }
+
+        captured_patches = []
+
+        async def fake_patch(item_id, updates):
+            captured_patches.append((item_id, updates.copy()))
+
+        published_service = MagicMock()
+        published_service.patch_async = AsyncMock(side_effect=fake_patch)
+
+        request = MagicMock()
+        request.item = MagicMock(**published_item)
+        request.item.get = MagicMock(return_value=None)
+        request.item_id = "test-item-1"
+        request.operation = "publish"
+
+        with patch(
+            "superdesk.publish_async.exchanges.content_exchange.PublishCache.init",
+            new_callable=AsyncMock,
+        ):
+            with patch(
+                "superdesk.publish_async.exchanges.content_exchange.get_resource_service",
+                return_value=published_service,
+            ):
+                with patch.object(
+                    exchange,
+                    "get_published_item_from_request",
+                    new_callable=AsyncMock,
+                    return_value=published_item,
+                ):
+                    with patch.object(
+                        exchange,
+                        "update_published_item",
+                        new_callable=AsyncMock,
+                    ):
+                        with patch.object(
+                            exchange,
+                            "_has_publish_queue_items",
+                            new_callable=AsyncMock,
+                            return_value=True,
+                        ):
+                            with patch.object(
+                                exchange,
+                                "_publish_item",
+                                new_callable=AsyncMock,
+                                side_effect=asyncio.CancelledError("request cancelled"),
+                            ):
+                                with self.assertRaises(asyncio.CancelledError):
+                                    await exchange.send(request)
+
+        self.assertTrue(len(captured_patches) >= 1)
+        last_patch_id, last_patch_updates = captured_patches[-1]
+        self.assertEqual(last_patch_id, published_item_id)
+        self.assertEqual(last_patch_updates[QUEUE_STATE], PublishState.QUEUED)

--- a/tests/publish_async/exchanges/content_exchange_tests.py
+++ b/tests/publish_async/exchanges/content_exchange_tests.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from bson import ObjectId
 
 from superdesk.tests import TestCase
+from superdesk.resource_fields import VERSION
 from superdesk.types import PublishState
 from superdesk.publish_async.exchanges.content_exchange import ContentPublishExchange
 from superdesk.publish_async.utils import QUEUE_STATE, PUBLISHED
@@ -25,6 +26,75 @@ class ContentExchangeCancelledErrorTestCase(TestCase):
         exchange._router = MagicMock()
         exchange.polling = False
         return exchange
+
+    async def test_has_publish_queue_items_checks_any_existing_row_for_item_version(self):
+        exchange = self._make_exchange()
+
+        request = MagicMock()
+        request.item = {VERSION: 7}
+        request.item_id = "test-item-1"
+
+        cursor = MagicMock()
+        cursor.to_list = AsyncMock(return_value=[{"state": "failed"}])
+
+        queue_service = MagicMock()
+        queue_service.find = AsyncMock(return_value=cursor)
+
+        with patch(
+            "superdesk.publish_async.exchanges.content_exchange.PublishQueueResource.get_service",
+            return_value=queue_service,
+        ):
+            has_queue_items = await exchange._has_publish_queue_items(request)
+
+        self.assertTrue(has_queue_items)
+        queue_service.find.assert_awaited_once_with(
+            {
+                "item_id": "test-item-1",
+                "item_version": 7,
+            },
+            max_results=1,
+        )
+
+    async def test_cancellation_cleanup_still_updates_state_when_cleanup_await_is_cancelled(self):
+        exchange = self._make_exchange()
+
+        published_service = MagicMock()
+        published_service.patch_async = AsyncMock()
+        request = MagicMock()
+        request.item = {"version": 7}
+        request.item_id = "test-item-1"
+        request.operation = "publish"
+
+        lookup_started = asyncio.Event()
+        finish_lookup = asyncio.Event()
+
+        async def delayed_updates(*args, **kwargs):
+            lookup_started.set()
+            await finish_lookup.wait()
+            return {QUEUE_STATE: PublishState.QUEUED, "error_message": "request cancelled"}
+
+        async def run_cleanup():
+            await exchange._reset_published_item_after_cancellation(
+                published_service,
+                ObjectId(),
+                request,
+                asyncio.CancelledError("request cancelled"),
+                MagicMock(),
+                "Publish request cancelled during routing",
+            )
+
+        with patch.object(exchange, "_get_cancellation_error_updates", side_effect=delayed_updates):
+            cleanup_await = asyncio.create_task(run_cleanup())
+            await lookup_started.wait()
+
+            cleanup_await.cancel()
+            await cleanup_await
+
+            finish_lookup.set()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        published_service.patch_async.assert_awaited_once()
 
     async def test_cancellation_resets_queue_state_to_pending_when_no_queue_items_exist(self):
         exchange = self._make_exchange()


### PR DESCRIPTION
when the task is cancelled check if the items
were already created and only restart it if
they are missing.

SDCP-1208

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

