### PR TITLE
[SDESK-7980] - Image upload dialogue does not clear

### DIFF
--- a/superdesk/media/crop.py
+++ b/superdesk/media/crop.py
@@ -260,7 +260,10 @@ class CropService:
             return
 
         update_renditions = updates.get("renditions", {})
-        renditions = deepcopy(original.get("renditions", {}))
+        # a freshly uploaded picture can have `renditions` set to None until the async
+        # rendition task populates it; normalise to a dict so the crop logic is safe.
+        original_renditions = original.get("renditions") or {}
+        renditions = deepcopy(original_renditions)
         # keep renditions updates (urls may have changed)
         renditions.update(update_renditions)
         renditions = {k: renditions[k] for k in renditions if renditions[k]}
@@ -269,7 +272,7 @@ class CropService:
             original_image = updates["renditions"]["original"]
         else:
             try:
-                original_image = original["renditions"]["original"]
+                original_image = original_renditions["original"]
             except KeyError:
                 return
 
@@ -277,7 +280,7 @@ class CropService:
             if not self.get_crop_by_name(key):
                 continue
 
-            original_crop = original.get("renditions", {}).get(key, {})
+            original_crop = original_renditions.get(key, {})
             fields = ("CropLeft", "CropTop", "CropRight", "CropBottom")
             crop_data = update_renditions.get(key, {})
             if any(crop_data.get(name) != original_crop.get(name) for name in fields) and not crop_data.get("media"):
@@ -334,7 +337,7 @@ class CropService:
         """
         update_renditions = updates.get("renditions", {})
         if original.get(ITEM_TYPE) == CONTENT_TYPE.PICTURE and update_renditions:
-            renditions = original.get("renditions", {})
+            renditions = original.get("renditions") or {}
             for key in update_renditions:
                 if self.get_crop_by_name(key) and update_renditions.get(key, {}).get("media") != renditions.get(
                     key, {}

--- a/tests/media/crop_test.py
+++ b/tests/media/crop_test.py
@@ -123,6 +123,14 @@ class CropTestCase(TestCase):
         self.assertEqual(ex.message, "Original file couldn't be found")
         self.assertEqual(ex.status_code, 400)
 
+    def test_create_multiple_crops_when_original_has_no_renditions(self):
+        updates = {"headline": "foo"}
+        original = {"type": "picture", "renditions": None}
+
+        self.service.create_multiple_crops(updates, original)
+
+        self.assertNotIn("renditions", updates)
+
     def test_validate_crop_converts_to_int(self):
         crop = {"width": "300", "height": 200}
         self.service._validate_values(crop)


### PR DESCRIPTION
### Purpose
This PR fixes a server-side crash that prevented saving a freshly-uploaded image. When an image is uploaded, its `renditions` are generated asynchronously, so the item briefly has `renditions: null`. Saving metadata in that window caused `create_multiple_crops` to raise `AttributeError: 'NoneType' object has no attribute 'update'`, which surfaced to the client as a generic `400`, so the upload dialogue never cleared.

### What has changed
- `superdesk/media/crop.py`: `create_multiple_crops` now normalises a `None` `renditions` value to an empty dict before use. A fresh upload has the key present but `null`, so `.get("renditions", {})` returned `None` instead of `{}`. The normalised value is reused for the original-rendition lookup and the per-crop comparison, so the method returns early when there is nothing to crop yet instead of crashing.
- Applied the same guard to `_delete_replaced_crop_files`.
- Added a regression test in `tests/media/crop_test.py`.

### Steps to test
1. Upload an image into a desk.
2. Fill in the metadata and save immediately, before renditions finish generating.
3. The item saves successfully (`PATCH /api/archive/<id>` returns `200`) and the upload dialogue closes.

Companion PR: https://github.com/superdesk/superdesk-client-core/pull/5283

Resolves: https://sofab.atlassian.net/browse/SDESK-7980
