### PR TITLE
fix sentry logging on planning ingest error

### DIFF
--- a/superdesk/errors.py
+++ b/superdesk/errors.py
@@ -56,11 +56,10 @@ def log_exception(message, extra=None, data=None):
     """
     if not extra:
         extra = {}
+    else:
+        extra = dict(extra)
     if data:
         extra["file"] = save_error_data(data)
-    for k, v in extra.items():
-        message = "{} {}={}".format(message, k, v)
-    if data:
         extra["data"] = data
     try:
         logger.exception(message, extra=extra)
@@ -126,8 +125,6 @@ class SuperdeskApiError(SuperdeskError):
 
         if exception:
             logger.exception(message or exception, extra=extra)
-        elif message:
-            logger.error("HTTP Exception {} has been raised: {}".format(status_code, message), extra=extra)
 
     def to_dict(self) -> dict:
         """Create dict for json response."""
@@ -275,6 +272,14 @@ class SuperdeskIngestError(SuperdeskErrorWithNotifications):
                 message = "{}: {} on channel {}".format(self, exception, self.provider_name)
             else:
                 message = "{}: {}".format(self, exception)
+
+            if item is not None:
+                if extra is None:
+                    extra = {}
+                item_guid = item.get("guid") or item.get("_id") or item.get("id") or ""
+                item_name = item.get("headline") or item.get("slugline") or item.get("name") or ""
+                extra.setdefault("item_id", item_guid)
+                extra.setdefault("item_name", item_name)
 
             log_exception(message, extra=extra, data=data)
 

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -582,8 +582,6 @@ async def ingest_items(items, provider, feeding_service, rule_set=None, routing_
     updated_items = ingest_service.find({"_id": {"$in": created_ids}}, max_results=len(created_ids))
     app = get_current_app()
     app.data._search_backend(ingest_collection).bulk_insert(ingest_collection, list(updated_items))
-    if failed_items:
-        logger.error("Failed to ingest items", extra={"failed_items": list(failed_items)})
     return failed_items
 
 

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -25,9 +25,17 @@ class MockLoggingHandler(logging.Handler):
 
     def emit(self, record):
         self.messages[record.levelname.lower()].append(record.getMessage())
+        self.records[record.levelname.lower()].append(record)
 
     def reset(self):
         self.messages = {
+            "debug": [],
+            "info": [],
+            "warning": [],
+            "error": [],
+            "critical": [],
+        }
+        self.records = {
             "debug": [],
             "info": [],
             "warning": [],
@@ -319,9 +327,9 @@ class ErrorsTestCase(TestCase):
             except Exception as ex:
                 raise ParserError.parseMessageError(ex, self.provider, data=data)
         self.assertEqual(len(self.mock_logger_handler.messages["error"]), 1)
-        message = self.mock_logger_handler.messages["error"][0]
-        self.assertIn("file=", message)
-        filename = message.split("file=")[1]
+        record = self.mock_logger_handler.records["error"][0]
+        self.assertTrue(hasattr(record, "file"))
+        filename = record.file
         with open(filename, "r") as file:
             self.assertEqual(data, file.read())
 
@@ -337,11 +345,11 @@ class ErrorsTestCase(TestCase):
         self.assertIsNotNone(exception.system_exception)
         self.assertEqual(exception.system_exception.args[0], "Testing parseFileError")
         self.assertEqual(len(self.mock_logger_handler.messages["error"]), 1)
-        message = self.mock_logger_handler.messages["error"][0]
-        self.assertIn("ParserError Error 1002 - Ingest file could not be parsed", message)
-        self.assertIn("Testing parseFileError on channel TestProvider", message)
-        self.assertIn("source=afp", message)
-        self.assertIn("file=test.txt", message)
+        record = self.mock_logger_handler.records["error"][0]
+        self.assertIn("ParserError Error 1002 - Ingest file could not be parsed", record.getMessage())
+        self.assertIn("Testing parseFileError on channel TestProvider", record.getMessage())
+        self.assertEqual(getattr(record, "source", None), "afp")
+        self.assertEqual(getattr(record, "file", None), "test.txt")
 
     def test_raise_newsmlOneParserError(self):
         with self.assertRaises(ParserError) as error_context:
@@ -541,8 +549,10 @@ class ErrorsTestCase(TestCase):
         self.assertIsNotNone(exception.system_exception)
         self.assertEqual(exception.system_exception.args[0], "Testing ftpUnknownParserError")
         self.assertEqual(len(self.mock_logger_handler.messages["error"]), 1)
+        record = self.mock_logger_handler.records["error"][0]
         self.assertEqual(
-            self.mock_logger_handler.messages["error"][0],
+            record.getMessage(),
             "IngestFtpError Error 5001 - FTP parser could not be found: "
-            "Testing ftpUnknownParserError on channel TestProvider file=test.xml",
+            "Testing ftpUnknownParserError on channel TestProvider",
         )
+        self.assertEqual(getattr(record, "file", None), "test.xml")


### PR DESCRIPTION
log it once instead of 3x

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

Resolves: #[issue-number]

