### PR TITLE
[SDBELGA-1125] - Resolve Elasticsearch backend when datasource source differs from endpoint

### DIFF
--- a/superdesk/datalayer.py
+++ b/superdesk/datalayer.py
@@ -216,15 +216,17 @@ class SuperdeskDataLayer(DataLayer):
     def _search_backend(self, resource, use_async: bool = False) -> Elastic | ElasticAsync | None:
         if resource.endswith(get_config(str, "VERSIONS")):
             return None
-        datasource = self.datasource(resource)
+        sources = get_config(dict, "SOURCES", {})
         try:
-            backend = get_config(dict, "SOURCES", {})[datasource[0]]["search_backend"]
+            backend = sources[self.datasource(resource)[0]]["search_backend"]
         except (KeyError, TypeError, AttributeError):
-            backend = None
+            # The datasource source may not itself be an endpoint (SOURCES is keyed by
+            # endpoint), so fall back to the endpoint's own config.
+            backend = (sources.get(resource) or {}).get("search_backend")
 
         if backend and use_async:
             backend += "_async"
-        return getattr(self, backend) if backend is not None else None
+        return getattr(self, backend) if backend else None
 
     @overload
     def _backend(self, resource: str) -> Mongo | None:


### PR DESCRIPTION
### Purpose
`_search_backend` looks up a resource's search backend by its datasource `source`, but `SOURCES` is keyed by endpoint. When the two differ (e.g. an endpoint pointing at the `unified_planning` collection), the lookup misses and the resource silently falls back to Mongo, so Elasticsearch queries stop filtering. Unblocks superdesk/superdesk-planning#2969.

### What has changed
- Keep the source-based lookup as the primary path, and fall back to the endpoint's own config (`SOURCES[resource]`) when it misses.
- Guard the lookup so a source that isn't a registered endpoint returns None instead of raising `KeyError`.

Resolves: [SDBELGA-1125](https://sofab.atlassian.net/browse/SDBELGA-1125)

[SDBELGA-1125]: https://sofab.atlassian.net/browse/SDBELGA-1125
