### PR TITLE
fix updating publish queue with old etag

### DIFF
--- a/superdesk/publish/publish_service.py
+++ b/superdesk/publish/publish_service.py
@@ -68,7 +68,8 @@ class PublishServiceBase:
                 if isawaitable(transmit_response):
                     await transmit_response
             except SuperdeskPublishError as error:
-                await self.update_item_status(queue_item["_id"], "error", error)
+                # the caller (consumer) is responsible for persisting the resulting queue item state,
+                # so it can do so in a single update using the etag it already holds
                 await self.close_transmitter(subscriber, error)
                 raise error
 

--- a/superdesk/publish_async/consumers/asyncio_consumer.py
+++ b/superdesk/publish_async/consumers/asyncio_consumer.py
@@ -147,7 +147,10 @@ class AsyncioPublishConsumer(PublishConsumer):
                 get_config(int, "MAX_TRANSMIT_RETRY_DELAY_MINUTES", 120),
             )
             try:
-                retry_attempt = task.retry_attempt or 0
+                # transmitters may update the queue item themselves (e.g. to store an error message),
+                # so re-read it to get the current etag
+                latest_task = await publish_queue_service.find_by_id(task.id) or current_task
+                retry_attempt = latest_task.retry_attempt or 0
                 timeout_minutes = compute_retry_timeout_minutes(
                     retry_attempt,
                     initial_retry_delay_minutes,
@@ -155,10 +158,10 @@ class AsyncioPublishConsumer(PublishConsumer):
                 )
                 updates: dict[str, object] = {LAST_UPDATED: utcnow()}
 
-                if task.retry_attempt < max_retry_attempt and not isinstance(e, PublishHTTPPushClientError):
+                if retry_attempt < max_retry_attempt and not isinstance(e, PublishHTTPPushClientError):
                     updates.update(
                         {
-                            "retry_attempt": task.retry_attempt + 1,
+                            "retry_attempt": retry_attempt + 1,
                             "state": PublishQueueState.RETRYING,
                             "next_retry_attempt_at": utcnow() + timedelta(minutes=timeout_minutes),
                         }
@@ -166,7 +169,7 @@ class AsyncioPublishConsumer(PublishConsumer):
                 else:
                     updates["state"] = PublishQueueState.FAILED
 
-                await publish_queue_service.update(task.id, updates, current_task.etag, current_task)
+                await publish_queue_service.update(latest_task.id, updates, latest_task.etag, latest_task)
                 return False
             except Exception:
                 logger.error("Failed to set the state for failed publish queue item.", extra=log_extra)

--- a/superdesk/publish_async/consumers/asyncio_consumer.py
+++ b/superdesk/publish_async/consumers/asyncio_consumer.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 from superdesk.types import PublishQueueResource, PublishQueueState, SubscribersResource, PublishConsumer
 from superdesk.core import get_config
-from superdesk.errors import PublishHTTPPushClientError
+from superdesk.errors import PublishHTTPPushClientError, SuperdeskPublishError
 from superdesk.utc import utcnow
 from superdesk.resource_fields import LAST_UPDATED
 from superdesk.publish import registered_transmitters
@@ -103,7 +103,11 @@ class AsyncioPublishConsumer(PublishConsumer):
             try:
                 transmitter = registered_transmitters[task.destination.delivery_type]
             except KeyError:
-                print(task.destination.delivery_type not in registered_transmitters)
+                logger.error(
+                    "No transmitter registered for delivery type %s",
+                    task.destination.delivery_type,
+                    extra=log_extra,
+                )
                 raise
 
             response = transmitter.transmit(task.to_dict(context={"use_objectid": True}))
@@ -147,16 +151,15 @@ class AsyncioPublishConsumer(PublishConsumer):
                 get_config(int, "MAX_TRANSMIT_RETRY_DELAY_MINUTES", 120),
             )
             try:
-                # transmitters may update the queue item themselves (e.g. to store an error message),
-                # so re-read it to get the current etag
-                latest_task = await publish_queue_service.find_by_id(task.id) or current_task
-                retry_attempt = latest_task.retry_attempt or 0
+                retry_attempt = current_task.retry_attempt or 0
                 timeout_minutes = compute_retry_timeout_minutes(
                     retry_attempt,
                     initial_retry_delay_minutes,
                     max_retry_delay_minutes,
                 )
                 updates: dict[str, object] = {LAST_UPDATED: utcnow()}
+                if isinstance(e, SuperdeskPublishError):
+                    updates["error_message"] = f"{e}:{e.system_exception}"
 
                 if retry_attempt < max_retry_attempt and not isinstance(e, PublishHTTPPushClientError):
                     updates.update(
@@ -169,7 +172,7 @@ class AsyncioPublishConsumer(PublishConsumer):
                 else:
                     updates["state"] = PublishQueueState.FAILED
 
-                await publish_queue_service.update(latest_task.id, updates, latest_task.etag, latest_task)
+                await publish_queue_service.update(current_task.id, updates, current_task.etag, current_task)
                 return False
             except Exception:
                 logger.error("Failed to set the state for failed publish queue item.", extra=log_extra)

--- a/tests/publish_async/consumers/asyncio_consumer_tests.py
+++ b/tests/publish_async/consumers/asyncio_consumer_tests.py
@@ -67,3 +67,54 @@ class AsyncioPublishConsumerTestCase(TestCase):
 
         expected_duration_ms = to_epoch_ms(transmit_completed_at) - to_epoch_ms(lifecycle_started_at)
         self.assertEqual(expected_duration_ms, second_update_args[1]["lifecycle_to_transmit_ms"])
+
+    async def test_uses_latest_etag_when_transmitter_updated_the_queue_item(self):
+        self.app.config["MAX_TRANSMIT_RETRY_ATTEMPT"] = 4
+        consumer = AsyncioPublishConsumer()
+
+        def make_task(etag, state, retry_attempt):
+            return PublishQueueResource(
+                id=queue_id,
+                etag=etag,
+                state=state,
+                retry_attempt=retry_attempt,
+                item_id="item-1",
+                item_version=1,
+                headline="headline",
+                publishing_action="published",
+                formatted_item="formatted",
+                subscriber_id=ObjectId(),
+                destination=SubscriberDestination(_id="d1", name="dest", format="ninjs", delivery_type="file"),
+            )
+
+        queue_id = ObjectId()
+        task = make_task("etag-pending", PublishQueueState.PENDING, 0)
+        in_progress_task = make_task("etag-in-progress", PublishQueueState.IN_PROGRESS, 0)
+        # the transmitter stores an error message on the queue item, which regenerates the etag
+        transmitter_updated_task = make_task("etag-from-transmitter", PublishQueueState.PENDING, 0)
+
+        queue_service = Mock()
+        queue_service.update = AsyncMock(return_value=in_progress_task)
+        queue_service.find_by_id = AsyncMock(return_value=transmitter_updated_task)
+
+        transmitter = Mock()
+        transmitter.transmit = Mock(side_effect=Exception("boom"))
+
+        with patch(
+            "superdesk.publish_async.consumers.asyncio_consumer.PublishQueueResource.get_service",
+            return_value=queue_service,
+        ):
+            with patch(
+                "superdesk.publish_async.consumers.asyncio_consumer.registered_transmitters", {"file": transmitter}
+            ):
+                result = await consumer.transmit_item(task)
+
+        self.assertFalse(result)
+        self.assertEqual(2, queue_service.update.await_count)
+
+        failure_update_args = queue_service.update.await_args_list[1].args
+        self.assertEqual(queue_id, failure_update_args[0])
+        self.assertEqual(PublishQueueState.RETRYING, failure_update_args[1]["state"])
+        self.assertEqual(1, failure_update_args[1]["retry_attempt"])
+        self.assertEqual("etag-from-transmitter", failure_update_args[2])
+        self.assertEqual(transmitter_updated_task, failure_update_args[3])

--- a/tests/publish_async/consumers/asyncio_consumer_tests.py
+++ b/tests/publish_async/consumers/asyncio_consumer_tests.py
@@ -68,7 +68,7 @@ class AsyncioPublishConsumerTestCase(TestCase):
         expected_duration_ms = to_epoch_ms(transmit_completed_at) - to_epoch_ms(lifecycle_started_at)
         self.assertEqual(expected_duration_ms, second_update_args[1]["lifecycle_to_transmit_ms"])
 
-    async def test_uses_latest_etag_when_transmitter_updated_the_queue_item(self):
+    async def test_uses_in_progress_etag_for_retry_update_without_rereading(self):
         self.app.config["MAX_TRANSMIT_RETRY_ATTEMPT"] = 4
         consumer = AsyncioPublishConsumer()
 
@@ -90,12 +90,10 @@ class AsyncioPublishConsumerTestCase(TestCase):
         queue_id = ObjectId()
         task = make_task("etag-pending", PublishQueueState.PENDING, 0)
         in_progress_task = make_task("etag-in-progress", PublishQueueState.IN_PROGRESS, 0)
-        # the transmitter stores an error message on the queue item, which regenerates the etag
-        transmitter_updated_task = make_task("etag-from-transmitter", PublishQueueState.PENDING, 0)
 
         queue_service = Mock()
         queue_service.update = AsyncMock(return_value=in_progress_task)
-        queue_service.find_by_id = AsyncMock(return_value=transmitter_updated_task)
+        queue_service.find_by_id = AsyncMock()
 
         transmitter = Mock()
         transmitter.transmit = Mock(side_effect=Exception("boom"))
@@ -111,10 +109,11 @@ class AsyncioPublishConsumerTestCase(TestCase):
 
         self.assertFalse(result)
         self.assertEqual(2, queue_service.update.await_count)
+        queue_service.find_by_id.assert_not_awaited()
 
         failure_update_args = queue_service.update.await_args_list[1].args
         self.assertEqual(queue_id, failure_update_args[0])
         self.assertEqual(PublishQueueState.RETRYING, failure_update_args[1]["state"])
         self.assertEqual(1, failure_update_args[1]["retry_attempt"])
-        self.assertEqual("etag-from-transmitter", failure_update_args[2])
-        self.assertEqual(transmitter_updated_task, failure_update_args[3])
+        self.assertEqual("etag-in-progress", failure_update_args[2])
+        self.assertEqual(in_progress_task, failure_update_args[3])


### PR DESCRIPTION
on error when setting retry

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

