### PR TITLE
[SDBELGA-1127] fix elastic mapping for dict items with dynamic == false

### DIFF
--- a/superdesk/core/elastic/mapping.py
+++ b/superdesk/core/elastic/mapping.py
@@ -19,7 +19,9 @@ logger = logging.getLogger(__name__)
 def _get_field_type_from_json_schema(
     schema: Dict[str, Any], props: Dict[str, Any], parent_props: Optional[Dict[str, Any]] = None
 ) -> Optional[Dict[str, Any]]:
-    if props.get("elastic_mapping"):
+    if props.get("elastic_mapping") and (
+        props["elastic_mapping"].get("dynamic") is not False or props["elastic_mapping"].get("properties")
+    ):
         return props["elastic_mapping"]
 
     if props.get("$ref"):
@@ -89,6 +91,13 @@ def _get_field_type_from_json_schema(
 
             if props.get("dynamic") is not None:
                 mapping["dynamic"] = props["dynamic"]
+
+            if (
+                parent_props is not None
+                and parent_props.get("elastic_mapping")
+                and parent_props["elastic_mapping"].get("dynamic") is not None
+            ):
+                mapping["dynamic"] = parent_props["elastic_mapping"]["dynamic"]
 
             return mapping
         except KeyError:

--- a/superdesk/core/resources/utils.py
+++ b/superdesk/core/resources/utils.py
@@ -71,11 +71,11 @@ def get_projection_arg(projection_data: ProjectedFieldArg | str | None) -> tuple
     :raises SuperdeskApiError.badRequestError: If the projection param is of an unsupported type
     """
 
+    if isinstance(projection_data, str):
+        projection_data = json.loads(projection_data)
     if not projection_data:
         # No projection will be used
         return None, None
-    elif isinstance(projection_data, str):
-        projection_data = json.loads(projection_data)
 
     if isinstance(projection_data, (list, set)):
         # Projection: include these fields only

--- a/superdesk/core/resources/utils.py
+++ b/superdesk/core/resources/utils.py
@@ -51,7 +51,7 @@ def get_projection_from_request(req: SearchRequest) -> tuple[bool, list[str]] | 
     return get_projection_arg(projection_data)
 
 
-def get_projection_arg(projection_data: ProjectedFieldArg | None) -> tuple[bool, list[str]] | tuple[None, None]:
+def get_projection_arg(projection_data: ProjectedFieldArg | str | None) -> tuple[bool, list[str]] | tuple[None, None]:
     """Get normalized projection argument from request
 
     Processes the given projection data and determines the type of projection to apply
@@ -74,7 +74,10 @@ def get_projection_arg(projection_data: ProjectedFieldArg | None) -> tuple[bool,
     if not projection_data:
         # No projection will be used
         return None, None
-    elif isinstance(projection_data, (list, set)):
+    elif isinstance(projection_data, str):
+        projection_data = json.loads(projection_data)
+
+    if isinstance(projection_data, (list, set)):
         # Projection: include these fields only
         return True, list(set(projection_data) | SYSTEM_FIELDS)
     elif isinstance(projection_data, dict):

--- a/tests/core/resource_model_test.py
+++ b/tests/core/resource_model_test.py
@@ -1,3 +1,4 @@
+from typing import Annotated
 from unittest import TestCase
 
 from pydantic import ValidationError
@@ -180,3 +181,31 @@ class ResourceModelTest(TestCase):
 
         # current class
         self.assertIn("power", RingOfPower._related_field_definitions)
+
+    def test_resource_field_with_disabled_dynamic_mapping(self):
+        class Place(Dataclass):
+            scheme: fields.Keyword | None = None
+            qcode: fields.Keyword | None = None
+            name: fields.Keyword | None = None
+
+        class Item(ResourceModel):
+            place: Annotated[list[Place] | None, fields.elastic_mapping({"type": "object", "dynamic": False})] = None
+
+        self.assertEqual(
+            get_elastic_mapping_from_model("item", Item),
+            {
+                "properties": {
+                    "_created": {"type": "date"},
+                    "_updated": {"type": "date"},
+                    "_etag": {"type": "text"},
+                    "place": {
+                        "dynamic": False,
+                        "properties": {
+                            "scheme": {"type": "keyword"},
+                            "qcode": {"type": "keyword"},
+                            "name": {"type": "keyword"},
+                        },
+                    },
+                },
+            },
+        )


### PR DESCRIPTION
### Purpose
In the Planning module the `place` field had an incorrect mapping of `{"dynamic": false, "type": "object"}`. It was missing the expected fields:
```json
{
    "dynamic": false,
    "properties":  {
        "code": {"type": "keyword"},
        "country": {"type": "keyword"},
        "country_code": {"type": "keyword"},
        "feature_class": {"type": "keyword"},
        "locality": {"type": "keyword"},
        "locality_code": {"type": "keyword"},
        "location": {"type": "geo_point"},
        "name": {"type": "keyword"},
        "qcode": {"type": "keyword"},
        "rel": {"type": "keyword"},
        "scheme": {"type": "keyword"},
        "state": {"type": "keyword"},
        "state_code": {"type": "keyword"},
        "world_region": {"type": "keyword"},
        "world_region_code": {"type": "keyword"},
    }
}
```

### What has changed
* When generating the elastic mapping, if a field contains `elastic_mapping` metadata and `"dynamic": false`, allow the rest of the field sub-types to be populated as well
* Additionally, improve `get_projection_arg` to support passing in a string

Resolves: [SDBELGA-1127](https://sofab.atlassian.net/browse/SDBELGA-1127)



[SDBELGA-1127]: https://sofab.atlassian.net/browse/SDBELGA-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ