### PR TITLE
release 3.0.0a11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ package_data = {
 
 setup(
     name="Superdesk-Core",
-    version="3.0.0a10",
+    version="3.0.0a11",
     description="Superdesk Core library",
     long_description=LONG_DESCRIPTION,
     author="petr jasek",

--- a/superdesk/__init__.py
+++ b/superdesk/__init__.py
@@ -33,7 +33,7 @@ from .signals import *  # noqa
 from apps.common.models.base_model import BaseModel
 from apps.common.components.base_component import BaseComponent
 
-__version__ = "3.0.0a10"
+__version__ = "3.0.0a11"
 
 API_NAME = "Superdesk API"
 SCHEMA_VERSION = 2


### PR DESCRIPTION
### Purpose
Cut the 3.0.0a11 alpha release of superdesk-core from `release/3.0-alpha`, so downstream projects (newsroom-core) can pin a tag that includes the `default_max_results` resource option from #3317.

### What has changed
- Bumped `version` in `setup.py` and `__version__` in `superdesk/__init__.py` from `3.0.0a10` to `3.0.0a11`, following the same pattern as the 3.0.0a10 release commit.

### Steps to test
1. Merge this PR.
2. Tag the merge commit as `v3.0.0-alpha.11` and publish the GitHub release from `v3.0.0-alpha.10` to `v3.0.0-alpha.11`.

Related : https://sofab.atlassian.net/browse/CPCN-1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)