### PR TITLE
fix expiry not working due to kill validation

### DIFF
--- a/apps/archive/commands.py
+++ b/apps/archive/commands.py
@@ -296,7 +296,7 @@ class RemoveExpiredContent:
         else:
             logger.info("%s Removing %d expired items from archived.", self.log_msg, len(expired))
 
-        removed = await archived_service.delete_docs_async(expired)
+        removed = await archived_service.delete_docs_without_callbacks_async(expired)
         for item in expired:
             if item["_id"] not in removed:
                 logger.error("%s Item was not removed from archived item=%s", self.log_msg, item["item_id"])

--- a/superdesk/eve_async/service.py
+++ b/superdesk/eve_async/service.py
@@ -93,6 +93,9 @@ class AsyncBaseService(BaseService):
             await self.on_deleted_async(doc)
         return res
 
+    async def delete_docs_without_callbacks_async(self, docs: list[dict]) -> list[ItemId]:
+        return await self.backend.delete_docs_async(self.datasource, docs)
+
     async def find_one_async(self, req: ParsedRequest | None, **lookup) -> dict | None:
         return await self.backend.find_one_async(self.datasource, req=req, **lookup)
 

--- a/tests/archive/commands_test.py
+++ b/tests/archive/commands_test.py
@@ -45,16 +45,21 @@ class RemoveExpiredContentTestCase(TestCase):
         assert await test_utils.count("archive") == 0
 
     async def test_expired_archived_picture(self):
+        expired_item_id = "test"
         await test_utils.post_items(
             "archived",
             [
                 {
                     "type": "picture",
                     "_id": ObjectId.from_datetime(datetime(2024, 1, 1)),
-                    "item_id": "test",
-                    "guid": "test",
+                    "item_id": expired_item_id,
+                    "guid": expired_item_id,
                 },
             ],
+        )
+        await test_utils.post_items(
+            "archive",
+            [{"_id": expired_item_id, "type": "text", "state": "published"}],
         )
 
         with patch.dict(self.app.config, {"ARCHIVED_EXPIRY_MINUTES": 1}):


### PR DESCRIPTION
it raises an error now:

SuperdeskApiError: Can't Kill as article is still available in production

avoid validation callbacks when removing expired articles.

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

