### PR TITLE
fix email transmitter

### DIFF
--- a/superdesk/core/emails.py
+++ b/superdesk/core/emails.py
@@ -25,6 +25,7 @@ __all__ = [
     "EmailRequest",
     "EmailAddress",
     "EmailFactory",
+    "send_email_async",
     "send_email",
 ]
 
@@ -184,14 +185,7 @@ SMTP_RETRY_ERRORS = (
 )
 
 
-@shared_task(
-    autoretry_for=SMTP_RETRY_ERRORS,
-    max_retries=3,
-    retry_backoff=True,  # Safely spaces retries (e.g., 2s, 4s, 8s)
-    retry_jitter=True,
-    soft_time_limit=120,
-)
-async def send_email(
+async def send_email_async(
     subject: str,
     sender: EmailAddress,
     recipients: list[EmailAddress],
@@ -218,5 +212,38 @@ async def send_email(
             attachments=attachments,
             use_lock=use_lock,
         ),
+        raise_exceptions=raise_exceptions,
+    )
+
+
+@shared_task(
+    autoretry_for=SMTP_RETRY_ERRORS,
+    max_retries=3,
+    retry_backoff=True,  # Safely spaces retries (e.g., 2s, 4s, 8s)
+    retry_jitter=True,
+    soft_time_limit=120,
+)
+async def send_email(
+    subject: str,
+    sender: EmailAddress,
+    recipients: list[EmailAddress],
+    text_body: str,
+    html_body: str,
+    cc: list[EmailAddress] | None = None,
+    bcc: list[EmailAddress] | None = None,
+    attachments: list[EmailAttachment] | None = None,
+    use_lock: bool = True,
+    raise_exceptions: bool = False,
+) -> None:
+    await send_email_async(
+        subject=subject,
+        sender=sender,
+        recipients=recipients,
+        text_body=text_body,
+        html_body=html_body,
+        cc=cc,
+        bcc=bcc,
+        attachments=attachments,
+        use_lock=use_lock,
         raise_exceptions=raise_exceptions,
     )

--- a/superdesk/publish/transmitters/email.py
+++ b/superdesk/publish/transmitters/email.py
@@ -11,7 +11,7 @@
 import json
 
 from superdesk.core import get_app_config, get_current_app
-from superdesk.core.emails import send_email, EmailAttachment
+from superdesk.core.emails import send_email_async, EmailAttachment
 from superdesk.publish import register_transmitter
 from superdesk.publish.publish_service import PublishService
 from superdesk.errors import PublishEmailError
@@ -86,7 +86,7 @@ class EmailPublishService(PublishService):
                     )
 
             # sending email in this task (don't send this as a Celery Task)
-            await send_email(
+            await send_email_async(
                 subject=subject,
                 sender=admins[0],
                 recipients=recipients,

--- a/tests/publish/transmitters/email_transmitter_tests.py
+++ b/tests/publish/transmitters/email_transmitter_tests.py
@@ -9,7 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import os
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 from superdesk import json
 from superdesk.publish.transmitters.email import EmailPublishService
@@ -99,3 +99,49 @@ class EmailPublishServiceTest(TestCase):
                 attachments.append((part.get_filename(), part.get_content_type(), content_id))
 
             self.assertEqual(attachments, [(MOCK_FILENAME, MOCK_CONTENT_TYPE, "<MainImage>")])
+
+
+class EmailPublishServiceAsyncWorkerTest(TestCase):
+    app_config = {"CELERY_USE_ASYNC_WORKER": True}
+
+    async def test_transmit_uses_in_process_email_sender(self):
+        self.assertTrue(self.app.config["CELERY_USE_ASYNC_WORKER"])
+        self.assertFalse(self.app.config["CELERY_TASK_ALWAYS_EAGER"])
+
+        item = {
+            "message_text": "Test",
+            "message_html": "<p>Test</p>",
+            "message_subject": "Test Subject",
+        }
+        queue_item = {
+            "item_id": "123",
+            "destination": {
+                "delivery_type": "email",
+                "config": {"recipients": "a@b.c.d"},
+                "name": "Email",
+                "format": "Email",
+            },
+            "formatted_item": json.dumps(item),
+        }
+
+        transmitter = EmailPublishService()
+        send_email_async = AsyncMock()
+
+        def fail_if_task_is_called(*args, **kwargs):
+            raise AssertionError("EmailPublishService must not await the Celery send_email task directly")
+
+        with patch("superdesk.publish.transmitters.email.send_email_async", send_email_async), patch(
+            "superdesk.publish.transmitters.email.send_email", side_effect=fail_if_task_is_called, create=True
+        ):
+            await transmitter._transmit(queue_item=queue_item, subscriber={})
+
+        send_email_async.assert_awaited_once_with(
+            subject="Test Subject",
+            sender=self.app.config["ADMINS"][0],
+            recipients=["a@b.c.d"],
+            text_body="Test",
+            html_body="<p>Test</p>",
+            bcc=[],
+            attachments=[],
+            raise_exceptions=True,
+        )


### PR DESCRIPTION
there is an error when sending emails from celery:

```
await send_email(
TypeError: object NoneType can't be used in 'await' expression
```

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

