### PR TITLE
[SDESK-7994] Take the AI answer length from the content profile

### DIFF
--- a/docs/ai.rst
+++ b/docs/ai.rst
@@ -114,7 +114,13 @@ Add an action for it. ``input_fields`` are read from the item, ``output_field`` 
 client writes an accepted answer to, and ``parameters`` holds everything that tunes how the answers
 are asked for: ``suggestions_count``, ``max_characters``, ``temperature`` and ``system_prompt``.
 Patching one parameter leaves the others alone, so a new knob does not become a new field on the
-resource:
+resource.
+
+``max_characters`` can be left out, in which case the length comes from the ``maxlength`` the
+content profile of the item gives ``output_field``. That is the length the field can actually
+store, so answers are asked to fit it by default and an action cannot quietly produce suggestions
+too long to save. Setting it on the action overrides the profile, for asking for something shorter
+than the field allows:
 
 .. code:: sh
 

--- a/features/ai_actions.feature
+++ b/features/ai_actions.feature
@@ -156,6 +156,86 @@ Feature: AI actions
         And the AI provider was not sent "The council met on Tuesday."
 
     @auth
+    Scenario: The answer length comes from the content profile when the action names none
+        Given a mocked AI provider at "https://provider.test/v1"
+        And "content_types"
+        """
+        [{"_id": "story", "label": "Story", "schema": {"headline": {"type": "string", "maxlength": 64}}}]
+        """
+        And an archive item "article-1" with data
+        """
+        {"profile": "story", "language": "en", "body_html": "<p>The council met on Tuesday.</p>"}
+        """
+        When we post to "/ai_providers"
+        """
+        {
+            "name": "OpenRouter",
+            "provider_type": "openai_compatible",
+            "base_url": "https://provider.test/v1",
+            "default_model": "openai/gpt-4o-mini"
+        }
+        """
+        Then we get OK response
+        When we post to "/ai_actions"
+        """
+        {
+            "name": "Headline suggestions",
+            "action_type": "suggestion",
+            "input_fields": ["body_html"],
+            "output_field": "headline",
+            "provider": "#ai_providers._id#"
+        }
+        """
+        Then we get OK response
+        When we run the AI action at "/ai_actions/#ai_actions._id#/run"
+        """
+        {"item_id": "article-1"}
+        """
+        Then we get OK response
+        And the AI instructions say "under 64 characters"
+
+    @auth
+    Scenario: An action that names a length overrides the content profile
+        Given a mocked AI provider at "https://provider.test/v1"
+        And "content_types"
+        """
+        [{"_id": "story", "label": "Story", "schema": {"headline": {"type": "string", "maxlength": 64}}}]
+        """
+        And an archive item "article-1" with data
+        """
+        {"profile": "story", "language": "en", "body_html": "<p>The council met on Tuesday.</p>"}
+        """
+        When we post to "/ai_providers"
+        """
+        {
+            "name": "OpenRouter",
+            "provider_type": "openai_compatible",
+            "base_url": "https://provider.test/v1",
+            "default_model": "openai/gpt-4o-mini"
+        }
+        """
+        Then we get OK response
+        When we post to "/ai_actions"
+        """
+        {
+            "name": "Headline suggestions",
+            "action_type": "suggestion",
+            "input_fields": ["body_html"],
+            "output_field": "headline",
+            "parameters": {"max_characters": 30},
+            "provider": "#ai_providers._id#"
+        }
+        """
+        Then we get OK response
+        When we run the AI action at "/ai_actions/#ai_actions._id#/run"
+        """
+        {"item_id": "article-1"}
+        """
+        Then we get OK response
+        And the AI instructions say "under 30 characters"
+        And the AI instructions do not mention "under 64 characters"
+
+    @auth
     Scenario: Running an action against an unknown item is a 404
         Given a mocked AI provider at "https://provider.test/v1"
         When we post to "/ai_providers"

--- a/features/steps/ai_steps.py
+++ b/features/steps/ai_steps.py
@@ -80,6 +80,18 @@ def step_then_provider_was_not_sent(context, text):
     assert text not in message, "provider was sent %s" % message
 
 
+@then('the AI instructions say "{text}"')
+def step_then_instructions_say(context, text):
+    instructions = _last_provider_message(context, "system")
+    assert text in instructions, "the instructions were %s" % instructions
+
+
+@then('the AI instructions do not mention "{text}"')
+def step_then_instructions_do_not_mention(context, text):
+    instructions = _last_provider_message(context, "system")
+    assert text not in instructions, "the instructions were %s" % instructions
+
+
 @when('we run the AI action at "{url}"')
 @async_run_until_complete
 async def step_when_we_run_the_ai_action(context, url):
@@ -139,7 +151,11 @@ def _last_provider_authorization(context):
 
 
 def _last_provider_user_message(context):
-    """Text of the user message of the last completion the provider was asked for
+    return _last_provider_message(context, "user")
+
+
+def _last_provider_message(context, role):
+    """Text of the message with the given role in the last completion the provider was asked for
 
     Skips the ``/models`` calls, which carry no body, so the step reads the completion even
     when a scenario listed the catalogue first.
@@ -147,9 +163,9 @@ def _last_provider_user_message(context):
 
     for request in reversed(_provider_requests(context)):
         messages = (request.get("json") or {}).get("messages") or []
-        contents = [message["content"] for message in messages if message.get("role") == "user"]
+        contents = [message["content"] for message in messages if message.get("role") == role]
 
         if contents:
             return contents[-1]
 
-    raise AssertionError("no completion was requested from a mocked AI provider")
+    raise AssertionError("no completion with a %s message was requested from a mocked AI provider" % role)

--- a/superdesk/ai/actions_service.py
+++ b/superdesk/ai/actions_service.py
@@ -1,7 +1,9 @@
+import logging
 from typing import Any, List
 
 from quart_babel import gettext
 
+from superdesk.content_types_async import ContentTypesService
 from superdesk.core import get_current_async_app
 from superdesk.core.resources import AsyncResourceService
 from superdesk.errors import SuperdeskApiError
@@ -21,6 +23,8 @@ from .prompts import (
 from .providers import get_client
 from .providers.base import CompletionMessage, CompletionRequest, CompletionResult
 from .providers_service import AIProvidersService
+
+logger = logging.getLogger(__name__)
 
 
 class AIActionsService(AsyncResourceService[AIAction]):
@@ -91,6 +95,7 @@ class AIActionsService(AsyncResourceService[AIAction]):
             )
 
         language = payload.language or item.get("language")
+        max_characters = await self._get_max_characters(action, item)
         request = CompletionRequest(
             model=model,
             messages=[
@@ -100,7 +105,7 @@ class AIActionsService(AsyncResourceService[AIAction]):
                         action.action_type,
                         output_field=action.output_field,
                         count=action.parameters.suggestions_count,
-                        max_characters=action.parameters.max_characters,
+                        max_characters=max_characters,
                         language=language,
                         system_prompt=action.parameters.system_prompt,
                     ),
@@ -149,8 +154,7 @@ class AIActionsService(AsyncResourceService[AIAction]):
                 "text": text,
                 # An answer that is too long is reported in full rather than cut, so the client can
                 # show the editor what the provider wrote and let them shorten it
-                "over_limit": action.parameters.max_characters is not None
-                and len(text) > action.parameters.max_characters,
+                "over_limit": max_characters is not None and len(text) > max_characters,
             }
             for text in answers
         ]
@@ -181,6 +185,30 @@ class AIActionsService(AsyncResourceService[AIAction]):
             )
 
         return parse_suggestions(result.content, action.parameters.suggestions_count)
+
+    async def _get_max_characters(self, action: AIAction, item: dict[str, Any]) -> int | None:
+        """How long an answer may be, from the action or from the content profile of the item
+
+        The profile is the length the field can actually store, so it is the default and
+        ``parameters.max_characters`` overrides it. ``None`` when neither names one.
+        """
+
+        if action.parameters.max_characters is not None:
+            return action.parameters.max_characters
+
+        try:
+            schema = await ContentTypesService().get_schema(item)
+        except Exception:
+            # Broad on purpose: the length is an enrichment, so nothing about reading the profile,
+            # from an item that has none to an unreachable database, should fail the run.
+            logger.exception("Failed to read the content profile of an item an AI action was run against")
+            return None
+
+        # A field with no maxlength, or one carrying something other than a number, means no limit
+        try:
+            return int((schema or {})[action.output_field]["maxlength"])
+        except (KeyError, TypeError, ValueError):
+            return None
 
     async def _get_item(self, item_id: str) -> dict[str, Any]:
         """Load the item as stored, without validating it against the archive model.

--- a/tests/ai/actions_test.py
+++ b/tests/ai/actions_test.py
@@ -280,6 +280,14 @@ class AIActionRunTestCase(TestCase):
         self.assertEqual(response.status_code, 200, await response.get_data())
         return await response.get_json()
 
+    async def _insert_profile(self, schema, profile_id="story"):
+        await self.async_app.mongo.get_collection_async("content_types").insert_one(
+            {"_id": profile_id, "label": profile_id, "schema": schema}
+        )
+
+    def _system_prompt(self, requests):
+        return next(message["content"] for message in requests[0]["json"]["messages"] if message["role"] == "system")
+
     async def _capture_completion(self, content=SUGGESTIONS_CONTENT):
         return capture_requests(self.http_mock, COMPLETIONS_URL, "POST", payload=completion_payload(content))
 
@@ -305,6 +313,47 @@ class AIActionRunTestCase(TestCase):
                 {"text": "Council meets on budget", "over_limit": False},
                 {"text": "Council votes on budget", "over_limit": False},
             ],
+        )
+
+    async def test_the_length_limit_comes_from_the_content_profile_when_the_action_names_none(self):
+        await self._insert_profile({"headline": {"type": "string", "maxlength": 64}})
+        requests = await self._capture_completion()
+        action = await self._create_action(parameters={})
+
+        await self._run(action["_id"])
+
+        self.assertIn("under 64 characters", self._system_prompt(requests))
+
+    async def test_the_action_length_limit_overrides_the_content_profile(self):
+        await self._insert_profile({"headline": {"type": "string", "maxlength": 64}})
+        requests = await self._capture_completion()
+        action = await self._create_action(parameters={"max_characters": 30})
+
+        await self._run(action["_id"])
+
+        prompt = self._system_prompt(requests)
+        self.assertIn("under 30 characters", prompt)
+        self.assertNotIn("under 64 characters", prompt)
+
+    async def test_no_length_is_asked_for_when_neither_the_action_nor_the_profile_names_one(self):
+        await self._insert_profile({"headline": {"type": "string"}})
+        requests = await self._capture_completion()
+        action = await self._create_action(parameters={})
+
+        await self._run(action["_id"])
+
+        self.assertNotIn("characters", self._system_prompt(requests))
+
+    async def test_a_suggestion_over_the_profile_limit_is_flagged(self):
+        await self._insert_profile({"headline": {"type": "string", "maxlength": 20}})
+        content = json.dumps({"suggestions": ["Council votes on the budget after a long debate", "Short one"]})
+        action = await self._create_action(parameters={})
+
+        body = await self._run_action(content, action=action)
+
+        self.assertEqual(
+            [suggestion["over_limit"] for suggestion in body["suggestions"]],
+            [True, False],
         )
 
     async def test_run_reports_the_provider_the_model_it_answered_with_and_the_token_usage(self):


### PR DESCRIPTION
An AI action that sets no `max_characters` now asks for answers that fit the `maxlength` its `output_field` has in the content profile of the item, so it cannot suggest a headline the editor is unable to save. Setting `max_characters` on the action still overrides it.

Missed the merge of superdesk/superdesk-core#3306, so it comes as its own PR.

Resolves: [SDESK-7994]


[SDESK-7994]: https://sofab.atlassian.net/browse/SDESK-7994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ