### PR TITLE
SDESK-7943: Archived:unarchive review fixes 

### DIFF
--- a/apps/archived/commands.py
+++ b/apps/archived/commands.py
@@ -63,6 +63,9 @@ class UnarchiveItemCommand:
         :param dry_run: If True, simulate without making changes.
         :return: Dict with 'success' and 'failed' lists.
         """
+        if expiry_days is not None and expiry_days < 0:
+            raise ValueError("expiry_days must be >= 0")
+
         results: dict[str, list] = {"success": [], "failed": []}
 
         for item_id in item_ids:
@@ -112,8 +115,8 @@ class UnarchiveItemCommand:
         try:
             for item in restore_order:
                 await self._restore_to_archive(item, expiry_days)
-                await self._restore_to_published(item)
                 restored_item_ids.append(item["item_id"])
+                await self._restore_to_published(item)
         except Exception:
             await self._rollback_restored_items(restored_item_ids)
             raise
@@ -153,14 +156,12 @@ class UnarchiveItemCommand:
                 if not ref_id or ref_id in seen_ids:
                     continue
 
-                ref_items = await (
-                    await archived_service.get_from_mongo_async(req=None, lookup={"item_id": ref_id})
-                ).to_list()
-                if not ref_items:
+                try:
+                    ref_item = await self._get_latest_archived_item(archived_service, ref_id)
+                except ValueError:
                     raise ValueError("No archived item found for package ref: {}".format(ref_id))
 
-                ref_items.sort(key=lambda x: x.get(VERSION, 0), reverse=True)
-                items.append(ref_items[0])
+                items.append(ref_item)
                 seen_ids.add(ref_id)
 
         # Check if item is part of a takes package

--- a/tests/archived/commands_test.py
+++ b/tests/archived/commands_test.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from bson import ObjectId
 from superdesk.tests import TestCase, utils as test_utils
 from apps.archived.commands import UnarchiveItemCommand
@@ -156,3 +158,61 @@ class UnarchiveItemCommandTestCase(TestCase):
         assert len(results["failed"]) == 1
         assert await test_utils.count("archived", {"item_id": "coll"}) == 1
         assert await test_utils.count("published", {"item_id": "coll"}) == 0
+
+    async def test_unarchive_negative_expiry_days_is_rejected(self):
+        with self.assertRaises(ValueError):
+            await UnarchiveItemCommand().run(["whatever"], expiry_days=-1)
+
+    async def test_unarchive_rolls_back_on_partial_failure(self):
+        member_id = "rollback-member"
+        package_id = "rollback-package"
+
+        await test_utils.post_items(
+            "archived",
+            [
+                {
+                    "_id": ObjectId(),
+                    "item_id": member_id,
+                    "guid": member_id,
+                    "type": "text",
+                    "state": "published",
+                    "headline": "Member",
+                },
+                {
+                    "_id": ObjectId(),
+                    "item_id": package_id,
+                    "guid": package_id,
+                    "type": "composite",
+                    "state": "published",
+                    "headline": "Package",
+                    "groups": [
+                        {"id": "root", "refs": [{"idRef": "main"}], "role": "grpRole:NEP"},
+                        {
+                            "id": "main",
+                            "refs": [{"residRef": member_id, "location": "archive"}],
+                            "role": "grpRole:main",
+                        },
+                    ],
+                },
+            ],
+        )
+
+        original_restore_to_published = UnarchiveItemCommand._restore_to_published
+
+        async def flaky(self, item):
+            if item["item_id"] == package_id:
+                raise RuntimeError("boom")
+            return await original_restore_to_published(self, item)
+
+        with mock.patch.object(UnarchiveItemCommand, "_restore_to_published", flaky):
+            results = await UnarchiveItemCommand().run([package_id])
+
+        assert results["success"] == []
+        assert len(results["failed"]) == 1
+
+        # nothing left half-restored in archive or published
+        for item_id in [member_id, package_id]:
+            assert await test_utils.count("archive", {"_id": item_id}) == 0
+            assert await test_utils.count("published", {"item_id": item_id}) == 0
+            # archived is only cleaned up after a fully successful restore
+            assert await test_utils.count("archived", {"item_id": item_id}) == 1

--- a/tests/archived/commands_test.py
+++ b/tests/archived/commands_test.py
@@ -160,7 +160,7 @@ class UnarchiveItemCommandTestCase(TestCase):
         assert await test_utils.count("published", {"item_id": "coll"}) == 0
 
     async def test_unarchive_negative_expiry_days_is_rejected(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "expiry_days must be >= 0"):
             await UnarchiveItemCommand().run(["whatever"], expiry_days=-1)
 
     async def test_unarchive_rolls_back_on_partial_failure(self):


### PR DESCRIPTION
Follow-up to the `release/2.9` backport (#3273) to add some of the fixes highlighted by the code review which have now been added here.

### Changes
- **Rollback fix (partial restore):** `restored_item_ids` is now appended right after `_restore_to_archive` succeeds, before `_restore_to_published`. Previously an item whose archive insert succeeded but publish then failed was left orphaned in `archive` because it never made it into the rollback list. Surfaced by the new rollback test below.
- **Negative expiry guard:** `run()` now fails fast with `ValueError("expiry_days must be >= 0")`.
- **Dedup:** package-ref collection reuses `_get_latest_archived_item` instead of fetching all versions and sorting in Python, preserving the existing package-ref error message.
