### PR TITLE
New ResourceConfig update_strategy

### DIFF
--- a/superdesk/core/resources/__init__.py
+++ b/superdesk/core/resources/__init__.py
@@ -19,7 +19,7 @@ from .model import (
     Dataclass,
     default_model_config,
 )
-from .resource_config import ResourceConfig
+from .resource_config import ResourceConfig, UpdateStrategy
 from .resource_manager import Resources
 from .resource_rest_endpoints import (
     RestEndpointConfig,
@@ -41,6 +41,7 @@ __all__ = [
     "ResourceModelWithObjectId",
     "ModelWithVersions",
     "ResourceConfig",
+    "UpdateStrategy",
     "dataclass",
     "Dataclass",
     "fields",

--- a/superdesk/core/resources/model.py
+++ b/superdesk/core/resources/model.py
@@ -37,7 +37,7 @@ from pydantic import (
 from pydantic.dataclasses import dataclass as pydataclass
 from pydantic_core import InitErrorDetails, PydanticCustomError, from_json
 
-from superdesk.core.types import BaseModel
+from superdesk.core.types import BaseModel, DefaultNoValue
 from superdesk.core.utils import generate_guid, GUID_NEWSML
 from superdesk.utils import merge_dicts_deep
 
@@ -263,6 +263,13 @@ class ResourceModel(BaseModel):
 
         return super().from_dict(values, context, include_unknown)
 
+    def clone_with(self, updates: dict[str, Any], deep: bool | object = DefaultNoValue, **kwargs) -> Self:
+        if deep is DefaultNoValue:
+            # If `deep` wasn't provided, fallback to using resource configured one
+            deep = self.get_config().update_strategy == UpdateStrategy.DEEP_MERGE
+
+        return super().clone_with(updates, deep, **kwargs)
+
     @classmethod
     def get_service(cls) -> "AsyncResourceService[Self]":
         """Helper function to get the service for this resource, without needing to import the service directly.
@@ -287,6 +294,13 @@ class ResourceModel(BaseModel):
 
         app = get_current_async_app()
         return app.resources.get_resource_service(cls.model_resource_name)
+
+    @classmethod
+    def get_config(cls) -> "ResourceConfig":
+        from superdesk.core import get_current_async_app
+
+        app = get_current_async_app()
+        return app.resources.get_config(cls.model_resource_name)
 
     @classmethod
     def get_related_links(cls, item: dict[str, Any]) -> dict[str, Any]:
@@ -402,3 +416,4 @@ def get_versioned_model(model: ResourceModel) -> ModelWithVersions | None:
 
 from .service import AsyncResourceService  # noqa: E402
 from .resource_signals import ResourceSignals  # noqa: E402
+from .resource_config import ResourceConfig, UpdateStrategy  # noqa: E402

--- a/superdesk/core/resources/model.py
+++ b/superdesk/core/resources/model.py
@@ -268,7 +268,7 @@ class ResourceModel(BaseModel):
             # If `deep` wasn't provided, fallback to using resource configured one
             deep = self.get_config().update_strategy == UpdateStrategy.DEEP_MERGE
 
-        return super().clone_with(updates, deep, **kwargs)
+        return super().clone_with(updates, cast(bool, deep), **kwargs)
 
     @classmethod
     def get_service(cls) -> "AsyncResourceService[Self]":

--- a/superdesk/core/resources/resource_config.py
+++ b/superdesk/core/resources/resource_config.py
@@ -1,7 +1,14 @@
 from typing import Union
 from dataclasses import dataclass
+from enum import Enum, unique
 
 from superdesk.core.types import SortListParam, ProjectedFieldArg, MongoResourceConfig, ElasticResourceConfig
+
+
+@unique
+class UpdateStrategy(Enum):
+    SHALLOW_MERGE = "SHALLOW_MERGE"
+    DEEP_MERGE = "DEEP_MERGE"
 
 
 @dataclass
@@ -58,6 +65,9 @@ class ResourceConfig:
 
     #: Boolean to indicate if websocket notifications should be sent for this resource (defaults to ``True``)
     send_ws_notifications: bool = True
+
+    #: Update strategy (shallow or deep merge) used to apply updates to an item
+    update_strategy: UpdateStrategy = UpdateStrategy.SHALLOW_MERGE
 
 
 from .resource_rest_endpoints import RestEndpointConfig  # noqa: E402

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -1304,5 +1304,5 @@ class AsyncCacheableService(AsyncResourceService[ResourceModelType]):
         return await self.find_by_id(_id)
 
 
-from .resource_config import ResourceConfig, UpdateStrategy  # noqa: E402
+from .resource_config import ResourceConfig  # noqa: E402
 from .model import get_versioned_model, model_has_versions  # noqa: E402

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -48,7 +48,6 @@ from superdesk.flask import g
 from superdesk.utc import utcnow
 from superdesk.cache import cache
 from superdesk.errors import SuperdeskApiError
-from superdesk.utils import merge_dicts_deep
 from superdesk.json_utils import SuperdeskJSONEncoder, cast_item
 from superdesk.resource_fields import ID_FIELD, VERSION_ID_FIELD, CURRENT_VERSION, LATEST_VERSION
 from superdesk.lookup_validation import validate_lookup_for_sensitive_fields

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -48,6 +48,7 @@ from superdesk.flask import g
 from superdesk.utc import utcnow
 from superdesk.cache import cache
 from superdesk.errors import SuperdeskApiError
+from superdesk.utils import merge_dicts_deep
 from superdesk.json_utils import SuperdeskJSONEncoder, cast_item
 from superdesk.resource_fields import ID_FIELD, VERSION_ID_FIELD, CURRENT_VERSION, LATEST_VERSION
 from superdesk.lookup_validation import validate_lookup_for_sensitive_fields
@@ -389,12 +390,10 @@ class AsyncResourceService(Generic[ResourceModelType]):
 
         # Construct a new ResourceModelType instance, to allow Pydantic to validate the changes
         # This is not efficient, but will do for now
-        updated = original.to_dict()
-        updated.update(updates)
-        updated.pop("_type", None)
+        updates.pop("_type", None)
         # Run the Pydantic sync validators, and get a model instance in return
         # Enable ``include_unknown`` so we get unknown field validation
-        model_instance = self.config.data_class.from_dict(updated, include_unknown=True)
+        model_instance = original.clone_with(updates, include_unknown=True)
 
         # Run the async validators
         await model_instance.validate_async()
@@ -1305,5 +1304,5 @@ class AsyncCacheableService(AsyncResourceService[ResourceModelType]):
         return await self.find_by_id(_id)
 
 
-from .resource_config import ResourceConfig  # noqa: E402
+from .resource_config import ResourceConfig, UpdateStrategy  # noqa: E402
 from .model import get_versioned_model, model_has_versions  # noqa: E402

--- a/superdesk/core/types/model.py
+++ b/superdesk/core/types/model.py
@@ -124,7 +124,7 @@ class BaseModel(PydanticModel):
     def clone(self) -> Self:
         return self.model_copy(deep=True)
 
-    def clone_with(self, updates: dict[str, Any]) -> Self:
+    def clone_with(self, updates: dict[str, Any], deep: bool = True, **kwargs) -> Self:
         """
         Deeply clones the instance and applies updates with proper validation.
 
@@ -136,8 +136,13 @@ class BaseModel(PydanticModel):
         """
 
         cloned_data = deepcopy(self.to_dict())
-        cloned_data = dict(merge_dicts_deep(cloned_data, updates))
-        return self.from_dict(cloned_data)
+
+        if deep:
+            cloned_data = dict(merge_dicts_deep(cloned_data, updates))
+        else:
+            cloned_data.update(updates)
+
+        return self.from_dict(cloned_data, **kwargs)
 
     def update_from_dict(self, updates: dict, deep: bool = False) -> None:
         if not deep:

--- a/superdesk/core/types/model.py
+++ b/superdesk/core/types/model.py
@@ -132,6 +132,7 @@ class BaseModel(PydanticModel):
         nested data classes or validate updates the given updates.
 
         :param updates: Attributes to update in the cloned instance.
+        :param deep: If `True`, will perform a deep merge otherwise a shallow key merge will be used
         :return: A new instance with the applied updates.
         """
 

--- a/tests/core/resource_service_test.py
+++ b/tests/core/resource_service_test.py
@@ -5,7 +5,7 @@ import simplejson as json
 from bson import ObjectId
 
 from superdesk.core.types import SearchRequest
-from superdesk.core.resources import AsyncResourceService
+from superdesk.core.resources import AsyncResourceService, UpdateStrategy
 from superdesk.core.elastic.base_client import ElasticCursor
 from superdesk.utc import utcnow
 from superdesk.utils import format_time
@@ -484,3 +484,29 @@ class TestResourceService(AsyncTestCase):
             es_item = await self.service.elastic.find_by_id(users[index].id)
             es_item.pop("_type", None)
             self.assertEqual(users[index], User(**es_item))
+
+    async def test_update_using_merge(self):
+        test_user = john_doe()
+        source_a = {"source_1": 1, "source_2": 2}
+        source_b = {"source_3": 3, "source_4": 4}
+        source_c = {"source_5": 5, "source_6": 6}
+
+        # Test initial config, should contain only `source_a`
+        test_user.my_dict = source_a
+        await self.service.create([test_user])
+        item = await self.service.find_by_id(test_user.id)
+        self.assertEqual(item.my_dict, source_a)
+
+        # Test default update_strategy of REPLACE (replacing `source_a` with `source_b` entirely)
+        self.service.config.update_strategy = UpdateStrategy.SHALLOW_MERGE
+        updated = await self.service.update(test_user.id, {"my_dict": source_b})
+        self.assertEqual(updated.my_dict, source_b)
+        item = await self.service.find_by_id(test_user.id)
+        self.assertEqual(item.my_dict, source_b)
+
+        # Test again, this time using MERGE (merging `source_c` into `source_b`)
+        self.service.config.update_strategy = UpdateStrategy.DEEP_MERGE
+        updated = await self.service.update(test_user.id, {"my_dict": source_c})
+        self.assertEqual(updated.my_dict, {**source_b, **source_c})
+        item = await self.service.find_by_id(test_user.id)
+        self.assertEqual(item.my_dict, {**source_b, **source_c})

--- a/tests/core/resource_service_test.py
+++ b/tests/core/resource_service_test.py
@@ -497,16 +497,16 @@ class TestResourceService(AsyncTestCase):
         item = await self.service.find_by_id(test_user.id)
         self.assertEqual(item.my_dict, source_a)
 
-        # Test default update_strategy of REPLACE (replacing `source_a` with `source_b` entirely)
-        self.service.config.update_strategy = UpdateStrategy.SHALLOW_MERGE
+        # Test default update_strategy of SHALLOW_MERGE (replacing `source_a` with `source_b` entirely)
+        self.assertEqual(self.service.config.update_strategy, UpdateStrategy.SHALLOW_MERGE)
         updated = await self.service.update(test_user.id, {"my_dict": source_b})
         self.assertEqual(updated.my_dict, source_b)
         item = await self.service.find_by_id(test_user.id)
         self.assertEqual(item.my_dict, source_b)
 
-        # Test again, this time using MERGE (merging `source_c` into `source_b`)
-        self.service.config.update_strategy = UpdateStrategy.DEEP_MERGE
-        updated = await self.service.update(test_user.id, {"my_dict": source_c})
-        self.assertEqual(updated.my_dict, {**source_b, **source_c})
-        item = await self.service.find_by_id(test_user.id)
-        self.assertEqual(item.my_dict, {**source_b, **source_c})
+        # Test again, this time using DEEP_MERGE (merging `source_c` into `source_b`)
+        with mock.patch.object(self.service.config, "update_strategy", UpdateStrategy.DEEP_MERGE):
+            updated = await self.service.update(test_user.id, {"my_dict": source_c})
+            self.assertEqual(updated.my_dict, {**source_b, **source_c})
+            item = await self.service.find_by_id(test_user.id)
+            self.assertEqual(item.my_dict, {**source_b, **source_c})


### PR DESCRIPTION
### Purpose
In the Eve resources we have a `merge_nested_documents` config to determine the update strategy of an item. This functionality was lacking in the core Pydantic based resources

### What has changed
* Add `update_strategy` to ResourceConfig, allowing `SHALLOW_MERGE` or `DEEP_MERGE` as value
* Use `update_strategy` in ResourceModel's `clone_with` functionality, so it's used at the resource type's core
* Use `clone_with` in the service when constructing the updated item
* Add tests for the `update_strategy` config
