### PR TITLE
[SDESK-7983] - Some feeding services are ingested but seem to be buggy

### DIFF
--- a/superdesk/celery_app/context_task.py
+++ b/superdesk/celery_app/context_task.py
@@ -122,13 +122,8 @@ class HybridAppContextTask(Task):
         # async with self.get_current_app().app_context():
         self.handle_exception(exc)
 
-    def _is_always_eager(self):
-        current_request = getattr(self, "request", None)
-        if current_request is None or not getattr(current_request, "id", None):
-            # If this task has not been bound to a request, then we're to process it directly
-            # This can happen when the task is called directly, instead of using `.delay` or `.apply_async`
-            return True
-
+    def _is_configured_always_eager(self):
+        """Return the configured eager flag, independent of request binding."""
         # Prefer Celery's canonical flag because task execution can happen outside
         # the expected app-context resolution path on some runtimes.
         task_app = getattr(self, "app", None)
@@ -141,6 +136,15 @@ class HybridAppContextTask(Task):
 
         app = self.get_current_app()
         return bool(app.config.get("CELERY_TASK_ALWAYS_EAGER", False))
+
+    def _is_always_eager(self):
+        current_request = getattr(self, "request", None)
+        if current_request is None or not getattr(current_request, "id", None):
+            # If this task has not been bound to a request, then we're to process it directly
+            # This can happen when the task is called directly, instead of using `.delay` or `.apply_async`
+            return True
+
+        return self._is_configured_always_eager()
 
     def AsyncResult(self, task_id, **kwargs):
         return AsyncTaskResult(task_id, backend=self.backend, app=self.app, **kwargs)
@@ -158,8 +162,8 @@ class HybridAppContextWorkerTask(HybridAppContextTask):
         """
         Schedules the task asynchronously. Awaits the result if `CELERY_TASK_ALWAYS_EAGER` is True.
         """
-        # directly run and await the task if eager
-        if self._is_always_eager():
+        # dispatch is eager based on configuration only, not on request binding
+        if self._is_configured_always_eager():
             async_result = super().apply_async(args=args, kwargs=kwargs, **other_kwargs)
             eager_result = async_result.get()
             return await eager_result if isawaitable(eager_result) else eager_result

--- a/superdesk/tests/worker_test.py
+++ b/superdesk/tests/worker_test.py
@@ -37,6 +37,11 @@ def sync_task_test(data: dict) -> None:
     service.create([data])
 
 
+@shared_task(store_async_result=True)
+async def value_task_test(n: int) -> int:
+    return n * 2
+
+
 @shared_task(soft_time_limit=0.5, time_limit=2)
 async def async_task_timeout_test(task_duration: int, cleanup_duration: int) -> None:
     service = get_resource_service("system_messages")

--- a/tests/celery_app/async_worker_test.py
+++ b/tests/celery_app/async_worker_test.py
@@ -6,6 +6,7 @@ import threading
 
 from superdesk import get_resource_service
 from superdesk.celery_app.async_worker import CeleryAsyncWorkerThread
+from superdesk.celery_app.task_result import AsyncTaskResult
 
 from superdesk.tests import TestCase, AsyncFlaskTestCase
 from superdesk.tests import worker_test
@@ -90,6 +91,12 @@ class CeleryAsyncWorkerTaskTestCase(TestCase):
                 "message": "Testing async celery worker and task",
             },
         )
+
+    async def test_delay_returns_async_result_handle(self):
+        # dispatched with no bound request and eager off: must return an async
+        # result handle for the broker, not run eager and drop it
+        result = await worker_test.value_task_test.delay(21)
+        self.assertIsInstance(result, AsyncTaskResult)
 
     async def test_task_no_timeout(self):
         service = get_resource_service("system_messages")

--- a/tests/celery_app/context_task_test.py
+++ b/tests/celery_app/context_task_test.py
@@ -49,3 +49,22 @@ class TestHybridAppContextTask(AsyncFlaskTestCase):
             expected_exc = SuperdeskError("Async exception")
             expected_msg = f"Error handling task: {str(expected_exc)}"
             mock_logger.exception.assert_called_once_with(expected_msg)
+
+    async def test_configured_always_eager_follows_config(self):
+        @self.app.celery.task()
+        def some_task():
+            return "ok"
+
+        self.assertTrue(some_task._is_configured_always_eager())
+
+
+class TestEagerDispatchDecision(AsyncFlaskTestCase):
+    app_config = {"CELERY_TASK_ALWAYS_EAGER": False}
+
+    async def test_unbound_dispatch_is_config_driven(self):
+        @self.app.celery.task()
+        def some_task():
+            return "ok"
+
+        self.assertFalse(some_task._is_configured_always_eager())
+        self.assertTrue(some_task._is_always_eager())

--- a/tests/celery_app/context_task_test.py
+++ b/tests/celery_app/context_task_test.py
@@ -55,13 +55,16 @@ class TestHybridAppContextTask(AsyncFlaskTestCase):
         def some_task():
             return "ok"
 
-        self.assertTrue(some_task._is_configured_always_eager())
+        self.assertEqual(
+            some_task._is_configured_always_eager(),
+            self.app.config.get("CELERY_TASK_ALWAYS_EAGER", False),
+        )
 
 
 class TestEagerDispatchDecision(AsyncFlaskTestCase):
     app_config = {"CELERY_TASK_ALWAYS_EAGER": False}
 
-    async def test_unbound_dispatch_is_config_driven(self):
+    async def test_unbound_task_eager_decision(self):
         @self.app.celery.task()
         def some_task():
             return "ok"


### PR DESCRIPTION
### Purpose
Ingested and uploaded pictures were saved with `renditions: null`, so images did not display. The async rendition task was dispatched from a request/ingest context where `_is_always_eager()` returns `True` (no bound `request.id`), forcing the eager branch that never retrieves the result — so renditions were dropped. 

### What has changed
- `superdesk/celery_app/context_task.py`: the dispatch decision in `apply_async` is now   config-driven via a new `_is_configured_always_eager()`. `_is_always_eager()` is unchanged and still governs the direct-call path, so calling a task directly stays  eager ( #3254  behaviour preserved). Tasks dispatched via `.delay()` now go to the  broker and their result is retrieved as intended.
- Added tests

### Steps to test
1. Set up an RSS ingest provider (e.g. BBC world feed) and run ingest.
   - Ingested picture items should now have populated `renditions`
     (`original`, `baseImage`, `thumbnail`, `viewImage`), not `null`, and thumbnails
     should render in the Ingest view.
2. In the editor, upload an image via the media icon, and separately drag an image from
   the Ingest list into `body_html`.
   - The image should render in the body; the created archive item's
     `associations.editor_0.renditions` should be fully populated.
3. Run the tests

Resolves: https://sofab.atlassian.net/browse/SDESK-7983
