### PR TITLE
[SDESK-7994] Enforce `available_models` on AI actions, not on the default model

### DIFF
--- a/docs/ai.rst
+++ b/docs/ai.rst
@@ -49,9 +49,10 @@ Three resources make it up:
     ``openai_compatible``, which covers OpenAI itself as well as OpenRouter, Azure style gateways
     and local runtimes. ``GET /api/ai_providers/<id>/models`` lists the models a stored provider
     offers and ``POST /api/ai_providers/<id>/test`` reports whether it answers at all.
-    ``available_models`` narrows that catalogue to the models the installation is prepared to use,
-    and ``default_model`` has to be one of them; leaving it empty allows every model the provider
-    offers.
+    ``available_models`` narrows that catalogue to the models an action may be built on, and is
+    enforced when an action is saved; leaving it empty allows every model the provider offers.
+    ``default_model`` is what an action naming no model falls back to, and is not restricted to
+    the shortlist, so a fallback can be one the actions themselves may not pick.
 
 ``ai_actions``
     What to ask for and of which provider: the item fields to send, the field the answers are
@@ -93,9 +94,10 @@ report what the editor did with the answers. ``$TOKEN`` is a Superdesk session t
     JSON="Content-Type: application/json"
 
 Register the provider. The key is stored but never returned, by this call or any other.
-``available_models`` is the shortlist ``default_model`` has to be picked from, so the hundreds of
-models a gateway offers do not all become the default; ``GET /api/ai_providers/<id>/models`` keeps
-listing the whole catalogue, which is what an administrator picks the shortlist from:
+``available_models`` is the shortlist an action's ``model`` has to be picked from, so the hundreds
+of models a gateway offers are not all on offer when building one; ``GET
+/api/ai_providers/<id>/models`` keeps listing the whole catalogue, which is what an administrator
+picks the shortlist from:
 
 .. code:: sh
 

--- a/features/ai_providers.feature
+++ b/features/ai_providers.feature
@@ -92,7 +92,7 @@ Feature: AI providers
         And the AI provider was called with no api key
 
     @auth
-    Scenario: Create fails with a default model outside available_models
+    Scenario: A default model outside available_models is accepted
         When we post to "/ai_providers"
         """
         {
@@ -103,18 +103,33 @@ Feature: AI providers
             "default_model": "openai/gpt-4o"
         }
         """
-        Then we get error 400
+        Then we get OK response
+        And we get existing resource
+        """
+        {"available_models": ["openai/gpt-4o-mini"], "default_model": "openai/gpt-4o"}
+        """
 
     @auth
-    Scenario: Patch fails when available_models drops the default model
+    Scenario: Patch fails when available_models drops a model an action uses
         When we post to "/ai_providers"
         """
         {
             "name": "OpenRouter",
             "provider_type": "openai_compatible",
             "base_url": "https://provider.test/v1",
-            "available_models": ["openai/gpt-4o-mini", "openai/gpt-4o"],
-            "default_model": "openai/gpt-4o"
+            "available_models": ["openai/gpt-4o-mini", "openai/gpt-4o"]
+        }
+        """
+        Then we get OK response
+        When we post to "/ai_actions"
+        """
+        {
+            "name": "Headline suggestions",
+            "action_type": "suggestion",
+            "input_fields": ["body_html"],
+            "output_field": "headline",
+            "provider": "#ai_providers._id#",
+            "model": "openai/gpt-4o"
         }
         """
         Then we get OK response
@@ -125,13 +140,9 @@ Feature: AI providers
         Then we get error 400
         When we patch "/ai_providers/#ai_providers._id#"
         """
-        {"available_models": ["openai/gpt-4o-mini"], "default_model": "openai/gpt-4o-mini"}
+        {"available_models": []}
         """
         Then we get OK response
-        And we get existing resource
-        """
-        {"available_models": ["openai/gpt-4o-mini"], "default_model": "openai/gpt-4o-mini"}
-        """
 
     @auth
     Scenario: The models endpoint lists the whole catalogue of the provider

--- a/superdesk/ai/actions_service.py
+++ b/superdesk/ai/actions_service.py
@@ -52,6 +52,40 @@ class AIActionsService(AsyncResourceService[AIAction]):
 
         await super().on_update(updates, original)
 
+    async def validate_create(self, doc: AIAction) -> None:
+        await super().validate_create(doc)
+
+        await self._check_model_available(doc.provider, doc.model)
+
+    async def validate_update(self, updates: dict[str, Any], original: AIAction, etag: str | None) -> dict[str, Any]:
+        updated = await super().validate_update(updates, original, etag)
+
+        await self._check_model_available(updated["provider"], updated.get("model"))
+
+        return updated
+
+    async def _check_model_available(self, provider_id: Any, model: str | None) -> None:
+        """Check the model against the shortlist its provider restricts actions to
+
+        :raises SuperdeskApiError: If the provider has a shortlist that does not hold the model
+        """
+
+        if model is None:
+            return
+
+        provider = await AIProvidersService().find_by_id(provider_id)
+
+        # A provider that does not exist is reported by the relation validator on the field
+        if provider is None or not provider.available_models:
+            return
+
+        if model not in provider.available_models:
+            raise SuperdeskApiError.badRequestError(
+                gettext("'model' '{model}' is not one of the provider's 'available_models': {models}").format(
+                    model=model, models=", ".join(provider.available_models)
+                )
+            )
+
     def _merge_parameters(self, updates: dict[str, Any], original: AIAction) -> None:
         """Apply a partial ``parameters`` payload onto the stored ones
 

--- a/superdesk/ai/models.py
+++ b/superdesk/ai/models.py
@@ -23,6 +23,10 @@ _http_url_adapter: TypeAdapter = TypeAdapter(AnyHttpUrl)
 # every request URL. Kept a plain ``str`` so it stays serializable for MongoDB storage.
 BaseUrlStr = Annotated[str, BeforeValidator(lambda value: str(_http_url_adapter.validate_python(value)).rstrip("/"))]
 
+# An empty string is stored as ``None``. A form clearing the field can only send an empty string,
+# and a single representation of "no model" keeps every reader from having to handle both.
+ModelName = Annotated[str | None, AfterValidator(lambda value: value or None)]
+
 
 def validate_provider_type() -> AfterValidator:
     """Validates that the value is the name of a registered AI provider type"""
@@ -45,7 +49,10 @@ class AIProvider(ResourceModelWithObjectId):
     provider_type: Annotated[str, validate_provider_type()]
     base_url: BaseUrlStr
     api_key: str | None = None
-    default_model: str | None = None
+
+    #: Fallback for an action that names no model. Deliberately not restricted to
+    #: ``available_models``, so a fallback can be one the actions themselves may not pick.
+    default_model: ModelName = None
 
     #: Models of the provider's catalogue that may be used, an empty list allowing all of them. A
     #: gateway answers with hundreds of models, most of which an administrator has no intention of
@@ -107,8 +114,9 @@ class AIAction(ResourceModelWithObjectId):
 
     provider: Annotated[fields.ObjectId, validate_data_relation_async("ai_providers")]
 
-    #: Model to run the action with, falls back to the provider's ``default_model``
-    model: str | None = None
+    #: Model to run the action with, one of the provider's ``available_models`` when it has any.
+    #: Falls back to the provider's ``default_model``.
+    model: ModelName = None
 
     parameters: AIActionParameters = Field(default_factory=AIActionParameters)
 

--- a/superdesk/ai/providers_service.py
+++ b/superdesk/ai/providers_service.py
@@ -11,15 +11,11 @@ from .models import AIProvider
 class AIProvidersService(AsyncResourceService[AIProvider]):
     """Service for the ``ai_providers`` resource.
 
-    ``default_model`` has to be one of ``available_models`` whenever the shortlist is not empty.
-    The two fields can be changed independently, so the check is made against the state the write
-    leaves behind rather than against what the payload carries.
+    ``available_models`` is the shortlist an AI action picks its model from, so a model cannot be
+    dropped from it while an action still names that model. ``default_model`` is outside that
+    shortlist by design: it is what an action naming no model falls back to, and it may point at a
+    model the actions themselves are not allowed to pick.
     """
-
-    async def validate_create(self, doc: AIProvider) -> None:
-        self._check_default_model(doc.default_model, doc.available_models)
-
-        await super().validate_create(doc)
 
     async def on_update(self, updates: dict[str, Any], original: AIProvider) -> None:
         if updates.get("api_key") == "":
@@ -28,35 +24,45 @@ class AIProvidersService(AsyncResourceService[AIProvider]):
             # the field out of the payload. An explicit ``null`` is the only way to clear it.
             updates.pop("api_key")
 
-        self._check_default_model(
-            updates.get("default_model", original.default_model),
-            updates.get("available_models", original.available_models),
-        )
-
         await super().on_update(updates, original)
 
-    def _check_default_model(self, default_model: Any, available_models: Any) -> None:
-        """Check the default model against the shortlist the provider restricts itself to
+    async def validate_update(self, updates: dict[str, Any], original: AIProvider, etag: str | None) -> dict[str, Any]:
+        updated = await super().validate_update(updates, original, etag)
 
-        On an update both values come straight from the client's payload, which is only validated
-        against the model afterwards, so either can still be of any shape. A value of the wrong
-        shape is left to that validation, which answers with the field that is malformed, instead
-        of being compared here against a value it cannot be compared to.
+        await self._check_models_in_use(original, updated.get("available_models") or [])
 
-        :raises SuperdeskApiError: If the shortlist is not empty and does not hold the default model
+        return updated
+
+    async def _check_models_in_use(self, original: AIProvider, available_models: list[str]) -> None:
+        """Refuse to narrow the shortlist past a model an action of this provider still names
+
+        :raises SuperdeskApiError: If an action would be left naming a model outside the shortlist
         """
 
-        if default_model is not None and not isinstance(default_model, str):
+        if not available_models:
+            # An empty shortlist allows every model, so no action can fall outside it
             return
 
-        if not isinstance(available_models, list) or not all(isinstance(model, str) for model in available_models):
+        dropped = sorted(set(original.available_models) - set(available_models))
+        if not dropped:
             return
 
-        if not available_models or default_model is None or default_model in available_models:
+        # Imported here because ``actions_service`` imports this module
+        from .actions_service import AIActionsService
+
+        cursor = await AIActionsService().find(
+            {"provider": original.id, "model": {"$in": dropped}},
+            max_results=100,
+            use_mongo=True,
+        )
+        actions = await cursor.to_list()
+
+        if not actions:
             return
 
         raise SuperdeskApiError.badRequestError(
-            gettext("'default_model' '{model}' is not one of 'available_models': {models}").format(
-                model=default_model, models=", ".join(available_models)
+            gettext("'available_models' cannot drop {models}, still used by AI actions: {actions}").format(
+                models=", ".join(sorted({action.model for action in actions if action.model})),
+                actions=", ".join(sorted(action.name for action in actions)),
             )
         )

--- a/tests/ai/actions_test.py
+++ b/tests/ai/actions_test.py
@@ -135,6 +135,82 @@ class AIActionsRestTestCase(TestCase):
         action = await self.service.find_by_id(created["_id"])
         self.assertEqual(str(action.provider), self.provider_id)
 
+    async def _create_restricted_provider(self, available_models):
+        response = await self.test_client.post(
+            "/api/ai_providers",
+            json={**PROVIDER, "name": "Restricted", "available_models": available_models},
+        )
+        self.assertEqual(response.status_code, 201, await response.get_data())
+        return (await response.get_json())["_id"]
+
+    async def test_a_model_outside_the_providers_available_models_is_rejected(self):
+        provider_id = await self._create_restricted_provider(["openai/gpt-4o-mini"])
+
+        response = await self.test_client.post(
+            "/api/ai_actions", json=self._payload(provider=provider_id, model="openai/gpt-4o")
+        )
+
+        self.assertEqual(response.status_code, 400)
+        message = (await response.get_json())["_message"]
+        self.assertIn("openai/gpt-4o", message)
+        self.assertIn("available_models", message)
+
+    async def test_a_model_the_provider_lists_is_accepted(self):
+        provider_id = await self._create_restricted_provider(["openai/gpt-4o-mini"])
+
+        created = await self._create_action(provider=provider_id, model="openai/gpt-4o-mini")
+
+        action = await self.service.find_by_id(created["_id"])
+        self.assertEqual(action.model, "openai/gpt-4o-mini")
+
+    async def test_no_model_is_accepted_whatever_the_provider_lists(self):
+        """The action falls back to ``default_model``, which the shortlist does not restrict"""
+
+        provider_id = await self._create_restricted_provider(["openai/gpt-4o-mini"])
+
+        created = await self._create_action(provider=provider_id, model=None)
+
+        self.assertIsNone((await self.service.find_by_id(created["_id"])).model)
+
+    async def test_an_empty_available_models_accepts_any_model(self):
+        created = await self._create_action(model="a-model-nobody-listed")
+
+        self.assertEqual((await self.service.find_by_id(created["_id"])).model, "a-model-nobody-listed")
+
+    async def test_patch_setting_a_model_outside_available_models_is_rejected(self):
+        provider_id = await self._create_restricted_provider(["openai/gpt-4o-mini"])
+        created = await self._create_action(provider=provider_id, model="openai/gpt-4o-mini")
+
+        response = await self.test_client.patch(
+            f"/api/ai_actions/{created['_id']}",
+            json={"model": "openai/gpt-4o"},
+            headers={"If-Match": created["_etag"]},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("available_models", (await response.get_json())["_message"])
+        self.assertEqual((await self.service.find_by_id(created["_id"])).model, "openai/gpt-4o-mini")
+
+    async def test_patch_moving_an_action_to_a_provider_that_lists_its_model(self):
+        provider_id = await self._create_restricted_provider(["openai/gpt-4o-mini"])
+        created = await self._create_action(model="openai/gpt-4o-mini")
+
+        response = await self.test_client.patch(
+            f"/api/ai_actions/{created['_id']}",
+            json={"provider": provider_id},
+            headers={"If-Match": created["_etag"]},
+        )
+
+        self.assertEqual(response.status_code, 200, await response.get_data())
+        self.assertEqual(str((await self.service.find_by_id(created["_id"])).provider), provider_id)
+
+    async def test_an_empty_model_is_stored_as_none(self):
+        """A form clearing the field can only send an empty string, so it means no model"""
+
+        created = await self._create_action(model="")
+
+        self.assertIsNone((await self.service.find_by_id(created["_id"])).model)
+
     async def test_empty_name_is_rejected(self):
         response = await self.test_client.post("/api/ai_actions", json=self._payload(name=""))
 

--- a/tests/ai/providers_test.py
+++ b/tests/ai/providers_test.py
@@ -201,27 +201,21 @@ class AIProvidersRestTestCase(TestCase):
         self.assertEqual(provider.config, {})
         self.assertEqual(provider.available_models, [])
 
-    async def test_creating_a_provider_whose_default_model_is_not_available_is_rejected(self):
-        response = await self.test_client.post(
-            "/api/ai_providers",
-            json={**PROVIDER, "available_models": ["openai/gpt-4o"]},
-        )
+    async def test_a_default_model_outside_available_models_is_accepted(self):
+        """The shortlist restricts the actions, not the fallback the provider hands them"""
 
-        self.assertEqual(response.status_code, 400)
-        message = (await response.get_json())["_message"]
-        self.assertIn("default_model", message)
-        self.assertIn("available_models", message)
-
-    async def test_creating_a_provider_whose_default_model_is_available_is_accepted(self):
-        created = await self._create_provider(available_models=["openai/gpt-4o", "openai/gpt-4o-mini"])
+        created = await self._create_provider(available_models=["openai/gpt-4o"], default_model="a-model-nobody-listed")
 
         provider = await self.service.find_by_id(created["_id"])
-        self.assertEqual(provider.available_models, ["openai/gpt-4o", "openai/gpt-4o-mini"])
-        self.assertEqual(provider.default_model, "openai/gpt-4o-mini")
+        self.assertEqual(provider.available_models, ["openai/gpt-4o"])
+        self.assertEqual(provider.default_model, "a-model-nobody-listed")
 
-    async def test_an_empty_available_models_allows_any_default_model(self):
-        created = await self._create_provider(available_models=[], default_model="a-model-nobody-listed")
+    async def test_patch_setting_a_default_model_outside_available_models_is_accepted(self):
+        created = await self._create_provider(available_models=["openai/gpt-4o-mini"])
 
+        response = await self._patch_provider(created, default_model="a-model-nobody-listed")
+
+        self.assertEqual(response.status_code, 200, await response.get_data())
         provider = await self.service.find_by_id(created["_id"])
         self.assertEqual(provider.default_model, "a-model-nobody-listed")
 
@@ -231,69 +225,19 @@ class AIProvidersRestTestCase(TestCase):
         provider = await self.service.find_by_id(created["_id"])
         self.assertIsNone(provider.default_model)
 
-    async def test_patch_setting_a_default_model_outside_available_models_is_rejected(self):
-        created = await self._create_provider(available_models=["openai/gpt-4o-mini"])
+    async def test_an_empty_default_model_is_stored_as_none(self):
+        """A form clearing the field can only send an empty string, so it means no default model"""
 
-        response = await self._patch_provider(created, default_model="openai/gpt-4o")
+        created = await self._create_provider(default_model="")
+        self.assertIsNone((await self.service.find_by_id(created["_id"])).default_model)
 
-        self.assertEqual(response.status_code, 400)
-        message = (await response.get_json())["_message"]
-        self.assertIn("default_model", message)
-        self.assertIn("available_models", message)
-
-        provider = await self.service.find_by_id(created["_id"])
-        self.assertEqual(provider.default_model, "openai/gpt-4o-mini")
-
-    async def test_patch_dropping_the_default_model_from_available_models_is_rejected(self):
-        created = await self._create_provider(available_models=["openai/gpt-4o", "openai/gpt-4o-mini"])
-
-        response = await self._patch_provider(created, available_models=["openai/gpt-4o"])
-
-        self.assertEqual(response.status_code, 400)
-        message = (await response.get_json())["_message"]
-        self.assertIn("default_model", message)
-        self.assertIn("available_models", message)
-
-        provider = await self.service.find_by_id(created["_id"])
-        self.assertEqual(provider.available_models, ["openai/gpt-4o", "openai/gpt-4o-mini"])
-
-    async def test_patch_moving_the_default_model_and_the_list_together_is_accepted(self):
-        created = await self._create_provider(available_models=["openai/gpt-4o-mini"])
-
-        response = await self._patch_provider(
-            created, available_models=["openai/gpt-4o"], default_model="openai/gpt-4o"
-        )
+        created = await self._create_provider(default_model="openai/gpt-4o")
+        response = await self._patch_provider(created, default_model="")
 
         self.assertEqual(response.status_code, 200, await response.get_data())
-        provider = await self.service.find_by_id(created["_id"])
-        self.assertEqual(provider.available_models, ["openai/gpt-4o"])
-        self.assertEqual(provider.default_model, "openai/gpt-4o")
-
-    async def test_patch_emptying_available_models_lifts_the_restriction(self):
-        created = await self._create_provider(available_models=["openai/gpt-4o-mini"])
-
-        response = await self._patch_provider(created, available_models=[], default_model="a-model-nobody-listed")
-
-        self.assertEqual(response.status_code, 200, await response.get_data())
-        provider = await self.service.find_by_id(created["_id"])
-        self.assertEqual(provider.available_models, [])
-        self.assertEqual(provider.default_model, "a-model-nobody-listed")
-
-    async def test_patch_clearing_the_default_model_with_a_null_accepts_any_shortlist(self):
-        """An explicit ``null`` clears the default model, so no shortlist can be in conflict with it"""
-
-        created = await self._create_provider(available_models=["openai/gpt-4o-mini"])
-
-        response = await self._patch_provider(created, available_models=["openai/gpt-4o"], default_model=None)
-
-        self.assertEqual(response.status_code, 200, await response.get_data())
-        provider = await self.service.find_by_id(created["_id"])
-        self.assertIsNone(provider.default_model)
-        self.assertEqual(provider.available_models, ["openai/gpt-4o"])
+        self.assertIsNone((await self.service.find_by_id(created["_id"])).default_model)
 
     async def test_patch_of_a_malformed_available_models_is_a_field_error(self):
-        """The cross-field check runs before the payload is validated, so it has to survive any shape"""
-
         created = await self._create_provider(available_models=["openai/gpt-4o-mini"])
 
         for available_models in ([123], ["openai/gpt-4o", None], "openai/gpt-4o", None, 5):
@@ -308,6 +252,79 @@ class AIProvidersRestTestCase(TestCase):
         created = await self._create_provider(available_models=["openai/gpt-4o-mini"])
 
         response = await self._patch_provider(created, name="OpenRouter free")
+
+        self.assertEqual(response.status_code, 200, await response.get_data())
+        provider = await self.service.find_by_id(created["_id"])
+        self.assertEqual(provider.available_models, ["openai/gpt-4o-mini"])
+
+    async def _create_action(self, created, model):
+        response = await self.test_client.post(
+            "/api/ai_actions",
+            json={
+                "name": f"Suggest with {model}",
+                "action_type": "suggestion",
+                "input_fields": ["body_html"],
+                "output_field": "headline",
+                "provider": created["_id"],
+                "model": model,
+            },
+        )
+        self.assertEqual(response.status_code, 201, await response.get_data())
+        return await response.get_json()
+
+    async def test_patch_dropping_a_model_an_action_uses_is_rejected(self):
+        created = await self._create_provider(available_models=["openai/gpt-4o", "openai/gpt-4o-mini"])
+        await self._create_action(created, "openai/gpt-4o")
+
+        response = await self._patch_provider(created, available_models=["openai/gpt-4o-mini"])
+
+        self.assertEqual(response.status_code, 400)
+        message = (await response.get_json())["_message"]
+        self.assertIn("openai/gpt-4o", message)
+        self.assertIn("Suggest with openai/gpt-4o", message)
+
+        provider = await self.service.find_by_id(created["_id"])
+        self.assertEqual(provider.available_models, ["openai/gpt-4o", "openai/gpt-4o-mini"])
+
+    async def test_patch_dropping_a_model_no_action_uses_is_accepted(self):
+        created = await self._create_provider(available_models=["openai/gpt-4o", "openai/gpt-4o-mini"])
+        await self._create_action(created, "openai/gpt-4o-mini")
+
+        response = await self._patch_provider(created, available_models=["openai/gpt-4o-mini"])
+
+        self.assertEqual(response.status_code, 200, await response.get_data())
+        provider = await self.service.find_by_id(created["_id"])
+        self.assertEqual(provider.available_models, ["openai/gpt-4o-mini"])
+
+    async def test_patch_emptying_available_models_is_accepted_whatever_the_actions_use(self):
+        """An empty shortlist allows every model, so no action can be left outside it"""
+
+        created = await self._create_provider(available_models=["openai/gpt-4o"])
+        await self._create_action(created, "openai/gpt-4o")
+
+        response = await self._patch_provider(created, available_models=[])
+
+        self.assertEqual(response.status_code, 200, await response.get_data())
+        provider = await self.service.find_by_id(created["_id"])
+        self.assertEqual(provider.available_models, [])
+
+    async def test_patch_widening_available_models_is_accepted(self):
+        created = await self._create_provider(available_models=["openai/gpt-4o"])
+        await self._create_action(created, "openai/gpt-4o")
+
+        response = await self._patch_provider(created, available_models=["openai/gpt-4o", "openai/gpt-4o-mini"])
+
+        self.assertEqual(response.status_code, 200, await response.get_data())
+        provider = await self.service.find_by_id(created["_id"])
+        self.assertEqual(provider.available_models, ["openai/gpt-4o", "openai/gpt-4o-mini"])
+
+    async def test_an_action_without_a_model_never_blocks_the_shortlist(self):
+        """It runs on ``default_model``, which the shortlist does not restrict"""
+
+        created = await self._create_provider(available_models=["openai/gpt-4o"])
+        await self._create_action(created, None)
+
+        response = await self._patch_provider(created, available_models=["openai/gpt-4o-mini"])
 
         self.assertEqual(response.status_code, 200, await response.get_data())
         provider = await self.service.find_by_id(created["_id"])


### PR DESCRIPTION
### Purpose

`available_models` was enforcing the wrong thing. The idea is that an admin shortlists which models a provider may be used with, and building an action is limited to those. But nothing ever checked an action's `model`. The only rule built on the shortlist guarded `default_model`, which is the one field that shouldn't be in it: it's the fallback for an action that names no model, and you might well want that to be something the actions can't pick themselves.

That also broke the settings UI. Clearing the default model on a provider with a shortlist did nothing, silently. The form can only say "no default" by sending an empty string, the server read that as a model name, didn't find `""` in the shortlist, and answered with an error carrying no field, which the form has no way to show. Caught in review on [#5365](https://github.com/superdesk/superdesk-client-core/pull/5365).

### What has changed

The check moved to where a model actually gets picked. An action's `model` now has to be in the provider's `available_models` when there is one, on create and update. `default_model` isn't restricted any more.

Narrowing the shortlist is refused while an action still uses a model you're dropping, and the error names them, otherwise the two just drift apart. Emptying it lifts the restriction, so that's still fine.

An empty `default_model` or `model` is stored as `null`, on one annotation shared by both. They already meant the same thing at run time, and one representation is easier to read than two.

Both checks sit in `validate_create` / `validate_update` instead of `on_update`, which runs before validation. The old one had to cope with a payload of any shape and carried a stack of isinstance guards for it. Those are gone.

### Steps to test

Create a provider with `available_models: ["a", "b"]`.

- An action with `model: "c"` is refused, `"a"` or no model saves.
- Dropping `"a"` from the shortlist while an action uses it is refused and names the action. Emptying the shortlist is fine.
- `default_model: "c"` saves, even though it's outside the shortlist.
- An empty `default_model` or `model` comes back as `null`.

In the UI (needs [#5365](https://github.com/superdesk/superdesk-client-core/pull/5365)): open a provider, pick some available models, clear the Default model, save. It saves, and the field is empty when you reopen.

Ticket: [SDESK-7994]


[SDESK-7994]: https://sofab.atlassian.net/browse/SDESK-7994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ