### PR TITLE
[SDBELGA-1113] Eve -> Pydantic compatibility layer

### DIFF
--- a/apps/desks_async/desks_async_service.py
+++ b/apps/desks_async/desks_async_service.py
@@ -1,5 +1,7 @@
 from typing import Any, Sequence
 import logging
+
+from bson import ObjectId
 from quart_babel import gettext as _
 
 from superdesk import get_resource_service
@@ -18,7 +20,9 @@ logger = logging.getLogger(__name__)
 class DesksAsyncService(AsyncResourceService[DesksResourceModel]):
     notification_key = "desk"
 
-    async def create(self, docs: Sequence[DesksResourceModel | dict[str, Any]]) -> list[DesksResourceModel]:
+    async def create(
+        self, docs: Sequence[DesksResourceModel | dict[str, Any]], skip_signals: bool = False
+    ) -> list[DesksResourceModel]:
         """Creates new desk.
 
         Overriding to check if the desk being created has Working and Incoming Stages. If not then Working and Incoming
@@ -136,7 +140,7 @@ class DesksAsyncService(AsyncResourceService[DesksResourceModel]):
                 message=_("Cannot delete desk as it has article(s) or referenced by versions of the article(s).")
             )
 
-    async def delete_many(self, lookup: dict[str, Any]) -> list[str]:
+    async def delete_many(self, lookup: dict[str, Any]) -> list[str | ObjectId]:
         """
         Overriding to delete stages before deleting a desk
         """

--- a/superdesk/archived_async/service.py
+++ b/superdesk/archived_async/service.py
@@ -136,7 +136,7 @@ class ArchivedService(AsyncResourceService[ArchivedResourceModel]):
     async def on_delete(self, doc: ArchivedResourceModel) -> None:
         await self.validate_delete_action(doc)
 
-    async def delete_many(self, lookup: dict[str, Any]) -> list[str]:
+    async def delete_many(self, lookup: dict[str, Any]) -> list[str | ObjectId]:
         if get_current_app().testing and len(lookup) == 0:
             return await super().delete_many(lookup)
         return []
@@ -166,6 +166,7 @@ class ArchivedService(AsyncResourceService[ArchivedResourceModel]):
         updates: dict[str, Any],
         etag: str | None = None,
         original: ArchivedResourceModel | None = None,
+        skip_signals: bool = False,
     ) -> ArchivedResourceModel:
         """Runs on update of archive item.
 

--- a/superdesk/auth_server/module.py
+++ b/superdesk/auth_server/module.py
@@ -27,16 +27,23 @@ class AuthServerClientService(AsyncResourceService[AuthServerClientResource]):
         original: AuthServerClientResource,
         updates: dict,
         validated_updates: dict,
+        replace: bool = False,
+        update_mongo: bool = True,
+        update_elastic: bool = True,
     ) -> dict:
         # We want to return to the client the provided/generated password
         # and not the hashed version stored in the DB
 
         if "password" not in updates:
-            return await super().update_in_dbs(item_id, original, updates, validated_updates)
+            return await super().update_in_dbs(
+                item_id, original, updates, validated_updates, replace, update_mongo, update_elastic
+            )
 
         unhashed_password = updates["password"]
         updates["password"] = bcrypt.hashpw(unhashed_password.encode(), bcrypt.gensalt()).decode()
-        updates_dict = await super().update_in_dbs(item_id, original, updates, validated_updates)
+        updates_dict = await super().update_in_dbs(
+            item_id, original, updates, validated_updates, replace, update_mongo, update_elastic
+        )
         updates_dict["password"] = unhashed_password
 
         return updates_dict

--- a/superdesk/core/resources/cursor.py
+++ b/superdesk/core/resources/cursor.py
@@ -167,3 +167,35 @@ class MongoResourceCursorAsync(ResourceCursorAsync[ResourceModelType], Generic[R
 
     async def count(self):
         return await self.collection.count_documents(self.lookup, collation=self.collation)
+
+
+class DictCursorAsync(Generic[ResourceModelType]):
+    """Wraps a ResourceCursorAsync and yields raw dicts instead of ResourceModel instances"""
+
+    def __init__(self, cursor: ResourceCursorAsync[ResourceModelType]):
+        self._cursor = cursor
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> dict:
+        item = await self._cursor.next()
+        if item is not None:
+            return item.to_dict()
+        raise StopAsyncIteration
+
+    async def next(self) -> dict[str, Any] | None:
+        item = await self._cursor.next()
+        return item.to_dict() if item else None
+
+    async def next_raw(self) -> dict[str, Any] | None:
+        return await self._cursor.next_raw()
+
+    def rewind(self) -> None:
+        self._cursor.rewind()
+
+    async def to_list(self) -> list[dict[str, Any]]:
+        return [item.to_dict() async for item in self._cursor]
+
+    async def count(self) -> int:
+        return await self._cursor.count()

--- a/superdesk/core/resources/fields.py
+++ b/superdesk/core/resources/fields.py
@@ -24,6 +24,7 @@ from pydantic import (
 from pydantic.json_schema import JsonSchemaValue
 from pydantic.dataclasses import dataclass
 from bson import ObjectId as BsonObjectId
+from superdesk.core.utils import str_to_date, date_to_str
 
 DefaultModelConfig = ConfigDict(
     arbitrary_types_allowed=True,
@@ -101,13 +102,18 @@ class CustomStringField(Generic[CustomStringFieldType], BaseCustomField):
             ]
         )
 
+        python_schema = core_schema.union_schema(
+            [
+                core_schema.is_instance_schema(cls.core_type),
+                from_str_schema,
+            ]
+        )
+
         return core_schema.json_or_python_schema(
             json_schema=from_str_schema,
-            python_schema=core_schema.union_schema(
-                [
-                    core_schema.is_instance_schema(cls.core_type),
-                    from_str_schema,
-                ]
+            python_schema=core_schema.no_info_after_validator_function(
+                lambda v: v.strip() if isinstance(v, str) else v,
+                python_schema,
             ),
             serialization=core_schema.plain_serializer_function_ser_schema(
                 cls.serialise_value,
@@ -124,6 +130,7 @@ if TYPE_CHECKING:
     Slugline = Annotated[str, ...]
     ObjectId = Annotated[BsonObjectId, ...]
     DateWithOptionalTime = Annotated[str, ...]
+    Date = Annotated[str, ...]
 else:
 
     class Keyword(CustomStringField, str):
@@ -212,6 +219,40 @@ else:
             ],
         }
         elastic_mapping = {"type": "date"}
+
+    class Date(CustomStringField):
+        json_schema = {
+            "type": "string",
+            "title": "Date",
+            "format": "date",
+            "examples": ["2025-07-21"],
+        }
+        elastic_mapping = {"type": "date"}
+
+
+class _UTCDatetimeAnnotation(BaseCustomField):
+    core_type = datetime
+    elastic_mapping = {"type": "date"}
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        _source_type: Any,
+        _handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        return core_schema.no_info_before_validator_function(
+            str_to_date,
+            # core_schema.datetime_schema(tz_constraint="aware")
+            core_schema.datetime_schema(
+                tz_constraint="aware",
+                serialization=core_schema.plain_serializer_function_ser_schema(
+                    lambda dt: date_to_str(dt), when_used="json"
+                ),
+            ),
+        )
+
+
+UTCDatetime = Annotated[datetime, _UTCDatetimeAnnotation()]
 
 
 def elastic_mapping(mapping: dict[str, Any]) -> WithJsonSchema:

--- a/superdesk/core/resources/fields.py
+++ b/superdesk/core/resources/fields.py
@@ -242,7 +242,6 @@ class _UTCDatetimeAnnotation(BaseCustomField):
     ) -> core_schema.CoreSchema:
         return core_schema.no_info_before_validator_function(
             str_to_date,
-            # core_schema.datetime_schema(tz_constraint="aware")
             core_schema.datetime_schema(
                 tz_constraint="aware",
                 serialization=core_schema.plain_serializer_function_ser_schema(

--- a/superdesk/core/resources/model.py
+++ b/superdesk/core/resources/model.py
@@ -32,6 +32,7 @@ from pydantic import (
     model_serializer,
     SerializerFunctionWrapHandler,
     RootModel,
+    AliasChoices,
 )
 from pydantic.dataclasses import dataclass as pydataclass
 from pydantic_core import InitErrorDetails, PydanticCustomError, from_json
@@ -168,7 +169,9 @@ class ResourceModel(BaseModel):
     id: Annotated[
         Union[str, ObjectId],
         Field(
-            validation_alias="_id", serialization_alias="_id", default_factory=lambda: generate_guid(type=GUID_NEWSML)
+            validation_alias=AliasChoices("_id", "id"),
+            serialization_alias="_id",
+            default_factory=lambda: generate_guid(type=GUID_NEWSML),
         ),
     ]
 
@@ -364,7 +367,14 @@ class ResourceModelWithObjectId(ResourceModel):
     """Base ResourceModel class to be used, if the resource uses an ObjectId for it's ID"""
 
     #: ID of the document
-    id: Annotated[ObjectId, Field(alias="_id", default_factory=ObjectId)]
+    id: Annotated[
+        ObjectId,
+        Field(
+            validation_alias=AliasChoices("_id", "id"),
+            serialization_alias="_id",
+            default_factory=ObjectId,
+        ),
+    ]
 
 
 @dataclass

--- a/superdesk/core/resources/model.py
+++ b/superdesk/core/resources/model.py
@@ -21,7 +21,6 @@ from typing import (
 )
 from inspect import get_annotations
 from copy import deepcopy
-from datetime import datetime
 from dataclasses import field as dataclass_field
 from typing_extensions import dataclass_transform, Self, overload
 
@@ -42,7 +41,7 @@ from superdesk.core.utils import generate_guid, GUID_NEWSML
 from superdesk.utils import merge_dicts_deep
 
 from .utils import get_model_aliased_fields, get_model_annotations, gen_url_for_related_resource
-from .fields import ObjectId
+from .fields import ObjectId, UTCDatetime
 
 default_model_config = ConfigDict(
     arbitrary_types_allowed=True,
@@ -51,6 +50,7 @@ default_model_config = ConfigDict(
     revalidate_instances="always",
     extra="allow",  # Allow any fields not defined in the ResourceModel/dataclass
     protected_namespaces=(),
+    str_strip_whitespace=True,
 )
 
 
@@ -78,7 +78,11 @@ class DataclassBase:
         result = nxt(self)
 
         # Include extra fields that were not part of the schema for this class
-        for key, value in self.__dict__.items():
+        instance_dict = getattr(self, "__dict__", None)
+        if not isinstance(result, dict) or not isinstance(instance_dict, dict):
+            return result
+
+        for key, value in instance_dict.items():
             if key in result:
                 # This field is already in the result, no further processing required
                 continue
@@ -161,16 +165,21 @@ class ResourceModel(BaseModel):
         return self.model_resource_name
 
     #: ID of the document
-    id: Annotated[Union[str, ObjectId], Field(alias="_id", default_factory=lambda: generate_guid(type=GUID_NEWSML))]
+    id: Annotated[
+        Union[str, ObjectId],
+        Field(
+            validation_alias="_id", serialization_alias="_id", default_factory=lambda: generate_guid(type=GUID_NEWSML)
+        ),
+    ]
 
     #: Etag of the document
     etag: Annotated[Optional[str], Field(alias="_etag")] = None
 
     #: Datetime the document was created
-    created: Annotated[Optional[datetime], Field(alias="_created")] = None
+    created: Annotated[UTCDatetime | None, Field(alias="_created")] = None
 
     #: Datetime the document was last updated
-    updated: Annotated[Optional[datetime], Field(alias="_updated")] = None
+    updated: Annotated[UTCDatetime | None, Field(alias="_updated")] = None
 
     def __init_subclass__(cls) -> None:
         """

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -484,11 +484,11 @@ class AsyncResourceService(Generic[ResourceModelType]):
 
         if update_mongo:
             if replace:
-                response = await self.mongo_async.replace_one(query, {"$set": updates_dict})
+                response = await self.mongo_async.replace_one(query, updates_dict)
             else:
                 response = await self.mongo_async.update_one(query, {"$set": updates_dict})
 
-            if original.etag is not None and response and response.acknowledged and response.modified_count == 0:
+            if original.etag is not None and response and response.acknowledged and response.matched_count == 0:
                 raise SuperdeskApiError.preconditionFailedError(_("Client and server etags don't match"))
 
         if update_elastic:

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -403,6 +403,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
         and MongoDB.
 
         :param docs: List of resources or dictionaries to create the registries
+        :param skip_signals: If `True`, will skip `on_create` and `on_created` signals
         :return: List of IDs for the created resources
         :raises Pydantic.ValidationError: If any of the docs provided are not valid
         """
@@ -554,6 +555,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
         :param updates: Dictionary to update
         :param etag: Optional etag, if provided will check etag against original item
         :param original: Optional original item, if not provided the service will retrieve it
+        :param skip_signals: If `True`, will skip `on_update` and `on_updated` signals
         :raises SuperdeskApiError.notFoundError: If original item not found
         """
 

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -487,8 +487,8 @@ class AsyncResourceService(Generic[ResourceModelType]):
             else:
                 response = await self.mongo_async.update_one(query, {"$set": updates_dict})
 
-            # if original.etag is not None and response and response.acknowledged and response.modified_count == 0:
-            #     raise RuntimeError("OriginalChangedError")
+            if original.etag is not None and response and response.acknowledged and response.modified_count == 0:
+                raise SuperdeskApiError.preconditionFailedError(_("Client and server etags don't match"))
 
         if update_elastic:
             try:

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -394,7 +394,9 @@ class AsyncResourceService(Generic[ResourceModelType]):
         # This will make sure values are of correct type for MongoDB (such as ObjectId)
         return model_instance.to_dict(context=self.get_storage_serialise_context())
 
-    async def create(self, docs: Sequence[ResourceModelType | dict]) -> List[ResourceModelType]:
+    async def create(
+        self, docs: Sequence[ResourceModelType | dict], skip_signals: bool = False
+    ) -> List[ResourceModelType]:
         """Creates a new resource
 
         Will automatically create the resource(s) in both Elasticsearch (if configured for this resource)
@@ -406,7 +408,8 @@ class AsyncResourceService(Generic[ResourceModelType]):
         """
 
         instances = await self._convert_dicts_to_model(docs)
-        await self.on_create(instances)
+        if not skip_signals:
+            await self.on_create(instances)
 
         for index, doc in enumerate(instances):
             await self.validate_create(doc)
@@ -415,7 +418,12 @@ class AsyncResourceService(Generic[ResourceModelType]):
                 versioned_model.current_version = 1
 
             doc.id, doc.etag = await self.insert_into_dbs(doc)
-            docs_entry = docs[index]
+            try:
+                docs_entry = docs[index]
+            except IndexError:
+                # This can happen if `on_create` adds more docs to the instances list
+                docs_entry = None
+
             if isinstance(docs_entry, dict):
                 docs_entry.update(
                     dict(
@@ -424,7 +432,8 @@ class AsyncResourceService(Generic[ResourceModelType]):
                     )
                 )
 
-        await self.on_created(instances)
+        if not skip_signals:
+            await self.on_created(instances)
         return instances
 
     async def insert_into_dbs(self, doc: ResourceModelType) -> tuple[str | ObjectId, str]:
@@ -454,6 +463,9 @@ class AsyncResourceService(Generic[ResourceModelType]):
         original: ResourceModelType,
         updates: dict,
         validated_updates: dict,
+        replace: bool = False,
+        update_mongo: bool = True,
+        update_elastic: bool = True,
     ) -> dict:
         updates_dict = {key: val for key, val in validated_updates.items() if key in updates}
         updates["_etag"] = updates_dict["_etag"] = self.generate_etag(validated_updates, self.config.etag_ignore_fields)
@@ -464,13 +476,27 @@ class AsyncResourceService(Generic[ResourceModelType]):
         if model_has_versions(original):
             updates.pop("_latest_version", None)
             updates_dict.pop("_latest_version", None)
-        response = await self.mongo_async.update_one({"_id": item_id}, {"$set": updates_dict})
-        try:
-            await self.elastic.update(item_id, updates_dict)
-        except ElasticNotConfiguredForResource:
-            pass
 
-        if self.config.versioning:
+        query: dict = {"_id": item_id}
+        if original.etag is not None:
+            query["_etag"] = original.etag
+
+        if update_mongo:
+            if replace:
+                response = await self.mongo_async.replace_one(query, {"$set": updates_dict})
+            else:
+                response = await self.mongo_async.update_one(query, {"$set": updates_dict})
+
+            # if original.etag is not None and response and response.acknowledged and response.modified_count == 0:
+            #     raise RuntimeError("OriginalChangedError")
+
+        if update_elastic:
+            try:
+                await self.elastic.update(str(item_id), updates_dict)
+            except ElasticNotConfiguredForResource:
+                pass
+
+        if update_mongo and self.config.versioning:
             await self.mongo_versioned_async.insert_one(self._get_versioned_document(validated_updates))
 
         return updates_dict
@@ -517,6 +543,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
         updates: Dict[str, Any],
         etag: str | None = None,
         original: ResourceModelType | None = None,
+        skip_signals: bool = False,
     ) -> ResourceModelType:
         """Updates an existing resource
 
@@ -537,11 +564,13 @@ class AsyncResourceService(Generic[ResourceModelType]):
         if original is None:
             raise SuperdeskApiError.notFoundError()
 
-        await self.on_update(updates, original)
+        if not skip_signals:
+            await self.on_update(updates, original)
         updates_dict = await self.update_in_dbs(
             item_id, original, updates, await self.validate_update(updates, original, etag)
         )
-        await self.on_updated(updates, original)
+        if not skip_signals:
+            await self.on_updated(updates, original)
 
         return original.clone_with(updates_dict)
 
@@ -578,7 +607,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
             pass
         await self.on_deleted(doc)
 
-    async def delete_many(self, lookup: Dict[str, Any]) -> List[str]:
+    async def delete_many(self, lookup: Dict[str, Any]) -> List[str | ObjectId]:
         """Deletes resource(s) using a lookup
 
         :param lookup: Dictionary for the lookup to find items to delete
@@ -586,7 +615,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
         """
 
         docs_to_delete = self.mongo_async.find(lookup).sort("_id", 1)
-        ids: List[str] = []
+        ids: List[str | ObjectId] = []
 
         async for data in docs_to_delete:
             doc = self.get_model_instance_from_dict(data)
@@ -774,7 +803,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
 
     @overload
     async def find(
-        self, req: SearchRequest
+        self, req: SearchRequest, *, use_mongo: bool = False
     ) -> ElasticsearchResourceCursorAsync[ResourceModelType] | MongoResourceCursorAsync[ResourceModelType]:
         ...
 

--- a/superdesk/core/resources/utils.py
+++ b/superdesk/core/resources/utils.py
@@ -11,6 +11,7 @@
 from typing import Any, Literal, cast
 from inspect import get_annotations
 
+from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 from quart_babel import gettext
 
@@ -195,7 +196,7 @@ def get_model_annotations(model_class: type["ResourceModel"]) -> dict[str, Any]:
     Traverses the class hierarchy up to (but not including) ResourceModel to collect all annotations.
     Parent class annotations are overridden by child class annotations.
     """
-    from .model import ResourceModel
+    from .model import ResourceModel, Dataclass
 
     annotations = {}
 
@@ -203,7 +204,7 @@ def get_model_annotations(model_class: type["ResourceModel"]) -> dict[str, Any]:
     # so child class annotations override parent class annotations
     for base_class in reversed(model_class.__mro__):
         try:
-            if base_class != ResourceModel and issubclass(base_class, ResourceModel):
+            if base_class != ResourceModel and issubclass(base_class, (BaseModel, Dataclass)):
                 annotations.update(get_annotations(base_class))
         except (TypeError, AttributeError):
             # skip classes that don't support annotations or have attribute errors

--- a/superdesk/core/resources/validators.py
+++ b/superdesk/core/resources/validators.py
@@ -223,8 +223,8 @@ def validate_unique_value_async(
         resource_config = app.resources.get_config(resource_name if resource_name else item.model_resource_name)
         collection = app.mongo.get_collection_async(resource_config.name)
 
-        query = {"_id": {"$ne": item.id}, field_name: {"$in": name} if isinstance(name, list) else name}
-        if await collection.find_one(query):
+        query: dict = {"_id": {"$ne": item.id}, field_name: {"$in": name} if isinstance(name, list) else name}
+        if await collection.count_documents(query) > 0:
             raise PydanticCustomError("unique", str(error_string) if error_string else gettext("Value must be unique"))
 
     return AsyncValidator(validate_unique_value_in_resource)
@@ -251,7 +251,7 @@ def validate_iunique_value_async(
         resource_config = app.resources.get_config(resource_name)
         collection = app.mongo.get_collection_async(resource_config.name)
 
-        query = {
+        query: dict = {
             "_id": {"$ne": item.id},
             field_name: (
                 {"$in": [re.compile("^{}$".format(re.escape(value.strip())), re.IGNORECASE) for value in name]}
@@ -260,7 +260,7 @@ def validate_iunique_value_async(
             ),
         }
 
-        if await collection.find_one(query):
+        if await collection.count_documents(query) > 0:
             raise PydanticCustomError("unique", str(error_string) if error_string else gettext("Value must be unique"))
 
     return AsyncValidator(validate_iunique_value_in_resource)
@@ -269,7 +269,7 @@ def validate_iunique_value_async(
 def convert_pydantic_validation_error_for_response(validation_error: ValidationError) -> Dict[str, Any]:
     return {
         "_status": "ERR",
-        "_error": {"code": 403, "message": "Insertion failure: 1 document(s) contain(s) error(s)"},
+        "_error": {"code": 400, "message": "Insertion failure: 1 document(s) contain(s) error(s)"},
         "_issues": get_field_errors_from_pydantic_validation_error(validation_error),
     }
 

--- a/superdesk/core/types/model.py
+++ b/superdesk/core/types/model.py
@@ -138,3 +138,15 @@ class BaseModel(PydanticModel):
         cloned_data = deepcopy(self.to_dict())
         cloned_data = dict(merge_dicts_deep(cloned_data, updates))
         return self.from_dict(cloned_data)
+
+    def update_from_dict(self, updates: dict, deep: bool = False) -> None:
+        if not deep:
+            for key, value in updates.items():
+                setattr(self, key, value)
+        else:
+            # First clone a new model instance with the updates deeply applied
+            temp_model = self.clone_with(updates)
+
+            # Then update the root level fields from the temporary model instance
+            for key in updates.keys():
+                setattr(self, key, getattr(temp_model, key))

--- a/superdesk/core/utils.py
+++ b/superdesk/core/utils.py
@@ -11,7 +11,7 @@
 from typing import TypeVar, cast, AsyncGenerator, Any
 from typing_extensions import Self
 from importlib import import_module
-from datetime import datetime, timezone
+from datetime import datetime, timezone, date, timedelta
 from uuid import uuid4
 import hashlib
 
@@ -66,12 +66,17 @@ def generate_guid(**hints) -> str:
     }
 
 
-def str_to_date(value: str | datetime | None) -> datetime | None:
+def str_to_date(value: str | datetime | date | None) -> datetime | None:
     """Convert a string to a datetime instance"""
 
     if isinstance(value, str):
-        value_dt = arrow.get(value).datetime
-        return value_dt if value_dt.tzinfo == timezone.utc else value_dt.astimezone(timezone.utc)
+        return arrow.get(value).datetime.astimezone(timezone.utc)
+    elif isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value if value.tzinfo == timezone.utc else value.astimezone(timezone.utc)
+    elif isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
 
     return value
 
@@ -79,7 +84,11 @@ def str_to_date(value: str | datetime | None) -> datetime | None:
 def date_to_str(value: datetime | None) -> str | None:
     """Convert a datetime instance to a string"""
 
-    date_format: str = get_app_config("DATE_FORMAT") or "%Y-%m-%dT%H:%M:%S+0000"
+    try:
+        date_format: str = get_app_config("DATE_FORMAT") or "%Y-%m-%dT%H:%M:%S+0000"
+    except RuntimeError:
+        date_format = "%Y-%m-%dT%H:%M:%S+0000"
+
     return datetime.strftime(value, date_format) if value else None
 
 

--- a/superdesk/datalayer.py
+++ b/superdesk/datalayer.py
@@ -20,6 +20,7 @@ from eve_elastic import Elastic, InvalidSearchString  # noqa
 from superdesk.core import get_current_async_app, get_config
 from superdesk.lock import lock, unlock
 from superdesk.json_utils import SuperdeskJSONEncoder
+from superdesk.eve_async.eve_to_pydantic_datalayer import EveToPydanticDataLayer
 
 from .eve_async import MongoAsync, ElasticAsync
 
@@ -143,7 +144,9 @@ class SuperdeskDataLayer(DataLayer):
 
     async def insert_async(self, resource, docs, **kwargs):
         service = superdesk.get_resource_service(resource)
-        if hasattr(service, "create_async"):
+        if isinstance(service.backend, EveToPydanticDataLayer):
+            return await service.create_async(docs, skip_signals=False, **kwargs)
+        elif hasattr(service, "create_async"):
             return await service.create_async(docs, **kwargs)
         return service.create(docs, **kwargs)
 
@@ -152,6 +155,8 @@ class SuperdeskDataLayer(DataLayer):
 
     async def update_async(self, resource, id_, updates, original):
         service = superdesk.get_resource_service(resource)
+        if isinstance(service.backend, EveToPydanticDataLayer):
+            return await service.update_async(id=id_, updates=updates, original=original, skip_signals=False)
         if hasattr(service, "update_async"):
             return await service.update_async(id=id_, updates=updates, original=original)
         return service.update(id=id_, updates=updates, original=original)

--- a/superdesk/eve_async/eve_to_pydantic_datalayer.py
+++ b/superdesk/eve_async/eve_to_pydantic_datalayer.py
@@ -1,0 +1,291 @@
+from typing import NoReturn
+
+from pydantic_core import ValidationError as PydanticValidationError
+from eve.utils import ParsedRequest
+
+from superdesk.core import get_current_async_app
+from superdesk.core.types import SearchRequest, SortParam, ItemId
+from superdesk.core.resources import AsyncResourceService
+from superdesk.core.resources.cursor import DictCursorAsync, MongoResourceCursorAsync
+from superdesk.eve_backend import EveBackend
+from superdesk.validation import ValidationError as SDValidationError
+from superdesk.core.resources.validators import get_field_errors_from_pydantic_validation_error
+from superdesk.errors import SuperdeskApiError
+
+
+class NonAsyncNotSupported(RuntimeError):
+    def __init__(self):
+        super().__init__("Non-async functionality is not supported")
+
+
+class EveToPydanticDataLayer(EveBackend):
+    def __init__(self, resource_name: str | None):
+        self._resource_name = resource_name
+
+    def get_service(self, endpoint_name: str) -> AsyncResourceService:
+        return get_current_async_app().resources.get_resource_service(self._resource_name or endpoint_name)
+
+    async def find_one_async(self, endpoint_name: str, req: ParsedRequest | None, mongo_options: None = None, **lookup):
+        if req is None:
+            async_req = SearchRequest(
+                where=lookup,
+                page=1,
+                max_results=1,
+                use_mongo=True,
+            )
+        else:
+            async_req = SearchRequest(
+                args=req.args,
+                where=req.where or lookup,
+                page=req.page,
+                max_results=req.max_results,
+                projection=req.projection,
+                use_mongo=True,
+            )
+
+        item = await self.get_service(endpoint_name).find_one(async_req)
+        return item.to_dict() if item else None
+
+    async def find_async(self, endpoint_name: str, where: dict, max_results: int = 0, sort: SortParam | None = None):
+        async_req = SearchRequest(
+            where=where,
+            page=1,
+            max_results=max_results,
+            use_mongo=True,
+            sort=sort,
+        )
+        return DictCursorAsync(await self.get_service(endpoint_name).find(async_req, use_mongo=True))
+
+    async def search_async(self, endpoint_name: str, source: dict):
+        return DictCursorAsync(await self.get_service(endpoint_name).search(source))
+
+    async def search_raw_async(self, endpoint_name: str, source: dict):
+        return DictCursorAsync(await self.get_service(endpoint_name).search(source))
+
+    async def get_async(self, endpoint_name: str, req: ParsedRequest, lookup: dict | None, **kwargs):
+        async_req = SearchRequest(
+            args=req.args,
+            where=req.where or lookup,
+            page=req.page,
+            max_results=req.max_results,
+            projection=req.projection,
+        )
+
+        return DictCursorAsync(await self.get_service(endpoint_name).find(async_req))
+
+    async def get_from_mongo_async(
+        self, endpoint_name: str, req: ParsedRequest, lookup: dict | None, perform_count: bool = False
+    ):
+        async_req = SearchRequest(
+            args=req.args,
+            where=req.where or lookup,
+            page=req.page,
+            max_results=req.max_results,
+            projection=req.projection,
+        )
+
+        cursor = await self.get_service(endpoint_name).find(async_req, use_mongo=True)
+        if not isinstance(cursor, MongoResourceCursorAsync):
+            raise SuperdeskApiError.internalError("Expected a MongoDB cursor")
+
+        return cursor.cursor
+
+    async def find_and_modify_async(self, endpoint_name: str, **kwargs) -> dict | None:
+        eve_mongo_backend = self._backend(endpoint_name, use_async=True)
+
+        if kwargs.get("query"):
+            kwargs["query"] = eve_mongo_backend._mongotize(kwargs["query"], endpoint_name)
+
+        return await self.get_service(endpoint_name).mongo_async.find_one_and_update(**kwargs)
+
+    async def create_async(self, endpoint_name: str, docs: list[dict], skip_signals: bool = False, **kwargs):
+        try:
+            new_items = await self.get_service(endpoint_name).create(docs, skip_signals=skip_signals)
+        except PydanticValidationError as error:
+            # re-raise the exception as a Cerberus/Eve type error
+            errors = get_field_errors_from_pydantic_validation_error(error)
+            raise SDValidationError(errors)
+
+        new_items_map = {item.id: item for item in new_items}
+
+        # Make sure to update the provided `docs` variable, as that's what's returned to the client
+        # when using Eve API layer
+        for doc in docs:
+            new_item = new_items_map.get(doc["_id"])
+            if new_item:
+                doc.update(new_item.to_dict())
+
+        # And add any generated items to the `docs` variable (such as recurring events)
+        provided_doc_ids = [str(doc["_id"]) for doc in docs]
+        for item in new_items:
+            if str(item.id) not in provided_doc_ids:
+                docs.append(item.to_dict())
+
+        return [item.id for item in new_items]
+
+    async def create_in_mongo_async(self, endpoint_name: str, docs: list[dict], **kwargs) -> list[ItemId]:
+        service = self.get_service(endpoint_name)
+        for doc in docs:
+            self.set_default_dates(doc)
+            if not doc.get("_etag"):
+                doc["_etag"] = service.generate_etag(doc, service.config.etag_ignore_fields)
+
+        return (await service.mongo_async.insert_many(docs, ordered=True)).inserted_ids
+
+    async def create_in_search_async(self, endpoint_name: str, docs: list[dict], **kwargs) -> list[ItemId]:
+        return await self.get_service(endpoint_name).elastic.insert(docs)
+
+    async def update_async(
+        self, endpoint_name: str, item_id: ItemId, updates: dict, original: dict, skip_signals: bool = False
+    ):
+        try:
+            updated_item = await self.get_service(endpoint_name).update(item_id, updates, skip_signals=skip_signals)
+        except PydanticValidationError as error:
+            # re-raise the exception as a Cerberus/Eve type error
+            errors = get_field_errors_from_pydantic_validation_error(error)
+            raise SDValidationError(errors)
+
+        updated_dict = updated_item.to_dict()
+        for key in updated_dict.keys():
+            # TODO-UNIFIED: Only assign fields to `updates` that have changed
+            updates[key] = updated_dict[key]
+
+        return updates
+
+    async def system_update_async(
+        self,
+        endpoint_name: str,
+        item_id: ItemId,
+        updates: dict,
+        original: dict,
+        change_request: bool = False,
+        push_notification: bool = True,
+    ):
+        return await self.get_service(endpoint_name).system_update(item_id, updates)
+
+    async def replace_async(self, endpoint_name: str, item_id: ItemId, document: dict, original: dict):
+        service = self.get_service(endpoint_name)
+        original_model = await service.find_by_id(item_id)
+        if not original_model:
+            raise SuperdeskApiError.notFoundError()
+
+        await service.update_in_dbs(item_id, original_model, document, document, replace=True)
+
+    async def update_in_mongo_async(self, endpoint_name: str, item_id: ItemId, updates: dict, original: dict):
+        service = self.get_service(endpoint_name)
+        original_model = await service.find_by_id(item_id)
+        if not original_model:
+            raise SuperdeskApiError.notFoundError()
+
+        await service.update_in_dbs(item_id, original_model, updates, updates, replace=False, update_elastic=False)
+
+    async def replace_in_mongo_async(self, endpoint_name: str, item_id: ItemId, document: dict, original: dict):
+        service = self.get_service(endpoint_name)
+        original_model = await service.find_by_id(item_id)
+        if not original_model:
+            raise SuperdeskApiError.notFoundError()
+
+        await service.update_in_dbs(item_id, original_model, document, document, replace=True, update_elastic=False)
+
+    async def replace_in_search_async(self, endpoint_name: str, item_id: ItemId, document: dict, original: dict):
+        service = self.get_service(endpoint_name)
+        original_model = await service.find_by_id(item_id)
+        if not original_model:
+            raise SuperdeskApiError.notFoundError()
+
+        await service.update_in_dbs(item_id, original_model, document, document, replace=True, update_mongo=False)
+
+    async def delete_async(self, endpoint_name: str, lookup: dict) -> list[ItemId]:
+        return await self.get_service(endpoint_name).delete_many(lookup)
+
+    async def delete_docs_async(self, endpoint_name: str, docs: list[dict]):
+        return await self.get_service(endpoint_name).delete_many({"_id": {"$in": [doc["_id"] for doc in docs]}})
+
+    async def delete_ids_from_mongo_async(self, endpoint_name: str, ids: list[ItemId]):
+        await self.delete_from_mongo_async(endpoint_name, {"_id": {"$in": ids}})
+
+    async def delete_from_mongo_async(self, endpoint_name: str, lookup: dict):
+        await self.get_service(endpoint_name).delete_many(lookup)
+
+    async def remove_from_search_async(self, endpoint_name: str, doc: dict):
+        await self.get_service(endpoint_name).elastic.remove(doc["_id"])
+
+    async def count_async(self, endpoint_name: str, lookup: dict | None = None) -> int:
+        return await self.get_service(endpoint_name).count(lookup, use_mongo=True)
+
+    # The following sync methods are not supported
+    def find_one(self, endpoint_name: str, req: ParsedRequest, **lookup) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def find(self, endpoint_name: str, where: dict, max_results: int = 0, sort: SortParam | None = None) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def search(self, endpoint_name: str, source: dict) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def search_raw(self, endpoint_name: str, source: dict) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def get(self, endpoint_name: str, req: ParsedRequest, lookup: dict | None, **kwargs) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def get_from_mongo(
+        self, endpoint_name: str, req: ParsedRequest, lookup: dict | None, perform_count: bool = False
+    ) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def find_and_modify(self, endpoint_name: str, **kwargs) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def create(self, endpoint_name: str, docs: list[dict], **kwargs) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def create_in_mongo(self, endpoint_name: str, docs: list[dict], **kwargs) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def create_in_search(self, endpoint_name: str, docs: list[dict], **kwargs) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def update(self, endpoint_name: str, item_id: ItemId, updates: dict, original: dict) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def system_update(
+        self,
+        endpoint_name: str,
+        item_id: ItemId,
+        updates: dict,
+        original: dict,
+        change_request: bool = False,
+        push_notification: bool = True,
+    ) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def replace(self, endpoint_name: str, item_id: ItemId, document: dict, original: dict) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def update_in_mongo(self, endpoint_name: str, item_id: ItemId, updates: dict, original: dict) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def replace_in_mongo(self, endpoint_name: str, item_id: ItemId, document: dict, original: dict) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def replace_in_search(self, endpoint_name: str, item_id: ItemId, document: dict, original: dict) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def delete(self, endpoint_name: str, lookup: dict) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def delete_docs(self, endpoint_name: str, docs: list[dict]) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def delete_ids_from_mongo(self, endpoint_name: str, ids: list[ItemId]) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def delete_from_mongo(self, endpoint_name: str, lookup: dict) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def remove_from_search(self, endpoint_name: str, doc: dict) -> NoReturn:
+        raise NonAsyncNotSupported()
+
+    def count(self, resource: str, lookup: dict | None = None) -> NoReturn:
+        raise NonAsyncNotSupported()

--- a/superdesk/eve_async/eve_to_pydantic_datalayer.py
+++ b/superdesk/eve_async/eve_to_pydantic_datalayer.py
@@ -93,8 +93,10 @@ class EveToPydanticDataLayer(EveBackend):
     async def find_and_modify_async(self, endpoint_name: str, **kwargs) -> dict | None:
         eve_mongo_backend = self._backend(endpoint_name, use_async=True)
 
-        if kwargs.get("query"):
-            kwargs["query"] = eve_mongo_backend._mongotize(kwargs["query"], endpoint_name)
+        query = kwargs.get("query") or kwargs.get("filter")
+        if query:
+            kwargs["filter"] = eve_mongo_backend._mongotize(query, endpoint_name)
+            kwargs.pop("query", None)
 
         return await self.get_service(endpoint_name).mongo_async.find_one_and_update(**kwargs)
 

--- a/superdesk/json_utils.py
+++ b/superdesk/json_utils.py
@@ -25,9 +25,14 @@ class SuperdeskJSONEncoder(MongoJSONEncoder, ElasticJSONSerializer):
         elif isinstance(obj, (Dataclass, BaseModel)):
             return obj.to_dict(mode="json")
         elif isinstance(obj, list):
-            return [self.default(item) for item in obj]
+            return [
+                item if isinstance(item, (str, int, float, bool, type(None))) else self.default(item) for item in obj
+            ]
         elif isinstance(obj, dict):
-            return {key: self.default(value) for key, value in obj.items()}
+            return {
+                key: (value if isinstance(value, (str, int, float, bool, type(None))) else self.default(value))
+                for key, value in obj.items()
+            }
         return super().default(obj)
 
 

--- a/superdesk/json_utils.py
+++ b/superdesk/json_utils.py
@@ -15,10 +15,19 @@ class SuperdeskJSONEncoder(MongoJSONEncoder, ElasticJSONSerializer):
     """Custom JSON encoder for elastic that can handle `bson.ObjectId`s."""
 
     def default(self, obj):
+        # Need to import here, cyclic import error
+        from superdesk.core.resources import Dataclass, BaseModel
+
         if isinstance(obj, LazyString):
             return str(obj)
         elif isinstance(obj, datetime.datetime):
             return obj.strftime(DATE_FORMAT)
+        elif isinstance(obj, (Dataclass, BaseModel)):
+            return obj.to_dict(mode="json")
+        elif isinstance(obj, list):
+            return [self.default(item) for item in obj]
+        elif isinstance(obj, dict):
+            return {key: self.default(value) for key, value in obj.items()}
         return super().default(obj)
 
 

--- a/superdesk/publish_async/formatters/base_exchange_formatter.py
+++ b/superdesk/publish_async/formatters/base_exchange_formatter.py
@@ -356,7 +356,7 @@ class BasePublishExchangeFormatter(PublishExchangeFormatter):
         if lifecycle_started_ms is None and lifecycle_started_at:
             lifecycle_started_ms = to_epoch_ms(lifecycle_started_at)
 
-        publish_queue_item = PublishQueueResource(
+        publish_queue_item = PublishQueueResource(  # type: ignore[call-arg]
             id=ObjectId(),
             state=queue_state,
             is_content_api=destination.delivery_type == "content_api",

--- a/superdesk/publish_async/resources/content_filters/service.py
+++ b/superdesk/publish_async/resources/content_filters/service.py
@@ -22,6 +22,7 @@ class ContentFiltersService(AsyncResourceService[ContentFiltersResource]):
         updates: dict[str, Any],
         etag: str | None = None,
         original: ContentFiltersResource | None = None,
+        skip_signals: bool = False,
     ) -> ContentFiltersResource:
         if isinstance(item_id, str):
             item_id = ObjectId(item_id)
@@ -33,7 +34,7 @@ class ContentFiltersService(AsyncResourceService[ContentFiltersResource]):
 
         updated = original.clone_with(updates)
         await self._validate_no_circular_reference(updated, item_id)
-        return await super().update(item_id, updates, etag, original)
+        return await super().update(item_id, updates, etag, original, skip_signals)
 
     async def on_delete(self, doc: ContentFiltersResource) -> None:
         # check if the filter is referenced by any subscribers...

--- a/superdesk/publish_async/utils/common.py
+++ b/superdesk/publish_async/utils/common.py
@@ -229,7 +229,7 @@ async def content_filter_to_elastic_query(doc: ContentFiltersResource, matching:
     return {"bool": expressions}
 
 
-ContentApiSubscriber = SubscribersResource(
+ContentApiSubscriber = SubscribersResource(  # type: ignore[call-arg]
     id=ObjectId("67be81e46f53273f423a2801"),  # Use our own ID here, so it can be used across processes, restarts etc
     name="_Content_API_",
     subscriber_type=SubscriberType.ALL,

--- a/superdesk/tests/fixtures/content_filters.py
+++ b/superdesk/tests/fixtures/content_filters.py
@@ -10,7 +10,7 @@ CONTENT_FILTER_MEDIA_ID = ObjectId()
 
 
 def content_filter_text() -> ContentFiltersResource:
-    return ContentFiltersResource(
+    return ContentFiltersResource(  # type: ignore[call-arg]
         id=CONTENT_FILTER_TEXT_ID,
         name="Text Content Filter",
         content_filter=[ContentFilter(expression=ContentFilterExpression(fc=[FILTER_CONDITION_TEXT_ID]))],
@@ -18,7 +18,7 @@ def content_filter_text() -> ContentFiltersResource:
 
 
 def content_filter_pictures() -> ContentFiltersResource:
-    return ContentFiltersResource(
+    return ContentFiltersResource(  # type: ignore[call-arg]
         id=CONTENT_FILTER_PICTURES_ID,
         name="Picture Content Filter",
         content_filter=[ContentFilter(expression=ContentFilterExpression(fc=[FILTER_CONDITION_PICTURE_ID]))],
@@ -26,7 +26,7 @@ def content_filter_pictures() -> ContentFiltersResource:
 
 
 def content_filter_videos() -> ContentFiltersResource:
-    return ContentFiltersResource(
+    return ContentFiltersResource(  # type: ignore[call-arg]
         id=CONTENT_FILTER_VIDEOS_ID,
         name="Video Content Filter",
         content_filter=[ContentFilter(expression=ContentFilterExpression(fc=[FILTER_CONDITION_VIDEO_ID]))],
@@ -34,7 +34,7 @@ def content_filter_videos() -> ContentFiltersResource:
 
 
 def content_filter_media() -> ContentFiltersResource:
-    return ContentFiltersResource(
+    return ContentFiltersResource(  # type: ignore[call-arg]
         id=CONTENT_FILTER_MEDIA_ID,
         name="Picture & Video Content Filter",
         content_filter=[

--- a/superdesk/tests/fixtures/desks.py
+++ b/superdesk/tests/fixtures/desks.py
@@ -7,7 +7,7 @@ SPORTS_DESK_ID = ObjectId()
 
 
 def sports_desk() -> DesksResourceModel:
-    return DesksResourceModel(
+    return DesksResourceModel(  # type: ignore[call-arg]
         id=SPORTS_DESK_ID,
         name="Sports",
     )

--- a/superdesk/tests/fixtures/filter_conditions.py
+++ b/superdesk/tests/fixtures/filter_conditions.py
@@ -7,7 +7,7 @@ FILTER_CONDITION_VIDEO_ID = ObjectId()
 
 
 def filter_condition_text() -> FilterConditionsResource:
-    return FilterConditionsResource(
+    return FilterConditionsResource(  # type: ignore[call-arg]
         id=FILTER_CONDITION_TEXT_ID,
         name="All Text",
         field="type",
@@ -17,7 +17,7 @@ def filter_condition_text() -> FilterConditionsResource:
 
 
 def filter_condition_picture() -> FilterConditionsResource:
-    return FilterConditionsResource(
+    return FilterConditionsResource(  # type: ignore[call-arg]
         id=FILTER_CONDITION_PICTURE_ID,
         name="All Pictures",
         field="type",
@@ -27,7 +27,7 @@ def filter_condition_picture() -> FilterConditionsResource:
 
 
 def filter_condition_video() -> FilterConditionsResource:
-    return FilterConditionsResource(
+    return FilterConditionsResource(  # type: ignore[call-arg]
         id=FILTER_CONDITION_VIDEO_ID,
         name="All Videos",
         field="type",

--- a/superdesk/tests/fixtures/products.py
+++ b/superdesk/tests/fixtures/products.py
@@ -18,7 +18,7 @@ MEDIA_PRODUCT_ID = ObjectId()
 
 
 def text_product() -> ProductsResource:
-    return ProductsResource(
+    return ProductsResource(  # type: ignore[call-arg]
         id=TEXT_PRODUCT_ID,
         name="Text Product",
         product_type=ProductTypes.BOTH,
@@ -30,7 +30,7 @@ def text_product() -> ProductsResource:
 
 
 def nsw_product() -> ProductsResource:
-    return ProductsResource(
+    return ProductsResource(  # type: ignore[call-arg]
         id=NSW_PRODUCT_ID,
         name="NSW",
         geo_restrictions="NSW",
@@ -38,7 +38,7 @@ def nsw_product() -> ProductsResource:
 
 
 def abcdef_product() -> ProductsResource:
-    return ProductsResource(
+    return ProductsResource(  # type: ignore[call-arg]
         id=ABCDEF_PRODUCT_ID,
         name="abcdef",
         codes="abc,def",
@@ -46,7 +46,7 @@ def abcdef_product() -> ProductsResource:
 
 
 def xyz_product() -> ProductsResource:
-    return ProductsResource(
+    return ProductsResource(  # type: ignore[call-arg]
         id=XYZ_PRODUCT_ID,
         name="xyz",
         codes="xyz",
@@ -54,7 +54,7 @@ def xyz_product() -> ProductsResource:
 
 
 def picture_product() -> ProductsResource:
-    return ProductsResource(
+    return ProductsResource(  # type: ignore[call-arg]
         id=PICTURE_PRODUCT_ID,
         name="Picture Product",
         product_type=ProductTypes.BOTH,
@@ -66,7 +66,7 @@ def picture_product() -> ProductsResource:
 
 
 def video_product() -> ProductsResource:
-    return ProductsResource(
+    return ProductsResource(  # type: ignore[call-arg]
         id=VIDEO_PRODUCT_ID,
         name="Video Product",
         product_type=ProductTypes.BOTH,
@@ -78,7 +78,7 @@ def video_product() -> ProductsResource:
 
 
 def media_product() -> ProductsResource:
-    return ProductsResource(
+    return ProductsResource(  # type: ignore[call-arg]
         id=MEDIA_PRODUCT_ID,
         name="Picture & Video Product",
         product_type=ProductTypes.BOTH,

--- a/superdesk/tests/fixtures/subscribers.py
+++ b/superdesk/tests/fixtures/subscribers.py
@@ -13,7 +13,7 @@ TEXT_SUBSCRIBER_ID = ObjectId()
 
 
 def text_subscriber() -> SubscribersResource:
-    return SubscribersResource(
+    return SubscribersResource(  # type: ignore[call-arg]
         id=TEXT_SUBSCRIBER_ID,
         name="text",
         email="text@subscriber.com",
@@ -33,7 +33,7 @@ def text_subscriber() -> SubscribersResource:
 
 
 def sub1_subscriber() -> SubscribersResource:
-    return SubscribersResource(
+    return SubscribersResource(  # type: ignore[call-arg]
         id=SUB1_ID,
         name="sub1",
         email="test@test.com",
@@ -54,7 +54,7 @@ def sub1_subscriber() -> SubscribersResource:
 
 
 def sub2_subscriber() -> SubscribersResource:
-    return SubscribersResource(
+    return SubscribersResource(  # type: ignore[call-arg]
         id=SUB2_ID,
         name="sub2",
         email="test@test.com",
@@ -81,7 +81,7 @@ def sub2_subscriber() -> SubscribersResource:
 
 
 def sub3_subscriber() -> SubscribersResource:
-    return SubscribersResource(
+    return SubscribersResource(  # type: ignore[call-arg]
         id=SUB3_ID,
         name="sub3",
         email="test@test.com",
@@ -102,7 +102,7 @@ def sub3_subscriber() -> SubscribersResource:
 
 
 def sub4_subscriber() -> SubscribersResource:
-    return SubscribersResource(
+    return SubscribersResource(  # type: ignore[call-arg]
         id=SUB4_ID,
         name="sub4",
         email="test@test.com",
@@ -123,7 +123,7 @@ def sub4_subscriber() -> SubscribersResource:
 
 
 def sub5_subscriber() -> SubscribersResource:
-    return SubscribersResource(
+    return SubscribersResource(  # type: ignore[call-arg]
         id=SUB5_ID,
         name="sub5",
         email="test@test.com",

--- a/superdesk/tests/fixtures/users.py
+++ b/superdesk/tests/fixtures/users.py
@@ -7,7 +7,7 @@ FOOBAR_USER_ID = ObjectId()
 
 
 def admin() -> UsersResourceModel:
-    return UsersResourceModel(
+    return UsersResourceModel(  # type: ignore[call-arg]
         id=ADMIN_USER_ID,
         username="admin",
         password="admin",
@@ -24,7 +24,7 @@ def admin() -> UsersResourceModel:
 
 
 def foobar() -> UsersResourceModel:
-    return UsersResourceModel(
+    return UsersResourceModel(  # type: ignore[call-arg]
         id=FOOBAR_USER_ID,
         username="foobar",
         password="admin",

--- a/superdesk/utils.py
+++ b/superdesk/utils.py
@@ -192,13 +192,35 @@ def merge_dicts_deep(dict1, dict2):
     unique_keys = set(dict1.keys()).union(dict2.keys())
 
     for k in unique_keys:
-        # need to merge
         if k in dict1 and k in dict2:
-            if isinstance(dict1[k], dict) and isinstance(dict2[k], dict):
-                yield (k, dict(merge_dicts_deep(dict1[k], dict2[k])))
+            val1, val2 = dict1[k], dict2[k]
+
+            if isinstance(val1, dict) and isinstance(val2, dict):
+                yield (k, dict(merge_dicts_deep(val1, val2)))
+
+            elif isinstance(val1, list) and isinstance(val2, list):
+                if not len(val1) or not len(val2):
+                    yield (k, val2)
+                else:
+                    merged_list = []
+                    for i in range(max(len(val1), len(val2))):
+                        if i >= len(val1):
+                            merged_list.append(val2[i])
+                        elif i >= len(val2):
+                            merged_list.append(val1[i])
+                        elif isinstance(val1[i], dict) and isinstance(val2[i], dict):
+                            merged_list.append(dict(merge_dicts_deep(val1[i], val2[i])))
+                        else:
+                            merged_list.append(val2[i])
+                    yield (k, merged_list)
+
+            elif isinstance(val1, set) and isinstance(val2, set):
+                yield (k, val1 | val2)
+
             else:
-                # if one of the values is not a dict - value from second dict overrides value from first one.
-                yield (k, dict2[k])
+                # Scalar or mismatched types — dict2 wins
+                yield (k, val2)
+
         elif k in dict1:
             yield (k, dict1[k])
         else:

--- a/superdesk/vocabularies_async/service.py
+++ b/superdesk/vocabularies_async/service.py
@@ -261,7 +261,7 @@ class VocabulariesService(AsyncResourceService[VocabulariesResourceModel]):
                 )
                 for keyword in keywords
             ]
-            cv = VocabulariesResourceModel(
+            cv = VocabulariesResourceModel(  # type: ignore[call-arg]
                 id=KEYWORDS_CV,
                 items=items,
                 management_type=CVAccessType.MANAGEABLE,

--- a/tests/core/resource_endpoints_test.py
+++ b/tests/core/resource_endpoints_test.py
@@ -402,13 +402,14 @@ class ResourceEndpointsTestCase(AsyncFlaskTestCase):
 
     @mock.patch("superdesk.core.resources.service.utcnow", return_value=NOW)
     async def test_endpoint(self, mock_utcnow):
+        self.maxDiff = None
         # Populate the users resource
         test_user = john_doe()
         test_user_dict = self.test_client.model_instance_to_json(test_user)
         test_user_dict.update(
             dict(
-                _created=format_time(NOW) + "Z",
-                _updated=format_time(NOW) + "Z",
+                _created=format_time(NOW) + "+0000",
+                _updated=format_time(NOW) + "+0000",
             )
         )
 

--- a/tests/legal_archive/legal_archive_test.py
+++ b/tests/legal_archive/legal_archive_test.py
@@ -80,6 +80,8 @@ class ImportLegalArchiveCommandTestCase(TestCase):
             ]
 
             await test_utils.post_items("validators", self.validators)
+            await test_utils.post_items("filter_conditions", [fixtures.filter_conditions.filter_condition_text()])
+            await test_utils.post_items("content_filters", [fixtures.content_filters.content_filter_text()])
             await test_utils.post_items("products", [fixtures.products.text_product()])
             await test_utils.post_items("subscribers", [fixtures.subscribers.text_subscriber()])
 

--- a/tests/publish/formatters/ninjs_newsroom_formatter_test.py
+++ b/tests/publish/formatters/ninjs_newsroom_formatter_test.py
@@ -37,7 +37,7 @@ class NewsroomNinjsFormatterTest(TestCase):
 
         cf_ids = await test_utils.post_items(
             "content_filters",
-            [{"content_filter": [{"expression": {"pf": [fc_ids[0]], "fc": [fc_ids[1]]}}], "name": "soccer-only3"}],
+            [{"content_filter": [{"expression": {"fc": [fc_ids[0], fc_ids[1]]}}], "name": "soccer-only3"}],
         )
 
         product_ids = await test_utils.post_items(

--- a/tests/publish_async/fixtures.py
+++ b/tests/publish_async/fixtures.py
@@ -19,14 +19,14 @@ PRODUCT_IDS = [ObjectId(), ObjectId()]
 SUBSCRIBER_IDS = [ObjectId(), ObjectId(), ObjectId()]
 
 FILTER_CONDITIONS = [
-    FilterConditionsResource(
+    FilterConditionsResource(  # type: ignore[call-arg]
         id=FILTER_CONDITION_IDS[0],
         field="headline",
         operator=FilterConditionOperator.LIKE,
         value="weather",
         name="filter-weather",
     ),
-    FilterConditionsResource(
+    FilterConditionsResource(  # type: ignore[call-arg]
         id=FILTER_CONDITION_IDS[1],
         field="anpa_category",
         operator=FilterConditionOperator.IN,
@@ -36,12 +36,12 @@ FILTER_CONDITIONS = [
 ]
 
 CONTENT_FILTERS = [
-    ContentFiltersResource(
+    ContentFiltersResource(  # type: ignore[call-arg]
         id=CONTENT_FILTER_IDS[0],
         content_filter=[ContentFilter(expression=ContentFilterExpression(fc=[FILTER_CONDITION_IDS[0]]))],
         name="content-filter-weather",
     ),
-    ContentFiltersResource(
+    ContentFiltersResource(  # type: ignore[call-arg]
         id=CONTENT_FILTER_IDS[1],
         content_filter=[ContentFilter(expression=ContentFilterExpression(fc=[FILTER_CONDITION_IDS[1]]))],
         name="content-filter-sports",
@@ -49,13 +49,13 @@ CONTENT_FILTERS = [
 ]
 
 PRODUCTS = [
-    ProductsResource(
+    ProductsResource(  # type: ignore[call-arg]
         id=PRODUCT_IDS[0],
         content_filter=ProductContentFilter(filter_id=CONTENT_FILTER_IDS[0], filter_type=ProductFilterType.PERMITTING),
         name="product-weather",
         codes="prod-weather1,prod-weather2",
     ),
-    ProductsResource(
+    ProductsResource(  # type: ignore[call-arg]
         id=PRODUCT_IDS[1],
         content_filter=ProductContentFilter(filter_id=CONTENT_FILTER_IDS[1], filter_type=ProductFilterType.PERMITTING),
         name="product-sports",
@@ -64,7 +64,7 @@ PRODUCTS = [
 ]
 
 SUBSCRIBERS = [
-    SubscribersResource(
+    SubscribersResource(  # type: ignore[call-arg]
         id=SUBSCRIBER_IDS[0],
         products=[PRODUCT_IDS[0]],
         name="subscriber-weather",
@@ -80,7 +80,7 @@ SUBSCRIBERS = [
         ],
         codes="sub-weather1,sub-weather2",
     ),
-    SubscribersResource(
+    SubscribersResource(  # type: ignore[call-arg]
         id=SUBSCRIBER_IDS[1],
         products=[PRODUCT_IDS[1]],
         name="subscriber-sports",
@@ -96,7 +96,7 @@ SUBSCRIBERS = [
         ],
         codes="sub-sports1,sub-sports2",
     ),
-    SubscribersResource(
+    SubscribersResource(  # type: ignore[call-arg]
         id=SUBSCRIBER_IDS[2],
         products=[PRODUCT_IDS[0], PRODUCT_IDS[1]],
         name="subscriber-all",


### PR DESCRIPTION
### Purpose
Implement an Eve to newer Pydantic based resource services layer, allowing `get_resource_service` and `app.data` functionality to use the Pydantic service instead of Eve.

### What has changed
Pydantic Service:
* On create or update, allow to skip the signals (on_create/d, on_update/d)
* Add `_etag` checking when updating a resource - by adding the `_etag` to the update/replace filter
* Support `replace` as well as `update` of a document
* New Eve datalayer: proxies the requests to/from the Pydantic based resource service

Models:
* New `DictCursorAsync` - provides async iterator, yielding dicts instead of model instances
* New `Date` field - value is a string, but stored as a date in elastic (used for Event `accreditation_deadline`)
* New `UTCDatetime` field - always stores the value in UTC (does the conversion when serialising)
* Improves `id` annotation - using `Field(alias="_id")` doesn't work well with Pydantic when redefining that field in an inherited model. Explicitly tell Pydantic the validation and serialisation alias name
* Use `UTCDatetime` for `created` and `updated` base fields
* By default, strip whitespace from string based fields
* Fix async validation not running for nested models/dataclasses (i.e. `validate_data_relation_async` on a nested dataclass was not running)
* Use `collection.count_documents` instead of `collection.find_one` in validate unique values
* New `update_from_dict` method on a model - updates the model in place
* Improve json utils: ability to serialise BaseModel or Dataclass
* Improve json utils: improve `merge_dicts_deep`

Resolves: SDBELGA-1113

