### PR TITLE
improve: Use MongoDB for `find_by_id` in AsyncResourceService

### DIFF
--- a/superdesk/content_types_async/service.py
+++ b/superdesk/content_types_async/service.py
@@ -125,8 +125,9 @@ class ContentTypesService(AsyncCacheableService[ContentTypesResourceModel]):
         item_id: str | ObjectId,
         version: int | None = None,
         projection: ProjectedFieldArg | None = None,
+        use_elastic: bool = False,
     ) -> dict | None:
-        doc_dict = await super().find_by_id_raw(item_id, version, projection)
+        doc_dict = await super().find_by_id_raw(item_id, version, projection, use_elastic)
         if not doc_dict:
             return None
 

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -234,16 +234,18 @@ class AsyncResourceService(Generic[ResourceModelType]):
         item_id: Union[str, ObjectId],
         version: int | None = None,
         projection: ProjectedFieldArg | None = None,
+        use_elastic: bool = False,
     ) -> Optional[ResourceModelType]:
         """Find a resource by ID
 
         :param item_id: ID of item to find
         :param version: Optional version to get
         :param projection: The field projections to be applied
+        :param use_elastic: If ``True`` will use Elasticsearch to get the document, else will use MongoDB by default
         :return: ``None`` if resource not found, otherwise an instance of ``ResourceModel`` for this resource
         """
 
-        item = await self.find_by_id_raw(item_id, version, projection)
+        item = await self.find_by_id_raw(item_id, version, projection, use_elastic)
         return None if item is None else self.get_model_instance_from_dict(item)
 
     async def find_by_id_raw(
@@ -251,19 +253,26 @@ class AsyncResourceService(Generic[ResourceModelType]):
         item_id: Union[str, ObjectId],
         version: int | None = None,
         projection: ProjectedFieldArg | None = None,
-    ) -> Optional[Dict[str, Any]]:
+        use_elastic: bool = False,
+    ) -> dict | None:
         """Find a resource by ID
 
         :param item_id: ID of item to find
         :param version: Optional version to get
         :param projection: The field projections to be applied
+        :param use_elastic: If ``True`` will use Elasticsearch to get the document, else will use MongoDB by default
         :return: ``None`` if resource not found, otherwise a dictionary of the item
         """
 
         item_id = ObjectId(item_id) if self.id_uses_objectid() else item_id
-        try:
-            item = await self.elastic.find_by_id(item_id, projection=projection)
-        except ElasticNotConfiguredForResource:
+        item: dict | None = None
+        if use_elastic:
+            try:
+                item = await self.elastic.find_by_id(str(item_id), projection=projection)
+            except ElasticNotConfiguredForResource:
+                pass
+
+        if item is None:
             projection_arg = self._get_mongo_projection_argument(SearchRequest(projection=projection))
             kwargs = {} if not projection_arg else {"projection": projection_arg}
             item = await self.mongo_async.find_one({"_id": item_id}, **kwargs)

--- a/tests/core/resource_endpoints_test.py
+++ b/tests/core/resource_endpoints_test.py
@@ -5,7 +5,7 @@ from superdesk.utils import format_time
 
 from superdesk.tests import AsyncFlaskTestCase
 
-from .modules.users import UserResourceService
+from .modules.users import UserResourceService, User
 from .fixtures.users import john_doe, jane_doe
 
 
@@ -67,8 +67,8 @@ class ResourceEndpointsTestCase(AsyncFlaskTestCase):
         test_user_dict = self.test_client.model_instance_to_json(test_user)
         test_user_dict.update(
             dict(
-                _created=format_time(NOW) + "+00:00",
-                _updated=format_time(NOW) + "+00:00",
+                _created=format_time(NOW) + "+0000",
+                _updated=format_time(NOW) + "+0000",
                 _etag=json_data["_etag"],
                 _links={"self": {"title": "User", "href": "users_async/user_1"}},
             )
@@ -98,8 +98,8 @@ class ResourceEndpointsTestCase(AsyncFlaskTestCase):
         test_user_dict = self.test_client.model_instance_to_json(test_user)
         test_user_dict.update(
             dict(
-                _created=format_time(NOW) + "+00:00",
-                _updated=format_time(NOW) + "+00:00",
+                _created=format_time(NOW) + "+0000",
+                _updated=format_time(NOW) + "+0000",
                 _etag=json_data["_etag"],
                 first_name="Foo",
                 last_name="Bar",

--- a/tests/core/signals_test.py
+++ b/tests/core/signals_test.py
@@ -296,9 +296,7 @@ class ResourceWebSignalsTestCase(AsyncFlaskTestCase):
                 ANY,
                 Response(
                     {
-                        **test_user.to_dict(),
-                        "_created": format_time(NOW) + "+00:00",
-                        "_updated": format_time(NOW) + "+00:00",
+                        **test_user.to_dict(context={"use_objectid": True}),
                         "_links": {"self": {"title": "User", "href": "users_async/user_1"}},
                     },
                     200,


### PR DESCRIPTION
### Purpose
With the newer Pydantic based resource services, we were using Elasticsearch when getting a document by it's ID.

### What has changed
* Provide a new `use_elastic` param to the `find_by_id` and `find_by_id_raw` methods, defaulting to False
* Use MongoDB as a fallback, even if item not found in Elasticsearch
