### PR TITLE
fix: Pydantic string field storing ObjectId instances

### DIFF
--- a/superdesk/core/resources/fields.py
+++ b/superdesk/core/resources/fields.py
@@ -97,7 +97,12 @@ class CustomStringField(Generic[CustomStringFieldType], BaseCustomField):
     ) -> core_schema.CoreSchema:
         from_str_schema = core_schema.chain_schema(
             [
-                core_schema.str_schema(),
+                core_schema.no_info_before_validator_function(
+                    lambda value: (
+                        str(value) if isinstance(value, BsonObjectId) and cls.core_type != BsonObjectId else value
+                    ),
+                    core_schema.str_schema(),
+                ),
                 core_schema.no_info_plain_validator_function(cls._validate),
             ]
         )

--- a/tests/core/resource_model_test.py
+++ b/tests/core/resource_model_test.py
@@ -4,7 +4,8 @@ from unittest import TestCase
 from pydantic import ValidationError
 from bson import ObjectId
 
-from superdesk.core.resources import fields, ResourceModel, ResourceModelWithObjectId, dataclass, Dataclass
+from superdesk.core import json
+from superdesk.core.resources import fields, ResourceModel, ResourceModelWithObjectId, dataclass, Dataclass, BaseModel
 from superdesk.core.elastic.resources import get_elastic_mapping_from_model
 from tests.core.modules.module_related_resources import RingOfPower
 
@@ -209,3 +210,50 @@ class ResourceModelTest(TestCase):
                 },
             },
         )
+
+    def test_string_field_with_objectid_value(self):
+        class Templates(BaseModel):
+            single_id: fields.Keyword
+            single_oid: fields.ObjectId
+            list_ids: list[fields.Keyword]
+            list_oids: list[fields.ObjectId]
+
+        ids = [ObjectId() for _ in range(3)]
+        item = Templates(
+            single_id=ids[0],
+            single_oid=ids[0],
+            list_ids=ids[1:],
+            list_oids=ids[1:],
+        )
+        self.assertEqual(item.single_id, str(ids[0]))
+        self.assertEqual(item.single_oid, ids[0])
+        self.assertEqual(item.list_ids, [str(ids[1]), str(ids[2])])
+        self.assertEqual(item.list_oids, [ids[1], ids[2]])
+
+        item = Templates.from_dict(
+            dict(
+                single_id=ids[0],
+                single_oid=ids[0],
+                list_ids=ids[1:],
+                list_oids=ids[1:],
+            )
+        )
+        self.assertEqual(item.single_id, str(ids[0]))
+        self.assertEqual(item.single_oid, ids[0])
+        self.assertEqual(item.list_ids, [str(ids[1]), str(ids[2])])
+        self.assertEqual(item.list_oids, [ids[1], ids[2]])
+
+        item = Templates.from_json(
+            json.dumps(
+                dict(
+                    single_id=str(ids[0]),
+                    single_oid=str(ids[0]),
+                    list_ids=[str(ids[1]), str(ids[2])],
+                    list_oids=[str(ids[1]), str(ids[2])],
+                )
+            )
+        )
+        self.assertEqual(item.single_id, str(ids[0]))
+        self.assertEqual(item.single_oid, ids[0])
+        self.assertEqual(item.list_ids, [str(ids[1]), str(ids[2])])
+        self.assertEqual(item.list_oids, [ids[1], ids[2]])


### PR DESCRIPTION
### Purpose
When serialising data, if a value looks like an ObjectId it tries to convert it. This causes a validation error for non-objectid fields in Pydantic.

### What has changed
* Modify the Pydantic serialiser for custom strings so that only the `fields.ObjectId` field will store the ObjectId instance, every other custom string type will store a string
* Add tests to cover this scenario

