### PR TITLE
fix: Remove null values in eve-2-pydantic create response

### DIFF
--- a/superdesk/eve_async/eve_to_pydantic_datalayer.py
+++ b/superdesk/eve_async/eve_to_pydantic_datalayer.py
@@ -117,6 +117,11 @@ class EveToPydanticDataLayer(EveBackend):
             if new_item:
                 doc.update(new_item.to_dict())
 
+            for key in list(doc.keys()):
+                # On create, remove any fields that are `None` (Pydantic requires every field to have a value)
+                if doc.get(key) is None:
+                    doc.pop(key)
+
         # And add any generated items to the `docs` variable (such as recurring events)
         provided_doc_ids = [str(doc["_id"]) for doc in docs]
         for item in new_items:


### PR DESCRIPTION
### Purpose
When creating an item through the Eve -> Pydantic layer, null values are returned. This was causing issues with some systems currently using eve

Required by: https://github.com/superdesk/superdesk-planning/pull/2967

