### PR TITLE
fix handling of cancalled asyncio routing tasks

### DIFF
--- a/superdesk/default_settings.py
+++ b/superdesk/default_settings.py
@@ -580,6 +580,20 @@ PUBLISH_CHANNELS: list[PublishChannelConfig] = [
         ),
     },
     {
+        # If the request is coming from the Web API and has associations
+        # then we handle this publish request via a celery task (aka `polling`)
+        # otherwise a Web API request might timeout and be cancelled
+        "item_types": ["text", "preformatted"],
+        "sender_types": ["api"],
+        "filter": lambda item: len(item.get("associations") or {}) > 0,
+        "config": ExchangeConfig(
+            exchange="content",
+            filter="content",
+            router="celery",
+            polling=True,
+        ),
+    },
+    {
         # If the request is coming from the Web API and has no associations
         # then we can handle this publish request via asyncio (aka instant publishing)
         "item_types": ["text", "preformatted"],

--- a/superdesk/publish_async/exchanges/content_exchange.py
+++ b/superdesk/publish_async/exchanges/content_exchange.py
@@ -76,6 +76,19 @@ class ContentPublishExchange(BasicPublishExchange):
 
     name = "content"
 
+    def _get_current_task_context(self) -> dict:
+        task = asyncio.current_task()
+        if task is None:
+            return {"task_name": None, "task_cancelled": None, "task_cancelling": None}
+
+        task_name = task.get_name() if hasattr(task, "get_name") else None
+        cancelling_count = task.cancelling() if hasattr(task, "cancelling") else None
+        return {
+            "task_name": task_name,
+            "task_cancelled": task.cancelled(),
+            "task_cancelling": cancelling_count,
+        }
+
     @staticmethod
     def _track_cancellation_cleanup_task(cleanup_task: asyncio.Task[None]) -> asyncio.Task[None]:
         _pending_cancellation_cleanup_tasks.add(cleanup_task)
@@ -197,6 +210,9 @@ class ContentPublishExchange(BasicPublishExchange):
                 error,
                 logger.warning,
                 "Publish request cancelled during routing",
+                cancellation_type=type(error).__name__,
+                cancellation_message=str(error),
+                **self._get_current_task_context(),
             )
             raise
         except Exception as error:
@@ -227,6 +243,8 @@ class ContentPublishExchange(BasicPublishExchange):
                 logger.error,
                 "Publish request interrupted by base exception",
                 exception_type=type(error).__name__,
+                exception_message=str(error),
+                **self._get_current_task_context(),
             )
             raise
 
@@ -280,14 +298,32 @@ class ContentPublishExchange(BasicPublishExchange):
             )
             error_updates = {QUEUE_STATE: PublishState.PENDING, ERROR_MESSAGE: str(error)}
 
+        error_type = type(error).__name__
+        error_args = [str(arg) for arg in getattr(error, "args", ())]
+
+        detailed_log_message = (
+            "%s (request_id=%s, item_id=%s, operation=%s, item_version=%s, "
+            "resolved_queue_state=%s, cancellation_error_type=%s, cancellation_error_args=%s)"
+        )
         log_method(
+            detailed_log_message,
             log_message,
+            request.request_id,
+            request.item_id,
+            request.operation,
+            request.item.get(VERSION),
+            error_updates[QUEUE_STATE],
+            error_type,
+            error_args,
             exc_info=True,
             extra=dict(
+                publish_request_id=request.request_id,
                 item_id=request.item_id,
                 operation=request.operation,
                 item_version=request.item.get(VERSION),
                 resolved_queue_state=error_updates[QUEUE_STATE],
+                cancellation_error_type=error_type,
+                cancellation_error_args=error_args,
                 **extra,
             ),
         )
@@ -301,21 +337,54 @@ class ContentPublishExchange(BasicPublishExchange):
             )
 
     async def _get_cancellation_error_updates(self, request: PublishRequest, error_message: str) -> dict:
-        queue_state = PublishState.PENDING
         if await self._has_publish_queue_items(request):
-            queue_state = PublishState.QUEUED
+            await self._clear_incomplete_publish_queue_items(request)
 
-        return {QUEUE_STATE: queue_state, ERROR_MESSAGE: error_message}
+        return {QUEUE_STATE: PublishState.PENDING, ERROR_MESSAGE: error_message}
+
+    def _get_incomplete_publish_queue_lookup(self, request: PublishRequest, item_version: int) -> dict:
+        return {
+            "$and": [
+                {"item_id": request.item_id},
+                {"item_version": item_version},
+                {
+                    "state": {
+                        "$in": [
+                            PublishQueueState.ROUTING,
+                            PublishQueueState.PENDING,
+                            PublishQueueState.IN_PROGRESS,
+                            PublishQueueState.RETRYING,
+                        ]
+                    }
+                },
+            ]
+        }
+
+    async def _clear_incomplete_publish_queue_items(self, request: PublishRequest) -> None:
+        item_version = request.item.get(VERSION)
+        if item_version is None:
+            return
+
+        queue_lookup = self._get_incomplete_publish_queue_lookup(request, item_version)
+        logger.info(
+            "Clearing incomplete publish_queue rows after cancellation " "(request_id=%s, item_id=%s, item_version=%s)",
+            request.request_id,
+            request.item_id,
+            item_version,
+            extra=dict(
+                publish_request_id=request.request_id,
+                item_id=request.item_id,
+                item_version=item_version,
+            ),
+        )
+        await PublishQueueResource.get_service().delete_many(queue_lookup)
 
     async def _has_publish_queue_items(self, request: PublishRequest) -> bool:
         item_version = request.item.get(VERSION)
         if item_version is None:
             return False
 
-        queue_lookup = {
-            "item_id": request.item_id,
-            "item_version": item_version,
-        }
+        queue_lookup = self._get_incomplete_publish_queue_lookup(request, item_version)
         queue_items = await (
             await PublishQueueResource.get_service().find(
                 queue_lookup,

--- a/superdesk/publish_async/exchanges/exchange_factory.py
+++ b/superdesk/publish_async/exchanges/exchange_factory.py
@@ -1,5 +1,7 @@
+import asyncio
 import logging
 from datetime import timedelta
+from uuid import uuid4
 
 from bson import ObjectId
 from quart_babel import gettext
@@ -255,15 +257,26 @@ class DefaultPublishExchangeFactory(PublishExchangeFactory, SingletonInstance):
 
         try:
             exchange = self.get_exchange(request)
-            logger.info(f"Sending request for {request.item_id} to {exchange}")
+            if request.request_id is None:
+                request.request_id = str(uuid4())
+            logger.info(
+                "Sending publish request_id=%s item_id=%s to %s",
+                request.request_id,
+                request.item_id,
+                exchange,
+                extra={"publish_request_id": request.request_id},
+            )
             response = await exchange.send(request)
             logger.info(
-                "Completed request for %s via %s (routed=%s, subscribers=%s, content_api_subscribers=%s)",
+                "Completed publish request_id=%s item_id=%s via %s "
+                "(routed=%s, subscribers=%s, content_api_subscribers=%s)",
+                request.request_id,
                 request.item_id,
                 exchange,
                 response.routed,
                 len(response.subscribers),
                 len(response.content_api_subscribers),
+                extra={"publish_request_id": request.request_id},
             )
             return response
         except KeyError as e:
@@ -271,6 +284,32 @@ class DefaultPublishExchangeFactory(PublishExchangeFactory, SingletonInstance):
             raise SuperdeskApiError.badRequestError(
                 message=gettext(f"Key is missing on article to be published: {e}"),
             ) from e
+        except asyncio.CancelledError as e:
+            logger.warning(
+                "Publish request cancelled in exchange factory "
+                "(request_id=%s, item_id=%s, operation=%s, item_type=%s, sender_type=%s, exchange=%s, "
+                "cancellation_type=%s, cancellation_message=%s)",
+                request.request_id,
+                request.item_id,
+                request.operation,
+                request.item_type,
+                request.sender_type,
+                exchange,
+                type(e).__name__,
+                str(e),
+                exc_info=True,
+                extra=dict(
+                    publish_request_id=request.request_id,
+                    item_id=request.item_id,
+                    operation=request.operation,
+                    item_type=request.item_type,
+                    sender_type=request.sender_type,
+                    exchange=str(exchange),
+                    cancellation_type=type(e).__name__,
+                    cancellation_message=str(e),
+                ),
+            )
+            raise
         except Exception as e:
             logger.exception("Something bad happened while publishing item", extra=dict(item_id=request.item_id))
             raise SuperdeskApiError.internalError(

--- a/superdesk/types/publish.py
+++ b/superdesk/types/publish.py
@@ -80,6 +80,9 @@ class PublishRequest(Dataclass):
     # Used by the PublishAction to specifically send to these subscribers only
     subscribers: list[SubscribersResource] | None = None
 
+    #: Correlation ID for linking exchange send/cancel/complete logs for one publish request
+    request_id: str | None = None
+
 
 class PublishRequestResponse(Dataclass):
     """

--- a/tests/publish_async/exchanges/content_exchange_tests.py
+++ b/tests/publish_async/exchanges/content_exchange_tests.py
@@ -14,9 +14,8 @@ class ContentExchangeCancelledErrorTestCase(TestCase):
     """
     Tests that asyncio.CancelledError (a BaseException, not Exception) during
     _publish_item() does not leave published.queue_state permanently stuck at
-    in_progress. The handler should reset the item to ``pending`` when no
-    queue rows were created, but keep it ``queued`` when routing already
-    produced publish_queue items.
+    in_progress. The handler should reset the item to ``pending`` and clean up
+    any incomplete publish_queue rows for the same item/version.
     """
 
     def _make_exchange(self):
@@ -49,8 +48,20 @@ class ContentExchangeCancelledErrorTestCase(TestCase):
         self.assertTrue(has_queue_items)
         queue_service.find.assert_awaited_once_with(
             {
-                "item_id": "test-item-1",
-                "item_version": 7,
+                "$and": [
+                    {"item_id": "test-item-1"},
+                    {"item_version": 7},
+                    {
+                        "state": {
+                            "$in": [
+                                "routing",
+                                "pending",
+                                "in-progress",
+                                "retrying",
+                            ]
+                        }
+                    },
+                ]
             },
             max_results=1,
         )
@@ -71,7 +82,7 @@ class ContentExchangeCancelledErrorTestCase(TestCase):
         async def delayed_updates(*args, **kwargs):
             lookup_started.set()
             await finish_lookup.wait()
-            return {QUEUE_STATE: PublishState.QUEUED, "error_message": "request cancelled"}
+            return {QUEUE_STATE: PublishState.PENDING, "error_message": "request cancelled"}
 
         async def run_cleanup():
             await exchange._reset_published_item_after_cancellation(
@@ -170,7 +181,7 @@ class ContentExchangeCancelledErrorTestCase(TestCase):
             "queue_state must be reset to 'pending' so the background worker can retry",
         )
 
-    async def test_cancellation_keeps_queue_state_queued_when_queue_items_exist(self):
+    async def test_cancellation_resets_to_pending_and_cleans_incomplete_queue_items_when_rows_exist(self):
         exchange = self._make_exchange()
 
         published_item_id = ObjectId()
@@ -224,14 +235,21 @@ class ContentExchangeCancelledErrorTestCase(TestCase):
                         ):
                             with patch.object(
                                 exchange,
-                                "_publish_item",
+                                "_clear_incomplete_publish_queue_items",
                                 new_callable=AsyncMock,
-                                side_effect=asyncio.CancelledError("request cancelled"),
-                            ):
-                                with self.assertRaises(asyncio.CancelledError):
-                                    await exchange.send(request)
+                            ) as clear_queue_items:
+                                with patch.object(
+                                    exchange,
+                                    "_publish_item",
+                                    new_callable=AsyncMock,
+                                    side_effect=asyncio.CancelledError("request cancelled"),
+                                ):
+                                    with self.assertRaises(asyncio.CancelledError):
+                                        await exchange.send(request)
+
+        clear_queue_items.assert_awaited_once_with(request)
 
         self.assertTrue(len(captured_patches) >= 1)
         last_patch_id, last_patch_updates = captured_patches[-1]
         self.assertEqual(last_patch_id, published_item_id)
-        self.assertEqual(last_patch_updates[QUEUE_STATE], PublishState.QUEUED)
+        self.assertEqual(last_patch_updates[QUEUE_STATE], PublishState.PENDING)

--- a/tests/publish_async/exchanges/content_exchange_tests.py
+++ b/tests/publish_async/exchanges/content_exchange_tests.py
@@ -34,7 +34,7 @@ class ContentExchangeCancelledErrorTestCase(TestCase):
         request.item_id = "test-item-1"
 
         cursor = MagicMock()
-        cursor.to_list = AsyncMock(return_value=[{"state": "failed"}])
+        cursor.to_list = AsyncMock(return_value=[{"state": "pending"}])
 
         queue_service = MagicMock()
         queue_service.find = AsyncMock(return_value=cursor)

--- a/tests/publish_async/exchanges/exchange_factory_tests.py
+++ b/tests/publish_async/exchanges/exchange_factory_tests.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import timedelta
 from unittest import mock
 
@@ -201,3 +202,47 @@ class ExchangeFactoryTestCase(TestCase):
 
         self.assertIn(stale_routing.id, task_ids, "stale routing item should be picked up for retry")
         self.assertNotIn(fresh_routing.id, task_ids, "fresh routing item should not be picked up yet")
+
+    async def test_send_propagates_cancelled_error(self):
+        factory = DefaultPublishExchangeFactory()
+
+        request = PublishRequest(
+            item={"_id": "item-1", "type": "text"},
+            item_id="item-1",
+            item_type="text",
+            operation="publish",
+            published_state="published",
+            sender_type=PublishSenderType.API,
+        )
+
+        mock_exchange = mock.AsyncMock()
+        mock_exchange.send.side_effect = asyncio.CancelledError("cancelled")
+
+        with mock.patch.object(factory, "get_exchange", return_value=mock_exchange):
+            with self.assertRaises(asyncio.CancelledError):
+                await factory.send(request)
+
+    async def test_send_returns_response_when_exchange_send_succeeds(self):
+        factory = DefaultPublishExchangeFactory()
+
+        request = PublishRequest(
+            item={"_id": "item-1", "type": "text"},
+            item_id="item-1",
+            item_type="text",
+            operation="publish",
+            published_state="published",
+            sender_type=PublishSenderType.API,
+        )
+
+        response = mock.MagicMock()
+        response.routed = True
+        response.subscribers = []
+        response.content_api_subscribers = set()
+
+        mock_exchange = mock.AsyncMock()
+        mock_exchange.send.return_value = response
+
+        with mock.patch.object(factory, "get_exchange", return_value=mock_exchange):
+            result = await factory.send(request)
+
+        self.assertIs(result, response)

--- a/tests/publish_async/publish_channel_config_tests.py
+++ b/tests/publish_async/publish_channel_config_tests.py
@@ -76,3 +76,28 @@ class PublishChannelConfigTestCase(TestCase):
                 polling=False,
             ),
         )
+
+    async def test_publish_channel_config_with_associations(self):
+        self.assertEqual(
+            get_publish_channel_config({}, ContentType.TEXT, "publish", "api"),
+            ExchangeConfig(
+                exchange="content",
+                filter="content",
+                formatter="default",
+                router="asyncio",
+                polling=False,
+            ),
+        )
+
+        self.assertEqual(
+            get_publish_channel_config(
+                {"associations": {"test": {"_id": "item_2"}}}, ContentType.TEXT, "publish", "api"
+            ),
+            ExchangeConfig(
+                exchange="content",
+                filter="content",
+                formatter="default",
+                router="celery",
+                polling=True,
+            ),
+        )


### PR DESCRIPTION
avoid partial publishing on cancel

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

