### PR TITLE
fix publish queue processing time for corrections

### DIFF
--- a/apps/publish/content/common.py
+++ b/apps/publish/content/common.py
@@ -18,6 +18,7 @@ from quart_babel import gettext as _
 from superdesk.types import PublishRequest, PublishSenderType, SubscriberType, DesksResourceModel, PublishOperation
 from superdesk.publish_async.commands import publish_item
 from superdesk.publish_async.utils import get_utc_publish_schedule, SCHEDULE_SETTINGS, PUBLISH_SCHEDULE, get_residrefs
+from superdesk.lifecycle_timing import to_epoch_ms
 import superdesk.users.user_metrics as user_metrics
 
 from apps.archive.resource import ArchiveResource
@@ -217,6 +218,26 @@ class BasePublishService(AsyncBaseService):
         await self._process_publish_updates(original, updates)
         await self._mark_media_item_as_used(updates, original)
         await update_refs(updates, original)
+        self._reset_lifecycle_started_at_for_action(updates, original)
+
+    def _reset_lifecycle_started_at_for_action(self, updates: dict, original: dict) -> None:
+        """Restart lifecycle timing for this publish action (correct/kill/takedown/resend, etc).
+
+        The very first publish keeps its own timing (possibly from ingest), set separately
+        in ``ArchivePublishService``. Any subsequent publishing action should measure
+        ``lifecycle_to_transmit_ms`` from when that action was initiated, not from the
+        item's original first publish/creation.
+        """
+        if not original.get("firstpublished"):
+            return
+
+        lifecycle_timing = dict(original.get("lifecycle_timing") or {})
+        lifecycle_timing.update(updates.get("lifecycle_timing") or {})
+
+        action_started_at = utcnow(microseconds=True)
+        lifecycle_timing["lifecycle_started_at"] = action_started_at
+        lifecycle_timing["lifecycle_started_ms"] = to_epoch_ms(action_started_at)
+        updates["lifecycle_timing"] = lifecycle_timing
 
     async def on_updated_async(self, updates, original):
         should_track_published_articles = (  # should be computed before re-fetching original

--- a/tests/archive/archive_test.py
+++ b/tests/archive/archive_test.py
@@ -33,7 +33,7 @@ from apps.archive.common import (
     get_dateline_city,
     transtype_metadata,
 )
-from apps.publish.content import publish
+from apps.publish.content import publish, common
 from apps.search_providers import register_search_provider, registered_search_providers
 
 from werkzeug.datastructures import ImmutableMultiDict
@@ -397,6 +397,43 @@ class ArchiveTestCase(TestCase):
         self.assertEqual(to_epoch_ms(first_publish_at), published["lifecycle_timing"]["first_published_ms"])
         self.assertEqual(to_epoch_ms(first_publish_at), published["lifecycle_timing"]["lifecycle_started_ms"])
         self.assertEqual(0, published["lifecycle_timing"]["lifecycle_to_first_publish_ms"])
+
+    async def test_correction_resets_lifecycle_started_at_to_action_time(self):
+        await test_utils.post_items("products", fixtures.products.all_products())
+        await test_utils.post_items("subscribers", [fixtures.subscribers.sub5_subscriber()])
+
+        archive_service = superdesk.get_resource_service("archive")
+        publish_service = superdesk.get_resource_service("archive_publish")
+        correct_service = superdesk.get_resource_service("archive_correct")
+        item = {
+            "_id": "foo-correct",
+            "guid": "foo-correct",
+            "unique_name": "foo-correct",
+            "type": "text",
+            "state": CONTENT_STATE.SUBMITTED,
+            "_current_version": 1,
+            "headline": "foo-correct",
+        }
+
+        await archive_service.create_async([item])
+
+        first_publish_at = utcnow() + timedelta(seconds=30)
+        with mock.patch.object(publish, "utcnow", lambda **kwargs: first_publish_at):
+            await publish_service.patch_async("foo-correct", {"body_html": "original"})
+
+        published = self.app.data.find_one("archive", req=None, _id="foo-correct")
+        self.assertEqual(first_publish_at, published["lifecycle_timing"]["lifecycle_started_at"])
+
+        correction_at = first_publish_at + timedelta(hours=5)
+        with mock.patch.object(common, "utcnow", lambda **kwargs: correction_at):
+            await correct_service.patch_async("foo-correct", {"body_html": "corrected"})
+
+        corrected = self.app.data.find_one("archive", req=None, _id="foo-correct")
+        # firstpublished must be untouched, but lifecycle timing restarts for this correction
+        self.assertEqual(first_publish_at, corrected["firstpublished"])
+        self.assertEqual(correction_at, corrected["lifecycle_timing"]["lifecycle_started_at"])
+        self.assertEqual(to_epoch_ms(correction_at), corrected["lifecycle_timing"]["lifecycle_started_ms"])
+        self.assertNotEqual(first_publish_at, corrected["lifecycle_timing"]["lifecycle_started_at"])
 
     async def test_first_publish_preserves_existing_lifecycle_timing_fields(self):
         await test_utils.post_items("products", fixtures.products.all_products())


### PR DESCRIPTION
it shows time since first publishing instead of the time since the correction was published.

SDESK-7979

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

