### PR TITLE
fix: ETag publish_queue issue on transmit success

### DIFF
--- a/superdesk/publish/publish_service.py
+++ b/superdesk/publish/publish_service.py
@@ -67,7 +67,6 @@ class PublishServiceBase:
                 transmit_response = self._transmit(queue_item, subscriber) or []
                 if isawaitable(transmit_response):
                     await transmit_response
-                await self.update_item_status(queue_item["_id"], "success")
             except SuperdeskPublishError as error:
                 await self.update_item_status(queue_item["_id"], "error", error)
                 await self.close_transmitter(subscriber, error)


### PR DESCRIPTION
### Purpose
Since https://github.com/superdesk/superdesk-core/pull/3282 (fixing etag checking on updates) there is an etag conflict on publish_queue collection on a successful publish. This is because both the consumer and transmitter are both trying to update the publish_queue with `success` status.

### What has changed
* Remove the status update from the transmitter, leave this responsibility to the consumer (but still let the transmitter catch `SuperdeskPublishError` and store status and error there)
