### PR TITLE
[CPCN-1217] - Add default_max_results option to ResourceConfig

### DIFF
--- a/superdesk/core/resources/resource_config.py
+++ b/superdesk/core/resources/resource_config.py
@@ -47,6 +47,9 @@ class ResourceConfig:
     #: Optional sorting for this resource
     default_sort: SortListParam | None = None
 
+    #: Optional page size used when a search does not set ``max_results`` (defaults to 25)
+    default_max_results: int | None = None
+
     #: Optional list of sensitive fields that should not be allowed in filters
     sensitive_fields: list[str] | None = None
 

--- a/superdesk/core/resources/resource_rest_endpoints.py
+++ b/superdesk/core/resources/resource_rest_endpoints.py
@@ -115,9 +115,6 @@ class RestEndpointConfig:
 
     additional_lookup: AdditionalLookupConfig | None = None
 
-    #: Page size for the resource GET endpoint when the request has no ``max_results``, defaults to 25
-    default_max_results: int | None = None
-
 
 def get_id_url_type(data_class: type[ResourceModel]) -> str:
     """Get the URL param type for the ID field for route registration"""
@@ -642,9 +639,6 @@ class ResourceRestEndpoints(RestEndpoints):
             lookup = self.construct_parent_item_lookup(request)
             self.update_where_filter(params, lookup)
 
-        if self.endpoint_config.default_max_results and request.get_url_arg("max_results") is None:
-            params.max_results = self.endpoint_config.default_max_results
-
         params.args = cast(SearchArgs, params.model_extra)
         signals = self.resource_config.data_class.get_signals()
         await signals.web.on_search.send(request, params)
@@ -659,7 +653,9 @@ class ResourceRestEndpoints(RestEndpoints):
             _items=items,
             _meta=dict(
                 page=params.page,
-                max_results=params.max_results if params.max_results is not None else 25,
+                max_results=params.max_results
+                if params.max_results is not None
+                else self.service.get_default_max_results(),
                 total=count,
             ),
         )
@@ -725,15 +721,16 @@ class ResourceRestEndpoints(RestEndpoints):
         )
 
         version = (req.args or {}).get("version")
-        q = querydef(req.max_results, req.where, req.sort, version, req.page, other_params)
+        max_results = req.max_results if req.max_results is not None else self.service.get_default_max_results()
+        q = querydef(max_results, req.where, req.sort, version, req.page, other_params)
 
         if doc_count:
             links["self"]["href"] += q
 
         pagination_ink = links["self"]["href"].split("?")[0]
-        if req.page * req.max_results < (doc_count or 0):
+        if req.page * max_results < (doc_count or 0):
             q = querydef(
-                req.max_results,
+                max_results,
                 req.where,
                 req.sort,
                 version,
@@ -743,9 +740,9 @@ class ResourceRestEndpoints(RestEndpoints):
             links["next"] = {"title": "next page", "href": f"{pagination_ink}{q}"}
 
             if doc_count:
-                last_page = int(math.ceil(doc_count / req.max_results))
+                last_page = int(math.ceil(doc_count / max_results))
                 q = querydef(
-                    req.max_results,
+                    max_results,
                     req.where,
                     req.sort,
                     version,
@@ -759,7 +756,7 @@ class ResourceRestEndpoints(RestEndpoints):
 
         if req.page > 1:
             q = querydef(
-                req.max_results,
+                max_results,
                 req.where,
                 req.sort,
                 version,

--- a/superdesk/core/resources/resource_rest_endpoints.py
+++ b/superdesk/core/resources/resource_rest_endpoints.py
@@ -115,6 +115,9 @@ class RestEndpointConfig:
 
     additional_lookup: AdditionalLookupConfig | None = None
 
+    #: Page size for the resource GET endpoint when the request has no ``max_results``, defaults to 25
+    default_max_results: int | None = None
+
 
 def get_id_url_type(data_class: type[ResourceModel]) -> str:
     """Get the URL param type for the ID field for route registration"""
@@ -638,6 +641,9 @@ class ResourceRestEndpoints(RestEndpoints):
         if len(self.endpoint_config.parent_links or []):
             lookup = self.construct_parent_item_lookup(request)
             self.update_where_filter(params, lookup)
+
+        if self.endpoint_config.default_max_results and request.get_url_arg("max_results") is None:
+            params.max_results = self.endpoint_config.default_max_results
 
         params.args = cast(SearchArgs, params.model_extra)
         signals = self.resource_config.data_class.get_signals()

--- a/superdesk/core/resources/service.py
+++ b/superdesk/core/resources/service.py
@@ -823,7 +823,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
         self,
         req: dict,
         page: int = 1,
-        max_results: int = 25,
+        max_results: int | None = None,
         sort: SortParam | None = None,
         projection: ProjectedFieldArg | None = None,
         use_mongo: bool = False,
@@ -834,7 +834,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
         self,
         req: SearchRequest | dict,
         page: int = 1,
-        max_results: int = 25,
+        max_results: int | None = None,
         sort: SortParam | None = None,
         projection: ProjectedFieldArg | None = None,
         use_mongo: bool = False,
@@ -843,7 +843,7 @@ class AsyncResourceService(Generic[ResourceModelType]):
 
         :param req: SearchRequest instance, or a lookup dictionary, for the search params to be used
         :param page: The page number to retrieve (defaults to 1)
-        :param max_results: The maximum number of results to retrieve per page (defaults to 25)
+        :param max_results: The maximum number of results to retrieve per page (defaults to resource default, or 25)
         :param sort: The sort order to use (defaults to resource default sort, or not sorting applied)
         :param projection: The field projections to be applied
         :param use_mongo: If ``True`` will force use mongo, else will attempt elastic first
@@ -868,6 +868,9 @@ class AsyncResourceService(Generic[ResourceModelType]):
 
         if search_request.sort is None:
             search_request.sort = self.config.default_sort
+
+        if search_request.max_results is None:
+            search_request.max_results = self.get_default_max_results()
 
         try:
             if not use_mongo:
@@ -915,10 +918,22 @@ class AsyncResourceService(Generic[ResourceModelType]):
     def _validate_lookup(self, lookup: dict | list | None):
         validate_lookup_for_sensitive_fields(lookup, self.config.sensitive_fields or [])
 
+    def get_default_max_results(self) -> int:
+        """Get the page size for searches that do not set ``max_results``"""
+
+        if self.config.default_max_results is not None:
+            return self.config.default_max_results
+        elif self.config.elastic is not None:
+            return self.config.elastic.default_max_results
+        return 25
+
     async def _mongo_find(
         self, req: SearchRequest, versioned: bool = False
     ) -> MongoResourceCursorAsync[ResourceModelType]:
         kwargs: Dict[str, Any] = {}
+
+        if req.max_results is None:
+            req.max_results = self.get_default_max_results()
 
         if req.max_results:
             kwargs["limit"] = req.max_results

--- a/superdesk/core/types/search.py
+++ b/superdesk/core/types/search.py
@@ -150,9 +150,8 @@ class SearchRequest(BaseModel):
     #: Sorting to be used
     sort: SortParam | None = None
 
-    #: Maximum number of documents to be returned
-    # TODO-ASYNC: Support None for `max_results`, and let the underlying resource service handle that instead
-    max_results: int = 25
+    #: Maximum number of documents to be returned, uses the resource default when not set
+    max_results: int | None = None
 
     #: The page number to be returned
     page: int = 1

--- a/superdesk/publish_async/resources/subscribers/rest_api.py
+++ b/superdesk/publish_async/resources/subscribers/rest_api.py
@@ -24,7 +24,11 @@ class SubscriberRestEndpoints(ResourceRestEndpoints):
                     _items=[cast(dict, subscribers)],
                     _meta=RestResponseMeta(
                         page=1,
-                        max_results=params.max_results,
+                        max_results=(
+                            params.max_results
+                            if params.max_results is not None
+                            else self.service.get_default_max_results()
+                        ),
                         total=1,
                     ),
                 )

--- a/tests/core/modules/topics.py
+++ b/tests/core/modules/topics.py
@@ -57,6 +57,7 @@ company_folder_config = ResourceConfig(
     datasource_name="topic_folders",
     data_class=CompanyFolder,
     service=CompanyFolderService,
+    default_max_results=2,
     rest_endpoints=RestEndpointConfig(
         auth=False,
         parent_links=[
@@ -66,7 +67,6 @@ company_folder_config = ResourceConfig(
             )
         ],
         url="topic_folders",
-        default_max_results=2,
     ),
 )
 

--- a/tests/core/modules/topics.py
+++ b/tests/core/modules/topics.py
@@ -66,6 +66,7 @@ company_folder_config = ResourceConfig(
             )
         ],
         url="topic_folders",
+        default_max_results=2,
     ),
 )
 

--- a/tests/core/resource_parent_links_test.py
+++ b/tests/core/resource_parent_links_test.py
@@ -133,3 +133,25 @@ class ResourceParentLinksTestCase(AsyncFlaskTestCase):
         config = self.async_app.resources.get_config("company_topic_folders")
         endpoint = ResourceRestEndpoints(config, config.rest_endpoints)
         self.assertEqual(endpoint.get_resource_url(), 'companies/<regex("[\\w,.:_-]+"):company>/topic_folders')
+
+    async def test_default_max_results(self):
+        # company_topic_folders is configured with default_max_results=2
+        response = await self.test_client.post("/api/companies", json=dict(name="Sourcefabric"))
+        self.assertEqual(response.status_code, 201)
+        company_id = (await response.get_json())["_id"]
+        folders_url = f"/api/companies/{company_id}/topic_folders"
+
+        for name in ("Sports", "Finance", "Politics"):
+            response = await self.test_client.post(folders_url, json=dict(name=name, section="wire"))
+            self.assertEqual(response.status_code, 201)
+
+        response = await self.test_client.get(folders_url)
+        data = await response.get_json()
+        self.assertEqual(data["_meta"], {"page": 1, "max_results": 2, "total": 3})
+        self.assertEqual(len(data["_items"]), 2)
+
+        # explicit max_results still wins
+        response = await self.test_client.get(f"{folders_url}?max_results=10")
+        data = await response.get_json()
+        self.assertEqual(data["_meta"]["max_results"], 10)
+        self.assertEqual(len(data["_items"]), 3)

--- a/tests/core/resource_parent_links_test.py
+++ b/tests/core/resource_parent_links_test.py
@@ -135,7 +135,7 @@ class ResourceParentLinksTestCase(AsyncFlaskTestCase):
         self.assertEqual(endpoint.get_resource_url(), 'companies/<regex("[\\w,.:_-]+"):company>/topic_folders')
 
     async def test_default_max_results(self):
-        # company_topic_folders is configured with default_max_results=2
+        # company_topic_folders has default_max_results=2
         response = await self.test_client.post("/api/companies", json=dict(name="Sourcefabric"))
         self.assertEqual(response.status_code, 201)
         company_id = (await response.get_json())["_id"]
@@ -145,12 +145,20 @@ class ResourceParentLinksTestCase(AsyncFlaskTestCase):
             response = await self.test_client.post(folders_url, json=dict(name=name, section="wire"))
             self.assertEqual(response.status_code, 201)
 
+        # service
+        service = self.async_app.resources.get_resource_service("company_topic_folders")
+        cursor = await service.find({})
+        self.assertEqual(len(await cursor.to_list()), 2)
+        cursor = await service.find({}, max_results=10)
+        self.assertEqual(len(await cursor.to_list()), 3)
+
+        # REST API
         response = await self.test_client.get(folders_url)
         data = await response.get_json()
         self.assertEqual(data["_meta"], {"page": 1, "max_results": 2, "total": 3})
         self.assertEqual(len(data["_items"]), 2)
 
-        # explicit max_results still wins
+        # explicit max_results wins
         response = await self.test_client.get(f"{folders_url}?max_results=10")
         data = await response.get_json()
         self.assertEqual(data["_meta"]["max_results"], 10)

--- a/tests/core/resource_service_test.py
+++ b/tests/core/resource_service_test.py
@@ -429,13 +429,13 @@ class TestResourceService(AsyncTestCase):
         await assert_es_find_called_with(
             SearchRequest(), expected=SearchRequest(where=None, page=1, max_results=25, sort=None)
         )
-        expected = SearchRequest()
+        expected = SearchRequest(max_results=25)
         await assert_es_find_called_with(SearchRequest(), expected=expected)
         expected.where = {}
         await assert_es_find_called_with({}, expected=expected)
 
         sort_query = [("last_name.keyword", 1), ("first_name.keyword", 1)]
-        expected = SearchRequest(sort=sort_query)
+        expected = SearchRequest(sort=sort_query, max_results=25)
         await assert_es_find_called_with(SearchRequest(sort=sort_query), expected=expected)
         expected.where = {}
         await assert_es_find_called_with({}, sort=sort_query, expected=expected)
@@ -454,17 +454,30 @@ class TestResourceService(AsyncTestCase):
         sort_query = [("email.keyword", 1)]
 
         with mock.patch.object(self.service.config, "default_sort", sort_query):
-            expected = SearchRequest(sort=sort_query)
+            expected = SearchRequest(sort=sort_query, max_results=25)
             await assert_es_find_called_with(SearchRequest(), expected=expected)
             expected.where = {}
             await assert_es_find_called_with({}, expected=expected)
 
             # Test passing in sort param with default sort configured
             custom_sort_query = [("scores", 1)]
-            expected = SearchRequest(sort=custom_sort_query)
+            expected = SearchRequest(sort=custom_sort_query, max_results=25)
             await assert_es_find_called_with(SearchRequest(sort=custom_sort_query), expected=expected)
             expected.where = {}
             await assert_es_find_called_with({}, sort=custom_sort_query, expected=expected)
+
+        # Test with default max_results in the resource config
+        with mock.patch.object(self.service.config, "default_max_results", 5):
+            expected = SearchRequest(max_results=5)
+            await assert_es_find_called_with(SearchRequest(), expected=expected)
+            expected.where = {}
+            await assert_es_find_called_with({}, expected=expected)
+
+            # explicit max_results wins
+            expected = SearchRequest(max_results=10)
+            await assert_es_find_called_with(SearchRequest(max_results=10), expected=expected)
+            expected.where = {}
+            await assert_es_find_called_with({}, max_results=10, expected=expected)
 
     async def test_bulk_update(self):
         users = all_users()

--- a/tests/core/signals_test.py
+++ b/tests/core/signals_test.py
@@ -316,6 +316,7 @@ class ResourceWebSignalsTestCase(AsyncFlaskTestCase):
                     args={"source": '{"query":{"match":{"first_name":"John"}}}'},
                     source='{"query":{"match":{"first_name":"John"}}}',
                     projection={"token": False},
+                    max_results=25,  # set by the service on the same instance after the signal
                 ),
             ],
             [


### PR DESCRIPTION
### Purpose
Allow a resource to set its default page size via `ResourceConfig`, applied to every search on that resource, instead of subclassing `ResourceRestEndpoints` and overriding `search_items`.

### What has changed
- Added `default_max_results` to `ResourceConfig`, next to `default_sort`.
- `SearchRequest.max_results` is now `int | None` and defaults to `None`, meaning "not set".
- `AsyncResourceService.find` resolves a missing `max_results` from the resource config, falling back to the elastic config default and then 25. The mongo path applies the same fallback, matching what the elastic client already does. An explicit `max_results` always wins, and resources without the option keep the current 25.
- The REST GET endpoint no longer handles the default itself; it passes `None` through and the service fills it in.
- Added tests covering the service and the REST API, and updated existing expectations for the new default.

### Steps to test
1. Set `default_max_results` on a resource's `ResourceConfig`.
2. Call `find` on its service without `max_results`, or GET the resource without a `max_results` param, with more items than the configured value. The number of items and `_meta.max_results` match the configured value.
3. Repeat with an explicit `max_results`. The explicit value is used.

Resolves : https://sofab.atlassian.net/browse/CPCN-1217

Works with : https://github.com/superdesk/newsroom-core/pull/1561
