### PR TITLE
fix lifecycle timing on resend

### DIFF
--- a/apps/publish/content/resend.py
+++ b/apps/publish/content/resend.py
@@ -27,6 +27,7 @@ from superdesk.errors import SuperdeskApiError
 from superdesk.metadata.item import CONTENT_TYPE, ITEM_TYPE, ITEM_STATE, CONTENT_STATE
 from apps.archive.common import is_genre, BROADCAST_GENRE, ITEM_RESEND
 from superdesk.publish_async.commands import publish_item
+from superdesk.lifecycle_timing import reset_lifecycle_started_at
 from apps.archive.common import ITEM_OPERATION
 from quart_babel import gettext as _
 
@@ -76,6 +77,8 @@ class ResendService(AsyncBaseService):
         article = await self._validate_article(article_id, article_version)
         subscribers = await self._validate_subscribers(doc.get("subscribers"), article)
         remove_is_queued(article)
+        # timing must be measured from this resend, not from the original publish
+        reset_lifecycle_started_at(article)
         signals.item_resend.send(self, item=article)
 
         publish_response = await publish_item(

--- a/superdesk/lifecycle_timing.py
+++ b/superdesk/lifecycle_timing.py
@@ -38,6 +38,15 @@ def set_lifecycle_started_at(item: dict, started_at: datetime | None = None) -> 
     return started
 
 
+def reset_lifecycle_started_at(item: dict, started_at: datetime | None = None) -> datetime:
+    """Restart lifecycle timing, overriding any value kept from a previous publishing action."""
+    timing = ensure_lifecycle_timing(item)
+    started = started_at or utcnow(microseconds=True)
+    timing["lifecycle_started_at"] = started
+    timing["lifecycle_started_ms"] = to_epoch_ms(started)
+    return started
+
+
 def set_ingest_started_at(item: dict, started_at: datetime | None = None) -> datetime:
     return set_lifecycle_started_at(item, started_at)
 

--- a/superdesk/publish_async/exchanges/content_exchange.py
+++ b/superdesk/publish_async/exchanges/content_exchange.py
@@ -121,6 +121,7 @@ class ContentPublishExchange(BasicPublishExchange):
             return PublishRequestResponse(routed=False)
 
         published_item_id = ObjectId(published_item[ID_FIELD])
+        await self._merge_request_lifecycle_timing(request, published_item, published_item_id)
 
         if self.polling and published_item.get(QUEUE_STATE) == PublishState.PUSHED:
             # This request will be processed by ``PublishExchangeFactory.send_scheduled_or_pending_content``
@@ -440,6 +441,25 @@ class ContentPublishExchange(BasicPublishExchange):
                 request.target_media_type = SubscriberType.DIGITAL
 
         return response if response else await super().send(request)
+
+    async def _merge_request_lifecycle_timing(
+        self, request: PublishRequest, published_item: dict, published_item_id: ObjectId
+    ) -> None:
+        """Apply the request item lifecycle timing onto the published item.
+
+        The published document keeps the timing of the action which created it, so an action
+        restarting it (eg. resend) would lose its own start time once ``request.item`` gets
+        replaced by the published document.
+        """
+
+        request_timing = (request.item or {}).get("lifecycle_timing") or {}
+        published_timing = published_item.get("lifecycle_timing") or {}
+        if not request_timing or request_timing == published_timing:
+            return
+
+        merged_timing = {**published_timing, **request_timing}
+        published_item["lifecycle_timing"] = merged_timing
+        await get_resource_service(PUBLISHED).patch_async(published_item_id, {"lifecycle_timing": merged_timing})
 
     async def set_published_item_pending(self, item_id: ObjectId) -> None:
         """

--- a/superdesk/publish_async/exchanges/content_exchange.py
+++ b/superdesk/publish_async/exchanges/content_exchange.py
@@ -454,10 +454,13 @@ class ContentPublishExchange(BasicPublishExchange):
 
         request_timing = (request.item or {}).get("lifecycle_timing") or {}
         published_timing = published_item.get("lifecycle_timing") or {}
-        if not request_timing or request_timing == published_timing:
+        if not request_timing:
             return
 
         merged_timing = {**published_timing, **request_timing}
+        if merged_timing == published_timing:
+            return
+
         published_item["lifecycle_timing"] = merged_timing
         await get_resource_service(PUBLISHED).patch_async(published_item_id, {"lifecycle_timing": merged_timing})
 

--- a/tests/publish_async/exchanges/content_exchange_tests.py
+++ b/tests/publish_async/exchanges/content_exchange_tests.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bson import ObjectId
@@ -6,6 +7,8 @@ from bson import ObjectId
 from superdesk.tests import TestCase
 from superdesk.resource_fields import VERSION
 from superdesk.types import PublishState
+from superdesk.lifecycle_timing import to_epoch_ms
+from superdesk.utc import utcnow
 from superdesk.publish_async.exchanges.content_exchange import ContentPublishExchange
 from superdesk.publish_async.utils import QUEUE_STATE, PUBLISHED
 
@@ -253,3 +256,133 @@ class ContentExchangeCancelledErrorTestCase(TestCase):
         last_patch_id, last_patch_updates = captured_patches[-1]
         self.assertEqual(last_patch_id, published_item_id)
         self.assertEqual(last_patch_updates[QUEUE_STATE], PublishState.PENDING)
+
+
+class ContentExchangeLifecycleTimingTestCase(TestCase):
+    """
+    Tests that the lifecycle timing carried by the request item is not lost when
+    ``send()`` replaces ``request.item`` with the document from the ``published``
+    collection - eg. a resend restarts the timing on the in-memory article only.
+    """
+
+    def _make_exchange(self):
+        exchange = ContentPublishExchange.__new__(ContentPublishExchange)
+        exchange._filter = MagicMock()
+        exchange._formatter = MagicMock()
+        exchange._router = MagicMock()
+        exchange.polling = False
+        return exchange
+
+    async def test_request_lifecycle_timing_overrides_stored_published_timing(self):
+        exchange = self._make_exchange()
+
+        published_item_id = ObjectId()
+        first_published_at = utcnow()
+        resent_at = first_published_at + timedelta(hours=3)
+        published_item = {
+            "_id": published_item_id,
+            "item_id": "test-item-1",
+            "lifecycle_timing": {
+                "first_published_at": first_published_at,
+                "lifecycle_started_at": first_published_at,
+                "lifecycle_started_ms": to_epoch_ms(first_published_at),
+            },
+        }
+
+        request = MagicMock()
+        request.item = {
+            "item_id": "test-item-1",
+            "lifecycle_timing": {
+                "lifecycle_started_at": resent_at,
+                "lifecycle_started_ms": to_epoch_ms(resent_at),
+            },
+        }
+        request.item_id = "test-item-1"
+
+        published_service = MagicMock()
+        published_service.patch_async = AsyncMock()
+
+        with patch(
+            "superdesk.publish_async.exchanges.content_exchange.get_resource_service",
+            return_value=published_service,
+        ):
+            await exchange._merge_request_lifecycle_timing(request, published_item, published_item_id)
+
+        merged_timing = published_item["lifecycle_timing"]
+        self.assertEqual(resent_at, merged_timing["lifecycle_started_at"])
+        self.assertEqual(to_epoch_ms(resent_at), merged_timing["lifecycle_started_ms"])
+        # fields not part of this action are kept
+        self.assertEqual(first_published_at, merged_timing["first_published_at"])
+        published_service.patch_async.assert_awaited_once_with(published_item_id, {"lifecycle_timing": merged_timing})
+
+    async def test_unchanged_lifecycle_timing_is_not_patched(self):
+        exchange = self._make_exchange()
+
+        published_item_id = ObjectId()
+        lifecycle_timing = {"lifecycle_started_at": utcnow()}
+        published_item = {"_id": published_item_id, "lifecycle_timing": dict(lifecycle_timing)}
+
+        request = MagicMock()
+        request.item = {"lifecycle_timing": dict(lifecycle_timing)}
+
+        published_service = MagicMock()
+        published_service.patch_async = AsyncMock()
+
+        with patch(
+            "superdesk.publish_async.exchanges.content_exchange.get_resource_service",
+            return_value=published_service,
+        ):
+            await exchange._merge_request_lifecycle_timing(request, published_item, published_item_id)
+
+        published_service.patch_async.assert_not_awaited()
+
+    async def test_send_keeps_request_lifecycle_timing_on_published_item(self):
+        exchange = self._make_exchange()
+
+        published_item_id = ObjectId()
+        resent_at = utcnow()
+        published_item = {
+            "_id": published_item_id,
+            "item_id": "test-item-1",
+            "lifecycle_timing": {"lifecycle_started_at": resent_at - timedelta(hours=3)},
+        }
+
+        request = MagicMock()
+        request.item = {
+            "item_id": "test-item-1",
+            "lifecycle_timing": {"lifecycle_started_at": resent_at, "lifecycle_started_ms": to_epoch_ms(resent_at)},
+        }
+        request.item_id = "test-item-1"
+        request.publish_to_content_api = False
+
+        published_service = MagicMock()
+        published_service.patch_async = AsyncMock()
+
+        publish_response = MagicMock()
+        publish_response.content_api_subscribers = []
+
+        with patch(
+            "superdesk.publish_async.exchanges.content_exchange.PublishCache.init",
+            new_callable=AsyncMock,
+        ):
+            with patch(
+                "superdesk.publish_async.exchanges.content_exchange.get_resource_service",
+                return_value=published_service,
+            ):
+                with patch.object(
+                    exchange,
+                    "get_published_item_from_request",
+                    new_callable=AsyncMock,
+                    return_value=published_item,
+                ):
+                    with patch.object(exchange, "update_published_item", new_callable=AsyncMock):
+                        with patch.object(
+                            exchange,
+                            "_publish_item",
+                            new_callable=AsyncMock,
+                            return_value=publish_response,
+                        ) as publish_item_mock:
+                            await exchange.send(request)
+
+        published_request = publish_item_mock.await_args.args[0]
+        self.assertEqual(resent_at, published_request.item["lifecycle_timing"]["lifecycle_started_at"])


### PR DESCRIPTION
reset it instead of showing the time
since first publishing

SDESK-7979

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

